### PR TITLE
Unified net server socket polling

### DIFF
--- a/src/net/chat.rs
+++ b/src/net/chat.rs
@@ -636,10 +636,13 @@ impl ConversationP2P {
     /// This is a non-blocking operation. The caller needs to call .try_flush() or .flush() on the
     /// returned Write to finish sending.
     pub fn relay_signed_message(&mut self, msg: StacksMessage) -> Result<ReplyHandleP2P, net_error> {
+        let _name = msg.get_message_name();
         let mut handle = self.connection.make_relay_handle()?;
         msg.consensus_serialize(&mut handle)?;
 
         self.stats.msgs_tx += 1;
+        
+        test_debug!("{:?}: relay-send({}) {}", &self, self.stats.msgs_tx, _name);
         Ok(handle)
     }
     
@@ -647,10 +650,14 @@ impl ConversationP2P {
     /// This is a non-blocking operation.  The caller needs to call .try_flush() or .flush() on the
     /// returned handle to finish sending.
     pub fn send_signed_request(&mut self, msg: StacksMessage, ttl: u64) -> Result<ReplyHandleP2P, net_error> {
+        let _name = msg.get_message_name();
+
         let mut handle = self.connection.make_request_handle(msg.request_id(), ttl)?;
         msg.consensus_serialize(&mut handle)?;
 
         self.stats.msgs_tx += 1;
+
+        test_debug!("{:?}: request-send({}) {}", &self, self.stats.msgs_tx, _name);
         Ok(handle)
     }
 

--- a/src/net/p2p.rs
+++ b/src/net/p2p.rs
@@ -284,6 +284,8 @@ pub struct PeerNetwork {
 
     // network I/O
     network: Option<NetworkState>,
+    p2p_network_handle: usize,
+    http_network_handle: usize,
 
     // info on the burn chain we're tracking 
     pub burnchain: Burnchain,
@@ -321,11 +323,12 @@ pub struct PeerNetwork {
     pub prune_inbound_counts: HashMap<NeighborKey, u64>,
 
     // http endpoint, used for driving HTTP conversations (some of which we initiate)
-    pub http: Option<HttpPeer>
+    pub http: HttpPeer
 }
 
 impl PeerNetwork {
     pub fn new(peerdb: PeerDB, local_peer: LocalPeer, peer_version: u32, burnchain: Burnchain, chain_view: BurnchainView, connection_opts: ConnectionOptions) -> PeerNetwork {
+        let http = HttpPeer::new(local_peer.network_id, burnchain.clone(), chain_view.clone(), connection_opts.clone(), 0);
         PeerNetwork {
             local_peer: local_peer,
             peer_version: peer_version,
@@ -344,6 +347,8 @@ impl PeerNetwork {
 
             handles: VecDeque::new(),
             network: None,
+            p2p_network_handle: 0,
+            http_network_handle: 0,
 
             burnchain: burnchain,
             connection_opts: connection_opts,
@@ -367,7 +372,7 @@ impl PeerNetwork {
             prune_outbound_counts : HashMap::new(),
             prune_inbound_counts : HashMap::new(),
 
-            http: None,
+            http: http,
         }
     }
 
@@ -388,17 +393,39 @@ impl PeerNetwork {
     }
 
     /// start serving.
-    /// TODO: take a listen buffer length as an option
     pub fn bind(&mut self, my_addr: &SocketAddr, http_addr: &SocketAddr) -> Result<(), net_error> {
-        let net = NetworkState::bind(my_addr, 500)?;
-        let mut http = HttpPeer::new(self.local_peer.network_id, self.burnchain.clone(), self.chain_view.clone(), self.connection_opts.clone());
-        http.bind(http_addr, 500)?;
+        let mut net = NetworkState::new(800)?;
+
+        let p2p_handle = net.bind(my_addr)?;
+        let http_handle = net.bind(http_addr)?;
 
         test_debug!("{:?}: bound on p2p {:?}, http {:?}", &self.local_peer, my_addr, http_addr);
 
         self.network = Some(net);
-        self.http = Some(http);
+        self.p2p_network_handle = p2p_handle;
+        self.http_network_handle = http_handle;
+
+        self.http.set_server_handle(http_handle);
+
         Ok(())
+    }
+
+    /// Run a closure with the network state
+    pub fn with_network_state<F, R>(peer_network: &mut PeerNetwork, closure: F) -> Result<R, net_error>
+    where
+        F: FnOnce(&mut PeerNetwork, &mut NetworkState) -> Result<R, net_error>
+    {
+        let mut net = peer_network.network.take();
+        let res = match net {
+            Some(ref mut network_state) => {
+                closure(peer_network, network_state)
+            },
+            None => {
+                return Err(net_error::NotConnected);
+            }
+        };
+        peer_network.network = net;
+        res
     }
     
     /// Create a network handle for another thread to use to communicate with remote peers
@@ -517,9 +544,9 @@ impl PeerNetwork {
                 return Err(net_error::NotConnected);
             },
             Some(ref mut network) => {
-                let sock = network.connect(&neighbor.addrbytes.to_socketaddr(neighbor.port))?;
+                let sock = NetworkState::connect(&neighbor.addrbytes.to_socketaddr(neighbor.port))?;
                 let next_event_id = network.next_event_id();
-                network.register(next_event_id, &sock)?;
+                network.register(self.p2p_network_handle, next_event_id, &sock)?;
 
                 self.connecting.insert(next_event_id, (sock, true));
                 next_event_id
@@ -854,7 +881,7 @@ impl PeerNetwork {
             Ok(addr) => addr,
             Err(e) => {
                 warn!("Failed to get peer address of {:?}: {:?}", &socket, &e);
-                self.deregister_socket(socket);
+                self.deregister_socket(event_id, socket);
                 return Err(net_error::SocketError);
             }
         };
@@ -862,20 +889,20 @@ impl PeerNetwork {
         let neighbor_opt = match self.lookup_peer(self.chain_view.burn_block_height, &client_addr) {
             Ok(neighbor_opt) => neighbor_opt,
             Err(e) => {
-                self.deregister_socket(socket);
+                self.deregister_socket(event_id, socket);
                 return Err(e);
             }
         };
 
         let (pubkey_opt, neighbor_key) = match neighbor_opt {
             Some(neighbor) => (Some(neighbor.public_key.clone()), neighbor.addr),
-            None => (None, NeighborKey::from_socketaddr(self.peer_version, self.local_peer.network_id, &client_addr))
+            None => (None, NeighborKey::from_socketaddr(self.peer_version, self.local_peer.network_id, &client_addr))       // TODO: this is _not_ the neighbor's peer version and network id!
         };
 
         match self.can_register_peer(&neighbor_key, outbound) {
             Ok(_) => {},
             Err(e) => {
-                self.deregister_socket(socket);
+                self.deregister_socket(event_id, socket);
                 return Err(e);
             }
         }
@@ -883,7 +910,10 @@ impl PeerNetwork {
         let mut new_convo = ConversationP2P::new(self.local_peer.network_id, self.peer_version, &self.burnchain, &client_addr, &self.connection_opts, outbound, event_id);
         new_convo.set_public_key(pubkey_opt);
         
-        test_debug!("{:?}: Registered {} as event {} (outbound={})", &self.local_peer, &client_addr, event_id, outbound);
+        test_debug!("{:?}: Registered {} as event {} ({:?},outbound={})", &self.local_peer, &client_addr, event_id, &neighbor_key, outbound);
+
+        assert!(!self.sockets.contains_key(&event_id));
+        assert!(!self.peers.contains_key(&event_id));
 
         self.sockets.insert(event_id, socket);
         self.peers.insert(event_id, new_convo);
@@ -907,10 +937,10 @@ impl PeerNetwork {
     }
 
     /// Deregister a socket from our p2p network instance.
-    fn deregister_socket(&mut self, socket: mio_net::TcpStream) -> () {
+    fn deregister_socket(&mut self, event_id: usize, socket: mio_net::TcpStream) -> () {
         match self.network {
             Some(ref mut network) => {
-                let _ = network.deregister(&socket);
+                let _ = network.deregister(event_id, &socket);
             },
             None => {}
         }
@@ -941,7 +971,7 @@ impl PeerNetwork {
                 match self.sockets.get_mut(&event_id) {
                     None => {},
                     Some(ref sock) => {
-                        let _ = network.deregister(sock);
+                        let _ = network.deregister(event_id, sock);
                         to_remove.push(event_id);   // force it to close anyway
                     }
                 }
@@ -988,7 +1018,8 @@ impl PeerNetwork {
         self.deregister_neighbor(neighbor);
     }
 
-    /// Sign a p2p message to be sent to a particular peer we're having a conversation with
+    /// Sign a p2p message to be sent to a particular peer we're having a conversation with.
+    /// The peer must already be connected.
     pub fn sign_for_peer(&mut self, peer_key: &NeighborKey, message_payload: StacksMessageType) -> Result<StacksMessage, net_error> {
         match self.events.get(&peer_key) {
             None => {
@@ -1028,7 +1059,7 @@ impl PeerNetwork {
             match self.network {
                 Some(ref mut network) => {
                     // add to poller
-                    if let Err(_e) = network.register(event_id, &client_sock) {
+                    if let Err(_e) = network.register(self.p2p_network_handle, event_id, &client_sock) {
                         continue;
                     }
                 },
@@ -1538,15 +1569,13 @@ impl PeerNetwork {
             }
         }
 
-        match self.http {
-            Some(ref mut http) => {
-                for dead_event in broken_http_peers.drain(..) {
-                    debug!("{:?}: De-register broken HTTP connection {}", &self.local_peer, dead_event);
-                    http.deregister_http(dead_event);
-                }
-            },
-            None => {}
-        }
+        let _ = PeerNetwork::with_network_state(self, |ref mut network, ref mut network_state| {
+            for dead_event in broken_http_peers.drain(..) {
+                debug!("{:?}: De-register broken HTTP connection {}", &network.local_peer, dead_event);
+                network.http.deregister_http(network_state, dead_event);
+            }
+            Ok(())
+        });
 
         for broken_neighbor in broken_p2p_peers.drain(..) {
             debug!("{:?}: De-register broken neighbor {:?}", &self.local_peer, &broken_neighbor);
@@ -1886,7 +1915,7 @@ impl PeerNetwork {
     }
     
 
-    /// Update networking state.
+    /// Update p2p networking state.
     /// -- accept new connections
     /// -- send data on ready sockets
     /// -- receive data on ready sockets
@@ -1913,9 +1942,6 @@ impl PeerNetwork {
         // update local-peer state
         self.local_peer = PeerDB::get_local_peer(self.peerdb.conn())
             .map_err(net_error::DBError)?;
-
-        // handle network I/O requests from other threads, and get back reply handles to them
-        self.dispatch_requests();
 
         // set up new inbound conversations
         self.process_new_sockets(&mut poll_state)?;
@@ -1948,6 +1974,8 @@ impl PeerNetwork {
         self.disconnect_unresponsive();
 
         // do some Actual Work(tm)
+        // do this _after_ processing new sockets, so the act of opening a socket doesn't trample
+        // an already-used network ID
         let do_prune = self.do_network_work(burndb, chainstate, dns_client_opt, &mut network_result)?;
 
         // send out any queued messages.
@@ -1987,21 +2015,25 @@ impl PeerNetwork {
             self.rekey(None);
         }
 
-        // finally, update our relay statistics, so we know who to forward messages to
+        // update our relay statistics, so we know who to forward messages to
         self.update_relayer_stats(&network_result);
+
+        // finally, handle network I/O requests from other threads, and get back reply handles to them.
+        // do this after processing new sockets, so we don't accidentally re-use an event ID.
+        self.dispatch_requests();
       
         Ok(network_result)
     }
 
     /// Top-level main-loop circuit to take.
-    /// -- polls the peer network state to get new sockets and detect ready sockets
+    /// -- polls the peer network and http network server sockets to get new sockets and detect ready sockets
     /// -- carries out network conversations
     /// -- receives and dispatches requests from other threads
-    /// -- runs the http peer main loop
-    /// Returns the table of unhandled p2p network messages to be acted upon, keyed by the neighbors
+    /// -- runs the p2p and http peer main loop
+    /// Returns the table of unhandled network messages to be acted upon, keyed by the neighbors
     /// that sent them (i.e. keyed by their event IDs)
     pub fn run(&mut self, burndb: &mut BurnDB, chainstate: &mut StacksChainState, mempool: &mut MemPoolDB, dns_client_opt: Option<&mut DNSClient>, poll_timeout: u64) -> Result<NetworkResult, net_error> {
-        let p2p_poll_state = match self.network {
+        let mut poll_states = match self.network {
             None => {
                 test_debug!("{:?}: network not connected", &self.local_peer);
                 Err(net_error::NotConnected)
@@ -2011,16 +2043,16 @@ impl PeerNetwork {
             }
         }?;
 
+        let p2p_poll_state = poll_states.remove(&self.p2p_network_handle).expect("BUG: no poll state for p2p network handle");
+        let http_poll_state = poll_states.remove(&self.http_network_handle).expect("BUG: no poll state for http network handle");
+
         let mut result = self.dispatch_network(burndb, chainstate, dns_client_opt, p2p_poll_state)?;
-       
-        match self.http {
-            Some(ref mut http) => {
-                let http_stacks_msgs = http.run(self.chain_view.clone(), burndb, &mut self.peerdb, chainstate, mempool, poll_timeout)?;
-                result.consume_http_uploads(http_stacks_msgs);
-            },
-            None => {}
-        }
-        
+      
+        PeerNetwork::with_network_state(self, |ref mut network, ref mut network_state| {
+            let http_stacks_msgs = network.http.run(network_state, network.chain_view.clone(), burndb, &mut network.peerdb, chainstate, mempool, http_poll_state)?;
+            result.consume_http_uploads(http_stacks_msgs);
+            Ok(())
+        })?;
         Ok(result)
     }
 }
@@ -2142,7 +2174,7 @@ mod test {
                     test_debug!("Dispatched {} requests", dispatch_count);
                 }
 
-                let mut poll_state = match p2p.network {
+                let mut poll_states = match p2p.network {
                     None => {
                         panic!("network not connected");
                     },
@@ -2151,8 +2183,10 @@ mod test {
                     }
                 };
 
-                p2p.process_new_sockets(&mut poll_state).unwrap();
-                p2p.process_connecting_sockets(&mut poll_state);
+                let mut p2p_poll_state = poll_states.remove(&p2p.p2p_network_handle).unwrap();
+
+                p2p.process_new_sockets(&mut p2p_poll_state).unwrap();
+                p2p.process_connecting_sockets(&mut p2p_poll_state);
 
                 thread::sleep(time::Duration::from_millis(1000));
             }
@@ -2251,8 +2285,10 @@ mod test {
                     }
                 };
 
-                p2p.process_new_sockets(&mut poll_state).unwrap();
-                p2p.process_connecting_sockets(&mut poll_state);
+                let mut p2p_poll_state = poll_state.remove(&p2p.p2p_network_handle).unwrap();
+
+                p2p.process_new_sockets(&mut p2p_poll_state).unwrap();
+                p2p.process_connecting_sockets(&mut p2p_poll_state);
 
                 let mut banned = p2p.process_bans().unwrap();
                 if banned.len() > 0 {

--- a/src/net/poll.rs
+++ b/src/net/poll.rs
@@ -28,6 +28,7 @@ use util::db::DBConn;
 use std::net;
 use std::net::SocketAddr;
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::time::Duration;
 use std::io;
 use std::io::Read;
@@ -68,15 +69,43 @@ impl NetworkPollState {
     }
 }
 
-pub struct NetworkState {
+// state for a single network server 
+pub struct NetworkServerState {
     addr: SocketAddr,
+    server_socket: mio_net::TcpListener,
+    server_event: mio::Token,
+}
+
+// state for the entire network
+pub struct NetworkState {
     poll: mio::Poll,
-    server: mio_net::TcpListener,
     events: mio::Events,
+    event_capacity: usize,
+    servers: Vec<NetworkServerState>,
     count: usize,
+    event_map: HashMap<usize, usize>        // map socket events to their registered server socket (including server sockets)
 }
 
 impl NetworkState {
+    pub fn new(event_capacity: usize) -> Result<NetworkState, net_error> {
+        let poll = mio::Poll::new()
+            .map_err(|e| {
+                error!("Failed to initialize poller: {:?}", e);
+                net_error::BindError
+            })?;
+        
+        let events = mio::Events::with_capacity(event_capacity);
+
+        Ok(NetworkState {
+            poll: poll,
+            events: events,
+            event_capacity: event_capacity,
+            servers: vec![],
+            count: 1,
+            event_map: HashMap::new()
+        })
+    }
+
     fn bind_address(addr: &SocketAddr) -> Result<mio_net::TcpListener, net_error> {
         if !cfg!(test) {
             mio_net::TcpListener::bind(addr)
@@ -112,66 +141,87 @@ impl NetworkState {
         }
     }
 
-    pub fn bind(addr: &SocketAddr, capacity: usize) -> Result<NetworkState, net_error> {
+    /// Bind to the given socket address.
+    /// Returns the handle to the poll state, used to key network poll events.
+    pub fn bind(&mut self, addr: &SocketAddr) -> Result<usize, net_error> {
         let server = NetworkState::bind_address(addr)?;
-        let poll = mio::Poll::new()
-            .map_err(|e| {
-                error!("Failed to initialize poller: {:?}", e);
-                net_error::BindError
-            })?;
+        let next_server_event = self.next_event_id();
 
-        let events = mio::Events::with_capacity(capacity);
-
-        poll.register(&server, SERVER, mio::Ready::readable(), mio::PollOpt::edge())
+        self.poll.register(&server, mio::Token(next_server_event), mio::Ready::readable(), mio::PollOpt::edge())
             .map_err(|e| {
                 error!("Failed to register server socket: {:?}", &e);
                 net_error::BindError
             })?;
 
-        Ok(NetworkState {
+        let network_server = NetworkServerState {
             addr: addr.clone(),
-            poll: poll,
-            server: server,
-            events: events,
-            count: 1
-        })
-    }
+            server_socket: server,
+            server_event: mio::Token(next_server_event),
+        };
 
-    /// next event ID
-    pub fn next_event_id(&mut self) -> usize {
-        let ret = self.count;
-        self.count += 1;
-        ret
+        assert!(!self.event_map.contains_key(&next_server_event));
+
+        self.servers.push(network_server);
+        self.event_map.insert(next_server_event, 0);        // server events always mapped to 0
+
+        Ok(next_server_event)
     }
 
     /// Register a socket for read/write notifications with this poller
-    pub fn register(&mut self, event_id: usize, sock: &mio_net::TcpStream) -> Result<(), net_error> {
+    pub fn register(&mut self, server_event_id: usize, event_id: usize, sock: &mio_net::TcpStream) -> Result<(), net_error> {
         self.poll.register(sock, mio::Token(event_id), Ready::all(), PollOpt::edge())
             .map_err(|e| {
                 error!("Failed to register socket: {:?}", &e);
                 net_error::RegisterError
-            })
+            })?;
+
+        // this is a server event
+        assert!(self.event_map.contains_key(&server_event_id));
+        assert_eq!(self.event_map.get(&server_event_id), Some(&0));
+
+        // this event ID is not in use
+        assert!(!self.event_map.contains_key(&event_id));
+
+        self.event_map.insert(event_id, server_event_id);
+        test_debug!("Register socket {:?} as event {} on server {}", sock, event_id, server_event_id);
+        Ok(())
     }
 
     /// Deregister a socket event
-    pub fn deregister(&mut self, sock: &mio_net::TcpStream) -> Result<(), net_error> {
+    pub fn deregister(&mut self, event_id: usize, sock: &mio_net::TcpStream) -> Result<(), net_error> {
         self.poll.deregister(sock)
             .map_err(|e| {
-                error!("Failed to deregister socket: {:?}", &e);
+                error!("Failed to deregister socket {}: {:?}", event_id, &e);
                 net_error::RegisterError
             })?;
 
         sock.shutdown(Shutdown::Both)
             .map_err(|_e| net_error::SocketError)?;
 
-        test_debug!("Socket deregistered: {:?}", sock);
+        self.event_map.remove(&event_id);
+        test_debug!("Socket deregistered: {}, {:?}", event_id, sock);
         Ok(())
+    }
+
+    fn make_next_event_id(&self, cur_count: usize, in_use: &HashSet<usize>) -> usize {
+        let mut ret = cur_count;
+        while self.event_map.contains_key(&ret) || in_use.contains(&ret) {
+            ret = (ret + 1) % self.event_capacity;
+        }
+        ret
+    }
+
+    /// next event ID
+    pub fn next_event_id(&mut self) -> usize {
+        let ret = self.make_next_event_id(self.count, &HashSet::new());
+        self.count = (ret + 1) % self.event_capacity;
+        ret
     }
 
     /// Connect to a remote peer, but don't register it with the poll handle.
     /// The underlying connect(2) is _asynchronous_, so the caller will need to register it with a
     /// poll handle and wait for it to be connected.
-    pub fn connect(&mut self, addr: &SocketAddr) -> Result<mio_net::TcpStream, net_error> {
+    pub fn connect(addr: &SocketAddr) -> Result<mio_net::TcpStream, net_error> {
         let stream = mio_net::TcpStream::connect(addr)
             .map_err(|_e| {
                 test_debug!("Failed to convert to mio stream: {:?}", &_e);
@@ -205,21 +255,38 @@ impl NetworkState {
         Ok(stream)
     }
 
-    /// Poll socket states
-    pub fn poll(&mut self, timeout: u64) -> Result<NetworkPollState, net_error> {
+    /// Poll all server sockets.
+    /// Returns a map between network server handles (returned by bind()) and their new polling state
+    pub fn poll(&mut self, timeout: u64) -> Result<HashMap<usize, NetworkPollState>, net_error> {
+        self.events.clear();
         self.poll.poll(&mut self.events, Some(Duration::from_millis(timeout)))
             .map_err(|e| {
                 error!("Failed to poll: {:?}", &e);
                 net_error::PollError
             })?;
+
+        let mut poll_states = HashMap::new();
+        for server in self.servers.iter() {
+            // pre-populate with server tokens
+            let server_event_id = usize::from(server.server_event);
+            poll_states.insert(server_event_id, NetworkPollState::new());
+        }
+
+        let mut new_events = HashSet::new();
        
-        let mut poll_state = NetworkPollState::new();
         for event in &self.events {
-            match event.token() {
-                SERVER => {
+            let token = event.token();
+            let mut is_server_event = false;
+
+            for server in self.servers.iter() {
+                // server token?
+                if token == server.server_event {
                     // new inbound connection(s)
+                    is_server_event = true;
+                    let poll_state = poll_states.get_mut(&usize::from(token)).expect(&format!("BUG: FATAL: no poll state registered for server {}", usize::from(token)));
+                    
                     loop {
-                        let (client_sock, _client_addr) = match self.server.accept() {
+                        let (client_sock, _client_addr) = match server.server_socket.accept() {
                             Ok((client_sock, client_addr)) => (client_sock, client_addr),
                             Err(e) => {
                                 match e.kind() {
@@ -233,18 +300,41 @@ impl NetworkState {
                             }
                         };
 
-                        test_debug!("New socket accepted from {:?} (event {}): {:?}", &_client_addr, self.count, &client_sock);
-                        poll_state.new.insert(self.count, client_sock);
-                        self.count += 1;
+                        let next_event_id = self.make_next_event_id(self.count, &new_events);
+                        self.count = (next_event_id + 1) % self.event_capacity;
+
+                        new_events.insert(next_event_id);
+                        
+                        test_debug!("New socket accepted from {:?} (event {}) on server {:?}: {:?}", &_client_addr, next_event_id, &server.server_socket, &client_sock);
+                        poll_state.new.insert(next_event_id, client_sock);
+                    }
+
+                    break;
+                }
+            }
+
+            if is_server_event {
+                continue;
+            }
+
+            // event for a client of one of our servers.  which one?
+            let event_id = usize::from(token);
+            match self.event_map.get(&event_id) {
+                Some(server_event_id) => {
+                    if let Some(poll_state) = poll_states.get_mut(server_event_id) {
+                        test_debug!("Wakeup socket event {} on server {}", event_id, server_event_id);
+                        poll_state.ready.push(event_id);
+                    }
+                    else {
+                        panic!("Unknown server event ID {}", server_event_id);
                     }
                 },
-                mio::Token(event_id) => {
-                    // I/O available 
-                    poll_state.ready.push(event_id);
+                None => {
+                    panic!("Surreptitious readiness event {}", event_id);
                 }
             }
         }
 
-        Ok(poll_state)
+        Ok(poll_states)
     }
 }

--- a/src/net/server.rs
+++ b/src/net/server.rs
@@ -62,8 +62,8 @@ pub struct HttpPeer {
     // outbound connections that are pending connection 
     pub connecting: HashMap<usize, (mio_net::TcpStream, Option<UrlString>, Option<HttpRequestType>)>,
 
-    // network I/O
-    network: Option<NetworkState>,
+    // server network handle
+    pub http_server_handle: usize,
 
     // info on the burn chain we're tracking 
     pub burnchain: Burnchain,
@@ -73,7 +73,7 @@ pub struct HttpPeer {
 }
 
 impl HttpPeer {
-    pub fn new(network_id: u32, burnchain: Burnchain, chain_view: BurnchainView, conn_opts: ConnectionOptions) -> HttpPeer {
+    pub fn new(network_id: u32, burnchain: Burnchain, chain_view: BurnchainView, conn_opts: ConnectionOptions, server_handle: usize) -> HttpPeer {
         HttpPeer {
             network_id: network_id,
             chain_view: chain_view,
@@ -81,19 +81,15 @@ impl HttpPeer {
             sockets: HashMap::new(),
 
             connecting: HashMap::new(),
-
-            network: None,
+            http_server_handle: server_handle,
 
             burnchain: burnchain,
             connection_opts: conn_opts
         }
     }
 
-    /// start serving
-    pub fn bind(&mut self, my_addr: &SocketAddr, max_sockets: usize) -> Result<(), net_error> {
-        let net = NetworkState::bind(my_addr, max_sockets)?;
-        self.network = Some(net);
-        Ok(())
+    pub fn set_server_handle(&mut self, h: usize) -> () {
+        self.http_server_handle = h;
     }
 
     /// Is there a HTTP conversation open to this data_url that is not in progress?
@@ -117,23 +113,14 @@ impl HttpPeer {
     /// its origin.  Once connected, optionally send the given request.
     /// Idempotent -- will not re-connect if already connected and there is a free conversation channel open 
     /// (will return Error::AlreadyConnected with the event ID)
-    pub fn connect_http(&mut self, data_url: UrlString, addr: SocketAddr, request: Option<HttpRequestType>) -> Result<usize, net_error> {
+    pub fn connect_http(&mut self, network_state: &mut NetworkState, data_url: UrlString, addr: SocketAddr, request: Option<HttpRequestType>) -> Result<usize, net_error> {
         if let Some(event_id) = self.find_free_conversation(&data_url) {
             return Err(net_error::AlreadyConnected(event_id));
         }
 
-        let (sock, next_event_id) = match self.network {
-            None => {
-                test_debug!("HTTP not connected");
-                return Err(net_error::NotConnected);
-            },
-            Some(ref mut network) => {
-                let sock = network.connect(&addr)?;
-                let next_event_id = network.next_event_id();
-                network.register(next_event_id, &sock)?;
-                (sock, next_event_id)
-            }
-        };
+        let sock = NetworkState::connect(&addr)?;
+        let next_event_id = network_state.next_event_id();
+        network_state.register(self.http_server_handle, next_event_id, &sock)?;
 
         self.connecting.insert(next_event_id, (sock, Some(data_url), request));
         Ok(next_event_id)
@@ -169,20 +156,10 @@ impl HttpPeer {
         Ok(())
     }
 
-    /// remove a socket from our poller
-    fn deregister_socket(&mut self, socket: mio_net::TcpStream) -> () {
-        match self.network {
-            Some(ref mut network) => {
-                let _ = network.deregister(&socket);
-            }
-            None => {}
-        }
-    }
-
     /// Low-level method to register a socket/event pair on the p2p network interface.
     /// Call only once the socket is connected (called once the socket triggers ready).
     /// Will destroy the socket if we can't register for whatever reason.
-    fn register_http(&mut self, event_id: usize, socket: mio_net::TcpStream, outbound_url: Option<UrlString>, initial_request: Option<HttpRequestType>) -> Result<(), net_error> {
+    fn register_http(&mut self, network_state: &mut NetworkState, event_id: usize, socket: mio_net::TcpStream, outbound_url: Option<UrlString>, initial_request: Option<HttpRequestType>) -> Result<(), net_error> {
         let client_addr = match socket.peer_addr() {
             Ok(addr) => addr,
             Err(e) => {
@@ -194,7 +171,7 @@ impl HttpPeer {
         match self.can_register_http(&client_addr, outbound_url.as_ref()) {
             Ok(_) => {},
             Err(e) => {
-                self.deregister_socket(socket);
+                let _ = network_state.deregister(event_id, &socket);
                 return Err(e);
             }
         }
@@ -213,7 +190,7 @@ impl HttpPeer {
             match new_convo.send_request(request) {
                 Ok(_) => {},
                 Err(e) => {
-                    self.deregister_socket(socket);
+                    let _ = network_state.deregister(event_id, &socket);
                     return Err(e);
                 }
             }
@@ -225,26 +202,21 @@ impl HttpPeer {
     }
     
     /// Deregister a socket/event pair
-    pub fn deregister_http(&mut self, event_id: usize) -> () {
+    pub fn deregister_http(&mut self, network_state: &mut NetworkState, event_id: usize) -> () {
         if self.peers.contains_key(&event_id) {
             // kill the conversation
             self.peers.remove(&event_id);
         }
 
         let mut to_remove : Vec<usize> = vec![];
-        match self.network {
+        match self.sockets.get_mut(&event_id) {
             None => {},
-            Some(ref mut network) => {
-                match self.sockets.get_mut(&event_id) {
-                    None => {},
-                    Some(ref sock) => {
-                        let _ = network.deregister(sock);
-                        to_remove.push(event_id);   // force it to close anyway
-                    }
-                }
+            Some(ref sock) => {
+                let _ = network_state.deregister(event_id, sock);
+                to_remove.push(event_id);   // force it to close anyway
             }
         }
-
+        
         for event_id in to_remove {
             // remove socket
             self.sockets.remove(&event_id);
@@ -253,7 +225,7 @@ impl HttpPeer {
     }
     
     /// Remove slow/unresponsive peers
-    fn disconnect_unresponsive(&mut self) -> () {
+    fn disconnect_unresponsive(&mut self, network_state: &mut NetworkState) -> () {
         let now = get_epoch_time_secs();
         let mut to_remove = vec![];
         for (event_id, convo) in self.peers.iter() {
@@ -277,13 +249,13 @@ impl HttpPeer {
         }
 
         for event_id in to_remove.drain(0..) {
-            self.deregister_http(event_id);
+            self.deregister_http(network_state, event_id);
         }
     }
     
     /// Process new inbound HTTP connections we just accepted.
     /// Returns the event IDs of sockets we need to register
-    fn process_new_sockets(&mut self, poll_state: &mut NetworkPollState) -> Result<Vec<usize>, net_error> {
+    fn process_new_sockets(&mut self, network_state: &mut NetworkState, poll_state: &mut NetworkPollState) -> Result<Vec<usize>, net_error> {
         let mut registered = vec![];
 
         for (event_id, client_sock) in poll_state.new.drain() {
@@ -292,18 +264,11 @@ impl HttpPeer {
                 continue;
             }
 
-            match self.network {
-                Some(ref mut network) => {
-                    if let Err(_e) = network.register(event_id, &client_sock) {
-                        continue;
-                    }
-                },
-                None => {
-                    test_debug!("HTTP not connected");
-                    return Err(net_error::NotConnected);
-                }
+            if let Err(_e) = network_state.register(self.http_server_handle, event_id, &client_sock) {
+                continue;
             }
-            if let Err(_e) = self.register_http(event_id, client_sock, None, None) {
+
+            if let Err(_e) = self.register_http(network_state, event_id, client_sock, None, None) {
                 continue;
             }
             registered.push(event_id);
@@ -366,13 +331,13 @@ impl HttpPeer {
     }
 
     /// Process newly-connected sockets
-    fn process_connecting_sockets(&mut self, poll_state: &mut NetworkPollState) -> () {
+    fn process_connecting_sockets(&mut self, network_state: &mut NetworkState, poll_state: &mut NetworkPollState) -> () {
         for event_id in poll_state.ready.iter() {
             if self.connecting.contains_key(event_id) {
                 let (socket, data_url, initial_request_opt) = self.connecting.remove(event_id).unwrap();
                 debug!("Event {} connected ({:?})", event_id, &data_url);
 
-                if let Err(_e) = self.register_http(*event_id, socket, data_url.clone(), initial_request_opt) {
+                if let Err(_e) = self.register_http(network_state, *event_id, socket, data_url.clone(), initial_request_opt) {
                     debug!("Failed to register HTTP connection ({}, {:?})", event_id, data_url);
                 }
             }
@@ -493,34 +458,30 @@ impl HttpPeer {
     /// -- receive data on ready sockets
     /// -- clear out timed-out requests
     /// Returns the list of messages to forward along to the peer network.
-    fn dispatch_network(&mut self, new_chain_view: BurnchainView, burndb: &mut BurnDB, peerdb: &mut PeerDB,
-                        chainstate: &mut StacksChainState, mempool: &mut MemPoolDB, mut poll_state: NetworkPollState) -> Result<Vec<StacksMessageType>, net_error> {
-        if self.network.is_none() {
-            test_debug!("HTTP not connected");
-            return Err(net_error::NotConnected);
-        }
+    pub fn run(&mut self, network_state: &mut NetworkState, new_chain_view: BurnchainView, burndb: &mut BurnDB, peerdb: &mut PeerDB,
+               chainstate: &mut StacksChainState, mempool: &mut MemPoolDB, mut poll_state: NetworkPollState) -> Result<Vec<StacksMessageType>, net_error> {
 
         // update burnchain snapshot
         self.chain_view = new_chain_view;
 
         // set up new inbound conversations
-        self.process_new_sockets(&mut poll_state)?;
+        self.process_new_sockets(network_state, &mut poll_state)?;
 
         // set up connected sockets
-        self.process_connecting_sockets(&mut poll_state);
+        self.process_connecting_sockets(network_state, &mut poll_state);
 
         // run existing conversations, clear out broken ones, and get back messages forwarded to us
         let (stacks_msgs, error_events) = self.process_ready_sockets(&mut poll_state, burndb, peerdb, chainstate, mempool);
         for error_event in error_events {
             debug!("Failed HTTP connection on event {}", error_event);
-            self.deregister_http(error_event);
+            self.deregister_http(network_state, error_event);
         }
 
         // move conversations along
         let close_events = self.flush_conversations(chainstate);
         for close_event in close_events {
             debug!("Close HTTP connection on event {}", close_event);
-            self.deregister_http(close_event);
+            self.deregister_http(network_state, close_event);
         }
 
         // remove timed-out requests 
@@ -529,35 +490,17 @@ impl HttpPeer {
         }
         
         // clear out slow or non-responsive peers
-        self.disconnect_unresponsive();
+        self.disconnect_unresponsive(network_state);
 
         // send out any queued messages.
         // this has the intentional side-effect of activating some sockets as writeable.
         let error_outbound_events = self.send_outbound_messages();
         for error_event in error_outbound_events {
             debug!("Failed HTTP connection on event {}", error_event);
-            self.deregister_http(error_event);
+            self.deregister_http(network_state, error_event);
         }
      
         Ok(stacks_msgs)
-    }
-
-    /// Top-level main-loop circuit to take for http server and clients.
-    /// -- polls the http server state to get new sockets and detect ready sockets
-    /// -- carries out http network conversations
-    pub fn run(&mut self, new_chain_view: BurnchainView, burndb: &mut BurnDB, peerdb: &mut PeerDB,
-               chainstate: &mut StacksChainState, mempool: &mut MemPoolDB, poll_timeout: u64) -> Result<Vec<StacksMessageType>, net_error> {
-        let poll_state = match self.network {
-            None => {
-                test_debug!("HTTP not connected");
-                Err(net_error::NotConnected)
-            },
-            Some(ref mut network) => {
-                network.poll(poll_timeout)
-            }
-        }?;
-
-        self.dispatch_network(new_chain_view, burndb, peerdb, chainstate, mempool, poll_state)
     }
 }
 


### PR DESCRIPTION
This fixes #1416 and #1423.  Now, calling `PeerNetwork::run()` will poll readiness on both the p2p and http server sockets and their clients.  Interacting with the RESTful API should be noticeably faster.