### PR TITLE
Fix Stacks.toml path for testnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ cargo run --bin blockstack-cli publish b8d99fd45da58038d630d9855d3ca2466e8e0f89d
 You can observe the state machine in action locally by running:
 
 ```bash
-cargo testnet ./testnet/helium/Stacks.toml
+cargo testnet ./testnet/Stacks.toml
 ```
 
 `Stacks.toml` is a configuration file that you can use for setting genesis balances or configuring Event observers.  You can grant an address an initial account balance by adding the following entries:


### PR DESCRIPTION
I was trying out the testnet instructions in the neadme and it seems the `helium` directory no longer exists. There's a `Stacks.toml` file in what would have been that directory's parents which seems to work. This pull request updates the readme to reflect that.