### PR TITLE
feat: add eval_at_chaintip to clarity-cli

### DIFF
--- a/sample-programs/tokens-mint.clar
+++ b/sample-programs/tokens-mint.clar
@@ -1,0 +1,5 @@
+(begin
+  (as-contract
+    (contract-call? 'S1G2081040G2081040G2081040G208105NK8PE5.tokens mint! u100)
+  )
+)


### PR DESCRIPTION
I learned that `clarity-cli eval` will advance to a new block. Testing certain scenarios required me to evaluate queries that wouldn't advance the chaintip. So, I added this, thanks to @jcnelson 's tip.

I tried to abstract some of the `eval` logic to be a little bit DRY, but there is still a good bit of repetition. The only real change is to use `at_chaintip` instead of `at_block`. I would love to see how someone with more Rust experience would do this - I mainly didn't know how to separate the proc into something reusable.