### PR TITLE
Some helpful debugging tools

### DIFF
--- a/src/blockstack_cli.rs
+++ b/src/blockstack_cli.rs
@@ -39,7 +39,6 @@ This CLI has these methods:
   contract-call    used to generate and sign a contract-call transaction
   generate-sk      used to generate a secret key for transaction signing
   token-transfer   used to generate and sign a transfer transaction
-  deserialize-tx   used to deserialize a hex-serialized stacks transaction
 
 For usage information on those methods, call `blockstack-cli [method] -h`
 
@@ -87,11 +86,6 @@ const GENERATE_USAGE: &str = "blockstack-cli (options) generate-sk
 
 This method generates a secret key, outputting the hex encoding of the
 secret key, the corresponding public key, and the corresponding P2PKH Stacks address.";
-
-const DESERIALIZE_USAGE: &str = "blockstack-cli (options) deserialize-tx
-
-This method deserializes a hex-serialized transaction (passed in via stdin), displaying
-the transaction's payload debug output, as well as the origin and nonce of the sender";
 
 
 #[derive(Debug)]
@@ -405,23 +399,6 @@ fn main_handler(mut argv: Vec<String>) -> Result<String, CliError> {
             "publish" => handle_contract_publish(args, tx_version, chain_id),
             "token-transfer" => handle_token_transfer(args, tx_version, chain_id),
             "generate-sk" => generate_secret_key(args, tx_version),
-            "deserialize-tx" => {
-                if args.len() > 0 {
-                    return Err(CliError::Message(format!("USAGE:\n {}", DESERIALIZE_USAGE)));
-                }
-                let content = {
-                    let mut buffer = String::new();
-                    io::stdin().read_to_string(&mut buffer).unwrap();
-                    buffer
-                };
-                let de_hexed = hex_bytes(content.trim()).unwrap();
-                let tx: StacksTransaction = StacksTransaction::consensus_deserialize(&mut de_hexed.as_slice()).unwrap();
-                let payload = tx.payload;
-                Ok(format!("Origin Address: {} (main) / {} (test)\nNonce: {}\n{:?}", 
-                           tx.auth.origin().address_mainnet(), tx.auth.origin().address_testnet(),
-                           tx.auth.origin().nonce(),
-                           payload))
-            },
             _ => Err(CliError::Usage)
         }
     } else {

--- a/src/blockstack_cli.rs
+++ b/src/blockstack_cli.rs
@@ -39,6 +39,7 @@ This CLI has these methods:
   contract-call    used to generate and sign a contract-call transaction
   generate-sk      used to generate a secret key for transaction signing
   token-transfer   used to generate and sign a transfer transaction
+  deserialize-tx   used to deserialize a hex-serialized stacks transaction
 
 For usage information on those methods, call `blockstack-cli [method] -h`
 
@@ -86,6 +87,11 @@ const GENERATE_USAGE: &str = "blockstack-cli (options) generate-sk
 
 This method generates a secret key, outputting the hex encoding of the
 secret key, the corresponding public key, and the corresponding P2PKH Stacks address.";
+
+const DESERIALIZE_USAGE: &str = "blockstack-cli (options) deserialize-tx
+
+This method deserializes a hex-serialized transaction (passed in via stdin), displaying
+the transaction's payload debug output, as well as the origin and nonce of the sender";
 
 
 #[derive(Debug)]
@@ -399,6 +405,23 @@ fn main_handler(mut argv: Vec<String>) -> Result<String, CliError> {
             "publish" => handle_contract_publish(args, tx_version, chain_id),
             "token-transfer" => handle_token_transfer(args, tx_version, chain_id),
             "generate-sk" => generate_secret_key(args, tx_version),
+            "deserialize-tx" => {
+                if args.len() > 0 {
+                    return Err(CliError::Message(format!("USAGE:\n {}", DESERIALIZE_USAGE)));
+                }
+                let content = {
+                    let mut buffer = String::new();
+                    io::stdin().read_to_string(&mut buffer).unwrap();
+                    buffer
+                };
+                let de_hexed = hex_bytes(content.trim()).unwrap();
+                let tx: StacksTransaction = StacksTransaction::consensus_deserialize(&mut de_hexed.as_slice()).unwrap();
+                let payload = tx.payload;
+                Ok(format!("Origin Address: {} (main) / {} (test)\nNonce: {}\n{:?}", 
+                           tx.auth.origin().address_mainnet(), tx.auth.origin().address_testnet(),
+                           tx.auth.origin().nonce(),
+                           payload))
+            },
             _ => Err(CliError::Usage)
         }
     } else {

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -1157,7 +1157,7 @@ pub const MAX_BROADCAST_OUTBOUND_RECEIVERS : usize = 8;
 pub const MAX_BROADCAST_INBOUND_RECEIVERS : usize = 16;
 
 // messages can't be bigger than 16MB plus the preamble and relayers
-pub const MAX_PAYLOAD_LEN : u32 = (1 + 16 * 1024 * 1024);
+pub const MAX_PAYLOAD_LEN : u32 = 1 + 16 * 1024 * 1024;
 pub const MAX_MESSAGE_LEN : u32 = MAX_PAYLOAD_LEN + (PREAMBLE_ENCODED_SIZE + MAX_RELAYERS_LEN * RELAY_DATA_ENCODED_SIZE);
 
 // maximum value of a blocks's inv data bitlen.


### PR DESCRIPTION
These are two CLI commands that are helpful when debugging issues on testnet:


`blockstack-cli deserialize-tx`

```
$ TX=80800000000400ac4c9ee4b46177277081ba8f9494bde950b8a021000000000000000000000000000000010000721047d6db33d19ec889e4d7806cc51fab30f064311eeaed6d5555a0d5b3fb2b37b30426001325314a797cb8593a307d77fceaf53f5e02f015a053f4ff7ccf6e03020000000000051a79f327494e237a5fa36a43f88b033c365acd136e00000000000003e800000000000000000000000000000000000000000000000000000000000000000000
$ echo $TX | blockstack-cli deserialize-tx
Origin Address: SP2P4S7Q4PHGQE9VGG6X8Z54MQQMN1E50455MMT7Q (main) / ST2P4S7Q4PHGQE9VGG6X8Z54MQQMN1E5047ZHVAF7 (test)
Nonce: 0
TokenTransfer(Standard(StandardPrincipalData(26, [121, 243, 39, 73, 78, 35, 122, 95, 163, 106, 67, 248, 139, 3, 60, 54, 90, 205, 19, 110])), 1000, 00000000000000000000000000000000000000000000000000000000000000000000)
```

`blockstack-core local eval_at_block`

```
$ echo "(get-status 'STRYYQQ9M8KAF4NS7WNZQYY59X93XEKR31JP64CP)" | blockstack-core local eval_at_block 7aedf9db311b864ae5b780682409c5fd30c64b20db3c76407c9ff64a7ede92c9 STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6.status /tmp/stacks-testnet-ecda561a9dbf378d/chainstate/chain-00000080-testnet/vm/clarity/
STRYYQQ9M8KAF4NS7WNZQYY59X93XEKR31JP64CP
Program executed successfully! Output: 
0x01020304
```

Which lets you run a provided script, in the provided contract context, at the specified chain tip (this can be run directly against a follower node's `/vm/clarity` folder).

Should we add something along these commands to the core CLI? If so, I'll add some test cases. The `eval_at` command could probably also be improved to not require the (index) block-hash, and instead just try to find the chain tip.

If you don't think we should add these, I can also just abandon!