### PR TITLE
Fix/net edge triggers and burnchain neon fixes

### DIFF
--- a/src/burnchains/bitcoin/indexer.rs
+++ b/src/burnchains/bitcoin/indexer.rs
@@ -492,7 +492,7 @@ impl BitcoinIndexer {
                 db_height - REORG_BATCH_SIZE
             };
 
-        while start_block > 0 && !found {
+        while !found {
             debug!("Search for reorg'ed headers from {} - {}", start_block, start_block + REORG_BATCH_SIZE);
 
             // copy over the head of the existing headers so we can fetch to the .reorg file
@@ -532,8 +532,10 @@ impl BitcoinIndexer {
                     error!("Failed to read reorg headers from {} to {}", start_block, start_block + REORG_BATCH_SIZE);
                     e
                 })?;
-              
-            for i in (start_block..(start_block + REORG_BATCH_SIZE)).rev() {
+            
+            let max_headers_len = if canonical_headers.len() < reorg_headers.len() { canonical_headers.len() } else { reorg_headers.len() };
+            let max_height = start_block + (max_headers_len as u64);
+            for i in (start_block..max_height).rev() {
                 if canonical_headers[(i - start_block) as usize] == reorg_headers[(i - start_block) as usize] {
                     // shared history 
                     new_tip = i + 1;
@@ -542,7 +544,11 @@ impl BitcoinIndexer {
                 }
             }
 
-            start_block -= REORG_BATCH_SIZE;
+            if start_block == 0 {
+                break;
+            }
+
+            start_block = start_block.saturating_sub(REORG_BATCH_SIZE);
         }
 
         debug!("Chain history is consistent up to {}", new_tip);

--- a/src/burnchains/bitcoin/network.rs
+++ b/src/burnchains/bitcoin/network.rs
@@ -226,14 +226,15 @@ impl BitcoinIndexer {
                             // need to try again
                             backoff = 2.0 * backoff + (backoff * rng.gen_range(0.0, 1.0));
                         }
-                        Err(_) => {
+                        Err(e) => {
                             // propagate other network error
-                            return handshake_result;
+                            warn!("Failed to handshake with {}:{}: {:?}", &self.config.peer_host, self.config.peer_port, &e);
+                            return Err(e);
                         }
                     }
                 }
                 Err(err_msg) => {
-                    error!("Failed to connect to peer: {}", err_msg);
+                    error!("Failed to connect to peer {}:{}: {}", &self.config.peer_host, self.config.peer_port, err_msg);
                     backoff = 2.0 * backoff + (backoff * rng.gen_range(0.0, 1.0));
                 }
             }

--- a/src/burnchains/bitcoin/spv.rs
+++ b/src/burnchains/bitcoin/spv.rs
@@ -422,6 +422,11 @@ impl BitcoinMessageHandler for SpvClient {
         let start_height = self.cur_block_height;
         self.end_block_height = Some(indexer.runtime.block_height);
 
+        if indexer.runtime.block_height <= start_height {
+            debug!("Have all headers up to {}", start_height);
+            return Ok(false);
+        }
+
         debug!("Get headers {}-{}", self.cur_block_height, self.end_block_height.unwrap());
         self.send_next_getheaders(indexer, start_height).and_then(|_r| Ok(true))
     }

--- a/src/burnchains/burnchain.rs
+++ b/src/burnchains/burnchain.rs
@@ -90,6 +90,14 @@ use burnchains::bitcoin::indexer::FIRST_BLOCK_TESTNET as BITCOIN_FIRST_BLOCK_TES
 use burnchains::bitcoin::indexer::FIRST_BLOCK_REGTEST as BITCOIN_FIRST_BLOCK_REGTEST;
 
 impl BurnchainStateTransition {
+    pub fn noop() -> BurnchainStateTransition {
+        BurnchainStateTransition {
+            burn_dist: vec![],
+            accepted_ops: vec![],
+            consumed_leader_keys: vec![]
+        }
+    }
+
     pub fn from_block_ops<'a>(tx: &mut BurnDBTx<'a>, parent_snapshot: &BlockSnapshot, block_ops: &Vec<BlockstackOperationType>) -> Result<BurnchainStateTransition, burnchain_error> {
         // block commits and support burns discovered in this block.
         let mut block_commits: Vec<LeaderBlockCommitOp> = vec![];
@@ -729,7 +737,7 @@ impl Burnchain {
             })?;
         
         if new_height < db_height {
-            warn!("Detected burnchain reorg at height {}. Re-sync'ing...", new_height);
+            warn!("Detected burnchain reorg at height {} (< {}). Re-sync'ing...", new_height, db_height);
 
             // drop associated headers as well 
             indexer.drop_headers(&headers_path, new_height)?;

--- a/src/chainstate/burn/db/burndb.rs
+++ b/src/chainstate/burn/db/burndb.rs
@@ -2326,6 +2326,7 @@ mod tests {
         };
 
         first_snapshot.index_root = initial_snapshot.index_root.clone();
+        first_snapshot.burn_header_timestamp = initial_snapshot.burn_header_timestamp;
         assert_eq!(initial_snapshot, first_snapshot);
 
         {
@@ -2346,6 +2347,7 @@ mod tests {
         };
 
         next_snapshot.index_root = initial_snapshot.index_root.clone();
+        next_snapshot.burn_header_timestamp = initial_snapshot.burn_header_timestamp;
         assert_eq!(initial_snapshot, next_snapshot);
 
         {
@@ -2366,6 +2368,7 @@ mod tests {
         };
 
         snapshot_with_sortition.index_root = next_snapshot_2.index_root.clone();
+        snapshot_with_sortition.burn_header_timestamp = next_snapshot_2.burn_header_timestamp;
         assert_eq!(snapshot_with_sortition, next_snapshot_2);
     }
 

--- a/src/net/chat.rs
+++ b/src/net/chat.rs
@@ -1064,7 +1064,7 @@ impl ConversationP2P {
                     }
                 },
                 Err(e) => {
-                    info!("{:?}: failed to recv: {:?}", self, &e);
+                    info!("{:?}: failed to recv on P2P conversation: {:?}", self, &e);
                     return Err(e);
                 }
             }
@@ -1093,7 +1093,7 @@ impl ConversationP2P {
                     }
                 },
                 Err(e) => {
-                    info!("{:?}: failed to send: {:?}", self, &e);
+                    info!("{:?}: failed to send on P2P conversation: {:?}", self, &e);
                     return Err(e);
                 }
             }

