### PR TITLE
Feature/more latenight neon bugfixes

### DIFF
--- a/src/burnchains/bitcoin/indexer.rs
+++ b/src/burnchains/bitcoin/indexer.rs
@@ -66,7 +66,8 @@ pub const FIRST_BLOCK_TESTNET: u64 = 0;
 pub const FIRST_BLOCK_REGTEST: u64 = 0;
 
 // batch size for searching for a reorg 
-const REORG_BATCH_SIZE: u64 = 200;
+// kept small since sometimes bitcoin will just send us one header at a time
+const REORG_BATCH_SIZE: u64 = 16;
 
 pub fn network_id_to_bytes(network_id: BitcoinNetworkType) -> u32 {
     match network_id {

--- a/src/burnchains/burnchain.rs
+++ b/src/burnchains/burnchain.rs
@@ -520,16 +520,19 @@ impl Burnchain {
         let mut ret = Vec::with_capacity(checked_ops.len());
 
         let mut all_keys : HashSet<VRFPublicKey> = HashSet::new();
+        let mut all_ptrs : HashSet<(u64, u32)> = HashSet::new();
         for op in checked_ops.drain(..) {
             match op {
                 BlockstackOperationType::LeaderKeyRegister(data) => {
-                    if all_keys.contains(&data.public_key) {
+                    let key_loc = (data.block_height, data.vtxindex);
+                    if all_keys.contains(&data.public_key) || all_ptrs.contains(&key_loc) {
                         // duplicate
                         warn!("REJECTED({}) leader key register {} at {},{}: Duplicate VRF key", data.block_height, &data.txid, data.block_height, data.vtxindex);
                     }
                     else {
                         // first case
                         all_keys.insert(data.public_key.clone());
+                        all_ptrs.insert(key_loc);
                         ret.push(BlockstackOperationType::LeaderKeyRegister(data));
                     }
                 },

--- a/src/chainstate/burn/distribution.rs
+++ b/src/chainstate/burn/distribution.rs
@@ -82,7 +82,7 @@ impl BurnSamplePoint {
         let mut key_index : BTreeMap<(u64, u32), usize> = BTreeMap::new();
         for i in 0..consumed_leader_keys.len() {
             let key_loc = (consumed_leader_keys[i].block_height, consumed_leader_keys[i].vtxindex);
-            assert!(key_index.get(&key_loc).is_none());
+            assert!(key_index.get(&key_loc).is_none(), format!("duplicate entry: {:?}", &key_loc));
 
             key_index.insert(key_loc, i);
         }

--- a/src/net/neighbors.rs
+++ b/src/net/neighbors.rs
@@ -1573,6 +1573,7 @@ impl PeerNetwork {
             if self.walk_count > NUM_INITIAL_WALKS && self.walk_deadline > get_epoch_time_secs() {
                 // we've done enough walks for an initial mixing,
                 // so throttle ourselves down until the walk deadline passes.
+                debug!("Wait until {} to walk again", self.walk_deadline);
                 return (true, None);
             }
         }
@@ -1679,7 +1680,7 @@ impl PeerNetwork {
                 };
 
                 if reset {
-                    test_debug!("{:?}: random walk restart", &self.local_peer);
+                    debug!("{:?}: random walk restart", &self.local_peer);
                     self.walk = None;
                     done = true;        // move onto the next p2p work item
                 }

--- a/src/net/relay.rs
+++ b/src/net/relay.rs
@@ -454,7 +454,16 @@ impl Relayer {
             }
         };
 
-        chainstate.preprocess_anchored_block(burn_tx, burn_header_hash, sn.burn_header_timestamp, block, &sn.parent_burn_header_hash)
+        // find the snapshot of the parent of this block
+        let parent_block_snapshot = match StacksChainState::get_block_snapshot_of_parent_stacks_block(burn_tx, burn_header_hash, &block.block_hash())? {
+            Some(sn) => sn,
+            None => {
+                debug!("Received block with unknown parent snapshot: {}/{}", burn_header_hash, &block.block_hash());
+                return Ok(false);
+            }
+        };
+        
+        chainstate.preprocess_anchored_block(burn_tx, burn_header_hash, sn.burn_header_timestamp, block, &parent_block_snapshot.burn_header_hash)
     }
 
     /// Coalesce a set of microblocks into relayer hints and MicroblocksData messages, as calculated by

--- a/testnet/src/config.rs
+++ b/testnet/src/config.rs
@@ -70,7 +70,7 @@ lazy_static! {
         soft_max_neighbors_per_host: 10,
         soft_max_neighbors_per_org: 100,
         soft_max_clients_per_host: 1000,
-        walk_interval: 9223372036854775807,
+        walk_interval: 20,
         dns_timeout: 15_000,
         max_inflight_blocks: 6,
         .. std::default::Default::default()

--- a/testnet/src/tests/mempool.rs
+++ b/testnet/src/tests/mempool.rs
@@ -51,6 +51,9 @@ pub fn make_bad_stacks_transfer(sender: &StacksPrivateKey, nonce: u64, fee_rate:
 #[test]
 fn mempool_setup_chainstate() {
     let mut conf = super::new_test_conf();
+    
+    // force seeds to be the same
+    conf.node.seed = vec![0x00];
 
     conf.burnchain.commit_anchor_block_within = 1500;
     
@@ -60,7 +63,7 @@ fn mempool_setup_chainstate() {
 
     let num_rounds = 4;
 
-    let mut run_loop = RunLoop::new(conf);
+    let mut run_loop = RunLoop::new(conf.clone());
 
     run_loop.callbacks.on_new_tenure(|round, _burnchain_tip, chain_tip, tenure| {
         let contract_sk = StacksPrivateKey::from_hex(SK_1).unwrap();
@@ -264,10 +267,10 @@ fn mempool_setup_chainstate() {
             eprintln!("Err: {:?}", e);
             assert!(if let MemPoolRejection::NoCoinbaseViaMempool = e { true } else { false });
 
-
             // find the correct priv-key
             let mut secret_key = None;
-            let conf = super::new_test_conf();
+            let mut conf = super::new_test_conf();
+            conf.node.seed = vec![0x00];
 
             let mut keychain = Keychain::default(conf.node.seed.clone());
             for _i in 0..4 {


### PR DESCRIPTION
This fixes a few crucial bugs we discovered at the last minute:

* When processing a Stacks block, use it's block commit's parent block commit's burn header hash (not the penultimate burn header hash).  This ensures that the follower will process all of the miner's blocks, even if they are on multiple Stacks forks.

* Fix a problem where a VRF key could be accepted twice, leading to a panic

* Set the walk interval to 20 seconds, not for the time it takes to reach the heat death of the universe.  Otherwise the node will stop crawling the leader's invs after about 2 minutes.

* Better logging