### PR TITLE
Mempool Admission Checks

### DIFF
--- a/src/chainstate/stacks/auth.rs
+++ b/src/chainstate/stacks/auth.rs
@@ -887,15 +887,15 @@ impl TransactionAuth {
         }
     }
 
-    pub fn verify(&self, initial_sighash: &Txid) -> Result<bool, net_error> {
+    pub fn verify(&self, initial_sighash: &Txid) -> Result<(), net_error> {
         let origin_sighash = self.verify_origin(initial_sighash)?;
         match *self {
             TransactionAuth::Standard(_) => {
-                Ok(true)
+                Ok(())
             }
             TransactionAuth::Sponsored(_, ref sponsor_condition) => {
                 sponsor_condition.verify(&origin_sighash, &TransactionAuthFlags::AuthSponsored)
-                    .and_then(|_sigh| Ok(true))
+                    .and_then(|_sigh| Ok(()))
             }
         }
     }

--- a/src/chainstate/stacks/block.rs
+++ b/src/chainstate/stacks/block.rs
@@ -545,12 +545,7 @@ impl StacksBlock {
 
 impl StacksMessageCodec for StacksMicroblockHeader {
     fn consensus_serialize<W: Write>(&self, fd: &mut W) -> Result<(), net_error> {
-        write_next(fd, &self.version)?;
-        write_next(fd, &self.sequence)?;
-        write_next(fd, &self.prev_block)?;
-        write_next(fd, &self.tx_merkle_root)?;
-        write_next(fd, &self.signature)?;
-        Ok(())
+        self.serialize(fd, false)
     }
 
     fn consensus_deserialize<R: Read>(fd: &mut R) -> Result<StacksMicroblockHeader, net_error> {
@@ -593,18 +588,24 @@ impl StacksMicroblockHeader {
         Ok(())
     }
 
-    pub fn verify(&mut self, pubk_hash: &Hash160) -> Result<(), net_error> {
+    fn serialize<W: Write>(&self, fd: &mut W, empty_sig: bool) -> Result<(), net_error> {
+        write_next(fd, &self.version)?;
+        write_next(fd, &self.sequence)?;
+        write_next(fd, &self.prev_block)?;
+        write_next(fd, &self.tx_merkle_root)?;
+        if empty_sig {
+            write_next(fd, &MessageSignature::empty())?;
+        } else {
+            write_next(fd, &self.signature)?;
+        }
+        Ok(())
+    }
+
+    pub fn verify(&self, pubk_hash: &Hash160) -> Result<(), net_error> {
         let mut digest_bits = [0u8; 32];
         let mut sha2 = Sha512Trunc256::new();
 
-        let sig_bits = self.signature.clone();
-        self.signature = MessageSignature::empty();
-
-        let mut bytes = vec![];
-        self.consensus_serialize(&mut bytes).expect("BUG: failed to serialize to a vec");
-        self.signature = sig_bits;
-        
-        sha2.input(&bytes[..]);
+        self.serialize(&mut sha2, true).expect("BUG: failed to serialize to a vec");
         digest_bits.copy_from_slice(sha2.result().as_slice());
 
         let mut pubk = StacksPublicKey::recover_to_pubkey(&digest_bits, &self.signature)

--- a/src/chainstate/stacks/db/accounts.rs
+++ b/src/chainstate/stacks/db/accounts.rs
@@ -28,7 +28,7 @@ use chainstate::stacks::db::*;
 use chainstate::stacks::db::blocks::*;
 use vm::database::*;
 use vm::database::marf::*;
-
+use vm::clarity::ClarityConnection;
 use vm::types::*;
 
 use util::db::*;
@@ -129,16 +129,16 @@ impl MinerReward {
 }
 
 impl StacksChainState {
-    pub fn get_account<'a>(clarity_tx: &mut ClarityTx<'a>, principal: &PrincipalData) -> StacksAccount {
-        clarity_tx.connection().with_clarity_db_readonly(|ref mut db| {
+    pub fn get_account<T: ClarityConnection>(clarity_tx: &mut T, principal: &PrincipalData) -> StacksAccount {
+        clarity_tx.with_clarity_db_readonly(|ref mut db| {
             let stx_balance = db.get_account_stx_balance(principal);
             let nonce = db.get_account_nonce(principal);
-            Ok(StacksAccount {
+            StacksAccount {
                 principal: principal.clone(),
                 stx_balance,
                 nonce
-            })
-        }).expect("FATAL: failed to query account")
+            }
+        })
     }
 
     pub fn get_account_ft<'a>(clarity_tx: &mut ClarityTx<'a>, contract_id: &QualifiedContractIdentifier, token_name: &str, principal: &PrincipalData) -> Result<u128, Error> {

--- a/src/chainstate/stacks/db/blocks.rs
+++ b/src/chainstate/stacks/db/blocks.rs
@@ -55,10 +55,7 @@ use util::strings::StacksString;
 use util::get_epoch_time_secs;
 use util::hash::to_hex;
 
-use util::retry::{
-    BoundReader,
-    ReadCounter
-};
+use util::retry::BoundReader;
 
 use chainstate::burn::db::burndb::*;
 
@@ -155,6 +152,7 @@ pub enum MemPoolRejection {
     PoisonMicroblocksDoNotConflict,
     NoAnchorBlockWithPubkeyHash(Hash160),
     InvalidMicroblocks,
+    NonMatchingVersionBytes(u8, u8),
     NoCoinbaseViaMempool
 }
 
@@ -2748,10 +2746,10 @@ impl StacksChainState {
         Ok(ret)
     }
 
+    /// This function bounds the max read on fd to MAX_MESSAGE_LEN, so it does not need to be passed a bounded reader.
     pub fn will_admit_mempool_tx<R: Read>(&mut self, current_burn: &BurnchainHeaderHash, current_block: &BlockHeaderHash, fd: &mut R) -> Result<StacksTransaction, MemPoolRejection> {
         // 1: it should parse as a tx.
-        let mut fd_counter = ReadCounter::from_reader(fd);
-        let tx = StacksTransaction::consensus_deserialize(&mut fd_counter)
+        let (tx, tx_size) = StacksTransaction::consensus_deserialize_with_len(fd)
             .map_err(|e| MemPoolRejection::DeserializationFailure(e))?;
 
         // 2: it must be validly signed.
@@ -2760,7 +2758,6 @@ impl StacksChainState {
 
         // 3: it must pay a tx fee
         let fee = tx.get_fee_rate();
-        let tx_size = fd_counter.read_count();
 
         if fee < MINIMUM_TX_FEE || 
            fee / tx_size < MINIMUM_TX_FEE_RATE_PER_BYTE {
@@ -2773,6 +2770,11 @@ impl StacksChainState {
                 .map_err(|e| MemPoolRejection::BadNonces(e))
         })?;
 
+        let sender_version_byte = origin.principal.version();
+        if sender_version_byte != payer.principal.version() {
+            return Err(MemPoolRejection::NonMatchingVersionBytes(sender_version_byte, payer.principal.version()))
+        }
+
         // 5: the paying account must have enough funds
         if fee as u128 > payer.stx_balance {
             return Err(MemPoolRejection::NotEnoughFunds(fee as u128, payer.stx_balance))
@@ -2780,7 +2782,12 @@ impl StacksChainState {
 
         // 6: payload-specific checks
         match &tx.payload {
-            TransactionPayload::TokenTransfer(_addr, amount, _memo) => {
+            TransactionPayload::TokenTransfer(addr, amount, _memo) => {
+                // version byte matches?
+                if sender_version_byte != addr.version {
+                    return Err(MemPoolRejection::NonMatchingVersionBytes(sender_version_byte, addr.version))
+                }
+
                 // got the funds?
                 let total_spent = (*amount as u128) +
                     if origin == payer {
@@ -2794,6 +2801,11 @@ impl StacksChainState {
             },
             TransactionPayload::ContractCall(TransactionContractCall {
                 address, contract_name, function_name, function_args }) => {
+                // version byte matches?
+                if sender_version_byte != address.version {
+                    return Err(MemPoolRejection::NonMatchingVersionBytes(sender_version_byte, address.version))
+                }
+
                 let contract_identifier = QualifiedContractIdentifier::new(address.clone().into(), contract_name.clone());
 
                 let function_type = self.with_read_only_clarity_tx(current_burn, current_block, |conn| {

--- a/src/chainstate/stacks/db/blocks.rs
+++ b/src/chainstate/stacks/db/blocks.rs
@@ -2804,7 +2804,7 @@ impl StacksChainState {
                     .ok_or_else(|| MemPoolRejection::NoSuchPublicFunction)?;
 
                 let arg_types: Vec<_> = function_args.iter().map(|x| TypeSignature::type_of(x)).collect();
-                function_type.check_args(&arg_types)
+                function_type.check_args(&mut (), &arg_types)
                     .map_err(|e| MemPoolRejection::BadFunctionArgument(e))?;
             },
             TransactionPayload::SmartContract(TransactionSmartContract { name, code_body: _ }) => {

--- a/src/chainstate/stacks/db/headers.rs
+++ b/src/chainstate/stacks/db/headers.rs
@@ -156,13 +156,6 @@ impl StacksChainState {
 
     /// Get a stacks header info by burn block and block hash (i.e. by primary key).
     /// Does not get back data about the parent microblock stream.
-    pub fn get_all_anchored_block_header_info(&self, block_hash: &BlockHeaderHash) -> Result<Vec<StacksHeaderInfo>, Error> {
-        let sql = "SELECT * FROM block_headers WHERE block_hash = ?1";
-        query_rows(&self.headers_db, sql, &[block_hash]).map_err(Error::DBError)
-    }
-
-    /// Get a stacks header info by burn block and block hash (i.e. by primary key).
-    /// Does not get back data about the parent microblock stream.
     pub fn get_anchored_block_header_info(conn: &Connection, burn_header_hash: &BurnchainHeaderHash, block_hash: &BlockHeaderHash) -> Result<Option<StacksHeaderInfo>, Error> {
         let sql = "SELECT * FROM block_headers WHERE burn_header_hash = ?1 AND block_hash = ?2".to_string();
         let args: &[&dyn ToSql] = &[&burn_header_hash, &block_hash];

--- a/src/chainstate/stacks/db/headers.rs
+++ b/src/chainstate/stacks/db/headers.rs
@@ -177,7 +177,7 @@ impl StacksChainState {
 
     /// Get a stacks header info by index block hash (i.e. by the hash of the burn block header
     /// hash and the block hash -- the hash of the primary key)
-    fn get_stacks_block_header_info_by_index_block_hash(conn: &Connection, index_block_hash: &BlockHeaderHash) -> Result<Option<StacksHeaderInfo>, Error> {
+    pub fn get_stacks_block_header_info_by_index_block_hash(conn: &Connection, index_block_hash: &BlockHeaderHash) -> Result<Option<StacksHeaderInfo>, Error> {
         let sql = "SELECT * FROM block_headers WHERE index_block_hash = ?1".to_string();
         let mut rows = query_rows::<StacksHeaderInfo, _>(conn, &sql, &[&index_block_hash]).map_err(Error::DBError)?;
         let cnt = rows.len();

--- a/src/chainstate/stacks/db/headers.rs
+++ b/src/chainstate/stacks/db/headers.rs
@@ -156,6 +156,13 @@ impl StacksChainState {
 
     /// Get a stacks header info by burn block and block hash (i.e. by primary key).
     /// Does not get back data about the parent microblock stream.
+    pub fn get_all_anchored_block_header_info(&self, block_hash: &BlockHeaderHash) -> Result<Vec<StacksHeaderInfo>, Error> {
+        let sql = "SELECT * FROM block_headers WHERE block_hash = ?1";
+        query_rows(&self.headers_db, sql, &[block_hash]).map_err(Error::DBError)
+    }
+
+    /// Get a stacks header info by burn block and block hash (i.e. by primary key).
+    /// Does not get back data about the parent microblock stream.
     pub fn get_anchored_block_header_info(conn: &Connection, burn_header_hash: &BurnchainHeaderHash, block_hash: &BlockHeaderHash) -> Result<Option<StacksHeaderInfo>, Error> {
         let sql = "SELECT * FROM block_headers WHERE burn_header_hash = ?1 AND block_hash = ?2".to_string();
         let args: &[&dyn ToSql] = &[&burn_header_hash, &block_hash];
@@ -166,6 +173,7 @@ impl StacksChainState {
 
         Ok(rows.pop())
     }
+
 
     /// Get a stacks header info by index block hash (i.e. by the hash of the burn block header
     /// hash and the block hash -- the hash of the primary key)

--- a/src/chainstate/stacks/db/mod.rs
+++ b/src/chainstate/stacks/db/mod.rs
@@ -80,10 +80,17 @@ use vm::analysis::analysis_db::AnalysisDatabase;
 use vm::ast::build_ast;
 use vm::contexts::OwnedEnvironment;
 use vm::database::marf::MarfedKV;
-use vm::database::SqliteConnection;
-use vm::clarity::ClarityInstance;
-use vm::clarity::ClarityBlockConnection;
-use vm::clarity::Error as clarity_error;
+use vm::database::{
+    SqliteConnection,
+    ClarityDatabase
+};
+use vm::clarity::{
+    ClarityInstance,
+    ClarityConnection,
+    ClarityBlockConnection,
+    ClarityReadOnlyConnection,
+    Error as clarity_error
+};
 use vm::representations::ClarityName;
 use vm::representations::ContractName;
 
@@ -249,6 +256,18 @@ impl<'a> BlocksDBTx<'a> {
 pub struct ClarityTx<'a> {
     block: ClarityBlockConnection<'a>,
     pub config: DBConfig
+}
+
+impl ClarityConnection for ClarityTx<'_> {
+    fn with_clarity_db_readonly<F, R>(&mut self, to_do: F) -> R
+    where F: FnOnce(&mut ClarityDatabase) -> R {
+        ClarityConnection::with_clarity_db_readonly(&mut self.block, to_do)
+    }
+
+    fn with_analysis_db_readonly<F, R>(&mut self, to_do: F) -> R
+    where F: FnOnce(&mut AnalysisDatabase) -> R {
+        self.block.with_analysis_db_readonly(to_do)
+    }
 }
 
 impl<'a> ClarityTx<'a> {
@@ -831,25 +850,41 @@ impl StacksChainState {
                                                  parent_burn_hash, parent_block, new_burn_hash, new_block)
     }
 
+    fn begin_read_only_clarity_tx<'a>(&'a mut self, parent_burn_hash: &BurnchainHeaderHash, parent_block: &BlockHeaderHash) -> ClarityReadOnlyConnection<'a> {
+        let index_block = StacksChainState::get_parent_index_block(parent_burn_hash, parent_block);
+        self.clarity_state.read_only_connection(&index_block, &self.headers_db)
+    }
+
+    pub fn with_read_only_clarity_tx<F, R>(&mut self, parent_burn_hash: &BurnchainHeaderHash, parent_block: &BlockHeaderHash, to_do: F) -> R
+    where F: FnOnce(&mut ClarityReadOnlyConnection) -> R {
+        let mut conn = self.begin_read_only_clarity_tx(parent_burn_hash, parent_block);
+        let result = to_do(&mut conn);
+        conn.done();
+        result
+    }
+
+    fn get_parent_index_block(parent_burn_hash: &BurnchainHeaderHash, parent_block: &BlockHeaderHash) -> BlockHeaderHash {
+        if *parent_block == BOOT_BLOCK_HASH {
+            // begin boot block
+            test_debug!("Begin processing boot block");
+            TrieFileStorage::block_sentinel()
+        }
+        else if *parent_block == FIRST_STACKS_BLOCK_HASH {
+            // begin first-ever block
+            test_debug!("Begin processing first-ever block");
+            StacksBlockHeader::make_index_block_hash(&FIRST_BURNCHAIN_BLOCK_HASH, &FIRST_STACKS_BLOCK_HASH)
+        }
+        else {
+            // subsequent block
+            StacksBlockHeader::make_index_block_hash(parent_burn_hash, parent_block)
+        }
+    }
+
     /// Create a Clarity VM database transaction
     fn inner_clarity_tx_begin<'a>(conf: DBConfig, headers_db: &'a Connection, clarity_instance: &'a mut ClarityInstance, parent_burn_hash: &BurnchainHeaderHash, parent_block: &BlockHeaderHash, new_burn_hash: &BurnchainHeaderHash, new_block: &BlockHeaderHash) -> ClarityTx<'a> {
         // mix burn header hash and stacks block header hash together, since the stacks block hash
         // it not guaranteed to be globally unique (but the burn header hash _is_).
-        let parent_index_block = 
-            if *parent_block == BOOT_BLOCK_HASH {
-                // begin boot block
-                test_debug!("Begin processing boot block");
-                TrieFileStorage::block_sentinel()
-            }
-            else if *parent_block == FIRST_STACKS_BLOCK_HASH {
-                // begin first-ever block
-                test_debug!("Begin processing first-ever block");
-                StacksBlockHeader::make_index_block_hash(&FIRST_BURNCHAIN_BLOCK_HASH, &FIRST_STACKS_BLOCK_HASH)
-            }
-            else {
-                // subsequent block
-                StacksBlockHeader::make_index_block_hash(parent_burn_hash, parent_block)
-            };
+        let parent_index_block = StacksChainState::get_parent_index_block(parent_burn_hash, parent_block);
 
         let new_index_block = StacksBlockHeader::make_index_block_hash(new_burn_hash, new_block);
 

--- a/src/chainstate/stacks/miner.rs
+++ b/src/chainstate/stacks/miner.rs
@@ -169,7 +169,6 @@ impl StacksBlockBuilder {
 
         self.prev_microblock_header = StacksMicroblockHeader::first_unsigned(&block.block_hash(), &Sha512Trunc256Sum([0u8; 32]));
 
-        // this should actually be the index-block-hash.
         self.prev_microblock_header.prev_block = block.block_hash();
         self.anchored_done = true;
 

--- a/src/chainstate/stacks/mod.rs
+++ b/src/chainstate/stacks/mod.rs
@@ -57,7 +57,7 @@ use chainstate::stacks::index::Error as marf_error;
 use chainstate::stacks::db::StacksHeaderInfo;
 use chainstate::stacks::db::accounts::MinerReward;
 
-use net::StacksMessageCodec;
+use net::{StacksMessageCodec, MAX_MESSAGE_LEN};
 use net::codec::{read_next, write_next};
 use net::Error as net_error;
 
@@ -84,6 +84,8 @@ pub const C32_ADDRESS_VERSION_TESTNET_MULTISIG: u8 = 21;        // N
 
 pub const STACKS_BLOCK_VERSION: u8 = 0;
 pub const STACKS_MICROBLOCK_VERSION: u8 = 0;
+
+pub const MAX_TRANSACTION_LEN: u32 = MAX_MESSAGE_LEN;
 
 impl From<StacksAddress> for StandardPrincipalData {
     fn from(addr: StacksAddress) -> StandardPrincipalData {

--- a/src/chainstate/stacks/mod.rs
+++ b/src/chainstate/stacks/mod.rs
@@ -87,7 +87,14 @@ pub const STACKS_MICROBLOCK_VERSION: u8 = 0;
 
 impl From<StacksAddress> for StandardPrincipalData {
     fn from(addr: StacksAddress) -> StandardPrincipalData {
-        StandardPrincipalData(addr.version, addr.bytes.as_bytes().clone())
+        StandardPrincipalData(addr.version, addr.bytes.0)
+    }
+}
+
+impl From<StacksAddress> for PrincipalData {
+    fn from(addr: StacksAddress) -> PrincipalData {
+        PrincipalData::from(
+            StandardPrincipalData::from(addr))
     }
 }
 

--- a/src/chainstate/stacks/transaction.rs
+++ b/src/chainstate/stacks/transaction.rs
@@ -367,29 +367,18 @@ impl StacksMessageCodec for TransactionPostCondition {
     }
 }
 
-impl StacksMessageCodec for StacksTransaction {
-    fn consensus_serialize<W: Write>(&self, fd: &mut W) -> Result<(), net_error> {
-        write_next(fd, &(self.version as u8))?;
-        write_next(fd, &self.chain_id)?;
-        write_next(fd, &self.auth)?;
-        write_next(fd, &(self.anchor_mode as u8))?;
-        write_next(fd, &(self.post_condition_mode as u8))?;
-        write_next(fd, &self.post_conditions)?;
-        write_next(fd, &self.payload)?;
-        Ok(())
-    }
+impl StacksTransaction {
+    pub fn consensus_deserialize_with_len<R: Read>(fd: &mut R) -> Result<(StacksTransaction, u64), net_error> {
+        let mut bound_read = BoundReader::from_reader(fd, MAX_TRANSACTION_LEN.into());
+        let fd = &mut bound_read;
 
-    fn consensus_deserialize<R: Read>(fd: &mut R) -> Result<StacksTransaction, net_error> {
         let version_u8 : u8             = read_next(fd)?;
         let chain_id : u32              = read_next(fd)?;
         let auth : TransactionAuth      = read_next(fd)?;
         let anchor_mode_u8 : u8         = read_next(fd)?;
         let post_condition_mode_u8 : u8 = read_next(fd)?;
-        let post_conditions : Vec<TransactionPostCondition> = {
-            let mut bound_read = BoundReader::from_reader(fd, MAX_MESSAGE_LEN as u64);
-            read_next(&mut bound_read)
-        }?;
-        
+        let post_conditions : Vec<TransactionPostCondition> = read_next(fd)?;
+
         let payload : TransactionPayload = read_next(fd)?;
 
         let version = 
@@ -448,7 +437,7 @@ impl StacksMessageCodec for StacksTransaction {
             }
         };
 
-        Ok(StacksTransaction {
+        Ok((StacksTransaction {
             version,
             chain_id,
             auth,
@@ -456,7 +445,25 @@ impl StacksMessageCodec for StacksTransaction {
             post_condition_mode,
             post_conditions,
             payload
-        })
+        }, fd.num_read()))
+    }
+}
+
+impl StacksMessageCodec for StacksTransaction {
+    fn consensus_serialize<W: Write>(&self, fd: &mut W) -> Result<(), net_error> {
+        write_next(fd, &(self.version as u8))?;
+        write_next(fd, &self.chain_id)?;
+        write_next(fd, &self.auth)?;
+        write_next(fd, &(self.anchor_mode as u8))?;
+        write_next(fd, &(self.post_condition_mode as u8))?;
+        write_next(fd, &self.post_conditions)?;
+        write_next(fd, &self.payload)?;
+        Ok(())
+    }
+
+    fn consensus_deserialize<R: Read>(fd: &mut R) -> Result<StacksTransaction, net_error> {
+        StacksTransaction::consensus_deserialize_with_len(fd)
+            .map(|(result, _)| result)
     }
 }
 

--- a/src/chainstate/stacks/transaction.rs
+++ b/src/chainstate/stacks/transaction.rs
@@ -668,7 +668,7 @@ impl StacksTransaction {
     }
 
     /// Verify this transaction's signatures
-    pub fn verify(&self) -> Result<bool, net_error> {
+    pub fn verify(&self) -> Result<(), net_error> {
         self.auth.verify(&self.verify_begin())
     }
 
@@ -1051,7 +1051,7 @@ mod test {
     // serialized data changes.
     fn test_signature_and_corruption(signed_tx: &StacksTransaction, corrupt_origin: bool, corrupt_sponsor: bool) -> () {
         // signature is well-formed otherwise
-        assert!(signed_tx.verify().unwrap());
+        signed_tx.verify().unwrap();
 
         // mess with the auth hash code
         let mut corrupt_tx_hash_mode = signed_tx.clone();

--- a/src/core/mempool.rs
+++ b/src/core/mempool.rs
@@ -1,0 +1,115 @@
+use burnchains::BurnchainHeaderHash;
+use chainstate::burn::BlockHeaderHash;
+use chainstate::stacks::{
+    StacksTransaction,
+    db::StacksChainState,
+    db::blocks::MemPoolRejection
+};
+use std::io::Read;
+
+pub struct MempoolAdmitter {
+    // mempool admission should have its own chain state view.
+    //   the mempool admitter interacts with the chain state
+    //   exclusively in read-only fashion, however, it should have
+    //   its own instance of things like the MARF index, because otherwise
+    //   mempool admission tests would block with chain processing.
+    chainstate: StacksChainState,
+    cur_block: BlockHeaderHash,
+    cur_burn_block: BurnchainHeaderHash,
+}
+
+impl MempoolAdmitter {
+    pub fn new(chainstate: StacksChainState, cur_block: BlockHeaderHash, cur_burn_block: BurnchainHeaderHash) -> MempoolAdmitter {
+        MempoolAdmitter { chainstate, cur_block, cur_burn_block }
+    }
+
+    pub fn set_block(&mut self, cur_block: &BlockHeaderHash, cur_burn_block: &BurnchainHeaderHash) {
+        self.cur_burn_block = cur_burn_block.clone();
+        self.cur_block = cur_block.clone();
+    }
+
+    pub fn will_admit_tx<R: Read>(&mut self, tx: &mut R) -> Result<StacksTransaction, MemPoolRejection> {
+        self.chainstate.will_admit_mempool_tx(&self.cur_burn_block, &self.cur_block, tx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use vm::tests::integrations::*;
+    use vm::{
+        database::HeadersDB,
+        types::QualifiedContractIdentifier,
+        Value, ClarityName, ContractName, errors::RuntimeErrorType, errors::Error as ClarityError };
+    use chainstate::stacks::{
+        StacksPrivateKey, db::StacksChainState };
+    use chainstate::burn::VRFSeed;
+    use burnchains::Address;
+    use address::AddressHashMode;
+    use net::{Error as NetError, StacksMessageCodec};
+    use util::{log, strings::StacksString, hash::hex_bytes, hash::to_hex};
+
+    use util::db::{DBConn, FromRow};
+    use testnet;
+    use testnet::mem_pool::MemPool;
+
+    const FOO_CONTRACT: &'static str = "(define-public (foo) (ok 1))
+                                        (define-public (bar (x uint)) (ok x))";
+    const SK_1: &'static str = "a1289f6438855da7decf9b61b852c882c398cff1446b2a0f823538aa2ebef92e01";
+    const SK_2: &'static str = "4ce9a8f7539ea93753a36405b16e8b57e15a552430410709c2b6d65dca5c02e201";
+    const SK_3: &'static str = "cb95ddd0fe18ec57f4f3533b95ae564b3f1ae063dbf75b46334bd86245aef78501";
+
+    #[test]
+    fn mempool_setup_chainstate() {
+        let mut conf = testnet::tests::new_test_conf();
+
+        conf.burnchain_block_time = 1500;
+
+        let contract_sk = StacksPrivateKey::from_hex(SK_1).unwrap();
+        let contract_addr = to_addr(&contract_sk);
+
+        let num_rounds = 4;
+
+        let mut run_loop = testnet::RunLoop::new_with_boot_exec(conf, |clarity_tx| {
+            // lets dole out some stacks.
+            clarity_tx.connection().with_clarity_db(|db| {
+                db.set_account_stx_balance(&contract_addr.clone().into(), 100000);
+                Ok(())
+            }).unwrap();
+        });
+
+        run_loop.apply_on_new_tenures(|round, tenure| {
+            let contract_sk = StacksPrivateKey::from_hex(SK_1).unwrap();
+            if round == 0 { // block-height = 2
+                let publish_tx = make_contract_publish(&contract_sk, 0, 100, "foo_contract", FOO_CONTRACT);
+                eprintln!("Tenure in 1 started!");
+                tenure.mem_pool.submit(publish_tx);
+            }
+        });
+
+        run_loop.apply_on_new_chain_states(|round, ref mut chainstate, bhh| {
+            let contract_sk = StacksPrivateKey::from_hex(SK_1).unwrap();
+            let contract_addr = to_addr(&contract_sk);
+
+            if round == 3 {
+                let block_header = StacksChainState::get_stacks_block_header_info_by_index_block_hash(
+                    &mut chainstate.headers_db, bhh)
+                    .unwrap().unwrap();
+                let burn_hash = &block_header.burn_header_hash;
+                let block_hash = &block_header.anchored_header.block_hash();
+
+                // let's throw some transactions at it.
+                // first a couple valid ones:
+                let tx = make_contract_publish(&contract_sk, 1, 1000, "bar_contract", FOO_CONTRACT);
+                chainstate.will_admit_mempool_tx(burn_hash, block_hash, &mut tx.as_slice()).unwrap();
+
+                let tx = make_contract_call(&contract_sk, 1, 200, &contract_addr, "foo_contract", "bar", &[Value::UInt(1)]);
+                chainstate.will_admit_mempool_tx(burn_hash, block_hash, &mut tx.as_slice()).unwrap();
+
+                // now an invalid one.
+                chainstate.will_admit_mempool_tx(burn_hash, block_hash, &mut vec![0u8, 0u8, 0u8, 0u8].as_slice()).unwrap_err();
+            }
+        });
+
+        run_loop.start(num_rounds);
+    }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -23,6 +23,8 @@ use burnchains::Error as burnchain_error;
 use chainstate::burn::BlockHeaderHash;
 use util::log;
 
+pub mod mempool;
+
 // fork set identifier -- to be mixed with the consensus hash (encodes the version)
 pub const SYSTEM_FORK_SET_VERSION : [u8; 4] = [23u8, 0u8, 0u8, 0u8];
 

--- a/src/testnet/node.rs
+++ b/src/testnet/node.rs
@@ -71,12 +71,12 @@ pub struct Node {
 impl Node {
 
     /// Instantiate and initialize a new node, given a config
-    pub fn new(config: NodeConfig, average_block_time: u64) -> Self {
-        
+    pub fn new<F>(config: NodeConfig, average_block_time: u64, boot_block_exec: F) -> Self
+    where F: FnOnce(&mut ClarityTx) -> () {
         let seed = Sha256Sum::from_data(format!("{}", config.name).as_bytes());
         let keychain = Keychain::default(seed.as_bytes().to_vec());
 
-        let chain_state = match StacksChainState::open(false, TESTNET_CHAIN_ID, &config.path) {
+        let chain_state = match StacksChainState::open_and_exec(false, TESTNET_CHAIN_ID, &config.path, boot_block_exec) {
             Ok(res) => res,
             Err(_) => panic!("Error while opening chain state at path {:?}", config.path)
         };

--- a/src/util/db.rs
+++ b/src/util/db.rs
@@ -148,7 +148,7 @@ macro_rules! impl_byte_array_from_column {
 }
 
 /// boilerplate code for querying rows 
-pub fn query_rows<T, P>(conn: &Connection, sql_query: &String, sql_args: P) -> Result<Vec<T>, Error>
+pub fn query_rows<T, P>(conn: &Connection, sql_query: &str, sql_args: P) -> Result<Vec<T>, Error>
 where
     P: IntoIterator,
     P::Item: ToSql,

--- a/src/util/retry.rs
+++ b/src/util/retry.rs
@@ -81,36 +81,6 @@ impl<'a, R: Read> Read for RetryReader<'a, R> {
 }
 
 /// A Read that will only read up to a given number of bytes before EOF'ing.
-pub struct ReadCounter<'a, R: Read> {
-    fd: &'a mut R,
-    read_so_far: u64
-}
-
-impl<'a, R: Read> ReadCounter<'a, R> {
-    pub fn from_reader(reader: &'a mut R) -> ReadCounter<'a, R> {
-        ReadCounter {
-            fd: reader,
-            read_so_far: 0
-        }
-    }
-
-    pub fn read_count(&self) -> u64 {
-        self.read_so_far
-    }
-}
-
-impl <'a, R: Read> Read for ReadCounter<'a, R> {
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        self.read_so_far.checked_add(buf.len() as u64)
-            .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "Read would overflow u64".to_string()))?;
-
-        let nr = self.fd.read(buf)?;
-        self.read_so_far += nr as u64;
-        Ok(nr)
-    }
-}
-
-/// A Read that will only read up to a given number of bytes before EOF'ing.
 pub struct BoundReader<'a, R: Read> {
     fd: &'a mut R,
     max_len: u64,

--- a/src/vm/analysis/analysis_db.rs
+++ b/src/vm/analysis/analysis_db.rs
@@ -69,6 +69,10 @@ impl <'a> AnalysisDatabase <'a> {
         self.store.prepare_for_contract_metadata(contract_identifier, Sha512Trunc256Sum([0; 32]));
     }
 
+    pub fn has_contract(&mut self, contract_identifier: &QualifiedContractIdentifier) -> bool {
+        self.store.has_metadata_entry(contract_identifier, AnalysisDatabase::storage_key())
+    }
+
     pub fn load_contract(&mut self, contract_identifier: &QualifiedContractIdentifier) -> Option<ContractAnalysis> {
         self.store.get_metadata(contract_identifier, AnalysisDatabase::storage_key())
             // treat NoSuchContract error thrown by get_metadata as an Option::None --

--- a/src/vm/clarity.rs
+++ b/src/vm/clarity.rs
@@ -44,6 +44,12 @@ pub struct ClarityBlockConnection<'a> {
     cost_track: Option<LimitedCostTracker>
 }
 
+pub struct ClarityReadOnlyConnection<'a> {
+    datastore: MarfedKV,
+    parent: &'a mut ClarityInstance,
+    header_db: &'a dyn HeadersDB,
+}
+
 #[derive(Debug)]
 pub enum Error {
     Analysis(CheckError),
@@ -138,6 +144,22 @@ impl ClarityInstance {
         }
     }
 
+    pub fn read_only_connection<'a>(&'a mut self, at_block: &BlockHeaderHash, header_db: &'a dyn HeadersDB) -> ClarityReadOnlyConnection<'a> {
+        let mut datastore = self.datastore.take()
+            // this is a panicking failure, because there should be _no instance_ in which a ClarityBlockConnection
+            //   doesn't restore it's parent's datastore
+            .expect("FAIL: use of begin_block while prior block neither committed nor rolled back.");
+
+        datastore
+            .set_chain_tip(at_block);
+
+        ClarityReadOnlyConnection {
+            datastore,
+            header_db,
+            parent: self
+        }
+    }
+
     #[cfg(test)]
     pub fn eval_read_only(&mut self, at_block: &BlockHeaderHash, header_db: &dyn HeadersDB,
                           contract: &QualifiedContractIdentifier, program: &str) -> Result<Value, Error> {
@@ -156,6 +178,62 @@ impl ClarityInstance {
             .expect("FAIL: attempt to recover database connection from clarity instance which is still open");
 
         datastore
+    }
+}
+
+pub trait ClarityConnection {
+    /// Do something to the underlying DB that involves only reading.
+    fn with_clarity_db_readonly<F, R>(&mut self, to_do: F) -> R
+    where F: FnOnce(&mut ClarityDatabase) -> R;
+    fn with_analysis_db_readonly<F, R>(&mut self, to_do: F) -> R
+    where F: FnOnce(&mut AnalysisDatabase) -> R;
+}
+
+impl ClarityConnection for ClarityBlockConnection <'_> {
+    /// Do something to the underlying DB that involves only reading.
+    fn with_clarity_db_readonly<F, R>(&mut self, to_do: F) -> R
+    where F: FnOnce(&mut ClarityDatabase) -> R {
+        let mut db = ClarityDatabase::new(&mut self.datastore, &self.header_db);
+        db.begin();
+        let result = to_do(&mut db);
+        db.roll_back();
+        result
+    }
+
+    fn with_analysis_db_readonly<F, R>(&mut self, to_do: F) -> R
+    where F: FnOnce(&mut AnalysisDatabase) -> R {
+        let mut db = AnalysisDatabase::new(&mut self.datastore);
+        db.begin();
+        let result = to_do(&mut db);
+        db.roll_back();
+        result
+    }
+}
+
+impl ClarityConnection for ClarityReadOnlyConnection <'_> {
+    fn with_clarity_db_readonly<F, R>(&mut self, to_do: F) -> R
+    where F: FnOnce(&mut ClarityDatabase) -> R {
+        let mut db = ClarityDatabase::new(&mut self.datastore, &self.header_db);
+        db.begin();
+        let result = to_do(&mut db);
+        db.roll_back();
+        result
+    }
+
+    fn with_analysis_db_readonly<F, R>(&mut self, to_do: F) -> R
+    where F: FnOnce(&mut AnalysisDatabase) -> R {
+        let mut db = AnalysisDatabase::new(&mut self.datastore);
+        db.begin();
+        let result = to_do(&mut db);
+        db.roll_back();
+        result
+    }
+}
+
+impl <'a> ClarityReadOnlyConnection <'a> {
+    pub fn done(mut self) {
+        self.datastore.rollback();
+        self.parent.datastore.replace(self.datastore);
     }
 }
 
@@ -241,16 +319,6 @@ impl <'a> ClarityBlockConnection <'a> {
     pub fn with_clarity_db_readonly<F, R>(&mut self, to_do: F) -> Result<R, Error>
     where F: FnOnce(&mut ClarityDatabase) -> Result<R, Error> {
         let mut db = ClarityDatabase::new(&mut self.datastore, &self.header_db);
-        db.begin();
-        let result = to_do(&mut db);
-        db.roll_back();
-        result
-    }
-
-    /// Do something to the underlying DB that involves only reading.
-    pub fn with_analysis_db_readonly<F, R>(&mut self, to_do: F) -> R
-    where F: FnOnce(&mut AnalysisDatabase) -> R {
-        let mut db = AnalysisDatabase::new(&mut self.datastore);
         db.begin();
         let result = to_do(&mut db);
         db.roll_back();

--- a/src/vm/clarity.rs
+++ b/src/vm/clarity.rs
@@ -231,8 +231,7 @@ impl ClarityConnection for ClarityReadOnlyConnection <'_> {
 }
 
 impl <'a> ClarityReadOnlyConnection <'a> {
-    pub fn done(mut self) {
-        self.datastore.rollback();
+    pub fn done(self) {
         self.parent.datastore.replace(self.datastore);
     }
 }

--- a/src/vm/clarity.rs
+++ b/src/vm/clarity.rs
@@ -247,6 +247,16 @@ impl <'a> ClarityBlockConnection <'a> {
         result
     }
 
+    /// Do something to the underlying DB that involves only reading.
+    pub fn with_analysis_db_readonly<F, R>(&mut self, to_do: F) -> R
+    where F: FnOnce(&mut AnalysisDatabase) -> R {
+        let mut db = AnalysisDatabase::new(&mut self.datastore);
+        db.begin();
+        let result = to_do(&mut db);
+        db.roll_back();
+        result
+    }
+
     /// Analyze a provided smart contract, but do not write the analysis to the AnalysisDatabase
     pub fn analyze_smart_contract(&mut self, identifier: &QualifiedContractIdentifier, contract_content: &str)
                                   -> Result<(ContractAST, ContractAnalysis), Error> {

--- a/src/vm/database/marf.rs
+++ b/src/vm/database/marf.rs
@@ -219,7 +219,6 @@ impl MarfedKV {
         &self.chain_tip
     }
 
-    #[cfg(test)]
     pub fn set_chain_tip(&mut self, bhh: &BlockHeaderHash) {
         self.chain_tip = bhh.clone();
     }

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -24,7 +24,7 @@ pub mod docs;
 pub mod analysis;
 
 #[cfg(test)]
-mod tests;
+pub mod tests;
 
 pub use vm::types::Value;
 use vm::callables::CallableType;

--- a/src/vm/tests/integrations.rs
+++ b/src/vm/tests/integrations.rs
@@ -18,12 +18,12 @@ use util::db::{DBConn, FromRow};
 use testnet;
 use testnet::mem_pool::MemPool;
 
-fn serialize_sign_standard_single_sig_tx(payload: TransactionPayload,
-                                         sender: &StacksPrivateKey, nonce: u64) -> Vec<u8> {
+pub fn serialize_sign_standard_single_sig_tx(payload: TransactionPayload,
+                                         sender: &StacksPrivateKey, nonce: u64, fee_rate: u64) -> Vec<u8> {
     let mut spending_condition = TransactionSpendingCondition::new_singlesig_p2pkh(StacksPublicKey::from_private(sender))
         .expect("Failed to create p2pkh spending condition from public key.");
     spending_condition.set_nonce(nonce);
-    spending_condition.set_fee_rate(0);
+    spending_condition.set_fee_rate(fee_rate);
     let auth = TransactionAuth::Standard(spending_condition);
     let unsigned_tx = StacksTransaction::new(TransactionVersion::Testnet, auth, payload);
     let mut tx_signer = StacksTransactionSigner::new(&unsigned_tx);
@@ -34,17 +34,17 @@ fn serialize_sign_standard_single_sig_tx(payload: TransactionPayload,
     buf
 }
 
-fn make_contract_publish(sender: &StacksPrivateKey, nonce: u64, contract_name: &str, contract_content: &str) -> Vec<u8> {
+pub fn make_contract_publish(sender: &StacksPrivateKey, nonce: u64, fee_rate: u64, contract_name: &str, contract_content: &str) -> Vec<u8> {
     let name = ContractName::from(contract_name);
     let code_body = StacksString::from_string(&contract_content.to_string()).unwrap();
 
     let payload = TransactionSmartContract { name, code_body };
 
-    serialize_sign_standard_single_sig_tx(payload.into(), sender, nonce)
+    serialize_sign_standard_single_sig_tx(payload.into(), sender, nonce, fee_rate)
 }
 
-fn make_contract_call(
-    sender: &StacksPrivateKey, nonce: u64,
+pub fn make_contract_call(
+    sender: &StacksPrivateKey, nonce: u64, fee_rate: u64,
     contract_addr: &StacksAddress, contract_name: &str,
     function_name: &str, function_args: &[Value]) -> Vec<u8> {
 
@@ -57,10 +57,10 @@ fn make_contract_call(
         function_args: function_args.iter().map(|x| x.clone()).collect()
     };
 
-    serialize_sign_standard_single_sig_tx(payload.into(), sender, nonce)
+    serialize_sign_standard_single_sig_tx(payload.into(), sender, nonce, fee_rate)
 }
 
-fn to_addr(sk: &StacksPrivateKey) -> StacksAddress {
+pub fn to_addr(sk: &StacksPrivateKey) -> StacksAddress {
     StacksAddress::from_public_keys(
         C32_ADDRESS_VERSION_TESTNET_SINGLESIG, &AddressHashMode::SerializeP2PKH, 1, &vec![StacksPublicKey::from_private(sk)])
         .unwrap()
@@ -155,11 +155,11 @@ fn integration_test_get_info() {
         let principal_sk = StacksPrivateKey::from_hex(SK_2).unwrap();
 
         if round == 1 { // block-height = 2
-            let publish_tx = make_contract_publish(&contract_sk, 0, "get-info", GET_INFO_CONTRACT);
+            let publish_tx = make_contract_publish(&contract_sk, 0, 0, "get-info", GET_INFO_CONTRACT);
             eprintln!("Tenure in 1 started!");
             tenure.mem_pool.submit(publish_tx);
         } else if round >= 2 { // block-height > 2
-            let tx = make_contract_call(&principal_sk, (round - 2).into(), &to_addr(&contract_sk), "get-info", "update-info", &[]);
+            let tx = make_contract_call(&principal_sk, (round - 2).into(), 0, &to_addr(&contract_sk), "get-info", "update-info", &[]);
             tenure.mem_pool.submit(tx);
         }
 

--- a/src/vm/tests/mod.rs
+++ b/src/vm/tests/mod.rs
@@ -11,7 +11,7 @@ use vm::database::{ClarityDatabase, MarfedKV, MemoryBackingStore,
 use chainstate::stacks::index::storage::{TrieFileStorage};
 use chainstate::burn::BlockHeaderHash;
 
-mod integrations;
+pub mod integrations;
 mod forking;
 mod assets;
 mod iterables;

--- a/src/vm/types/mod.rs
+++ b/src/vm/types/mod.rs
@@ -404,6 +404,15 @@ impl fmt::Display for Value {
 }
 
 impl PrincipalData {
+    pub fn version(&self) -> u8 {
+        match self {
+            PrincipalData::Standard(StandardPrincipalData(version, _)) => *version,
+            PrincipalData::Contract(QualifiedContractIdentifier { issuer, name: _ }) => {
+                issuer.0
+            }
+        }
+    }
+
     pub fn parse_qualified_contract_principal(literal: &str) -> Result<PrincipalData> {
         let contract_id = QualifiedContractIdentifier::parse(literal)?;
         Ok(PrincipalData::Contract(contract_id))


### PR DESCRIPTION
This PR implements admission checks for transactions into the mempool.

Transactions are checked to ensure they:

1. Parse correctly
2. Have paid fees
3. Paying accounts have enough funds for stacks transfers and fees
4. Nonces are correct (note: this precludes replace-by-fee for the moment)
5. Payload specific checks (e.g., ContractAlreadyExists for publishes)

These checks _require_ querying chainstate. To this end, there was some refactoring to allow the checking code to use a read-only Clarity database connection.