### PR TITLE
Readme: add requirement note for libssl

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ The first step is to ensure that you have Rust and the support software installe
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ```
 
+Building `stacks-blockchain` requires libssl sources, depending on your Linux distribution, you may need to manually install the `libssl-dev` package.
+
 From there, you can clone this repository:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The first step is to ensure that you have Rust and the support software installe
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ```
 
-Building `stacks-blockchain` requires libssl sources, depending on your Linux distribution, you may need to manually install the `libssl-dev` package.
+Building `stacks-blockchain` requires libssl sources. Depending on your Linux distribution, you may need to manually install the `libssl-dev` package.
 
 From there, you can clone this repository:
 


### PR DESCRIPTION
This adds a note that libssl source is required for compiling Stacks blockchain on many distros. See  #1501