### PR TITLE
Fix: correct expression id labeling post-sugar-expansion

### DIFF
--- a/src/vm/ast/definition_sorter/tests.rs
+++ b/src/vm/ast/definition_sorter/tests.rs
@@ -12,7 +12,7 @@ fn run_scoped_parsing_helper(contract: &str) -> ParseResult<ContractAST> {
     let contract_identifier = QualifiedContractIdentifier::transient();
     let pre_expressions = parser::parse(contract)?;
     let mut contract_ast = ContractAST::new(contract_identifier.clone(), pre_expressions);
-    ExpressionIdentifier::run_pass(&mut contract_ast)?;
+    ExpressionIdentifier::run_pre_expression_pass(&mut contract_ast)?;
     DefinitionSorter::run_pass(&mut contract_ast, &mut ())?;
     Ok(contract_ast)
 }

--- a/src/vm/ast/expression_identifier/mod.rs
+++ b/src/vm/ast/expression_identifier/mod.rs
@@ -1,37 +1,37 @@
-use vm::representations::{PreSymbolicExpression};
+use vm::representations::{SymbolicExpressionCommon};
 use vm::representations::PreSymbolicExpressionType::List;
 use vm::ast::types::{ContractAST, BuildASTPass};
 use vm::ast::errors::{ParseResult, ParseErrors, ParseError};
 
-fn inner_relabel(args: &mut [PreSymbolicExpression], index: u64) -> ParseResult<u64> {
+fn inner_relabel<T: SymbolicExpressionCommon>(args: &mut [T], index: u64) -> ParseResult<u64> {
     let mut current = index.checked_add(1)
         .ok_or(ParseError::new(ParseErrors::TooManyExpressions))?;
     for expression in &mut args[..] {
-        expression.id = current;
-        current = match expression.pre_expr {
-            List(ref mut exprs) => {
-                inner_relabel(exprs, current)
-            },
-            _ => {
-                current.checked_add(1)
-                    .ok_or(ParseError::new(ParseErrors::TooManyExpressions))
-            },
+        expression.set_id(current);
+        current = if let Some(exprs) = expression.match_list_mut() {
+            inner_relabel(exprs, current)
+        } else {
+            current.checked_add(1)
+                .ok_or(ParseError::new(ParseErrors::TooManyExpressions))
         }?;
     }
     Ok(current)
 }
 
-pub fn update_expression_id(exprs: &mut [PreSymbolicExpression]) -> ParseResult<()> {
+pub fn update_expression_id<T: SymbolicExpressionCommon>(exprs: &mut [T]) -> ParseResult<()> {
     inner_relabel(exprs, 0)?;
     Ok(())
 }
 
 pub struct ExpressionIdentifier;
 
-impl BuildASTPass for ExpressionIdentifier {
-
-    fn run_pass(contract_ast: &mut ContractAST) -> ParseResult<()> {
-        update_expression_id(& mut contract_ast.pre_expressions)?;
+impl ExpressionIdentifier {
+    pub fn run_pre_expression_pass(contract_ast: &mut ContractAST) -> ParseResult<()> {
+        update_expression_id(contract_ast.pre_expressions.as_mut_slice())?;
+        Ok(())
+    }
+    pub fn run_expression_pass(contract_ast: &mut ContractAST) -> ParseResult<()> {
+        update_expression_id(contract_ast.expressions.as_mut_slice())?;
         Ok(())
     }
 }

--- a/src/vm/ast/mod.rs
+++ b/src/vm/ast/mod.rs
@@ -92,7 +92,7 @@ mod tests {
                 assert!(! visited.contains_key(&x.id));
                 visited.insert(x.id, true);
                 Ok(())
-            });
+            }).unwrap();
         }
     }
 }

--- a/src/vm/ast/sugar_expander/mod.rs
+++ b/src/vm/ast/sugar_expander/mod.rs
@@ -83,7 +83,7 @@ impl SugarExpander {
                     }                    
                 },
             };
-            expr.id = pre_expr.id;
+            // expr.id will be set by the subsequent expression identifier pass.
             expr.span = pre_expr.span.clone();
             expressions.push(expr);
         }

--- a/src/vm/representations.rs
+++ b/src/vm/representations.rs
@@ -92,6 +92,40 @@ pub struct PreSymbolicExpression {
     pub span: Span,
 }
 
+pub trait SymbolicExpressionCommon {
+    type S: SymbolicExpressionCommon;
+    fn set_id(&mut self, id: u64);
+    fn match_list_mut(&mut self) -> Option<&mut [Self::S]>;
+}
+
+impl SymbolicExpressionCommon for PreSymbolicExpression {
+    type S = PreSymbolicExpression;
+    fn set_id(&mut self, id: u64) {
+        self.id = id;
+    }
+    fn match_list_mut(&mut self) -> Option<&mut [PreSymbolicExpression]> {
+        if let PreSymbolicExpressionType::List(ref mut list) = self.pre_expr {
+            Some(list)
+        } else {
+            None
+        }
+    }
+}
+
+impl SymbolicExpressionCommon for SymbolicExpression {
+    type S = SymbolicExpression;
+    fn set_id(&mut self, id: u64) {
+        self.id = id;
+    }
+    fn match_list_mut(&mut self) -> Option<&mut [SymbolicExpression]> {
+        if let SymbolicExpressionType::List(ref mut list) = self.expr {
+            Some(list)
+        } else {
+            None
+        }
+    }
+}
+
 impl PreSymbolicExpression {
     #[cfg(feature = "developer-mode")]
     fn cons() -> PreSymbolicExpression {


### PR DESCRIPTION
Because the sugar expander can create new AST nodes, the expression identifier needs to run a second time after the sugar expansion.