### PR TITLE
Enable TX-level rollbacks in Clarity connections

### DIFF
--- a/src/chainstate/stacks/db/accounts.rs
+++ b/src/chainstate/stacks/db/accounts.rs
@@ -28,7 +28,7 @@ use chainstate::stacks::db::*;
 use chainstate::stacks::db::blocks::*;
 use vm::database::*;
 use vm::database::marf::*;
-use vm::clarity::ClarityConnection;
+use vm::clarity::{ClarityConnection, ClarityTransactionConnection};
 use vm::types::*;
 
 use util::db::*;
@@ -160,8 +160,8 @@ impl StacksChainState {
     /// Called each time a transaction is invoked from this principal, to e.g.
     /// debit the STX-denominated tx fee or transfer/burn STX.
     /// DOES NOT UPDATE THE NONCE
-    pub fn account_debit<'a>(clarity_tx: &mut ClarityTx<'a>, principal: &PrincipalData, amount: u64) {
-        clarity_tx.connection().with_clarity_db(|ref mut db| {
+    pub fn account_debit(clarity_tx: &mut ClarityTransactionConnection, principal: &PrincipalData, amount: u64) {
+        clarity_tx.with_clarity_db(|ref mut db| {
             let cur_balance = db.get_account_stx_balance(principal);
             
             // last line of defense: if we don't have sufficient funds, panic.
@@ -178,8 +178,8 @@ impl StacksChainState {
 
     /// Called each time a transaction sends STX to this principal.
     /// No nonce update is needed, since the transfer action is not taken by the principal.
-    pub fn account_credit<'a>(clarity_tx: &mut ClarityTx<'a>, principal: &PrincipalData, amount: u64) {
-        clarity_tx.connection().with_clarity_db(|ref mut db| {
+    pub fn account_credit(clarity_tx: &mut ClarityTransactionConnection, principal: &PrincipalData, amount: u64) {
+        clarity_tx.with_clarity_db(|ref mut db| {
             let cur_balance = db.get_account_stx_balance(principal);
             let final_balance = cur_balance.checked_add(amount as u128).expect("FATAL: account balance overflow");
             db.set_account_stx_balance(principal, final_balance as u128);
@@ -189,8 +189,8 @@ impl StacksChainState {
     }
    
     /// Increment an account's nonce
-    pub fn update_account_nonce<'a>(clarity_tx: &mut ClarityTx<'a>, account: &StacksAccount) {
-        clarity_tx.connection().with_clarity_db(|ref mut db| {
+    pub fn update_account_nonce(clarity_tx: &mut ClarityTransactionConnection, account: &StacksAccount) {
+        clarity_tx.with_clarity_db(|ref mut db| {
             let next_nonce = account.nonce.checked_add(1).expect("OUT OF NONCES");
             db.set_account_nonce(&account.principal, next_nonce);
             Ok(())

--- a/src/chainstate/stacks/db/blocks.rs
+++ b/src/chainstate/stacks/db/blocks.rs
@@ -2524,7 +2524,7 @@ impl StacksChainState {
 
         let miner_reward_total = miner_reward.total();
       
-        clarity_tx.connection().with_clarity_db(|ref mut db| {
+        clarity_tx.connection().as_transaction(|x| { x.with_clarity_db(|ref mut db| {
             // (+ reward (get available (default-to (tuple (available 0) (authorized 'false)) (map-get rewards ((miner))))))
             let miner_status_opt = db.fetch_entry(&miner_contract_id, BOOT_CODE_MINER_REWARDS_MAP, &miner_principal)?;
             let new_miner_status = 
@@ -2570,7 +2570,7 @@ impl StacksChainState {
             debug!("Grant miner {} {} STX", miner_reward.address.to_string(), miner_reward_total);
             db.set_entry(&miner_contract_id, BOOT_CODE_MINER_REWARDS_MAP, miner_principal, new_miner_status)?;
             Ok(())
-        }).map_err(Error::ClarityError)?;
+        })}).map_err(Error::ClarityError)?;
         Ok(())
     }
 

--- a/src/chainstate/stacks/db/mod.rs
+++ b/src/chainstate/stacks/db/mod.rs
@@ -260,11 +260,6 @@ pub struct ClarityTx<'a> {
 }
 
 impl ClarityConnection for ClarityTx<'_> {
-    fn with_clarity_db_readonly<F, R>(&mut self, to_do: F) -> R
-    where F: FnOnce(&mut ClarityDatabase) -> R {
-        ClarityConnection::with_clarity_db_readonly(&mut self.block, to_do)
-    }
-
     fn with_clarity_db_readonly_owned<F, R>(&mut self, to_do: F) -> R
     where F: FnOnce(ClarityDatabase) -> (R, ClarityDatabase) {
         ClarityConnection::with_clarity_db_readonly_owned(&mut self.block, to_do)

--- a/src/chainstate/stacks/db/mod.rs
+++ b/src/chainstate/stacks/db/mod.rs
@@ -638,7 +638,10 @@ impl StacksChainState {
                 );
 
                 let boot_code_smart_contract = StacksTransaction::new(tx_version.clone(), boot_code_auth.clone(), smart_contract);
-                StacksChainState::process_transaction_payload(&mut clarity_tx, &boot_code_smart_contract, &boot_code_account)?;
+
+                clarity_tx.connection().as_transaction(|clarity| {
+                    StacksChainState::process_transaction_payload(clarity, &boot_code_smart_contract, &boot_code_account)
+                })?;
 
                 boot_code_account.nonce += 1;
             }
@@ -652,15 +655,20 @@ impl StacksChainState {
                 );
 
                 let boot_code_smart_contract = StacksTransaction::new(tx_version.clone(), boot_code_auth.clone(), smart_contract);
-                StacksChainState::process_transaction_payload(&mut clarity_tx, &boot_code_smart_contract, &boot_code_account)?;
+
+                clarity_tx.connection().as_transaction(|clarity| {
+                    StacksChainState::process_transaction_payload(clarity, &boot_code_smart_contract, &boot_code_account)
+                })?;
                 
                 boot_code_account.nonce += 1;
             }
 
             if let Some(initial_balances) = initial_balances {
                 for (address, amount) in initial_balances {
-                    StacksChainState::account_credit(&mut clarity_tx, &address, amount);
-                }    
+                    clarity_tx.connection().as_transaction(|clarity| {
+                        StacksChainState::account_credit(clarity, &address, amount)
+                    })
+                }
             }
 
             f(&mut clarity_tx);

--- a/src/chainstate/stacks/db/transactions.rs
+++ b/src/chainstate/stacks/db/transactions.rs
@@ -622,7 +622,7 @@ pub mod test {
         let mut conn = chainstate.block_begin(&FIRST_BURNCHAIN_BLOCK_HASH, &FIRST_STACKS_BLOCK_HASH, &BurnchainHeaderHash([1u8; 32]), &BlockHeaderHash([1u8; 32]));
 
         // give the spending account some stx
-        let account = StacksChainState::get_account(&mut conn, &addr.to_account_principal());
+        let _account = StacksChainState::get_account(&mut conn, &addr.to_account_principal());
         let recv_account = StacksChainState::get_account(&mut conn, &recv_addr.to_account_principal());
 
         assert_eq!(recv_account.stx_balance, 0);
@@ -975,7 +975,7 @@ pub mod test {
 
             let signed_tx = signer.get_tx().unwrap();
 
-            let contract_id = QualifiedContractIdentifier::new(StandardPrincipalData::from(addr.clone()), ContractName::from(contract_name.as_str()));
+            let _contract_id = QualifiedContractIdentifier::new(StandardPrincipalData::from(addr.clone()), ContractName::from(contract_name.as_str()));
 
             let account = StacksChainState::get_account(&mut conn, &addr.to_account_principal());
             assert_eq!(account.nonce, next_nonce);
@@ -1067,7 +1067,7 @@ pub mod test {
             assert_eq!(account.nonce, i as u64);
 
             // runtime error should be handled
-            let (fee, _) = StacksChainState::process_transaction(&mut conn, &signed_tx).unwrap();
+            let (_fee, _) = StacksChainState::process_transaction(&mut conn, &signed_tx).unwrap();
 
             // account nonce should increment
             let account = StacksChainState::get_account(&mut conn, &addr.to_account_principal());
@@ -1124,7 +1124,7 @@ pub mod test {
         let account = StacksChainState::get_account(&mut conn, &addr.to_account_principal());
         assert_eq!(account.nonce, 0);
         
-        let account_sponsor = StacksChainState::get_account(&mut conn, &addr_sponsor.to_account_principal());
+        let _account_sponsor = StacksChainState::get_account(&mut conn, &addr_sponsor.to_account_principal());
         assert_eq!(account.nonce, 0);
 
         let (fee, _) = StacksChainState::process_transaction(&mut conn, &signed_tx).unwrap();
@@ -1214,7 +1214,7 @@ pub mod test {
         assert_eq!(account.nonce, 1);
         
         let account_2 = StacksChainState::get_account(&mut conn, &addr_2.to_account_principal());
-        assert_eq!(account.nonce, 1);
+        assert_eq!(account_2.nonce, 1);
 
         let contract_res = StacksChainState::get_contract(&mut conn, &contract_id).unwrap();
         let var_res = StacksChainState::get_data_var(&mut conn, &contract_id, "bar").unwrap();
@@ -1259,7 +1259,7 @@ pub mod test {
         let mut conn = chainstate.block_begin(&FIRST_BURNCHAIN_BLOCK_HASH, &FIRST_STACKS_BLOCK_HASH, &BurnchainHeaderHash([1u8; 32]), &BlockHeaderHash([1u8; 32]));
         
         let contract_id = QualifiedContractIdentifier::new(StandardPrincipalData::from(addr.clone()), ContractName::from("hello-world"));
-        let (fee, _) = StacksChainState::process_transaction(&mut conn, &signed_tx).unwrap();
+        let (_fee, _) = StacksChainState::process_transaction(&mut conn, &signed_tx).unwrap();
 
         // contract-calls that don't commit
         let contract_calls = vec![
@@ -1292,7 +1292,7 @@ pub mod test {
             let account_2 = StacksChainState::get_account(&mut conn, &addr_2.to_account_principal());
             assert_eq!(account_2.nonce, next_nonce);
         
-            let (fee_, _) = StacksChainState::process_transaction(&mut conn, &signed_tx_2).unwrap();
+            let (_fee, _) = StacksChainState::process_transaction(&mut conn, &signed_tx_2).unwrap();
 
             // nonce should have incremented
             next_nonce += 1;
@@ -1341,7 +1341,7 @@ pub mod test {
         let signed_tx = signer.get_tx().unwrap();
         
         let mut conn = chainstate.block_begin(&FIRST_BURNCHAIN_BLOCK_HASH, &FIRST_STACKS_BLOCK_HASH, &BurnchainHeaderHash([1u8; 32]), &BlockHeaderHash([1u8; 32]));
-        let (fee, _) = StacksChainState::process_transaction(&mut conn, &signed_tx).unwrap();
+        let (_fee, _) = StacksChainState::process_transaction(&mut conn, &signed_tx).unwrap();
 
         // invalid contract-calls
         let contract_calls = vec![
@@ -1555,7 +1555,7 @@ pub mod test {
         let recv_addr = StacksAddress::from_public_keys(C32_ADDRESS_VERSION_TESTNET_SINGLESIG, &AddressHashMode::SerializeP2PKH, 1, &vec![StacksPublicKey::from_private(&privk_recipient)]).unwrap();
         let recv_principal = recv_addr.to_account_principal();
         let contract_id = QualifiedContractIdentifier::new(StandardPrincipalData::from(addr_publisher.clone()), contract_name.clone());
-        let contract_principal = PrincipalData::Contract(contract_id.clone());
+        let _contract_principal = PrincipalData::Contract(contract_id.clone());
 
         let asset_info = AssetInfo {
             contract_address: addr_publisher.clone(),
@@ -1707,7 +1707,7 @@ pub mod test {
 
         // mint names to recv_addr, and set a post-condition on the contract-principal to check it.
         // assert contract does not possess the name
-        for (i, pass_condition) in [NonfungibleConditionCode::Sent].iter().enumerate() {
+        for (_i, pass_condition) in [NonfungibleConditionCode::Sent].iter().enumerate() {
             let name = Value::buff_from(next_name.to_be_bytes().to_vec()).unwrap();
             next_name += 1;
 
@@ -1790,7 +1790,7 @@ pub mod test {
         
         // mint names to recv_addr, and set a post-condition on the contract-principal to check it.
         // assert contract still possesses the name (should fail)
-        for (i, fail_condition) in [NonfungibleConditionCode::NotSent].iter().enumerate() {
+        for (_i, fail_condition) in [NonfungibleConditionCode::NotSent].iter().enumerate() {
             let name = Value::buff_from(next_name.to_be_bytes().to_vec()).unwrap();
             next_name += 1;
 
@@ -1835,7 +1835,7 @@ pub mod test {
         let mut expected_next_name : u64 = 0;
 
         for tx_pass in post_conditions_pass.iter() {
-            let (fee, _) = StacksChainState::process_transaction(&mut conn, &tx_pass).unwrap();
+            let (_fee, _) = StacksChainState::process_transaction(&mut conn, &tx_pass).unwrap();
             expected_stackaroos_balance += 100;
             expected_nonce += 1;
 
@@ -1847,7 +1847,7 @@ pub mod test {
         }
         
         for tx_pass in post_conditions_pass_payback.iter() {
-            let (fee, _) = StacksChainState::process_transaction(&mut conn, &tx_pass).unwrap();
+            let (_fee, _) = StacksChainState::process_transaction(&mut conn, &tx_pass).unwrap();
             expected_stackaroos_balance -= 100;
             expected_payback_stackaroos_balance += 100;
             expected_recv_nonce += 1;
@@ -1865,8 +1865,8 @@ pub mod test {
             assert_eq!(account_recv_publisher_after.nonce, expected_recv_nonce);
         }
         
-        for (i, tx_pass) in post_conditions_pass_nft.iter().enumerate() {
-            let (fee, _) = StacksChainState::process_transaction(&mut conn, &tx_pass).unwrap();
+        for (_i, tx_pass) in post_conditions_pass_nft.iter().enumerate() {
+            let (_fee, _) = StacksChainState::process_transaction(&mut conn, &tx_pass).unwrap();
             expected_nonce += 1;
 
             let expected_value = Value::buff_from(expected_next_name.to_be_bytes().to_vec()).unwrap();
@@ -1880,7 +1880,7 @@ pub mod test {
         }
 
         for tx_fail in post_conditions_fail.iter() {
-            let (fee, _) = StacksChainState::process_transaction(&mut conn, &tx_fail).unwrap();
+            let (_fee, _) = StacksChainState::process_transaction(&mut conn, &tx_fail).unwrap();
             expected_nonce += 1;
             
             // no change in balance
@@ -1896,7 +1896,7 @@ pub mod test {
         }
         
         for tx_fail in post_conditions_fail_payback.iter() {
-            let (fee, _) = StacksChainState::process_transaction(&mut conn, &tx_fail).unwrap();
+            let (_fee, _) = StacksChainState::process_transaction(&mut conn, &tx_fail).unwrap();
             expected_recv_nonce += 1;
             
             // no change in balance
@@ -1915,8 +1915,8 @@ pub mod test {
             assert_eq!(account_publisher_after.nonce, expected_recv_nonce);
         }
 
-        for (i, tx_fail) in post_conditions_fail_nft.iter().enumerate() {
-            let (fee, _) = StacksChainState::process_transaction(&mut conn, &tx_fail).unwrap();
+        for (_i, tx_fail) in post_conditions_fail_nft.iter().enumerate() {
+            let (_fee, _) = StacksChainState::process_transaction(&mut conn, &tx_fail).unwrap();
             expected_nonce += 1;
            
             // nft shouldn't exist -- the nft-mint! should have been rolled back
@@ -2001,7 +2001,7 @@ pub mod test {
         let recv_addr = StacksAddress::from_public_keys(C32_ADDRESS_VERSION_TESTNET_SINGLESIG, &AddressHashMode::SerializeP2PKH, 1, &vec![StacksPublicKey::from_private(&privk_recipient)]).unwrap();
         let recv_principal = recv_addr.to_account_principal();
         let contract_id = QualifiedContractIdentifier::new(StandardPrincipalData::from(addr_publisher.clone()), contract_name.clone());
-        let contract_principal = PrincipalData::Contract(contract_id.clone());
+        let _contract_principal = PrincipalData::Contract(contract_id.clone());
 
         let asset_info = AssetInfo {
             contract_address: addr_publisher.clone(),
@@ -2039,7 +2039,7 @@ pub mod test {
 
         // mint 100 stackaroos and the name to recv_addr, and set a post-condition for each asset on the contract-principal
         // assert contract sent ==, <=, or >= 100 stackaroos
-        for (i, pass_condition) in [FungibleConditionCode::SentEq, FungibleConditionCode::SentGe, FungibleConditionCode::SentLe].iter().enumerate() {
+        for (_i, pass_condition) in [FungibleConditionCode::SentEq, FungibleConditionCode::SentGe, FungibleConditionCode::SentLe].iter().enumerate() {
             let name = Value::buff_from(next_name.to_be_bytes().to_vec()).unwrap();
             next_name += 1;
 
@@ -2087,7 +2087,7 @@ pub mod test {
         
         // recv_addr sends 100 stackaroos and name back to addr_publisher.
         // assert recv_addr sent ==, <=, or >= 100 stackaroos
-        for (i, pass_condition) in [FungibleConditionCode::SentEq, FungibleConditionCode::SentGe, FungibleConditionCode::SentLe].iter().enumerate() {
+        for (_i, pass_condition) in [FungibleConditionCode::SentEq, FungibleConditionCode::SentGe, FungibleConditionCode::SentLe].iter().enumerate() {
             let name = Value::buff_from(next_recv_name.to_be_bytes().to_vec()).unwrap();
             next_recv_name += 1;
 
@@ -2113,7 +2113,7 @@ pub mod test {
         // mint 100 stackaroos and the name to recv_addr, but neglect to set a fungible post-condition.
         // assert contract sent ==, <=, or >= 100 stackaroos, and that the name was removed from
         // the contract
-        for (i, fail_condition) in [FungibleConditionCode::SentEq, FungibleConditionCode::SentGe, FungibleConditionCode::SentLe].iter().enumerate() {
+        for (_i, fail_condition) in [FungibleConditionCode::SentEq, FungibleConditionCode::SentGe, FungibleConditionCode::SentLe].iter().enumerate() {
             let name = Value::buff_from(next_name.to_be_bytes().to_vec()).unwrap();
             next_name += 1;
 
@@ -2139,7 +2139,7 @@ pub mod test {
         // mint 100 stackaroos and the name to recv_addr, but neglect to set a non-fungible post-condition.
         // assert contract sent ==, <=, or >= 100 stackaroos, and that the name was removed from
         // the contract
-        for (i, fail_condition) in [FungibleConditionCode::SentEq, FungibleConditionCode::SentGe, FungibleConditionCode::SentLe].iter().enumerate() {
+        for (_i, fail_condition) in [FungibleConditionCode::SentEq, FungibleConditionCode::SentGe, FungibleConditionCode::SentLe].iter().enumerate() {
             let name = Value::buff_from(next_name.to_be_bytes().to_vec()).unwrap();
             next_name += 1;
 
@@ -2165,7 +2165,7 @@ pub mod test {
         // recv_addr sends 100 stackaroos and name back to addr_publisher, but forgets a fungible
         // post-condition.
         // assert recv_addr sent ==, <=, or >= 100 stackaroos
-        for (i, fail_condition) in [FungibleConditionCode::SentEq, FungibleConditionCode::SentGe, FungibleConditionCode::SentLe].iter().enumerate() {
+        for (_i, fail_condition) in [FungibleConditionCode::SentEq, FungibleConditionCode::SentGe, FungibleConditionCode::SentLe].iter().enumerate() {
             let name = Value::buff_from(final_recv_name.to_be_bytes().to_vec()).unwrap();
 
             let mut tx_contract_call_both = StacksTransaction::new(TransactionVersion::Testnet,
@@ -2187,12 +2187,12 @@ pub mod test {
             recv_nonce += 1;
         }
 
-        next_recv_name -= 3;    // reset
+        // never read: next_recv_name -= 3;    // reset
        
         // recv_addr sends 100 stackaroos and name back to addr_publisher, but forgets a non-fungible
         // post-condition.
         // assert recv_addr sent ==, <=, or >= 100 stackaroos
-        for (i, fail_condition) in [FungibleConditionCode::SentEq, FungibleConditionCode::SentGe, FungibleConditionCode::SentLe].iter().enumerate() {
+        for (_i, fail_condition) in [FungibleConditionCode::SentEq, FungibleConditionCode::SentGe, FungibleConditionCode::SentLe].iter().enumerate() {
             let name = Value::buff_from(final_recv_name.to_be_bytes().to_vec()).unwrap();
 
             let mut tx_contract_call_both = StacksTransaction::new(TransactionVersion::Testnet,
@@ -2235,8 +2235,8 @@ pub mod test {
         let mut expected_recv_nonce = 0;
         let mut expected_payback_stackaroos_balance = 0;
 
-        for (i, tx_pass) in post_conditions_pass.iter().enumerate() {
-            let (fee, _) = StacksChainState::process_transaction(&mut conn, &tx_pass).unwrap();
+        for (_i, tx_pass) in post_conditions_pass.iter().enumerate() {
+            let (_fee, _) = StacksChainState::process_transaction(&mut conn, &tx_pass).unwrap();
             expected_stackaroos_balance += 100;
             expected_nonce += 1;
 
@@ -2258,8 +2258,8 @@ pub mod test {
             assert_eq!(account_publisher_after.nonce, expected_nonce);
         }
         
-        for (i, tx_pass) in post_conditions_pass_payback.iter().enumerate() {
-            let (fee, _) = StacksChainState::process_transaction(&mut conn, &tx_pass).unwrap();
+        for (_i, tx_pass) in post_conditions_pass_payback.iter().enumerate() {
+            let (_fee, _) = StacksChainState::process_transaction(&mut conn, &tx_pass).unwrap();
             expected_stackaroos_balance -= 100;
             expected_payback_stackaroos_balance += 100;
             expected_recv_nonce += 1;
@@ -2290,8 +2290,8 @@ pub mod test {
             assert_eq!(account_recv_publisher_after.nonce, expected_recv_nonce);
         }
        
-        for (i, tx_fail) in post_conditions_fail.iter().enumerate() {
-            let (fee, _) = StacksChainState::process_transaction(&mut conn, &tx_fail).unwrap();
+        for (_i, tx_fail) in post_conditions_fail.iter().enumerate() {
+            let (_fee, _) = StacksChainState::process_transaction(&mut conn, &tx_fail).unwrap();
             expected_nonce += 1;
            
             // no change in balance
@@ -2315,9 +2315,9 @@ pub mod test {
             assert_eq!(account_publisher_after.nonce, expected_nonce);
         }
         
-        for (i, tx_fail) in post_conditions_fail_payback.iter().enumerate() {
+        for (_i, tx_fail) in post_conditions_fail_payback.iter().enumerate() {
             eprintln!("tx fail {:?}", &tx_fail);
-            let (fee, _) = StacksChainState::process_transaction(&mut conn, &tx_fail).unwrap();
+            let (_fee, _) = StacksChainState::process_transaction(&mut conn, &tx_fail).unwrap();
             expected_recv_nonce += 1;
            
             // no change in balance
@@ -2395,7 +2395,7 @@ pub mod test {
             asset_name: asset_info_2.asset_name.clone()
         };
         
-        let asset_id_3 = AssetIdentifier {
+        let _asset_id_3 = AssetIdentifier {
             contract_identifier: QualifiedContractIdentifier::new(StandardPrincipalData::from(asset_info_3.contract_address), asset_info_3.contract_name.clone()),
             asset_name: asset_info_3.asset_name.clone()
         };
@@ -2754,7 +2754,7 @@ pub mod test {
         let auth = TransactionAuth::from_p2pkh(&privk).unwrap();
         let addr = auth.origin().address_testnet();
         let origin = addr.to_account_principal();
-        let recv_addr = StacksAddress { version: 1, bytes: Hash160([0xff; 20]) };
+        let _recv_addr = StacksAddress { version: 1, bytes: Hash160([0xff; 20]) };
         let contract_addr = StacksAddress { version: 1, bytes: Hash160([0x01; 20]) };
 
         let asset_info = AssetInfo {
@@ -2871,7 +2871,7 @@ pub mod test {
         let auth = TransactionAuth::from_p2pkh(&privk).unwrap();
         let addr = auth.origin().address_testnet();
         let origin = addr.to_account_principal();
-        let recv_addr = StacksAddress { version: 1, bytes: Hash160([0xff; 20]) };
+        let _recv_addr = StacksAddress { version: 1, bytes: Hash160([0xff; 20]) };
 
         // stx-transfer for 123 microstx
         let mut stx_asset_map = AssetMap::new();

--- a/src/chainstate/stacks/db/transactions.rs
+++ b/src/chainstate/stacks/db/transactions.rs
@@ -628,7 +628,8 @@ pub mod test {
         assert_eq!(recv_account.stx_balance, 0);
         assert_eq!(recv_account.nonce, 0);
 
-        StacksChainState::account_credit(&mut conn, &addr.to_account_principal(), 223);
+        conn.connection().as_transaction(
+            |tx| StacksChainState::account_credit(tx, &addr.to_account_principal(), 223));
 
         let (fee, _) = StacksChainState::process_transaction(&mut conn, &signed_tx).unwrap();
         
@@ -761,8 +762,9 @@ pub mod test {
         ];
 
         let mut conn = chainstate.block_begin(&FIRST_BURNCHAIN_BLOCK_HASH, &FIRST_STACKS_BLOCK_HASH, &BurnchainHeaderHash([1u8; 32]), &BlockHeaderHash([1u8; 32]));
-        StacksChainState::account_credit(&mut conn, &addr.to_account_principal(), 123);
-        
+        conn.connection().as_transaction(
+            |tx| StacksChainState::account_credit(tx, &addr.to_account_principal(), 123));
+
         for (tx_stx_transfer, err_frag) in [tx_stx_transfer_same_receiver, tx_stx_transfer_wrong_network, tx_stx_transfer_wrong_chain_id, tx_stx_transfer_postconditions, tx_stx_transfer_wrong_nonce, tx_stx_transfer_wrong_nonce_sponsored].iter().zip(error_frags) {
             let mut signer = StacksTransactionSigner::new(&tx_stx_transfer);
             signer.sign_origin(&privk).unwrap();
@@ -843,7 +845,8 @@ pub mod test {
         assert_eq!(recv_account.stx_balance, 0);
 
         // give the spending account some stx
-        StacksChainState::account_credit(&mut conn, &addr.to_account_principal(), 123);
+        conn.connection().as_transaction(
+            |tx| StacksChainState::account_credit(tx, &addr.to_account_principal(), 123));
 
         let (fee, _) = StacksChainState::process_transaction(&mut conn, &signed_tx).unwrap();
         

--- a/src/chainstate/stacks/miner.rs
+++ b/src/chainstate/stacks/miner.rs
@@ -747,7 +747,7 @@ pub mod test {
                 .expect("FATAL: failed to construct miner principal key"));
 
             let miner_status = clarity_tx.with_clarity_db_readonly(|db| {
-                let miner_status_opt = db.fetch_entry(&miner_contract_id, BOOT_CODE_MINER_REWARDS_MAP, &miner_principal).unwrap();
+                let miner_status_opt = db.fetch_entry(&miner_contract_id, BOOT_CODE_MINER_REWARDS_MAP, &miner_principal)?;
                 let miner_status = match miner_status_opt {
                     Value::Optional(ref optional_data) => {
                         match optional_data.data {

--- a/src/chainstate/stacks/miner.rs
+++ b/src/chainstate/stacks/miner.rs
@@ -31,6 +31,7 @@ use chainstate::burn::BlockHeaderHash;
 use net::StacksMessageCodec;
 use net::Error as net_error;
 use net::codec::{read_next, write_next};
+use vm::clarity::ClarityConnection;
 
 use util::hash::MerkleTree;
 use util::hash::Sha512Trunc256Sum;
@@ -745,8 +746,8 @@ pub mod test {
                     (miner_participant_principal, Value::Principal(PrincipalData::Standard(StandardPrincipalData::from(addr.clone()))))])
                 .expect("FATAL: failed to construct miner principal key"));
 
-            let miner_status = clarity_tx.connection().with_clarity_db_readonly(|ref mut db| {
-                let miner_status_opt = db.fetch_entry(&miner_contract_id, BOOT_CODE_MINER_REWARDS_MAP, &miner_principal)?;
+            let miner_status = clarity_tx.with_clarity_db_readonly(|db| {
+                let miner_status_opt = db.fetch_entry(&miner_contract_id, BOOT_CODE_MINER_REWARDS_MAP, &miner_principal).unwrap();
                 let miner_status = match miner_status_opt {
                     Value::Optional(ref optional_data) => {
                         match optional_data.data {
@@ -782,8 +783,8 @@ pub mod test {
                     }
                 };
             
-                Ok(miner_status)
-            }).unwrap();
+                miner_status
+            });
 
             miner_status
         }

--- a/src/chainstate/stacks/miner.rs
+++ b/src/chainstate/stacks/miner.rs
@@ -747,7 +747,8 @@ pub mod test {
                 .expect("FATAL: failed to construct miner principal key"));
 
             let miner_status = clarity_tx.with_clarity_db_readonly(|db| {
-                let miner_status_opt = db.fetch_entry(&miner_contract_id, BOOT_CODE_MINER_REWARDS_MAP, &miner_principal)?;
+                let miner_status_opt = db.fetch_entry(&miner_contract_id, BOOT_CODE_MINER_REWARDS_MAP, &miner_principal)
+                    .expect("FATAL: Clarity DB Error");
                 let miner_status = match miner_status_opt {
                     Value::Optional(ref optional_data) => {
                         match optional_data.data {

--- a/src/core/mempool.rs
+++ b/src/core/mempool.rs
@@ -110,7 +110,7 @@ mod tests {
             }
         });
 
-        run_loop.apply_on_new_chain_states(|round, chainstate, block, chain_tip_info, _receipts| {
+        run_loop.apply_on_new_chain_states(|round, chainstate, _block, chain_tip_info, _receipts| {
         // run_loop.apply_on_new_chain_states(|round, ref mut chainstate, bhh| {
             let contract_sk = StacksPrivateKey::from_hex(SK_1).unwrap();
             let contract_addr = to_addr(&contract_sk);

--- a/src/testnet/helium/tests.rs
+++ b/src/testnet/helium/tests.rs
@@ -320,7 +320,7 @@ fn should_succeed_handling_malformed_and_valid_txs() {
     });
 
     // Use block's hook for asserting expectations
-    run_loop.apply_on_new_chain_states(|round, chain_state, block, chain_tip_info, _receipts| {
+    run_loop.apply_on_new_chain_states(|round, _chain_state, block, chain_tip_info, _receipts| {
         match round {
             0 => {
                 // Inspecting the chain at round 0.

--- a/src/vm/analysis/analysis_db.rs
+++ b/src/vm/analysis/analysis_db.rs
@@ -32,6 +32,9 @@ impl <'a> AnalysisDatabase <'a> {
             store: RollbackWrapper::new(store)
         }
     }
+    pub fn new_with_rollback_wrapper(store: RollbackWrapper<'a>) -> AnalysisDatabase<'a> {
+        AnalysisDatabase { store }
+    }
 
     pub fn execute <F, T, E> (&mut self, f: F) -> Result<T,E> where F: FnOnce(&mut Self) -> Result<T,E>, {
         self.begin();
@@ -136,6 +139,10 @@ impl <'a> AnalysisDatabase <'a> {
         let map_type = contract.get_map_type(map_name)
             .ok_or(CheckErrors::NoSuchMap(map_name.to_string()))?;
         Ok(map_type.clone())
+    }
+
+    pub fn destroy(self) -> RollbackWrapper<'a> {
+        self.store
     }
 
 }

--- a/src/vm/analysis/tests/costs.rs
+++ b/src/vm/analysis/tests/costs.rs
@@ -51,11 +51,12 @@ pub fn test_tracked_costs(prog: &str) -> ExecutionCost {
         let mut conn = clarity_instance.begin_block(&TrieFileStorage::block_sentinel(),
                                                     &BlockHeaderHash::from_bytes(&[0 as u8; 32]).unwrap(),
                                                     &NULL_HEADER_DB);
-
-        let (ct_ast, ct_analysis) = conn.analyze_smart_contract(&other_contract_id, contract_other).unwrap();
-        conn.initialize_smart_contract(
-            &other_contract_id, &ct_ast, contract_other, |_,_| false).unwrap();
-        conn.save_analysis(&other_contract_id, &ct_analysis).unwrap();
+        conn.as_transaction(|conn| {
+            let (ct_ast, ct_analysis) = conn.analyze_smart_contract(&other_contract_id, contract_other).unwrap();
+            conn.initialize_smart_contract(
+                &other_contract_id, &ct_ast, contract_other, |_,_| false).unwrap();
+            conn.save_analysis(&other_contract_id, &ct_analysis).unwrap();
+        });
 
         conn.commit_block();
     }
@@ -65,10 +66,12 @@ pub fn test_tracked_costs(prog: &str) -> ExecutionCost {
                                                     &BlockHeaderHash::from_bytes(&[1 as u8; 32]).unwrap(),
                                                     &NULL_HEADER_DB);
 
-        let (ct_ast, ct_analysis) = conn.analyze_smart_contract(&self_contract_id, &contract_self).unwrap();
-        conn.initialize_smart_contract(
-            &self_contract_id, &ct_ast, &contract_self, |_,_| false).unwrap();
-        conn.save_analysis(&self_contract_id, &ct_analysis).unwrap();
+        conn.as_transaction(|conn| {
+            let (ct_ast, ct_analysis) = conn.analyze_smart_contract(&self_contract_id, &contract_self).unwrap();
+            conn.initialize_smart_contract(
+                &self_contract_id, &ct_ast, &contract_self, |_,_| false).unwrap();
+            conn.save_analysis(&self_contract_id, &ct_analysis).unwrap();
+        });
 
         conn.commit_block().get_total()
     }

--- a/src/vm/analysis/tests/costs.rs
+++ b/src/vm/analysis/tests/costs.rs
@@ -25,7 +25,6 @@ pub fn test_tracked_costs(prog: &str) -> ExecutionCost {
     let mut clarity_instance = ClarityInstance::new(marf);
 
     let p1 = execute("'SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR");
-    let p2 = execute("'SM2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQVX8X0G");
 
     let p1_principal = match p1 {
         Value::Principal(PrincipalData::Standard(ref data)) => data.clone(),

--- a/src/vm/contexts.rs
+++ b/src/vm/contexts.rs
@@ -686,19 +686,28 @@ impl <'a,'b> Environment <'a,'b> {
                                         contract_content: &ContractAST, contract_string: &str) -> Result<()> {
         self.global_context.begin();
 
-        runtime_cost!(cost_functions::CONTRACT_STORAGE, self, contract_string.len())?;
+        // wrap in a closure so that `?` can be caught and the global_context can roll_back()
+        //  before returning.
+        let result = (|| {
+            runtime_cost!(cost_functions::CONTRACT_STORAGE, self, contract_string.len())?;
 
-        // first, store the contract _content hash_ in the data store.
-        //    this is necessary before creating and accessing metadata fields in the data store,
-        //      --or-- storing any analysis metadata in the data store.
-        self.global_context.database.insert_contract_hash(&contract_identifier, contract_string)?;
-        let memory_use = contract_string.len() as u64;
-        self.add_memory(memory_use)?;
+            if self.global_context.database.has_contract(&contract_identifier) {
+                return Err(CheckErrors::ContractAlreadyExists(contract_identifier.to_string()).into())
+            }
 
-        let result = Contract::initialize_from_ast(contract_identifier.clone(), 
-                                                   contract_content,
-                                                   &mut self.global_context);
-        self.drop_memory(memory_use);
+            // first, store the contract _content hash_ in the data store.
+            //    this is necessary before creating and accessing metadata fields in the data store,
+            //      --or-- storing any analysis metadata in the data store.
+            self.global_context.database.insert_contract_hash(&contract_identifier, contract_string)?;
+            let memory_use = contract_string.len() as u64;
+            self.add_memory(memory_use)?;
+
+            let result = Contract::initialize_from_ast(contract_identifier.clone(),
+                                                       contract_content,
+                                                       &mut self.global_context);
+            self.drop_memory(memory_use);
+            result
+        })();
 
         match result {
             Ok(contract) => {

--- a/src/vm/database/clarity_db.rs
+++ b/src/vm/database/clarity_db.rs
@@ -264,6 +264,11 @@ impl <'a> ClarityDatabase <'a> {
         self.insert_metadata(contract_identifier, &key, &contract);
     }
 
+    pub fn has_contract(&mut self, contract_identifier: &QualifiedContractIdentifier) -> bool {
+        let key = ClarityDatabase::make_metadata_key(StoreType::Contract, "contract");
+        self.store.has_metadata_entry(contract_identifier, &key)
+    }
+
     pub fn get_contract(&mut self, contract_identifier: &QualifiedContractIdentifier) -> Result<Contract> {
         let key = ClarityDatabase::make_metadata_key(StoreType::Contract, "contract");
         let data = self.fetch_metadata(contract_identifier, &key)?

--- a/src/vm/database/clarity_db.rs
+++ b/src/vm/database/clarity_db.rs
@@ -149,6 +149,10 @@ impl <'a> ClarityDatabase <'a> {
         }
     }
 
+    pub fn new_with_rollback_wrapper(store: RollbackWrapper<'a>, headers_db: &'a dyn HeadersDB) -> ClarityDatabase<'a> {
+        ClarityDatabase { store, headers_db }
+    }
+
     pub fn initialize(&mut self) {
     }
 
@@ -265,6 +269,10 @@ impl <'a> ClarityDatabase <'a> {
         let data = self.fetch_metadata(contract_identifier, &key)?
             .expect("Failed to read non-consensus contract metadata, even though contract exists in MARF.");
         Ok(data)
+    }
+
+    pub fn destroy(self) -> RollbackWrapper<'a> {
+        self.store
     }
 }
 

--- a/src/vm/database/key_value_wrapper.rs
+++ b/src/vm/database/key_value_wrapper.rs
@@ -86,6 +86,42 @@ pub struct RollbackWrapper <'a> {
     stack: Vec<RollbackContext>
 }
 
+
+// This is used for preserving rollback data longer
+//   than a BackingStore pointer. This is useful to prevent
+//   a real mess of lifetime parameters in the database/context
+//   and eval code.
+pub struct RollbackWrapperPersistedLog {
+    lookup_map: HashMap<String, Vec<String>>,
+    metadata_lookup_map: HashMap<(QualifiedContractIdentifier, String), Vec<String>>,
+    stack: Vec<RollbackContext>
+}
+
+impl From<RollbackWrapper<'_>> for RollbackWrapperPersistedLog {
+    fn from(o: RollbackWrapper<'_>) -> RollbackWrapperPersistedLog {
+        RollbackWrapperPersistedLog {
+            lookup_map: o.lookup_map,
+            metadata_lookup_map: o.metadata_lookup_map,
+            stack: o.stack
+        }
+    }
+}
+
+impl RollbackWrapperPersistedLog {
+    pub fn new() -> RollbackWrapperPersistedLog {
+        RollbackWrapperPersistedLog {
+            lookup_map: HashMap::new(),
+            metadata_lookup_map: HashMap::new(),
+            stack: Vec::new()
+        }
+    }
+
+    pub fn nest(&mut self) {
+        self.stack.push(RollbackContext { edits: Vec::new(),
+                                          metadata_edits: Vec::new() });
+    }
+}
+
 fn rollback_lookup_map<T>(key: &T, value: &RollbackValueCheck, lookup_map: &mut HashMap<T, Vec<String>>) -> String
 where T: Eq + Hash + Clone {
     let popped_value;
@@ -105,10 +141,19 @@ where T: Eq + Hash + Clone {
 impl <'a> RollbackWrapper <'a> {
     pub fn new(store: &'a mut dyn ClarityBackingStore) -> RollbackWrapper {
         RollbackWrapper {
-            store: store,
+            store,
             lookup_map: HashMap::new(),
             metadata_lookup_map: HashMap::new(),
             stack: Vec::new()
+        }
+    }
+
+    pub fn from_persisted_log(store: &'a mut dyn ClarityBackingStore, log: RollbackWrapperPersistedLog) -> RollbackWrapper {
+        RollbackWrapper {
+            store,
+            lookup_map: log.lookup_map,
+            metadata_lookup_map: log.metadata_lookup_map,
+            stack: log.stack
         }
     }
 
@@ -134,6 +179,10 @@ impl <'a> RollbackWrapper <'a> {
         for (key, value) in last_item.metadata_edits.drain(..) {
             rollback_lookup_map(&key, &value, &mut self.metadata_lookup_map);
         }
+    }
+
+    pub fn depth(&self) -> usize {
+        self.stack.len()
     }
 
     pub fn commit(&mut self) {

--- a/src/vm/database/mod.rs
+++ b/src/vm/database/mod.rs
@@ -6,7 +6,7 @@ mod key_value_wrapper;
 
 use std::collections::HashMap;
 
-pub use self::key_value_wrapper::{RollbackWrapper};
+pub use self::key_value_wrapper::{RollbackWrapper, RollbackWrapperPersistedLog};
 pub use self::clarity_db::{ClarityDatabase, HeadersDB, NULL_HEADER_DB, STORE_CONTRACT_SRC_INTERFACE};
 pub use self::structures::{ClaritySerializable, ClarityDeserializable};
 pub use self::sqlite::{SqliteConnection};

--- a/src/vm/tests/contracts.rs
+++ b/src/vm/tests/contracts.rs
@@ -175,53 +175,53 @@ fn test_simple_token_system() {
 
         let contract_ast = ast::build_ast(&contract_identifier, tokens_contract, &mut ()).unwrap();
 
-        block.initialize_smart_contract(&contract_identifier, &contract_ast, tokens_contract, |_, _| false)
-            .unwrap();
+        block.as_transaction(|tx| tx.initialize_smart_contract(&contract_identifier, &contract_ast, tokens_contract, |_, _| false)
+                             .unwrap());
 
         assert!(!is_committed(&
-            block.run_contract_call(&p2, &contract_identifier, "token-transfer",
-                                    &[p1.clone().into(), Value::UInt(210)], |_, _| false).unwrap().0));
+            block.as_transaction(|tx| tx.run_contract_call(&p2, &contract_identifier, "token-transfer",
+                                    &[p1.clone().into(), Value::UInt(210)], |_, _| false)).unwrap().0));
         assert!(is_committed(&
-            block.run_contract_call(&p1, &contract_identifier, "token-transfer",
-                                    &[p2.clone().into(), Value::UInt(9000)], |_, _| false).unwrap().0));
+            block.as_transaction(|tx| tx.run_contract_call(&p1, &contract_identifier, "token-transfer",
+                                    &[p2.clone().into(), Value::UInt(9000)], |_, _| false)).unwrap().0));
 
         assert!(!is_committed(&
-            block.run_contract_call(&p1, &contract_identifier, "token-transfer",
-                                    &[p2.clone().into(), Value::UInt(1001)], |_, _| false).unwrap().0));
+            block.as_transaction(|tx| tx.run_contract_call(&p1, &contract_identifier, "token-transfer",
+                                    &[p2.clone().into(), Value::UInt(1001)], |_, _| false)).unwrap().0));
         assert!(is_committed(& // send to self!
-            block.run_contract_call(&p1, &contract_identifier, "token-transfer",
-                                    &[p1.clone().into(), Value::UInt(1000)], |_, _| false).unwrap().0));
+            block.as_transaction(|tx| tx.run_contract_call(&p1, &contract_identifier, "token-transfer",
+                                    &[p1.clone().into(), Value::UInt(1000)], |_, _| false)).unwrap().0));
 
         assert_eq!(
-            block.eval_read_only(&contract_identifier,
-                                 "(my-get-token-balance 'SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR)").unwrap(),
+            block.as_transaction(|tx| tx.eval_read_only(&contract_identifier,
+                                 "(my-get-token-balance 'SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR)")).unwrap(),
             Value::UInt(1000));
         assert_eq!(
-            block.eval_read_only(&contract_identifier,
-                                 "(my-get-token-balance 'SM2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQVX8X0G)").unwrap(),
+            block.as_transaction(|tx| tx.eval_read_only(&contract_identifier,
+                                 "(my-get-token-balance 'SM2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQVX8X0G)")).unwrap(),
             Value::UInt(9200));
 
-        assert!(is_committed(&block.run_contract_call(&p1, &contract_identifier,
+        assert!(is_committed(&block.as_transaction(|tx| tx.run_contract_call(&p1, &contract_identifier,
                                                       "faucet",
-                                                      &[], |_, _| false).unwrap().0));
+                                                      &[], |_, _| false)).unwrap().0));
 
-        assert!(is_committed(&block.run_contract_call(&p1, &contract_identifier,
+        assert!(is_committed(&block.as_transaction(|tx| tx.run_contract_call(&p1, &contract_identifier,
                                                       "faucet",
-                                                      &[], |_, _| false).unwrap().0));
+                                                      &[], |_, _| false)).unwrap().0));
 
-        assert!(is_committed(&block.run_contract_call(&p1, &contract_identifier,
+        assert!(is_committed(&block.as_transaction(|tx| tx.run_contract_call(&p1, &contract_identifier,
                                                       "faucet",
-                                                      &[], |_, _| false).unwrap().0));
+                                                      &[], |_, _| false)).unwrap().0));
         
         assert_eq!(
-            block.eval_read_only(&contract_identifier,
-                                 "(my-get-token-balance 'SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR)").unwrap(),
+            block.as_transaction(|tx| tx.eval_read_only(&contract_identifier,
+                                 "(my-get-token-balance 'SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR)")).unwrap(),
             Value::UInt(1003));
 
         assert!(!is_committed(
-            &block.run_contract_call(&p1, &contract_identifier,
+            &block.as_transaction(|tx| tx.run_contract_call(&p1, &contract_identifier,
                                      "mint-after", 
-                                     &[Value::UInt(25)], |_, _| false).unwrap().0));
+                                     &[Value::UInt(25)], |_, _| false)).unwrap().0));
         block.commit_block();
     }
 
@@ -239,23 +239,23 @@ fn test_simple_token_system() {
                                         &test_block_headers(26),
                                         &NULL_HEADER_DB);
         assert!(is_committed(
-            &block.run_contract_call(&p1, &contract_identifier,
+            &block.as_transaction(|tx| tx.run_contract_call(&p1, &contract_identifier,
                                      "mint-after", 
-                                     &[Value::UInt(25)], |_, _| false).unwrap().0));
+                                     &[Value::UInt(25)], |_, _| false)).unwrap().0));
         
         assert!(!is_committed(
-            &block.run_contract_call(&p1, &contract_identifier,
+            &block.as_transaction(|tx| tx.run_contract_call(&p1, &contract_identifier,
                                      "faucet", 
-                                     &[], |_, _| false).unwrap().0));
+                                     &[], |_, _| false)).unwrap().0));
 
         assert_eq!(
-            block.eval_read_only(&contract_identifier,
-                                 "(my-get-token-balance 'SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR)").unwrap(),
+            block.as_transaction(|tx| tx.eval_read_only(&contract_identifier,
+                                 "(my-get-token-balance 'SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR)")).unwrap(),
             Value::UInt(1004));
         assert_eq!(
-            block.run_contract_call(&p1, &contract_identifier,
+            block.as_transaction(|tx| tx.run_contract_call(&p1, &contract_identifier,
                                     "my-get-token-balance",
-                                    &[p1.clone().into()], |_, _| false).unwrap().0,
+                                    &[p1.clone().into()], |_, _| false)).unwrap().0,
             Value::UInt(1004));
     }
 }

--- a/src/vm/tests/large_contract.rs
+++ b/src/vm/tests/large_contract.rs
@@ -51,11 +51,13 @@ pub fn rollback_log_memory_test() {
             contract.push_str(&exploder);
         }
 
-        let (ct_ast, _ct_analysis) = conn.analyze_smart_contract(&contract_identifier, &contract).unwrap();
-        assert!(format!("{:?}",
-                        conn.initialize_smart_contract(
-                            &contract_identifier, &ct_ast, &contract, |_,_| false).unwrap_err())
-                .contains("MemoryBalanceExceeded"));
+        conn.as_transaction(|conn| {
+            let (ct_ast, _ct_analysis) = conn.analyze_smart_contract(&contract_identifier, &contract).unwrap();
+            assert!(format!("{:?}",
+                            conn.initialize_smart_contract(
+                                &contract_identifier, &ct_ast, &contract, |_,_| false).unwrap_err())
+                    .contains("MemoryBalanceExceeded"));
+        });
     }
 }
 
@@ -94,11 +96,13 @@ pub fn let_memory_test() {
 
         contract.push_str(") 1)");
 
-        let (ct_ast, _ct_analysis) = conn.analyze_smart_contract(&contract_identifier, &contract).unwrap();
-        assert!(format!("{:?}",
-                        conn.initialize_smart_contract(
-                            &contract_identifier, &ct_ast, &contract, |_,_| false).unwrap_err())
-                .contains("MemoryBalanceExceeded"));
+        conn.as_transaction(|conn| {
+            let (ct_ast, _ct_analysis) = conn.analyze_smart_contract(&contract_identifier, &contract).unwrap();
+            assert!(format!("{:?}",
+                            conn.initialize_smart_contract(
+                                &contract_identifier, &ct_ast, &contract, |_,_| false).unwrap_err())
+                    .contains("MemoryBalanceExceeded"));
+        });
     }
 }
 
@@ -135,11 +139,13 @@ pub fn argument_memory_test() {
 
         contract.push_str(")");
 
-        let (ct_ast, _ct_analysis) = conn.analyze_smart_contract(&contract_identifier, &contract).unwrap();
-        assert!(format!("{:?}",
-                        conn.initialize_smart_contract(
-                            &contract_identifier, &ct_ast, &contract, |_,_| false).unwrap_err())
-                .contains("MemoryBalanceExceeded"));
+        conn.as_transaction(|conn| {
+            let (ct_ast, _ct_analysis) = conn.analyze_smart_contract(&contract_identifier, &contract).unwrap();
+            assert!(format!("{:?}",
+                            conn.initialize_smart_contract(
+                                &contract_identifier, &ct_ast, &contract, |_,_| false).unwrap_err())
+                    .contains("MemoryBalanceExceeded"));
+        });
     }
 }
 
@@ -195,16 +201,20 @@ pub fn fcall_memory_test() {
         eprintln!("{}", contract_ok);
         eprintln!("{}", contract_err);
 
-        let (ct_ast, _ct_analysis) = conn.analyze_smart_contract(&contract_identifier, &contract_ok).unwrap();
-        conn.initialize_smart_contract(
-            // initialize the ok contract without errs, but still abort.
-            &contract_identifier, &ct_ast, &contract_ok, |_,_| true).unwrap();
+        conn.as_transaction(|conn| {
+            let (ct_ast, _ct_analysis) = conn.analyze_smart_contract(&contract_identifier, &contract_ok).unwrap();
+            conn.initialize_smart_contract(
+                // initialize the ok contract without errs, but still abort.
+                &contract_identifier, &ct_ast, &contract_ok, |_,_| true).unwrap();
+        });
 
-        let (ct_ast, _ct_analysis) = conn.analyze_smart_contract(&contract_identifier, &contract_err).unwrap();
-        assert!(format!("{:?}",
-                        conn.initialize_smart_contract(
-                            &contract_identifier, &ct_ast, &contract_err, |_,_| false).unwrap_err())
-                .contains("MemoryBalanceExceeded"));
+        conn.as_transaction(|conn| {
+            let (ct_ast, _ct_analysis) = conn.analyze_smart_contract(&contract_identifier, &contract_err).unwrap();
+            assert!(format!("{:?}",
+                            conn.initialize_smart_contract(
+                                &contract_identifier, &ct_ast, &contract_err, |_,_| false).unwrap_err())
+                    .contains("MemoryBalanceExceeded"));
+        });
     }
 }
 
@@ -254,16 +264,20 @@ pub fn ccall_memory_test() {
             let contract_identifier = QualifiedContractIdentifier::local(&contract_name).unwrap();
 
             if i < (CONTRACTS-1) {
-                let (ct_ast, ct_analysis) = conn.analyze_smart_contract(&contract_identifier, &contract).unwrap();
-                conn.initialize_smart_contract(
-                    &contract_identifier, &ct_ast, &contract, |_,_| false).unwrap();
-                conn.save_analysis(&contract_identifier, &ct_analysis).unwrap();
+                conn.as_transaction(|conn| {
+                    let (ct_ast, ct_analysis) = conn.analyze_smart_contract(&contract_identifier, &contract).unwrap();
+                    conn.initialize_smart_contract(
+                        &contract_identifier, &ct_ast, &contract, |_,_| false).unwrap();
+                    conn.save_analysis(&contract_identifier, &ct_analysis).unwrap();
+                });
             } else {
-                let (ct_ast, _ct_analysis) = conn.analyze_smart_contract(&contract_identifier, &contract).unwrap();
-                assert!(format!("{:?}",
-                                conn.initialize_smart_contract(
-                            &contract_identifier, &ct_ast, &contract, |_,_| false).unwrap_err())
-                        .contains("MemoryBalanceExceeded"));
+                conn.as_transaction(|conn| {
+                    let (ct_ast, _ct_analysis) = conn.analyze_smart_contract(&contract_identifier, &contract).unwrap();
+                    assert!(format!("{:?}",
+                                    conn.initialize_smart_contract(
+                                        &contract_identifier, &ct_ast, &contract, |_,_| false).unwrap_err())
+                            .contains("MemoryBalanceExceeded"));
+                });
             }
         }
     }


### PR DESCRIPTION
This addresses #1376, by adding a third struct to vm::clarity -- `ClarityTransactionConnection` -- the three structs in vm::clarity correspond to:

1. ClarityInstance -- a struct that lives across blocks.
2. ClarityBlockConnection -- a struct for a single block. Aborts/commits operate on the whole block.
3. ClarityTransactionConnection -- a struct for a single transaction within a block. Aborts/commits operate on the whole transaction.

processTransaction and processTransactionPayload have been updated to use ClarityTransactionConnection. Tests are added for the transaction rollback functionality (and tests which previously required aspects to be commented out due to #1376 have had those parts uncommented).

While editing db::transactions, I also cleared out the compiler warnings from db::transactions::tests.