### PR TITLE
Resolve local leader / local follower config discrepancies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,13 @@
 FROM rust:latest as build
 
-WORKDIR /src/blockstack-core
+WORKDIR /src/stacks-blockchain
 
 COPY . .
 
-RUN cargo install --path . --root .
+RUN cd testnet && cargo install --path . --root .
 
 FROM debian:stable-slim
-COPY --from=build /src/blockstack-core/bin /bin
+RUN apt-get update && apt-get install -y --no-install-recommends libssl-dev
+COPY --from=build /src/stacks-blockchain/testnet/bin /bin
 
-CMD ["blockstack-core"]
+CMD ["stacks-node", "neon"]

--- a/testnet/conf/local-follower-conf.toml
+++ b/testnet/conf/local-follower-conf.toml
@@ -1,13 +1,13 @@
 [node]
 rpc_bind = "0.0.0.0:30443"
 p2p_bind = "0.0.0.0:30444"
-bootstrap_node = "048dd4f26101715853533dee005f0915375854fd5be73405f679c1917a5d4d16aaaf3c4c0d7a9c132a36b8c5fe1287f07dad8c910174d789eb24bdfb5ae26f5f27@127.0.0.1:20444"
+bootstrap_node = "04ee0b1602eb18fef7986887a7e8769a30c9df981d33c8380d255edef003abdcd243a0eb74afdf6740e6c423e62aec631519a24cf5b1d62bf8a3e06ddc695dcb77@127.0.0.1:20444"
 
 [burnchain]
 chain = "bitcoin"
 mode = "neon"
 peer_host = "127.0.0.1"
-rpc_port = 18443
+rpc_port = 28443
 peer_port = 18444
 
 [[mstx_balance]]

--- a/testnet/conf/local-leader-conf.toml
+++ b/testnet/conf/local-leader-conf.toml
@@ -8,9 +8,7 @@ local_peer_seed = "0000000000000000000000000000000000000000000000000000000000000
 chain = "bitcoin"
 mode = "neon"
 peer_host = "127.0.0.1"
-burnchain_op_tx_fee = 1000
-commit_anchor_block_within = 10000
-rpc_port = 18443
+rpc_port = 28443
 peer_port = 18444
 
 [[mstx_balance]]


### PR DESCRIPTION
The `bitcoin-neon-controller` has also been updated and now includes a conf matching these ones.
Steps:
- run `bitcoind`, assuming the following config:
```
disablewallet=0
txindex=1
chain=regtest
server=1
rpcuser=helium-node
rpcpassword=secret
```
- run bitcoin-neon-controller with `cargo run local-leader.toml.default`
- run `cargo testnet start --config testnet/conf/local-leader-conf.toml`
- run `cargo testnet start --config testnet/conf/local-follower-conf.toml`