### PR TITLE
feat: include contract ABI JSON in sidecar tx msg

### DIFF
--- a/src/chainstate/stacks/db/transactions.rs
+++ b/src/chainstate/stacks/db/transactions.rs
@@ -389,6 +389,7 @@ impl StacksChainState {
                     events: vec![StacksTransactionEvent::STXEvent(STXEventType::STXTransferEvent(event_data))],
                     result: Value::okay_true(),
                     stx_burned: 0,
+                    contract_analysis: None,
                 };
 
                 // no burns
@@ -426,7 +427,8 @@ impl StacksChainState {
                     transaction: tx.clone(),
                     events,
                     result,
-                    stx_burned: asset_map.get_stx_burned_total()
+                    stx_burned: asset_map.get_stx_burned_total(),
+                    contract_analysis: None,
                 };
 
                 Ok(receipt)
@@ -465,7 +467,8 @@ impl StacksChainState {
                             transaction: tx.clone(),
                             events: vec![],
                             result: Value::err_none(),
-                            stx_burned: 0
+                            stx_burned: 0,
+                            contract_analysis: None,
                         };
                 
                         // abort now -- no burns
@@ -504,7 +507,8 @@ impl StacksChainState {
                     transaction: tx.clone(),
                     events,
                     result: Value::okay_true(),
-                    stx_burned: asset_map.get_stx_burned_total()
+                    stx_burned: asset_map.get_stx_burned_total(),
+                    contract_analysis: Some(contract_analysis),
                 };
 
                 Ok(receipt)
@@ -529,7 +533,8 @@ impl StacksChainState {
                     transaction: tx.clone(),
                     events: vec![],
                     result: Value::okay_true(),
-                    stx_burned: 0
+                    stx_burned: 0,
+                    contract_analysis: None,
                 };
 
                 Ok(receipt)

--- a/src/chainstate/stacks/events.rs
+++ b/src/chainstate/stacks/events.rs
@@ -9,6 +9,7 @@ use vm::types::{
     QualifiedContractIdentifier,
     AssetIdentifier
 };
+use vm::analysis::ContractAnalysis;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct StacksTransactionReceipt {
@@ -16,6 +17,7 @@ pub struct StacksTransactionReceipt {
     pub events: Vec<StacksTransactionEvent>,
     pub result: Value,
     pub stx_burned: u128,
+    pub contract_analysis: Option<ContractAnalysis>,
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/src/testnet/helium/event_dispatcher.rs
+++ b/src/testnet/helium/event_dispatcher.rs
@@ -7,6 +7,7 @@ use serde_json::json;
 use serde::Serialize;
 
 use vm::types::{Value, QualifiedContractIdentifier, AssetIdentifier};
+use vm::analysis::{contract_interface_builder::build_contract_interface};
 use burnchains::Txid;
 use chainstate::stacks::StacksBlock;
 use chainstate::stacks::events::{StacksTransactionReceipt, StacksTransactionEvent, STXEventType, FTEventType, NFTEventType};
@@ -60,13 +61,19 @@ impl EventObserver {
                 let formatted_bytes: Vec<String> = bytes.iter().map(|b| format!("{:02x}", b)).collect();
                 formatted_bytes
             };
-
+            let contract_interface_json = {
+                match &artifact.contract_analysis {
+                    Some(analysis) => json!(build_contract_interface(analysis)),
+                    None => json!(null)
+                }
+            };
             let val = json!({
                 "txid": format!("0x{}", tx.txid()),
                 "tx_index": tx_index,
                 "success": success,
                 "raw_result": format!("0x{}", raw_result.join("")),
                 "raw_tx": format!("0x{}", raw_tx.join("")),
+                "contract_abi": contract_interface_json,
             });
             tx_index += 1;
             val

--- a/src/vm/analysis/type_checker/contexts.rs
+++ b/src/vm/analysis/type_checker/contexts.rs
@@ -8,7 +8,7 @@ use vm::contexts::MAX_CONTEXT_DEPTH;
 use vm::analysis::errors::{CheckResult, CheckError, CheckErrors};
 use vm::analysis::types::{ContractAnalysis};
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct TypeMap {
     map: HashMap<u64, TypeSignature>
 }

--- a/src/vm/analysis/types.rs
+++ b/src/vm/analysis/types.rs
@@ -14,7 +14,7 @@ pub trait AnalysisPass {
     fn run_pass(contract_analysis: &mut ContractAnalysis, analysis_db: &mut AnalysisDatabase) -> CheckResult<()>;
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct ContractAnalysis {
     pub contract_identifier: QualifiedContractIdentifier,
     pub private_function_types: BTreeMap<ClarityName, FunctionType>,

--- a/src/vm/costs/mod.rs
+++ b/src/vm/costs/mod.rs
@@ -46,7 +46,7 @@ impl CostTracker for () {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct LimitedCostTracker {
     total: ExecutionCost,
     limit: ExecutionCost


### PR DESCRIPTION
Part of https://github.com/blockstack/stacks-blockchain/issues/1266

Adds the contract ABI JSON to sidecar messages for deploy-contract tx types