--- a/src/net/chat.rs
+++ b/src/net/chat.rs
@@ -637,12 +637,14 @@ impl ConversationP2P {
     /// returned Write to finish sending.
     pub fn relay_signed_message(&mut self, msg: StacksMessage) -> Result<ReplyHandleP2P, net_error> {
         let _name = msg.get_message_name();
+        let _seq = msg.request_id();
+        
         let mut handle = self.connection.make_relay_handle()?;
         msg.consensus_serialize(&mut handle)?;
 
         self.stats.msgs_tx += 1;
         
-        test_debug!("{:?}: relay-send({}) {}", &self, self.stats.msgs_tx, _name);
+        debug!("{:?}: relay-send({}) {} seq {}", &self, self.stats.msgs_tx, _name, _seq);
         Ok(handle)
     }
     
@@ -651,13 +653,14 @@ impl ConversationP2P {
     /// returned handle to finish sending.
     pub fn send_signed_request(&mut self, msg: StacksMessage, ttl: u64) -> Result<ReplyHandleP2P, net_error> {
         let _name = msg.get_message_name();
+        let _seq = msg.request_id();
 
         let mut handle = self.connection.make_request_handle(msg.request_id(), ttl)?;
         msg.consensus_serialize(&mut handle)?;
 
         self.stats.msgs_tx += 1;
 
-        test_debug!("{:?}: request-send({}) {}", &self, self.stats.msgs_tx, _name);
+        debug!("{:?}: request-send({}) {} seq {}", &self, self.stats.msgs_tx, _name, _seq);
         Ok(handle)
     }
 
@@ -770,8 +773,8 @@ impl ConversationP2P {
         let updated = self.update_from_handshake_data(&message.preamble, &handshake_data)?;
         let _authentic_msg = if !updated { "same" } else if old_pubkey_opt.is_none() { "new" } else { "upgraded" };
 
-        test_debug!("Handshake from {:?} {} public key {:?} expires at {:?}", &self, _authentic_msg,
-                    &to_hex(&handshake_data.node_public_key.to_public_key().unwrap().to_bytes_compressed()), handshake_data.expire_block_height);
+        debug!("Handshake from {:?} {} public key {:?} expires at {:?}", &self, _authentic_msg,
+               &to_hex(&handshake_data.node_public_key.to_public_key().unwrap().to_bytes_compressed()), handshake_data.expire_block_height);
 
         if updated {
             // save the new key
@@ -780,7 +783,7 @@ impl ConversationP2P {
             neighbor.save_update(&mut tx)?;
             tx.commit().map_err(|e| net_error::DBError(db_error::SqliteError(e)))?;
             
-            test_debug!("{:?}: Re-key {:?} to {:?} expires {}", local_peer, &neighbor.addr, &to_hex(&neighbor.public_key.to_bytes_compressed()), neighbor.expire_block);
+            debug!("{:?}: Re-key {:?} to {:?} expires {}", local_peer, &neighbor.addr, &to_hex(&neighbor.public_key.to_bytes_compressed()), neighbor.expire_block);
         }
 
         let accept_data = HandshakeAcceptData::new(local_peer, self.heartbeat);
@@ -799,8 +802,8 @@ impl ConversationP2P {
         self.peer_heartbeat = handshake_accept.heartbeat_interval;
         self.stats.last_handshake_time = get_epoch_time_secs();
 
-        test_debug!("HandshakeAccept from {:?}: set public key to {:?} expiring at {:?} heartbeat {}s", &self,
-                    &to_hex(&handshake_accept.handshake.node_public_key.to_public_key().unwrap().to_bytes_compressed()), handshake_accept.handshake.expire_block_height, self.peer_heartbeat);
+        debug!("HandshakeAccept from {:?}: set public key to {:?} expiring at {:?} heartbeat {}s", &self,
+               &to_hex(&handshake_accept.handshake.node_public_key.to_public_key().unwrap().to_bytes_compressed()), handshake_accept.handshake.expire_block_height, self.peer_heartbeat);
         Ok(())
     }
     
@@ -832,7 +835,7 @@ impl ConversationP2P {
             .map(|n| NeighborAddress::from_neighbor(n))
             .collect();
         
-        test_debug!("{:?}: handle GetNeighbors from {:?}. Reply with {} neighbors", &local_peer, &self, neighbor_addrs.len());
+        debug!("{:?}: handle GetNeighbors from {:?}. Reply with {} neighbors", &local_peer, &self, neighbor_addrs.len());
 
         let payload = StacksMessageType::Neighbors( NeighborsData { neighbors: neighbor_addrs } );
         let reply = self.sign_reply(chain_view, &local_peer.private_key, payload, preamble.seq)?;
@@ -874,7 +877,7 @@ impl ConversationP2P {
 
         let blocks_inv_data : BlocksInvData = chainstate.get_blocks_inventory(&block_hashes).map_err(|e| net_error::from(e))?;
 
-        test_debug!("{:?}: Reply {:?} to request {:?}", &local_peer, &blocks_inv_data, get_blocks_inv);
+        debug!("{:?}: Handle GetBlocksInv from {:?}. Reply {:?} to request {:?}", &local_peer, &self, &blocks_inv_data, get_blocks_inv);
 
         let blocks_inv_payload = StacksMessageType::BlocksInv(blocks_inv_data);
         self.sign_and_reply(local_peer, burnchain_view, preamble, blocks_inv_payload)
@@ -1046,32 +1049,57 @@ impl ConversationP2P {
 
     /// Load data into our connection 
     pub fn recv<R: Read>(&mut self, r: &mut R) -> Result<usize, net_error> {
-        let res = self.connection.recv_data(r);
-        match res {
-            Ok(num_recved) => {
-                if num_recved > 0 {
-                    self.stats.last_recv_time = get_epoch_time_secs();
-                    self.stats.bytes_rx += num_recved as u64;
+        let mut total_recved = 0;
+        loop {
+            let res = self.connection.recv_data(r);
+            match res {
+                Ok(num_recved) => {
+                    total_recved += num_recved;
+                    if num_recved > 0 {
+                        self.stats.last_recv_time = get_epoch_time_secs();
+                        self.stats.bytes_rx += num_recved as u64;
+                    }
+                    else {
+                        break;
+                    }
+                },
+                Err(e) => {
+                    info!("{:?}: failed to recv: {:?}", self, &e);
+                    return Err(e);
                 }
-            },
-            Err(_) => {}
-        };
-        res
+            }
+        }
+        debug!("{:?}: received {} bytes", self, total_recved);
+        Ok(total_recved)
     }
 
     /// Write data out of our conversation 
     pub fn send<W: Write>(&mut self, w: &mut W) -> Result<usize, net_error> {
-        let res = self.connection.send_data(w);
-        match res {
-            Ok(num_sent) => {
-                if num_sent > 0 {
-                    self.stats.last_send_time = get_epoch_time_secs();
-                    self.stats.bytes_tx += num_sent as u64;
+        let mut total_sent = 0;
+        loop {
+            // queue next byte slice
+            self.try_flush()?;
+
+            let res = self.connection.send_data(w);
+            match res {
+                Ok(num_sent) => {
+                    total_sent += num_sent;
+                    if num_sent > 0 {
+                        self.stats.last_send_time = get_epoch_time_secs();
+                        self.stats.bytes_tx += num_sent as u64;
+                    }
+                    else {
+                        break;
+                    }
+                },
+                Err(e) => {
+                    info!("{:?}: failed to send: {:?}", self, &e);
+                    return Err(e);
                 }
-            },
-            Err(_) => {}
-        };
-        res
+            }
+        }
+        debug!("{:?}: sent {} bytes", self, total_sent);
+        Ok(total_sent)
     }
 
     /// Make progress on in-flight messages.
@@ -1291,6 +1319,7 @@ impl ConversationP2P {
             
             let now = get_epoch_time_secs();
             let _msgtype = msg.payload.get_message_name().to_owned();
+            let _seq = msg.request_id();
 
             if update_stats {
                 // successfully got a message -- update stats
@@ -1315,28 +1344,30 @@ impl ConversationP2P {
                 // got an unhandled message we didn't ask for
                 self.stats.msgs_rx_unsolicited += 1;
             }
+            
+            debug!("{:?}: Received message {}", &self, _msgtype);
 
             // Is there someone else waiting for this message?  If so, pass it along.
             let fulfill_opt = self.connection.fulfill_request(msg);
             match fulfill_opt {
                 None => {
-                    test_debug!("{:?}: Fulfilled pending message request (type {})", &self, _msgtype);
+                    debug!("{:?}: Fulfilled pending message request (type {} seq {})", &self, _msgtype, _seq);
                 },
                 Some(msg) => {
                     if consumed {
                         // already handled
-                        test_debug!("{:?}: Consumed message (type {})", &self, _msgtype);
+                        debug!("{:?}: Consumed message (type {} seq {})", &self, _msgtype, _seq);
                     }
                     else {
-                        test_debug!("{:?}: Try handling message (type {})", &self, _msgtype);
+                        test_debug!("{:?}: Try handling message (type {} seq {})", &self, _msgtype, _seq);
                         let msg_opt = self.handle_data_message(local_peer, peerdb, burndb, chainstate, burnchain_view, msg)?;
                         match msg_opt {
                             Some(msg) => {
-                                test_debug!("{:?}: Did not handle message (type {}); passing upstream", &self, _msgtype);
+                                debug!("{:?}: Did not handle message (type {} seq {}); passing upstream", &self, _msgtype, _seq);
                                 unsolicited.push(msg);
                             },
                             None => {
-                                test_debug!("{:?}: Handled message {}", &self, _msgtype);
+                                debug!("{:?}: Handled message {} seq {}", &self, _msgtype, _seq);
                             }
                         }
                     }

--- a/src/net/connection.rs
+++ b/src/net/connection.rs
@@ -106,29 +106,37 @@ impl<P: ProtocolFamily> ReceiverNotify<P> {
 pub struct NetworkReplyHandle<P: ProtocolFamily> {
     receiver_output: Option<Receiver<P::Message>>,
     request_pipe_write: Option<PipeWrite>,        // caller feeds in the message via this pipe endpoint.  Set to None on flush
-    deadline: u64
+    deadline: u64,
+    socket_event_id: usize
 }
 
 impl<P: ProtocolFamily> NetworkReplyHandle<P> {
-    pub fn new(output: Receiver<P::Message>, write: PipeWrite) -> NetworkReplyHandle<P> {
+    pub fn new(output: Receiver<P::Message>, write: PipeWrite, socket_event_id: usize) -> NetworkReplyHandle<P> {
         NetworkReplyHandle {
             receiver_output: Some(output),
             request_pipe_write: Some(write),
-            deadline: 0
+            deadline: 0,
+            socket_event_id: socket_event_id
         }
     }
 
-    pub fn new_relay(write: PipeWrite) -> NetworkReplyHandle<P> {
+    pub fn new_relay(write: PipeWrite, socket_event_id: usize) -> NetworkReplyHandle<P> {
         NetworkReplyHandle {
             receiver_output: None,
             request_pipe_write: Some(write),
-            deadline: 0
+            deadline: 0,
+            socket_event_id: socket_event_id
         }
     }
 
     /// deadline is in seconds
     pub fn set_deadline(&mut self, dl: u64) -> () {
         self.deadline = dl;
+    }
+
+    /// Get the associated socket event ID hint
+    pub fn get_event_id(&self) -> usize {
+        self.socket_event_id
     }
 
     /// Try to flush and receive.
@@ -195,12 +203,16 @@ impl<P: ProtocolFamily> NetworkReplyHandle<P> {
         match self.receiver_output {
             Some(ref mut output) => {
                 if timeout < 0 {
-                    output.recv()
-                        .map_err(|_e| net_error::ConnectionBroken)
+                    output.recv().map_err(|_e| {
+                        debug!("recv error: {:?}", &_e);
+                        net_error::ConnectionBroken
+                    })
                 }
                 else {
-                    output.recv_timeout(Duration::new(timeout as u64, 0))
-                        .map_err(|_e| net_error::ConnectionBroken)
+                    output.recv_timeout(Duration::new(timeout as u64, 0)).map_err(|_e| {
+                        debug!("recv timeout error: {:?}", &_e);
+                        net_error::ConnectionBroken
+                    })
                 }
             },
             None => {
@@ -1060,7 +1072,7 @@ impl<P: ProtocolFamily + Clone> NetworkConnection<P> {
                     continue;
                 }
                 Some(inflight) => {
-                    if inflight.ttl + get_epoch_time_secs() < now {
+                    if inflight.ttl < now {
                         // expired
                         debug!("Request timed out: seq={} ttl={} now={}", inflight.expected_seq, inflight.ttl, now); 
                         to_remove.push(i);
@@ -1084,13 +1096,13 @@ impl<P: ProtocolFamily + Clone> NetworkConnection<P> {
     /// Caller will need to write the message bytes into the resulting NetworkReplyHandle, and call
     /// flush() on it to make sure the data gets written out to the socket.
     /// ttl is in seconds
-    pub fn make_request_handle(&mut self, request_id: u32, ttl: u64) -> Result<NetworkReplyHandle<P>, net_error> {
+    pub fn make_request_handle(&mut self, request_id: u32, timeout: u64, socket_event_id: usize) -> Result<NetworkReplyHandle<P>, net_error> {
         let (send_ch, recv_ch) = sync_channel(1);
-        let recv_notify = ReceiverNotify::new(request_id, send_ch, ttl);
+        let recv_notify = ReceiverNotify::new(request_id, send_ch, timeout + get_epoch_time_secs());
         
         let (pipe_read, pipe_write) = Pipe::new();
-        let mut recv_handle = NetworkReplyHandle::new(recv_ch, pipe_write);
-        recv_handle.set_deadline(ttl + get_epoch_time_secs());
+        let mut recv_handle = NetworkReplyHandle::new(recv_ch, pipe_write, socket_event_id);
+        recv_handle.set_deadline(timeout + get_epoch_time_secs());
 
         self.outbox.queue_message(pipe_read, Some(recv_notify))?;
         Ok(recv_handle)
@@ -1098,11 +1110,11 @@ impl<P: ProtocolFamily + Clone> NetworkConnection<P> {
 
     /// Forward a message and expect no reply
     /// Returns a Write-able handle into which the message should be written, and flushed.
-    pub fn make_relay_handle(&mut self) -> Result<NetworkReplyHandle<P>, net_error> {
+    pub fn make_relay_handle(&mut self, socket_event_id: usize) -> Result<NetworkReplyHandle<P>, net_error> {
         let (pipe_read, pipe_write) = Pipe::new();
         self.outbox.queue_message(pipe_read, None)?;
 
-        let send_handle = NetworkReplyHandle::new_relay(pipe_write);
+        let send_handle = NetworkReplyHandle::new_relay(pipe_write, socket_event_id);
         Ok(send_handle)
     }
 
@@ -1209,7 +1221,7 @@ mod test {
 
         let mut pipes = vec![]; // keep pipes in-scope
         for i in 0..conn.options.outbox_maxlen {
-            let pipe = conn.make_relay_handle().unwrap();
+            let pipe = conn.make_relay_handle(0).unwrap();
             pipes.push(pipe);
         }
         
@@ -1357,7 +1369,7 @@ mod test {
 
         let mut handles = vec![]; // keep pipes in-scope
         for i in 0..conn.options.outbox_maxlen {
-            let handle = conn.make_request_handle(messages[i].request_id(), get_epoch_time_secs() + 60).unwrap();
+            let handle = conn.make_request_handle(messages[i].request_id(), 60, 0).unwrap();
             handles.push(handle);
         }
         
@@ -1552,7 +1564,7 @@ mod test {
         let mut pipes = vec![]; // keep pipes in-scope
         for i in 0..5 {
             test_debug!("Write ping {}", i);
-            let mut pipe = conn.make_relay_handle().unwrap();
+            let mut pipe = conn.make_relay_handle(0).unwrap();
             ping.consensus_serialize(&mut pipe).unwrap();
             pipes.push(pipe);
         }
@@ -1704,7 +1716,7 @@ mod test {
                 tmp.len()
             };
 
-            let mut pipe = conn.make_relay_handle().unwrap();
+            let mut pipe = conn.make_relay_handle(0).unwrap();
             ping.consensus_serialize(&mut pipe).unwrap();
             pipes.push(pipe);
             ping_vec.push(ping);
@@ -1795,7 +1807,7 @@ mod test {
                 tmp.len()
             };
 
-            let mut handle = conn.make_request_handle(ping.request_id(), get_epoch_time_secs() + 60).unwrap();
+            let mut handle = conn.make_request_handle(ping.request_id(), 60, 0).unwrap();
             ping.consensus_serialize(&mut handle).unwrap();
 
             handle_vec.push(handle);
@@ -1900,7 +1912,7 @@ mod test {
             };
            
             // 1-second timeout
-            let mut handle = conn.make_request_handle(ping.request_id(), get_epoch_time_secs() + 1).unwrap();
+            let mut handle = conn.make_request_handle(ping.request_id(), 1, 0).unwrap();
             ping.consensus_serialize(&mut handle).unwrap();
 
             handle_vec.push(handle);

--- a/src/net/connection.rs
+++ b/src/net/connection.rs
@@ -139,6 +139,11 @@ impl<P: ProtocolFamily> NetworkReplyHandle<P> {
         self.socket_event_id
     }
 
+    /// Are we expecting a reply?
+    pub fn expects_reply(&self) -> bool {
+        self.receiver_output.is_some()
+    }
+
     /// Try to flush and receive.
     /// Only call this once all sender data is bufferred up.
     /// Consumed the handle if it succeeds in both emptying the message buffer and getting a message.

--- a/src/net/download.rs
+++ b/src/net/download.rs
@@ -192,7 +192,7 @@ pub struct BlockDownloader {
 impl BlockDownloader {
     pub fn new(dns_timeout: u128, max_inflight_requests: u64) -> BlockDownloader {
         BlockDownloader {
-            state: BlockDownloaderState::GetBlocksBegin,
+            state: BlockDownloaderState::DNSLookupBegin,
 
             block_sortition_height: 0,
             microblock_sortition_height: 0,
@@ -348,13 +348,13 @@ impl BlockDownloader {
         for (block_key, event_id) in self.getblock_requests.drain() {
             match http.get_conversation(event_id) {
                 None => {
-                    debug!("Event {} ({:?}, {:?} for block {}) is not connected", &block_key.neighbor, &block_key.data_url, &block_key.index_block_hash, event_id);
-                    self.dead_peers.push(event_id);
+                    debug!("Event {} ({:?}, {:?} for block {}) is not connected yet", &block_key.neighbor, &block_key.data_url, &block_key.index_block_hash, event_id);
+                    pending_block_requests.insert(block_key, event_id);
                 }
                 Some(ref mut convo) => match convo.try_get_response() {
                     None => {
                         // still waiting
-                        debug!("Event {} ({:?}, {:?} for block {}) is still waiting for a response", &block_key.neighbor, &block_key.data_url, &block_key.index_block_hash, event_id);
+                        debug!("Event {} ({:?}, {:?} for block {}) is still waiting for a response", event_id, &block_key.neighbor, &block_key.data_url, &block_key.index_block_hash);
                         pending_block_requests.insert(block_key, event_id);
                     },
                     Some(http_response) => match http_response {
@@ -1020,17 +1020,18 @@ impl PeerNetwork {
         })
     }
 
-    fn connect_or_send_http_request(&mut self, data_url: UrlString, addr: SocketAddr, request: HttpRequestType) -> Result<usize, net_error> {
+    fn connect_or_send_http_request(&mut self, data_url: UrlString, addr: SocketAddr, request: HttpRequestType, chainstate: &mut StacksChainState) -> Result<usize, net_error> {
         PeerNetwork::with_network_state(self, |ref mut network, ref mut network_state| {
             match network.http.connect_http(network_state, data_url.clone(), addr.clone(), Some(request.clone())) {
                 Ok(event_id) => Ok(event_id),
                 Err(net_error::AlreadyConnected(event_id)) => {
-                    match network.http.get_conversation(event_id) {
-                        Some(ref mut convo) => {
+                    match network.http.get_conversation_and_socket(event_id) {
+                        (Some(ref mut convo), Some(ref mut socket)) => {
                             convo.send_request(request)?;
+                            HttpPeer::saturate_socket(socket, convo, chainstate)?;
                             Ok(event_id)
                         },
-                        None => {
+                        (_, _) => {
                             debug!("HTTP failed to connect to {:?}, {:?}", &data_url, &addr);
                             Err(net_error::PeerNotConnected)
                         }
@@ -1047,7 +1048,7 @@ impl PeerNetwork {
     /// create the HTTP request.  Pops requests off the front of request_keys, and returns once it successfully
     /// sends out a request via the HTTP peer.  Returns the event ID in the http peer that's
     /// handling the request.
-    fn begin_request<F>(network: &mut PeerNetwork, dns_lookups: &HashMap<UrlString, Option<Vec<SocketAddr>>>, request_name: &str, request_keys: &mut VecDeque<BlockRequestKey>, request_factory: F) -> Option<(BlockRequestKey, usize)> 
+    fn begin_request<F>(network: &mut PeerNetwork, dns_lookups: &HashMap<UrlString, Option<Vec<SocketAddr>>>, request_name: &str, request_keys: &mut VecDeque<BlockRequestKey>, chainstate: &mut StacksChainState, request_factory: F) -> Option<(BlockRequestKey, usize)> 
     where
         F: Fn(PeerHost, BlockHeaderHash) -> HttpRequestType
     {
@@ -1067,7 +1068,7 @@ impl PeerNetwork {
 
                         for addr in sockaddrs.iter() {
                             let request = request_factory(peerhost.clone(), key.index_block_hash.clone());
-                            match network.connect_or_send_http_request(key.data_url.clone(), addr.clone(), request) {
+                            match network.connect_or_send_http_request(key.data_url.clone(), addr.clone(), request, chainstate) {
                                 Ok(handle) => {
                                     debug!("{:?}: Begin HTTP request for {} {} to {:?} ({:?})", &network.local_peer, request_name, &key.index_block_hash, &key.neighbor, &key.data_url);
                                     return Some((key, handle));
@@ -1095,7 +1096,7 @@ impl PeerNetwork {
 
 
     /// Start fetching blocks
-    pub fn block_getblocks_begin(&mut self) -> Result<(), net_error> {
+    pub fn block_getblocks_begin(&mut self, chainstate: &mut StacksChainState) -> Result<(), net_error> {
         test_debug!("{:?}: block_getblocks_begin", &self.local_peer);
         PeerNetwork::with_downloader_state(self, |ref mut network, ref mut downloader| {
             let mut priority = PeerNetwork::prioritize_requests(&downloader.blocks_to_try);
@@ -1103,7 +1104,7 @@ impl PeerNetwork {
             for sortition_height in priority.drain(..) {
                 match downloader.blocks_to_try.get_mut(&sortition_height) {
                     Some(ref mut keys) => {
-                        match PeerNetwork::begin_request(network, &downloader.dns_lookups, "anchored block", keys, |peerhost, index_block_hash| HttpRequestType::GetBlock(HttpRequestMetadata::from_host(peerhost), index_block_hash)) {
+                        match PeerNetwork::begin_request(network, &downloader.dns_lookups, "anchored block", keys, chainstate, |peerhost, index_block_hash| HttpRequestType::GetBlock(HttpRequestMetadata::from_host(peerhost), index_block_hash)) {
                             Some((key, handle)) => {
                                 requests.insert(key.clone(), handle);
                             },
@@ -1130,7 +1131,7 @@ impl PeerNetwork {
     }
 
     /// Proceed to get microblocks 
-    pub fn block_getmicroblocks_begin(&mut self) -> Result<(), net_error> {
+    pub fn block_getmicroblocks_begin(&mut self, chainstate: &mut StacksChainState) -> Result<(), net_error> {
         test_debug!("{:?}: block_getmicroblocks_begin", &self.local_peer);
         PeerNetwork::with_downloader_state(self, |ref mut network, ref mut downloader| {
             let mut priority = PeerNetwork::prioritize_requests(&downloader.microblocks_to_try);
@@ -1138,7 +1139,7 @@ impl PeerNetwork {
             for sortition_height in priority.drain(..) {
                 match downloader.microblocks_to_try.get_mut(&sortition_height) {
                     Some(ref mut keys) => {
-                        match PeerNetwork::begin_request(network, &downloader.dns_lookups, "microblock stream", keys, |peerhost, index_block_hash| HttpRequestType::GetMicroblocksConfirmed(HttpRequestMetadata::from_host(peerhost), index_block_hash)) {
+                        match PeerNetwork::begin_request(network, &downloader.dns_lookups, "microblock stream", keys, chainstate, |peerhost, index_block_hash| HttpRequestType::GetMicroblocksConfirmed(HttpRequestMetadata::from_host(peerhost), index_block_hash)) {
                             Some((key, handle)) => {
                                 requests.insert(key.clone(), handle);
                             },
@@ -1175,7 +1176,7 @@ impl PeerNetwork {
         PeerNetwork::with_downloader_state(self, |ref mut network, ref mut downloader| {
             // extract blocks and microblocks downloaded
             for (request_key, block) in downloader.blocks.drain() {
-                test_debug!("Downloaded block {}/{} ({}) at sortition height {}", &request_key.burn_block_hash, &request_key.anchor_block_hash, &request_key.index_block_hash, request_key.sortition_height);
+                debug!("Downloaded block {}/{} ({}) at sortition height {}", &request_key.burn_block_hash, &request_key.anchor_block_hash, &request_key.index_block_hash, request_key.sortition_height);
                 blocks.push((request_key.burn_block_hash.clone(), block));
                 downloader.num_blocks_downloaded += 1;
 
@@ -1191,13 +1192,13 @@ impl PeerNetwork {
 
                 if StacksChainState::validate_parent_microblock_stream(&block_header, &child_block_header, &microblock_stream, true).is_some() {
                     // stream is valid!
-                    test_debug!("Downloaded valid microblock stream {}/{} at sortition height {}", &request_key.burn_block_hash, &request_key.anchor_block_hash, request_key.sortition_height);
+                    debug!("Downloaded valid microblock stream {}/{} at sortition height {}", &request_key.burn_block_hash, &request_key.anchor_block_hash, request_key.sortition_height);
                     microblocks.push((request_key.burn_block_hash.clone(), microblock_stream));
                     downloader.num_microblocks_downloaded += 1;
                 }
                 else {
                     // stream is not well-formed
-                    test_debug!("Microblock stream {:?}: {}/{} is invalid", request_key.sortition_height, &request_key.burn_block_hash, &request_key.anchor_block_hash);
+                    debug!("Microblock stream {:?}: {}/{} is invalid", request_key.sortition_height, &request_key.burn_block_hash, &request_key.anchor_block_hash);
                 }
 
                 // don't try again
@@ -1345,39 +1346,51 @@ impl PeerNetwork {
             }
         }
 
-        let dlstate = self.block_downloader.as_ref().unwrap().state;
         let mut done = false;
 
         let mut blocks = vec![];
         let mut microblocks = vec![];
 
-        match dlstate {
-            BlockDownloaderState::DNSLookupBegin => {
-                self.block_dns_lookups_begin(burndb, chainstate, dns_client)?;
-            },
-            BlockDownloaderState::DNSLookupFinish => {
-                self.block_dns_lookups_try_finish(dns_client)?;
-            },
-            BlockDownloaderState::GetBlocksBegin => {
-                self.block_getblocks_begin()?;
-            },
-            BlockDownloaderState::GetBlocksFinish => {
-                self.block_getblocks_try_finish()?;
-            },
-            BlockDownloaderState::GetMicroblocksBegin => {
-                self.block_getmicroblocks_begin()?;
-            },
-            BlockDownloaderState::GetMicroblocksFinish => {
-                self.block_getmicroblocks_try_finish()?;
-            },
-            BlockDownloaderState::Done => {
-                // did a pass.
-                // do we have more requests?
-                let (blocks_done, mut successful_blocks, mut successful_microblocks) = self.finish_downloads(burndb, chainstate)?;
+        let mut done_cycle = false;
+        while !done_cycle {
+            let dlstate = self.block_downloader.as_ref().unwrap().state;
+            debug!("{:?}: Download state is {:?}", &self.local_peer, &dlstate);
 
-                blocks.append(&mut successful_blocks);
-                microblocks.append(&mut successful_microblocks);
-                done = blocks_done;
+            match dlstate {
+                BlockDownloaderState::DNSLookupBegin => {
+                    self.block_dns_lookups_begin(burndb, chainstate, dns_client)?;
+                },
+                BlockDownloaderState::DNSLookupFinish => {
+                    self.block_dns_lookups_try_finish(dns_client)?;
+                },
+                BlockDownloaderState::GetBlocksBegin => {
+                    self.block_getblocks_begin(chainstate)?;
+                },
+                BlockDownloaderState::GetBlocksFinish => {
+                    self.block_getblocks_try_finish()?;
+                },
+                BlockDownloaderState::GetMicroblocksBegin => {
+                    self.block_getmicroblocks_begin(chainstate)?;
+                },
+                BlockDownloaderState::GetMicroblocksFinish => {
+                    self.block_getmicroblocks_try_finish()?;
+                },
+                BlockDownloaderState::Done => {
+                    // did a pass.
+                    // do we have more requests?
+                    let (blocks_done, mut successful_blocks, mut successful_microblocks) = self.finish_downloads(burndb, chainstate)?;
+
+                    blocks.append(&mut successful_blocks);
+                    microblocks.append(&mut successful_microblocks);
+                    done = blocks_done;
+
+                    done_cycle = true;
+                }
+            }
+        
+            let new_dlstate = self.block_downloader.as_ref().unwrap().state;
+            if new_dlstate == dlstate {
+                done_cycle = true;
             }
         }
 

--- a/src/net/download.rs
+++ b/src/net/download.rs
@@ -348,8 +348,14 @@ impl BlockDownloader {
         for (block_key, event_id) in self.getblock_requests.drain() {
             match http.get_conversation(event_id) {
                 None => {
-                    debug!("Event {} ({:?}, {:?} for block {}) is not connected yet", &block_key.neighbor, &block_key.data_url, &block_key.index_block_hash, event_id);
-                    pending_block_requests.insert(block_key, event_id);
+                    if http.is_connecting(event_id) {
+                        debug!("Event {} ({:?}, {:?} for block {} is not connected yet", &block_key.neighbor, &block_key.data_url, &block_key.index_block_hash, event_id);
+                        pending_block_requests.insert(block_key, event_id);
+                    }
+                    else {
+                        debug!("Event {} ({:?}, {:?} for block {} failed to connect", &block_key.neighbor, &block_key.data_url, &block_key.index_block_hash, event_id);
+                        self.dead_peers.push(event_id);
+                    }
                 }
                 Some(ref mut convo) => match convo.try_get_response() {
                     None => {
@@ -422,8 +428,14 @@ impl BlockDownloader {
             let rh_block_key = block_key.clone();
             match http.get_conversation(event_id) {
                 None => {
-                    debug!("Event {} ({:?}, {:?} for microblocks built by {:?}) is not connected", &block_key.neighbor, &block_key.data_url, &block_key.index_block_hash, event_id);
-                    self.dead_peers.push(event_id);
+                    if http.is_connecting(event_id) {
+                        debug!("Event {} ({:?}, {:?} for microblocks built by ({}) is not connected yet", &block_key.neighbor, &block_key.data_url, &block_key.index_block_hash, event_id);
+                        pending_microblock_requests.insert(block_key, event_id);
+                    }
+                    else {
+                        debug!("Event {} ({:?}, {:?} for microblocks built by ({}) failed to connect", &block_key.neighbor, &block_key.data_url, &block_key.index_block_hash, event_id);
+                        self.dead_peers.push(event_id);
+                    }
                 }
                 Some(ref mut convo) => match convo.try_get_response() {
                     None => {
@@ -1881,7 +1893,7 @@ pub mod test {
                                                // connections in each peer
                                                peer_configs[i].connection_opts.max_clients_per_host = 1;
                                                peer_configs[i].connection_opts.num_clients = 1;
-                                               peer_configs[i].connection_opts.idle_timeout = 5;
+                                               peer_configs[i].connection_opts.idle_timeout = 1;
                                            }
 
                                            for n in neighbors.drain(..) {

--- a/src/net/download.rs
+++ b/src/net/download.rs
@@ -1028,7 +1028,7 @@ impl PeerNetwork {
                     match network.http.get_conversation_and_socket(event_id) {
                         (Some(ref mut convo), Some(ref mut socket)) => {
                             convo.send_request(request)?;
-                            HttpPeer::saturate_socket(socket, convo, chainstate)?;
+                            HttpPeer::saturate_http_socket(socket, convo, chainstate)?;
                             Ok(event_id)
                         },
                         (_, _) => {

--- a/src/net/download.rs
+++ b/src/net/download.rs
@@ -1754,6 +1754,7 @@ pub mod test {
 
                                            for p in peer_configs.iter_mut() {
                                                p.connection_opts.disable_block_advertisement = true;
+                                               p.connection_opts.max_clients_per_host = 30;
                                            }
                                            
                                            let peer_0 = peer_configs[0].to_neighbor();
@@ -1811,6 +1812,7 @@ pub mod test {
                                            
                                            for p in peer_configs.iter_mut() {
                                                p.connection_opts.disable_block_advertisement = true;
+                                               p.connection_opts.max_clients_per_host = 30;
                                            }
 
                                            for i in 0..peer_configs.len() {

--- a/src/net/p2p.rs
+++ b/src/net/p2p.rs
@@ -452,8 +452,37 @@ impl PeerNetwork {
             return Err(net_error::PeerNotConnected);
         }
 
+        let socket_opt = self.sockets.get_mut(event_id);
+        if socket_opt.is_none() {
+            info!("No open socket for {:?}", &neighbor_key);
+            return Err(net_error::PeerNotConnected);
+        }
+
         let convo = convo_opt.unwrap();
-        convo.send_signed_request(message, ttl)
+        let client_sock = socket_opt.unwrap();
+
+        let mut rh = convo.send_signed_request(message, ttl)?;
+        
+        // saturate the socket
+        loop {
+            let send_res = convo.send(client_sock);
+            rh.try_flush()?;
+
+            match send_res {
+                Err(e) => {
+                    debug!("Failed to send data to event {} (socket {:?}): {:?}", event_id, &client_sock, &e);
+                    return Err(e);
+                },
+                Ok(sz) => {
+                    if sz == 0 {
+                        break;
+                    }
+                }
+            }
+        }
+        
+        // caller must send the remainder
+        Ok(rh)
     }
 
     /// Relay a signed message to a peer.
@@ -889,6 +918,7 @@ impl PeerNetwork {
         let neighbor_opt = match self.lookup_peer(self.chain_view.burn_block_height, &client_addr) {
             Ok(neighbor_opt) => neighbor_opt,
             Err(e) => {
+                debug!("Failed to look up peer {}: {:?}", client_addr, &e);
                 self.deregister_socket(event_id, socket);
                 return Err(e);
             }
@@ -902,6 +932,7 @@ impl PeerNetwork {
         match self.can_register_peer(&neighbor_key, outbound) {
             Ok(_) => {},
             Err(e) => {
+                debug!("Could not register peer {:?}: {:?}", &neighbor_key, &e);
                 self.deregister_socket(event_id, socket);
                 return Err(e);
             }
@@ -910,7 +941,7 @@ impl PeerNetwork {
         let mut new_convo = ConversationP2P::new(self.local_peer.network_id, self.peer_version, &self.burnchain, &client_addr, &self.connection_opts, outbound, event_id);
         new_convo.set_public_key(pubkey_opt);
         
-        test_debug!("{:?}: Registered {} as event {} ({:?},outbound={})", &self.local_peer, &client_addr, event_id, &neighbor_key, outbound);
+        debug!("{:?}: Registered {} as event {} ({:?},outbound={})", &self.local_peer, &client_addr, event_id, &neighbor_key, outbound);
 
         assert!(!self.sockets.contains_key(&event_id));
         assert!(!self.peers.contains_key(&event_id));
@@ -948,7 +979,7 @@ impl PeerNetwork {
 
     /// Deregister a socket/event pair
     pub fn deregister_peer(&mut self, event_id: usize) -> () {
-        test_debug!("{:?}: disconnect event {}", &self.local_peer, event_id);
+        test_debug!("{:?}: Disconnect event {}", &self.local_peer, event_id);
         if self.peers.contains_key(&event_id) {
             self.peers.remove(&event_id);
         }
@@ -987,6 +1018,7 @@ impl PeerNetwork {
 
     /// Deregister by neighbor key 
     pub fn deregister_neighbor(&mut self, neighbor_key: &NeighborKey) -> () {
+        debug!("Disconnect from {:?}", neighbor_key);
         let event_id = match self.events.get(&neighbor_key) {
             None => {
                 return;
@@ -998,6 +1030,7 @@ impl PeerNetwork {
 
     /// Deregister and ban a neighbor
     pub fn deregister_and_ban_neighbor(&mut self, neighbor: &NeighborKey) -> () {
+        debug!("Disconnect from and ban {:?}", neighbor);
         match self.events.get(neighbor) {
             Some(event_id) => {
                 self.bans.insert(*event_id);
@@ -1171,7 +1204,7 @@ impl PeerNetwork {
             match self.peers.get_mut(event_id) {
                 Some(ref mut convo) => {
                     // activity on a p2p socket
-                    test_debug!("{:?}: process p2p data from {:?}", &self.local_peer, convo);
+                    debug!("{:?}: process p2p data from {:?}", &self.local_peer, convo);
                     let mut convo_unhandled = match PeerNetwork::process_p2p_conversation(&self.local_peer, &mut self.peerdb, burndb, chainstate, &self.chain_view, *event_id, client_sock, convo) {
                         Ok((convo_unhandled, alive)) => {
                             if !alive {
@@ -1201,37 +1234,6 @@ impl PeerNetwork {
         }
 
         (to_remove, unhandled)
-    }
-
-    /// Make progress on sending any/all new outbound messages we have.
-    /// Meant to prime sockets so we wake up on the next loop pass immediately to finish sending.
-    fn send_outbound_messages(&mut self) -> Vec<usize> {
-        let mut to_remove = vec![];
-        for (event_id, convo) in self.peers.iter_mut() {
-            if !self.sockets.contains_key(&event_id) {
-                test_debug!("Rogue socket event {}", event_id);
-                to_remove.push(*event_id);
-                continue;
-            }
-
-            let client_sock_opt = self.sockets.get_mut(&event_id);
-            if client_sock_opt.is_none() {
-                test_debug!("No such socket event {}", event_id);
-                to_remove.push(*event_id);
-                continue;
-            }
-            let client_sock = client_sock_opt.unwrap();
-            let send_res = convo.send(client_sock);
-            match send_res {
-                Err(e) => {
-                    debug!("Failed to send data to event {} (socket {:?}): {:?}", event_id, &client_sock, &e);
-                    to_remove.push(*event_id);
-                    continue;
-                },
-                Ok(_) => {}
-            }
-        }
-        to_remove
     }
 
     /// Get stats for a neighbor 
@@ -1590,12 +1592,12 @@ impl PeerNetwork {
     fn do_network_work(&mut self, 
                        burndb: &mut BurnDB, 
                        chainstate: &mut StacksChainState, 
-                       dns_client_opt: Option<&mut DNSClient>, 
+                       mut dns_client_opt: Option<&mut DNSClient>, 
                        network_result: &mut NetworkResult) -> Result<bool, net_error> {
 
         // do some Actual Work(tm)
         let mut do_prune = false;
-        test_debug!("{:?}: network work state is {:?}", &self.local_peer, &self.work_state);
+        debug!("{:?}: network work state is {:?}", &self.local_peer, &self.work_state);
 
         match self.work_state {
             PeerNetworkWorkState::NeighborWalk => {
@@ -1615,8 +1617,8 @@ impl PeerNetwork {
             PeerNetworkWorkState::BlockDownload => {
                 // go fetch blocks
                 match dns_client_opt {
-                    Some(dns_client) => {
-                        if self.do_network_block_download(burndb, chainstate, dns_client, network_result)? {
+                    Some(ref mut dns_client) => {
+                        if self.do_network_block_download(burndb, chainstate, *dns_client, network_result)? {
                             // advance work state
                             self.work_state = PeerNetworkWorkState::Prune;
                         }
@@ -1920,13 +1922,12 @@ impl PeerNetwork {
     /// -- send data on ready sockets
     /// -- receive data on ready sockets
     /// -- clear out timed-out requests
-    fn dispatch_network(&mut self, 
+    fn dispatch_network(&mut self,
+                        network_result: &mut NetworkResult,
                         burndb: &mut BurnDB, 
                         chainstate: &mut StacksChainState, 
                         dns_client_opt: Option<&mut DNSClient>, 
-                        mut poll_state: NetworkPollState) -> Result<NetworkResult, net_error> {
-
-        let mut network_result = NetworkResult::new();
+                        mut poll_state: NetworkPollState) -> Result<(), net_error> {
 
         if self.network.is_none() {
             test_debug!("{:?}: network not connected", &self.local_peer);
@@ -1958,6 +1959,22 @@ impl PeerNetwork {
         let unhandled_messages = self.handle_unsolicited_messages(burndb, unsolicited_messages)?;
         network_result.consume_unsolicited(unhandled_messages);
 
+        // do some Actual Work(tm)
+        // do this _after_ processing new sockets, so the act of opening a socket doesn't trample
+        // an already-used network ID
+        let do_prune = self.do_network_work(burndb, chainstate, dns_client_opt, network_result)?;
+        if do_prune {
+            // prune back our connections if it's been a while
+            // (only do this if we're done with all other tasks).
+            // Also, process banned peers.
+            let mut dead_events = self.process_bans()?;
+            for dead in dead_events.drain(..) {
+                debug!("{:?}: Banned connection on event {}", &self.local_peer, dead);
+                self.deregister_peer(dead);
+            }
+            self.prune_connections();
+        }
+        
         // move conversations along
         let error_events = self.flush_relay_handles();
         for error_event in error_events {
@@ -1972,30 +1989,6 @@ impl PeerNetwork {
         
         // clear out peers that we haven't heard from in our heartbeat interval
         self.disconnect_unresponsive();
-
-        // do some Actual Work(tm)
-        // do this _after_ processing new sockets, so the act of opening a socket doesn't trample
-        // an already-used network ID
-        let do_prune = self.do_network_work(burndb, chainstate, dns_client_opt, &mut network_result)?;
-
-        // send out any queued messages.
-        // this has the intentional side-effect of activating some sockets as writeable.
-        let error_outbound_events = self.send_outbound_messages();
-        for error_event in error_outbound_events {
-            debug!("{:?}: Failed connection on event {}", &self.local_peer, error_event);
-            self.deregister_peer(error_event);
-        }
-        
-        if do_prune {
-            // prune back our connections if it's been a while
-            // (only do this if we're done with all other tasks).
-            // Also, process banned peers.
-            let mut dead_events = self.process_bans()?;
-            for dead in dead_events.drain(..) {
-                self.deregister_peer(dead);
-            }
-            self.prune_connections();
-        }
         
         // queue up pings to neighbors we haven't spoken to in a while
         self.queue_ping_heartbeats();
@@ -2021,8 +2014,8 @@ impl PeerNetwork {
         // finally, handle network I/O requests from other threads, and get back reply handles to them.
         // do this after processing new sockets, so we don't accidentally re-use an event ID.
         self.dispatch_requests();
-      
-        Ok(network_result)
+    
+        Ok(())
     }
 
     /// Top-level main-loop circuit to take.
@@ -2039,20 +2032,26 @@ impl PeerNetwork {
                 Err(net_error::NotConnected)
             },
             Some(ref mut network) => {
-                network.poll(poll_timeout)
+                debug!(">>>>>>>>>>>>>>>>>>>>>>> Begin Poll >>>>>>>>>>>>>>>>>>>>>>>>>>>>");
+                let poll_result = network.poll(poll_timeout);
+                debug!("<<<<<<<<<<<<<<<<<<<<<<<< End Poll <<<<<<<<<<<<<<<<<<<<<<<<<<<<");
+                poll_result
             }
         }?;
 
         let p2p_poll_state = poll_states.remove(&self.p2p_network_handle).expect("BUG: no poll state for p2p network handle");
         let http_poll_state = poll_states.remove(&self.http_network_handle).expect("BUG: no poll state for http network handle");
+  
+        let mut result = NetworkResult::new();
 
-        let mut result = self.dispatch_network(burndb, chainstate, dns_client_opt, p2p_poll_state)?;
-      
         PeerNetwork::with_network_state(self, |ref mut network, ref mut network_state| {
             let http_stacks_msgs = network.http.run(network_state, network.chain_view.clone(), burndb, &mut network.peerdb, chainstate, mempool, http_poll_state)?;
             result.consume_http_uploads(http_stacks_msgs);
             Ok(())
         })?;
+        
+        self.dispatch_network(&mut result, burndb, chainstate, dns_client_opt, p2p_poll_state)?;
+
         Ok(result)
     }
 }

--- a/src/net/poll.rs
+++ b/src/net/poll.rs
@@ -251,6 +251,12 @@ impl NetworkState {
                 net_error::ConnectionError
             })?;
 
+        if cfg!(test) {
+            // edge-trigger torture test
+            stream.set_send_buffer_size(32).unwrap();
+            stream.set_recv_buffer_size(32).unwrap();
+        }
+
         test_debug!("New socket connected to {:?}: {:?}", addr, &stream);
         Ok(stream)
     }

--- a/src/net/poll.rs
+++ b/src/net/poll.rs
@@ -147,7 +147,7 @@ impl NetworkState {
         let server = NetworkState::bind_address(addr)?;
         let next_server_event = self.next_event_id();
 
-        self.poll.register(&server, mio::Token(next_server_event), mio::Ready::readable(), mio::PollOpt::edge())
+        self.poll.register(&server, mio::Token(next_server_event), Ready::all(), PollOpt::edge())
             .map_err(|e| {
                 error!("Failed to register server socket: {:?}", &e);
                 net_error::BindError

--- a/src/net/relay.rs
+++ b/src/net/relay.rs
@@ -86,6 +86,7 @@ pub trait RelayPayload {
     /// Get a representative digest of this message.
     /// m1.get_digest() == m2.get_digest() --> m1 == m2
     fn get_digest(&self) -> Sha512Trunc256Sum;
+    fn get_id(&self) -> String;
 }
 
 impl RelayPayload for BlocksAvailableData {
@@ -95,12 +96,18 @@ impl RelayPayload for BlocksAvailableData {
         let h = Sha512Trunc256Sum::from_data(&bytes);
         h
     }
+    fn get_id(&self) -> String {
+        format!("{:?}", &self)
+    }
 }
 
 impl RelayPayload for StacksBlock {
     fn get_digest(&self) -> Sha512Trunc256Sum {
         let h = self.block_hash();
         Sha512Trunc256Sum(h.0)
+    }
+    fn get_id(&self) -> String {
+        format!("StacksBlock({})", self.block_hash())
     }
 }
 
@@ -109,12 +116,18 @@ impl RelayPayload for StacksMicroblock {
         let h = self.block_hash();
         Sha512Trunc256Sum(h.0)
     }
+    fn get_id(&self) -> String {
+        format!("StacksMicroblock({})", self.block_hash())
+    }
 }
 
 impl RelayPayload for StacksTransaction {
     fn get_digest(&self) -> Sha512Trunc256Sum {
         let h = self.txid();
         Sha512Trunc256Sum(h.0)
+    }
+    fn get_id(&self) -> String {
+        format!("Transaction({})", self.txid())
     }
 }
 
@@ -1526,6 +1539,10 @@ mod test {
                 test_debug!("{:?} outbox overflow; try again later", &peer.to_neighbor().addr);
                 return false;
             },
+            Err(net_error::SendError(msg)) => {
+                warn!("Failed to send to {:?}: SendError({})", &peer.to_neighbor().addr, msg);
+                return false;
+            }
             Err(e) => {
                 test_debug!("{:?} encountered fatal error when forwarding: {:?}", &peer.to_neighbor().addr, &e);
                 assert!(false);

--- a/src/net/relay.rs
+++ b/src/net/relay.rs
@@ -1177,7 +1177,7 @@ mod test {
         assert_eq!(relayer_stats.relay_stats.get(&na).unwrap().last_seen, 1);
         assert_eq!(relayer_stats.relay_updates.len(), 1);
 
-        let now = get_epoch_time_secs() + 60;
+        let now = get_epoch_time_secs() + 600;
 
         let relay_stats_2 = RelayStats {
             num_messages: 2,

--- a/src/net/rpc.rs
+++ b/src/net/rpc.rs
@@ -1067,7 +1067,7 @@ mod test {
 
             let all_relays_flushed = receiver.num_pending_outbound() == 0 && sender.num_pending_outbound() == 0;
             
-            let nw = sender.send(&mut pipe_write).unwrap();
+            let nw = sender.send(&mut pipe_write, sender_chainstate).unwrap();
             let nr = receiver.recv(&mut pipe_read).unwrap();
 
             test_debug!("res = {}, all_relays_flushed = {} ({},{}), nr = {}, nw = {}", res, all_relays_flushed, receiver.num_pending_outbound(), sender.num_pending_outbound(), nr, nw);

--- a/src/net/rpc.rs
+++ b/src/net/rpc.rs
@@ -209,7 +209,7 @@ impl ConversationHttp {
     
     /// Start a HTTP request from this peer, and expect a response.
     /// Returns the request handle; does not set the handle into this connection.
-    pub fn start_request(&mut self, req: HttpRequestType) -> Result<ReplyHandleHttp, net_error> {
+    fn start_request(&mut self, req: HttpRequestType) -> Result<ReplyHandleHttp, net_error> {
         test_debug!("{:?},id={}: Start HTTP request {:?}", &self.peer_host, self.conn_id, &req);
         let mut handle = self.connection.make_request_handle(HTTP_REQUEST_ID_RESERVED, get_epoch_time_secs() + self.timeout)?;
         let stacks_msg = StacksHttpMessage::Request(req);
@@ -949,16 +949,48 @@ impl ConversationHttp {
 
     /// Load data into our HTTP connection
     pub fn recv<R: Read>(&mut self, r: &mut R) -> Result<usize, net_error> {
-        self.connection.recv_data(r)
+        let mut total_recv = 0;
+        loop {
+            let nrecv = match self.connection.recv_data(r) {
+                Ok(nr) => nr,
+                Err(e) => {
+                    info!("{:?}: failed to recv: {:?}", self, &e);
+                    return Err(e);
+                }
+            };
+
+            total_recv += nrecv;
+            if nrecv == 0 {
+                break;
+            }
+        }
+        Ok(total_recv)
     }
 
-    /// Write data out of our HTTP connection 
-    pub fn send<W: Write>(&mut self, w: &mut W) -> Result<usize, net_error> {
-        let sz = self.connection.send_data(w)?;
-        if sz > 0 {
-            self.last_response_timestamp = get_epoch_time_secs();
+    /// Write data out of our HTTP connection.  Write as much as we can
+    pub fn send<W: Write>(&mut self, w: &mut W, chainstate: &mut StacksChainState) -> Result<usize, net_error> {
+        let mut total_sz = 0;
+        loop {
+            // prime the Write
+            self.try_flush(chainstate)?;
+
+            let sz = match self.connection.send_data(w) {
+                Ok(sz) => sz,
+                Err(e) => {
+                    info!("{:?}: failed to send: {:?}", self, &e);
+                    return Err(e);
+                }
+            };
+
+            total_sz += sz;
+            if sz > 0 {
+                self.last_response_timestamp = get_epoch_time_secs();
+            }
+            else {
+                break;
+            }
         }
-        Ok(sz)
+        Ok(total_sz)
     }
 
     /// Make a new getinfo request to this endpoint

--- a/src/net/rpc.rs
+++ b/src/net/rpc.rs
@@ -211,7 +211,7 @@ impl ConversationHttp {
     /// Returns the request handle; does not set the handle into this connection.
     fn start_request(&mut self, req: HttpRequestType) -> Result<ReplyHandleHttp, net_error> {
         test_debug!("{:?},id={}: Start HTTP request {:?}", &self.peer_host, self.conn_id, &req);
-        let mut handle = self.connection.make_request_handle(HTTP_REQUEST_ID_RESERVED, get_epoch_time_secs() + self.timeout)?;
+        let mut handle = self.connection.make_request_handle(HTTP_REQUEST_ID_RESERVED, get_epoch_time_secs() + self.timeout, self.conn_id)?;
         let stacks_msg = StacksHttpMessage::Request(req);
         self.connection.send_message(&mut handle, &stacks_msg)?;
         Ok(handle)
@@ -614,7 +614,7 @@ impl ConversationHttp {
     pub fn handle_request(&mut self, req: HttpRequestType, chain_view: &BurnchainView, burndb: &mut BurnDB, peerdb: &mut PeerDB,
                           chainstate: &mut StacksChainState, mempool: &mut MemPoolDB) -> Result<Option<StacksMessageType>, net_error> {
 
-        let mut reply = self.connection.make_relay_handle()?;
+        let mut reply = self.connection.make_relay_handle(self.conn_id)?;
         let keep_alive = req.metadata().keep_alive;
         let mut ret = None;
 
@@ -1064,6 +1064,8 @@ mod test {
            
             sender.try_flush(sender_chainstate).unwrap();
             receiver.try_flush(receiver_chainstate).unwrap();
+            
+            pipe_write.try_flush().unwrap();
 
             let all_relays_flushed = receiver.num_pending_outbound() == 0 && sender.num_pending_outbound() == 0;
             

--- a/src/net/rpc.rs
+++ b/src/net/rpc.rs
@@ -977,7 +977,7 @@ impl ConversationHttp {
             let sz = match self.connection.send_data(w) {
                 Ok(sz) => sz,
                 Err(e) => {
-                    info!("{:?}: failed to send: {:?}", self, &e);
+                    info!("{:?}: failed to send on HTTP conversation: {:?}", self, &e);
                     return Err(e);
                 }
             };

--- a/src/net/server.rs
+++ b/src/net/server.rs
@@ -367,6 +367,11 @@ impl HttpPeer {
         Ok((!convo_dead, msgs))
     }
 
+    /// Is an event in the process of connecting?
+    pub fn is_connecting(&self, event_id: usize) -> bool {
+        self.connecting.contains_key(&event_id)
+    }
+
     /// Process newly-connected sockets
     fn process_connecting_sockets(&mut self, network_state: &mut NetworkState, chainstate: &mut StacksChainState, poll_state: &mut NetworkPollState) -> () {
         for event_id in poll_state.ready.iter() {

--- a/src/net/server.rs
+++ b/src/net/server.rs
@@ -201,7 +201,7 @@ impl HttpPeer {
             }
 
             // prime the socket
-            match HttpPeer::saturate_socket(&mut socket, &mut new_convo, chainstate) {
+            match HttpPeer::saturate_http_socket(&mut socket, &mut new_convo, chainstate) {
                 Ok(_) => {},
                 Err(e) => {
                     let _ = network_state.deregister(event_id, &socket);
@@ -269,7 +269,7 @@ impl HttpPeer {
 
     /// Saturate a conversation's socket -- either sends the whole request, or fills the socket
     /// buffer.
-    pub fn saturate_socket(client_sock: &mut mio::net::TcpStream, convo: &mut ConversationHttp, chainstate: &mut StacksChainState) -> Result<(), net_error> {
+    pub fn saturate_http_socket(client_sock: &mut mio::net::TcpStream, convo: &mut ConversationHttp, chainstate: &mut StacksChainState) -> Result<(), net_error> {
         // saturate the socket
         loop {
             let send_res = convo.send(client_sock, chainstate);


### PR DESCRIPTION
This PR backports some essential fixes from the ongoing work in `feature/neon-network`.  In particular:

* It makes it so the network does not stall while sending messages.  Because our polling system is edge-triggered, we need to either send a message in its entirety, or fill the socket buffer so we can get woken up again when some space is freed up.  We had not been doing this in either the p2p server or http server, and our tests hadn't caught it because we were using a poll timeout of 0.

* Fixes a couple edge cases when synchronizing headers from a live Bitcoin node