### PR TITLE
Generate valid json in blockstack-cli generate-sk

### DIFF
--- a/src/blockstack_cli.rs
+++ b/src/blockstack_cli.rs
@@ -343,9 +343,9 @@ fn generate_secret_key(args: &[String], version: TransactionVersion) -> Result<S
         version, &AddressHashMode::SerializeP2PKH, 1, &vec![pk.clone()])
         .expect("Failed to generate address from public key");
     Ok(format!("{{ 
-  secretKey: \"{}\",
-  publicKey: \"{}\",
-  stacksAddress: \"{}\"
+  \"secretKey\": \"{}\",
+  \"publicKey\": \"{}\",
+  \"stacksAddress\": \"{}\"
 }}",
              sk.to_hex(),
              pk.to_hex(),


### PR DESCRIPTION
This PR
* changes the output of `blockstack-cli generate-sk` to valid JSON
* fixes #1366 