### PR TITLE
/v2/transactions HTTP improvements

### DIFF
--- a/docs/rpc-endpoints.md
+++ b/docs/rpc-endpoints.md
@@ -4,7 +4,42 @@
 
 This endpoint is for posting _raw_ transaction data to the node's mempool.
 
-Rejections result in a 400 error.
+Rejections result in a 400 error, with JSON data in the form:
+
+```
+{
+  "error": "transaction rejected",
+  "reason": "BadNonce",
+  "reason_data": {
+    "actual": 3,
+    "expected": 0,
+    "is_origin": true,
+    "principal": "ST2MVNFYF6H9DCMAV3HVNHTJVVE3CFWT1JYMH1EZB"
+  },
+  "txid": "0x4068179cb9169b969c80518d83890f8b808a70ab998dd227149221be9480a616"
+}
+```
+
+Possible values for the "reason" field are:
+
+* `Serialization`
+* `Deserialization`
+* `SignatureValidation`
+* `FeeTooLow`
+* `BadNonce`
+* `NotEnoughFunds`
+* `NoSuchContract`
+* `NoSuchPublicFunction`
+* `BadFunctionArgument`
+* `ContractAlreadyExists`
+* `PoisonMicroblocksDoNotConflict`
+* `PoisonMicroblockHasUnknownPubKeyHash`
+* `PoisonMicroblockIsInvalid`
+* `BadAddressVersionByte`
+* `NoCoinbaseViaMempool`
+* `ServerFailureNoSuchChainTip`
+* `ServerFailureDatabase`
+* `ServerFailureOther`
 
 ### GET /v2/accounts/[Principal]
 

--- a/src/chainstate/stacks/db/blocks.rs
+++ b/src/chainstate/stacks/db/blocks.rs
@@ -213,7 +213,7 @@ impl MemPoolRejection {
             Other(s) => ("ServerFailureOther", Some(json!({ "message": s })))
         };
         let mut result = json!({
-            "txid": format!("0x{}", txid.to_hex()),
+            "txid": format!("{}", txid.to_hex()),
             "error": "transaction rejected",
             "reason": reason_code,
         });

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -1036,7 +1036,7 @@ pub enum HttpResponseType {
     GetContractSrc(HttpResponseMetadata, ContractSrcResponse),
     // peer-given error responses
     BadRequest(HttpResponseMetadata, String),
-    BadRequestJSON(HttpResponseMetadata, HashMap<String, String>),
+    BadRequestJSON(HttpResponseMetadata, serde_json::Value),
     Unauthorized(HttpResponseMetadata, String),
     PaymentRequired(HttpResponseMetadata, String),
     Forbidden(HttpResponseMetadata, String),

--- a/src/net/rpc.rs
+++ b/src/net/rpc.rs
@@ -1200,7 +1200,7 @@ mod test {
     }
 
     #[test]
-        #[ignore]
+    #[ignore]
     fn test_rpc_getinfo() {
         let peer_server_info = RefCell::new(None);
         test_rpc("test_rpc_getinfo", 40000, 40001, 50000, 50001,

--- a/src/net/rpc.rs
+++ b/src/net/rpc.rs
@@ -621,15 +621,11 @@ impl ConversationHttp {
                         (HttpResponseType::TransactionID(response_metadata, txid), true)
                     }
                     Err(e) => {
-                        let mut rejection_info = HashMap::new();
-                        rejection_info.insert("txid".to_string(), txid.to_hex());
-                        rejection_info.insert("error".to_string(), "transaction rejected".to_string());
-                        rejection_info.insert("reason".to_string(), format!("{:?}", e));
-                        (HttpResponseType::BadRequestJSON(response_metadata, rejection_info), false)
+                        (HttpResponseType::BadRequestJSON(response_metadata, e.into_json(&txid)), false)
                     }
                 }
             };
-            
+
         response.send(http, fd).and_then(|_| Ok(accepted))
     }
 

