### PR TITLE
Replace `define` by `define-private` in documentation

### DIFF
--- a/src/vm/docs/mod.rs
+++ b/src/vm/docs/mod.rs
@@ -82,7 +82,7 @@ const NONE_KEYWORD: KeywordAPI = KeywordAPI {
     output_type: "(optional ?)",
     description: "Represents the _none_ option indicating no value for a given optional (analogous to a null value).",
     example: "
-(define (only-if-positive (a int))
+(define-public (only-if-positive (a int))
   (if (> a 0)
       (some a)
       none))
@@ -973,7 +973,7 @@ Like other kinds of definition statements, `define-map` may only be used at the 
 definition (i.e., you cannot put a define statement in the middle of a function body).",
     example: "
 (define-map squares ((x int)) ((square int)))
-(define (add-entry (x int))
+(define-private (add-entry (x int))
   (map-insert squares ((x 2)) ((square (* x x)))))
 (add-entry 1)
 (add-entry 2)
@@ -996,7 +996,7 @@ Like other kinds of definition statements, `define-data-var` may only be used at
 definition (i.e., you cannot put a define statement in the middle of a function body).",
     example: "
 (define-data-var size int 0)
-(define (set-size (value int))
+(define-private (set-size (value int))
   (var-set size value))
 (set-size 1)
 (set-size 2)


### PR DESCRIPTION
This PR
* corrects examples in the documentation, replacing `define` by `define-private`. `define` has been removed.