### PR TITLE
Faster and less mallocing to_hex()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,10 @@ path = "src/blockstack_cli.rs"
 name = "marf_bench"
 harness = false
 
+[[bench]]
+name = "large_contract_bench"
+harness = false
+
 [dependencies]
 byteorder = "1.1"
 rust-ini = "0.13"

--- a/benches/large_contract_bench.rs
+++ b/benches/large_contract_bench.rs
@@ -1,0 +1,119 @@
+#[macro_use]
+extern crate criterion;
+extern crate blockstack_lib;
+extern crate rand;
+
+use blockstack_lib::{
+    chainstate::stacks::index::storage::{TrieFileStorage},
+    chainstate::burn::BlockHeaderHash,
+    vm::types::{QualifiedContractIdentifier},
+    vm::database::{MarfedKV, NULL_HEADER_DB}, 
+    vm::clarity::ClarityInstance, 
+};
+
+use criterion::Criterion;
+
+pub fn rollback_log_memory_test() {
+    let marf = MarfedKV::temporary();
+    let mut clarity_instance = ClarityInstance::new(marf);
+    let EXPLODE_N = 100;
+
+    let contract_identifier = QualifiedContractIdentifier::local("foo").unwrap();
+
+    {
+        let mut conn = clarity_instance.begin_block(&TrieFileStorage::block_sentinel(),
+                                                    &BlockHeaderHash::from_bytes(&[0 as u8; 32]).unwrap(),
+                                                    &NULL_HEADER_DB);
+
+        let define_data_var = "(define-data-var XZ (buff 1048576) \"a\")";
+
+        let mut contract = define_data_var.to_string();
+        for i in 0..20 {
+            let cur_size = format!("{}", 2u32.pow(i));
+            contract.push_str("\n");
+            contract.push_str(
+                &format!("(var-set XZ (concat (unwrap-panic (as-max-len? (var-get XZ) u{}))
+                                             (unwrap-panic (as-max-len? (var-get XZ) u{}))))",
+                        cur_size, cur_size));
+        }
+        for i in 0..EXPLODE_N {
+            let exploder = format!("(define-data-var var-{} (buff 1048576) (var-get XZ))", i);
+            contract.push_str("\n");
+            contract.push_str(&exploder);
+        }
+
+        let (ct_ast, _ct_analysis) = conn.analyze_smart_contract(&contract_identifier, &contract).unwrap();
+        assert!(format!("{:?}",
+                        conn.initialize_smart_contract(
+                            &contract_identifier, &ct_ast, &contract, |_,_| false).unwrap_err())
+                .contains("MemoryBalanceExceeded"));
+    }
+}
+
+pub fn ccall_memory_test() {
+    let marf = MarfedKV::temporary();
+    let mut clarity_instance = ClarityInstance::new(marf);
+    let COUNT_PER_CONTRACT = 20;
+    let CONTRACTS = 5;
+
+    {
+        let mut conn = clarity_instance.begin_block(&TrieFileStorage::block_sentinel(),
+                                                    &BlockHeaderHash::from_bytes(&[0 as u8; 32]).unwrap(),
+                                                    &NULL_HEADER_DB);
+
+        let define_data_var = "(define-constant buff-0 \"a\")\n";
+
+        let mut contract = define_data_var.to_string();
+        for i in 0..20 {
+            contract.push_str(
+                &format!("(define-constant buff-{} (concat buff-{} buff-{}))\n",
+                         i+1, i, i));
+        }
+
+        for i in 0..COUNT_PER_CONTRACT {
+            contract.push_str(
+                &format!("(define-constant var-{} buff-20)\n", i));
+        }
+
+        contract.push_str("(define-public (call)\n");
+
+        let mut contracts = vec![];
+
+        for i in 0..CONTRACTS {
+            let mut my_contract = contract.clone();
+            if i == 0 {
+                my_contract.push_str("(ok 1))\n");
+            } else {
+                my_contract.push_str(&format!("(contract-call? .contract-{} call))\n", i - 1));
+            }
+            my_contract.push_str("(call)\n");
+            contracts.push(my_contract);
+        }
+
+        for (i, contract) in contracts.into_iter().enumerate() {
+            let contract_name = format!("contract-{}", i);
+            let contract_identifier = QualifiedContractIdentifier::local(&contract_name).unwrap();
+
+            if i < (CONTRACTS-1) {
+                let (ct_ast, ct_analysis) = conn.analyze_smart_contract(&contract_identifier, &contract).unwrap();
+                conn.initialize_smart_contract(
+                    &contract_identifier, &ct_ast, &contract, |_,_| false).unwrap();
+                conn.save_analysis(&contract_identifier, &ct_analysis).unwrap();
+            } else {
+                let (ct_ast, _ct_analysis) = conn.analyze_smart_contract(&contract_identifier, &contract).unwrap();
+                assert!(format!("{:?}",
+                                conn.initialize_smart_contract(
+                            &contract_identifier, &ct_ast, &contract, |_,_| false).unwrap_err())
+                        .contains("MemoryBalanceExceeded"));
+            }
+        }
+    }
+}
+
+pub fn basic_usage_benchmark(c: &mut Criterion) {
+    c.bench_function("rollback_log_memory_test", |b| b.iter(|| rollback_log_memory_test()));
+    c.bench_function("ccall_memory_test", |b| b.iter(|| ccall_memory_test()));
+}
+
+criterion_group!(benches, basic_usage_benchmark);
+criterion_main!(benches);