--- a/src/vm/ast/errors.rs
+++ b/src/vm/ast/errors.rs
@@ -46,7 +46,7 @@ pub enum ParseErrors {
 pub struct ParseError {
     pub err: ParseErrors,
     pub pre_expressions: Option<Vec<PreSymbolicExpression>>,
-    pub diagnostic:Diagnostic,
+    pub diagnostic: Diagnostic,
 }
 
 impl ParseError {

--- a/src/vm/ast/errors.rs
+++ b/src/vm/ast/errors.rs
@@ -46,7 +46,7 @@ pub enum ParseErrors {
 pub struct ParseError {
     pub err: ParseErrors,
     pub pre_expressions: Option<Vec<PreSymbolicExpression>>,
-    pub diagnostic: Diagnostic,
+    pub diagnostic:Diagnostic,
 }
 
 impl ParseError {

--- a/src/vm/clarity.rs
+++ b/src/vm/clarity.rs
@@ -876,7 +876,7 @@ mod tests {
                                        |_, _| false)).unwrap_err() {
                     Error::CostError(total, limit) => {
                         eprintln!("{}, {}", total, limit);
-                        (limit.runtime == 100 && total.runtime > 100)
+                        limit.runtime == 100 && total.runtime > 100
                     },
                     x => {
                         eprintln!("{}", x);

--- a/testnet/src/tests/integrations.rs
+++ b/testnet/src/tests/integrations.rs
@@ -13,7 +13,6 @@ use stacks::burnchains::Address;
 use stacks::net::{AccountEntryResponse, ContractSrcResponse, CallReadOnlyRequestBody};
 use stacks::net::StacksMessageCodec;
 use stacks::vm::clarity::ClarityConnection;
-use stacks::chainstate::stacks::C32_ADDRESS_VERSION_TESTNET_SINGLESIG;
 
 use crate::config::InitialBalance;
 use crate::helium::RunLoop;
@@ -520,15 +519,14 @@ fn integration_test_get_info() {
                 let tx_xfer = make_stacks_transfer(&spender_sk, round.into(), 200,
                                                    &StacksAddress::from_string(ADDR_4).unwrap().into(), 123);
 
-                let res = client.post(&path)
+                let res: String = client.post(&path)
                     .header("Content-Type", "application/octet-stream")
                     .body(tx_xfer.clone())
                     .send()
                     .unwrap()
-                    .text()
+                    .json()
                     .unwrap();
 
-                eprintln!("{}", res);
                 assert_eq!(res, format!("{}", StacksTransaction::consensus_deserialize(&mut &tx_xfer[..]).unwrap().txid()));
                 
                 // let's submit an invalid transaction!
@@ -947,9 +945,7 @@ fn mempool_errors() {
         let spender_sk = StacksPrivateKey::from_hex(SK_3).unwrap();
         let spender_addr = to_addr(&spender_sk);
 
-        let mut send_to = StacksAddress::from_string(ADDR_4).unwrap();
-        send_to.version = C32_ADDRESS_VERSION_TESTNET_SINGLESIG;
-        let mut send_to = send_to.into();
+        let send_to = StacksAddress::from_string(ADDR_4).unwrap().into();
 
         if round == 1 {
             // let's submit an invalid transaction!

--- a/testnet/src/tests/integrations.rs
+++ b/testnet/src/tests/integrations.rs
@@ -963,7 +963,7 @@ fn mempool_errors() {
                 .unwrap();
 
             eprintln!("{}", res);
-            assert_eq!(res.get("txid").unwrap().as_str().unwrap(), format!("0x{}", tx_xfer_invalid_tx.txid()));
+            assert_eq!(res.get("txid").unwrap().as_str().unwrap(), tx_xfer_invalid_tx.txid().to_string());
             assert_eq!(res.get("error").unwrap().as_str().unwrap(), "transaction rejected");
             assert_eq!(res.get("reason").unwrap().as_str().unwrap(), "BadNonce");
             let data = res.get("reason_data").unwrap();
@@ -985,7 +985,7 @@ fn mempool_errors() {
                 .unwrap();
 
             eprintln!("{}", res);
-            assert_eq!(res.get("txid").unwrap().as_str().unwrap(), format!("0x{}", tx_xfer_invalid_tx.txid()));
+            assert_eq!(res.get("txid").unwrap().as_str().unwrap(), tx_xfer_invalid_tx.txid().to_string());
             assert_eq!(res.get("error").unwrap().as_str().unwrap(), "transaction rejected");
             assert_eq!(res.get("reason").unwrap().as_str().unwrap(), "FeeTooLow");
             let data = res.get("reason_data").unwrap();
@@ -1005,7 +1005,7 @@ fn mempool_errors() {
                 .unwrap();
 
             eprintln!("{}", res);
-            assert_eq!(res.get("txid").unwrap().as_str().unwrap(), format!("0x{}", tx_xfer_invalid_tx.txid()));
+            assert_eq!(res.get("txid").unwrap().as_str().unwrap(), tx_xfer_invalid_tx.txid().to_string());
             assert_eq!(res.get("error").unwrap().as_str().unwrap(), "transaction rejected");
             assert_eq!(res.get("reason").unwrap().as_str().unwrap(), "NotEnoughFunds");
             let data = res.get("reason_data").unwrap();

--- a/testnet/src/tests/integrations.rs
+++ b/testnet/src/tests/integrations.rs
@@ -13,6 +13,7 @@ use stacks::burnchains::Address;
 use stacks::net::{AccountEntryResponse, ContractSrcResponse, CallReadOnlyRequestBody};
 use stacks::net::StacksMessageCodec;
 use stacks::vm::clarity::ClarityConnection;
+use stacks::chainstate::stacks::C32_ADDRESS_VERSION_TESTNET_SINGLESIG;
 
 use crate::config::InitialBalance;
 use crate::helium::RunLoop;
@@ -890,6 +891,133 @@ fn block_limit_runtime_test() {
                 assert_eq!(block.block.txs.len(), 4);
             },
             _ => {},
+        }
+    });
+
+    run_loop.start(num_rounds);
+}
+
+
+#[test]
+fn mempool_errors() {
+    let mut conf = super::new_test_conf();
+
+    conf.burnchain.commit_anchor_block_within = 5000;
+
+    let spender_addr = to_addr(&StacksPrivateKey::from_hex(SK_3).unwrap()).into();
+    conf.initial_balances.push(InitialBalance { 
+        address: spender_addr,
+        amount: 100300
+    });
+
+    let num_rounds = 2;
+
+    let rpc_bind = conf.node.rpc_bind.clone();
+
+    { 
+        let mut http_opt = HTTP_BINDING.lock().unwrap();
+        http_opt.replace(format!("http://{}", &rpc_bind));
+    }
+
+    let mut run_loop = RunLoop::new(conf);
+    run_loop.callbacks.on_new_tenure(|round, _burnchain_tip, chain_tip, tenure| {
+        let contract_sk = StacksPrivateKey::from_hex(SK_1).unwrap();
+        let header_hash = chain_tip.block.block_hash();
+        let burn_header_hash = chain_tip.metadata.burn_header_hash;
+
+        if round == 1 { // block-height = 2
+            let publish_tx = make_contract_publish(&contract_sk, 0, 0, "get-info", GET_INFO_CONTRACT);
+            eprintln!("Tenure in 1 started!");
+            tenure.mem_pool.submit_raw(&burn_header_hash, &header_hash,publish_tx).unwrap();
+        }
+
+        return
+    });
+
+    run_loop.callbacks.on_new_stacks_chain_state(|round, _chain_state, _block, _chain_tip_info| {
+        let contract_sk = StacksPrivateKey::from_hex(SK_1).unwrap();
+        let _contract_identifier =
+            QualifiedContractIdentifier::parse(
+                &format!("{}.{}", to_addr(&contract_sk), "hello-contract")).unwrap();
+        let http_origin = {
+            HTTP_BINDING.lock().unwrap().clone().unwrap()
+        };
+        let client = reqwest::blocking::Client::new();
+        let path = format!("{}/v2/transactions", &http_origin);
+        let spender_sk = StacksPrivateKey::from_hex(SK_3).unwrap();
+        let spender_addr = to_addr(&spender_sk);
+
+        let mut send_to = StacksAddress::from_string(ADDR_4).unwrap();
+        send_to.version = C32_ADDRESS_VERSION_TESTNET_SINGLESIG;
+        let mut send_to = send_to.into();
+
+        if round == 1 {
+            // let's submit an invalid transaction!
+            eprintln!("Test: POST {} (invalid)", path);
+            let tx_xfer_invalid = make_stacks_transfer(&spender_sk, 3, 200,     // bad nonce
+                                                       &send_to, 456);
+            let tx_xfer_invalid_tx = StacksTransaction::consensus_deserialize(&mut &tx_xfer_invalid[..]).unwrap();
+
+            let res = client.post(&path)
+                .header("Content-Type", "application/octet-stream")
+                .body(tx_xfer_invalid.clone())
+                .send()
+                .unwrap()
+                .json::<serde_json::Value>()
+                .unwrap();
+
+            eprintln!("{}", res);
+            assert_eq!(res.get("txid").unwrap().as_str().unwrap(), format!("0x{}", tx_xfer_invalid_tx.txid()));
+            assert_eq!(res.get("error").unwrap().as_str().unwrap(), "transaction rejected");
+            assert_eq!(res.get("reason").unwrap().as_str().unwrap(), "BadNonce");
+            let data = res.get("reason_data").unwrap();
+            assert_eq!(data.get("is_origin").unwrap().as_bool().unwrap(), true);
+            assert_eq!(data.get("principal").unwrap().as_str().unwrap(), &spender_addr.to_string());
+            assert_eq!(data.get("expected").unwrap().as_i64().unwrap(), 0);
+            assert_eq!(data.get("actual").unwrap().as_i64().unwrap(), 3);
+
+            let tx_xfer_invalid = make_stacks_transfer(&spender_sk, 0, 1, // bad fee
+                                                       &send_to, 456);
+            let tx_xfer_invalid_tx = StacksTransaction::consensus_deserialize(&mut &tx_xfer_invalid[..]).unwrap();
+
+            let res = client.post(&path)
+                .header("Content-Type", "application/octet-stream")
+                .body(tx_xfer_invalid.clone())
+                .send()
+                .unwrap()
+                .json::<serde_json::Value>()
+                .unwrap();
+
+            eprintln!("{}", res);
+            assert_eq!(res.get("txid").unwrap().as_str().unwrap(), format!("0x{}", tx_xfer_invalid_tx.txid()));
+            assert_eq!(res.get("error").unwrap().as_str().unwrap(), "transaction rejected");
+            assert_eq!(res.get("reason").unwrap().as_str().unwrap(), "FeeTooLow");
+            let data = res.get("reason_data").unwrap();
+            assert_eq!(data.get("expected").unwrap().as_u64().unwrap(), 180);
+            assert_eq!(data.get("actual").unwrap().as_u64().unwrap(), 1);
+
+            let tx_xfer_invalid = make_stacks_transfer(&contract_sk, 1, 200, // not enough funds!
+                                                       &send_to, 456);
+            let tx_xfer_invalid_tx = StacksTransaction::consensus_deserialize(&mut &tx_xfer_invalid[..]).unwrap();
+
+            let res = client.post(&path)
+                .header("Content-Type", "application/octet-stream")
+                .body(tx_xfer_invalid.clone())
+                .send()
+                .unwrap()
+                .json::<serde_json::Value>()
+                .unwrap();
+
+            eprintln!("{}", res);
+            assert_eq!(res.get("txid").unwrap().as_str().unwrap(), format!("0x{}", tx_xfer_invalid_tx.txid()));
+            assert_eq!(res.get("error").unwrap().as_str().unwrap(), "transaction rejected");
+            assert_eq!(res.get("reason").unwrap().as_str().unwrap(), "NotEnoughFunds");
+            let data = res.get("reason_data").unwrap();
+            assert_eq!(data.get("expected").unwrap().as_str().unwrap(),
+                       format!("0x{:032x}", 656));
+            assert_eq!(data.get("actual").unwrap().as_str().unwrap(),
+                       format!("0x{:032x}", 0));
+
         }
     });
 

--- a/testnet/src/tests/mempool.rs
+++ b/testnet/src/tests/mempool.rs
@@ -159,7 +159,7 @@ fn mempool_setup_chainstate() {
             let tx = StacksTransaction::consensus_deserialize(&mut tx_bytes.as_slice()).unwrap();
             let e = chain_state.will_admit_mempool_tx(burn_hash, block_hash, &tx, tx_bytes.len() as u64).unwrap_err(); 
             eprintln!("Err: {:?}", e);
-            assert!(if let MemPoolRejection::NotEnoughFunds(110000, 99900) = e { true } else { false });
+            assert!(if let MemPoolRejection::NotEnoughFunds(111000, 99900) = e { true } else { false });
 
             let tx_bytes = make_stacks_transfer(&contract_sk, 1, 99900, &other_addr, 1000);
             let tx = StacksTransaction::consensus_deserialize(&mut tx_bytes.as_slice()).unwrap();

--- a/testnet/src/tests/mod.rs
+++ b/testnet/src/tests/mod.rs
@@ -39,7 +39,7 @@ pub const SK_1: &'static str = "a1289f6438855da7decf9b61b852c882c398cff1446b2a0f
 pub const SK_2: &'static str = "4ce9a8f7539ea93753a36405b16e8b57e15a552430410709c2b6d65dca5c02e201";
 pub const SK_3: &'static str = "cb95ddd0fe18ec57f4f3533b95ae564b3f1ae063dbf75b46334bd86245aef78501";
 
-pub const ADDR_4: &'static str = "SP31DA6FTSJX2WGTZ69SFY11BH51NZMB0ZW97B5P0";
+pub const ADDR_4: &'static str = "ST31DA6FTSJX2WGTZ69SFY11BH51NZMB0ZZ239N96";
 
 lazy_static! {
     pub static ref PUBLISH_CONTRACT: Vec<u8> = make_contract_publish(


### PR DESCRIPTION
This addresses #1430 by making the `reason` field a well-defined set of strings, and making `reason_data` provide structured error data.

This also makes the "ok" response a JSON string, so that the `/v2/transactions` result is more in line with the other RPC endpoint responses (which are otherwise all JSON).

