### PR TITLE
Correct the description of post-conditions in SIP-005

### DIFF
--- a/sip/sip-005-blocks-and-transactions.md
+++ b/sip/sip-005-blocks-and-transactions.md
@@ -554,7 +554,8 @@ A _Non-fungible token post-condition_ body is encoded as follows:
 * A variable-length **principal**, containing the address of the standard account or contract
   account
 * A variable-length **asset info** structure that identifies the token type
-* A variable-length **asset name** string that names the token instance
+* A variable-length **asset name**, which is the Clarity value that names the token instance,
+  serialized according to the Clarity value serialization format.
 * A 1-byte **non-fungible condition code**
 
 A **principal** structure encodes either a standard account address or a


### PR DESCRIPTION
This resolves #1491 -- the description of NFT Post-Conditions in SIP-005 was incorrect. NFT names are serialized using the Clarity value serialization.