--- a/src/util/hash.rs
+++ b/src/util/hash.rs
@@ -18,6 +18,7 @@
 */
 
 use std::fmt;
+use std::fmt::Write;
 use std::mem;
 use std::char::from_digit;
 
@@ -576,8 +577,11 @@ pub fn hex_bytes(s: &str) -> Result<Vec<u8>, HexError> {
 
 /// Convert a slice of u8 to a hex string
 pub fn to_hex(s: &[u8]) -> String {
-    let r : Vec<String> = s.to_vec().iter().map(|b| format!("{:02x}", b)).collect();
-    return r.join("");
+    let mut r = String::with_capacity(s.len() * 2);
+    for b in s.iter() {
+        write!(r, "{:02x}", b).unwrap();
+    }
+    return r;
 }
 
 /// Convert a vec of u8 to a hex string

--- a/src/vm/database/marf.rs
+++ b/src/vm/database/marf.rs
@@ -151,7 +151,7 @@ impl MarfedKV {
         Ok( MarfedKV { marf, chain_tip, side_store } )
     }
 
-    #[cfg(test)]
+    // used by benchmarks
     pub fn temporary() -> MarfedKV {
         use std::env;
         use rand::Rng;


### PR DESCRIPTION
While poking around the large_contracts::rollback_log_memory_test trying to figure out some good estimates for initial block limits, I profiled the optimized version of that code. It turned out to be spending 90% of its time in `to_hex()`, so I tried to optimize that function a little bit using a with_capacity allocation and `write!`.

Before:

```
$ cargo bench --no-run
....
$ time ./target/release/large_contract_bench-386d9fe25a932f3f rollback
Gnuplot not found, disabling plotting
Testing rollback_log_memory_test
Success

Gnuplot not found, disabling plotting

real	0m17.965s
user	0m17.458s
sys	0m0.484s
```

After:

```
$ cargo bench --no-run
....
$ time ./target/release/large_contract_bench-386d9fe25a932f3f rollback
Gnuplot not found, disabling plotting
Testing rollback_log_memory_test
Success

Gnuplot not found, disabling plotting

real	0m3.804s
user	0m3.715s
sys	0m0.079s
```

Ultimately, the Clarity DB probably _shouldn't_ be using hex strings, and instead be just serializing and deserializing bytes, but this improvement speeds up Clarity's db and rollback_wrapper a significant amount for now (and anywhere else we're using to_hex, which is a pretty large number of places, though most of them are not that performance critical).