### PR TITLE
Mocknet to use StacksBlockBuilder::build_anchored_block 

### DIFF
--- a/testnet/src/tenure.rs
+++ b/testnet/src/tenure.rs
@@ -4,12 +4,14 @@ use super::node::{TESTNET_CHAIN_ID, ChainTip};
 use std::time::{Instant, Duration};
 use std::thread;
 
-use stacks::burnchains::Txid;
-use stacks::chainstate::stacks::db::{StacksChainState, ClarityTx};
-use stacks::chainstate::stacks::{StacksPrivateKey, StacksBlock, StacksWorkScore, StacksTransaction, StacksMicroblock, StacksBlockBuilder};
+use stacks::burnchains::PublicKey;
+use stacks::chainstate::stacks::db::{StacksChainState};
+use stacks::chainstate::stacks::{StacksPrivateKey, StacksBlock, StacksWorkScore, 
+                                 StacksPublicKey, StacksTransaction, StacksMicroblock, StacksBlockBuilder};
 use stacks::chainstate::burn::VRFSeed;
 use stacks::core::mempool::MemPoolDB;
 use stacks::util::vrf::VRFProof;
+use stacks::util::hash::Hash160;
 
 pub struct TenureArtifacts {
     pub anchored_block: StacksBlock,
@@ -19,7 +21,6 @@ pub struct TenureArtifacts {
 }
 
 pub struct Tenure {
-    block_builder: Option<StacksBlockBuilder>,
     coinbase_tx: StacksTransaction,
     config: Config,
     pub burnchain_tip: BurnchainTip,
@@ -27,6 +28,9 @@ pub struct Tenure {
     pub mem_pool: MemPoolDB,
     pub vrf_seed: VRFSeed,
     burn_fee_cap: u64,
+    vrf_proof: VRFProof,
+    microblock_pubkeyhash: Hash160,
+    parent_block_total_burn: u64
 }
 
 impl <'a> Tenure {
@@ -40,58 +44,36 @@ impl <'a> Tenure {
                vrf_proof: VRFProof,
                burn_fee_cap: u64) -> Tenure {
 
-        let ratio = StacksWorkScore {
-            burn: burnchain_tip.block_snapshot.total_burn,
-            work: parent_block.metadata.anchored_header.total_work.work + 1,
-        };
+        let mut microblock_pubkey = StacksPublicKey::from_private(&microblock_secret_key);
+        microblock_pubkey.set_compressed(true);
+        let microblock_pubkeyhash = Hash160::from_data(&microblock_pubkey.to_bytes());
 
-        let block_builder = match burnchain_tip.block_snapshot.total_burn {
-            0 => StacksBlockBuilder::first(
-                1, 
-                &parent_block.metadata.burn_header_hash, 
-                parent_block.metadata.burn_header_timestamp, 
-                &vrf_proof, 
-                &microblock_secret_key),
-            _ => StacksBlockBuilder::from_parent(
-                1, 
-                &parent_block.metadata, 
-                &ratio, 
-                &vrf_proof, 
-                &microblock_secret_key)
-        };
+        let parent_block_total_burn = burnchain_tip.block_snapshot.total_burn;
 
         Self {
-            block_builder: Some(block_builder),
             coinbase_tx,
             config,
             burnchain_tip,
             mem_pool,
             parent_block,
             vrf_seed: VRFSeed::from_proof(&vrf_proof),
+            vrf_proof,
             burn_fee_cap,
-        }
-    }
-
-    pub fn handle_txs(&mut self, clarity_tx: &mut ClarityTx<'a>, txs_in_mempool: Vec<StacksTransaction>, candidates: &mut Vec<Txid>) {
-        for tx in txs_in_mempool {
-            if candidates.contains(&tx.txid()) {
-                continue;
-            }
-
-            let res = self.block_builder.as_mut()
-                .expect("BUG: attempted to process tx in tenure that already committed")
-                .try_mine_tx(clarity_tx, &tx);
-            match res {
-                Err(e) => error!("Failed mining transaction - {}", e),
-                Ok(_) => {
-                    candidates.push(tx.txid());
-                },
-            };
+            microblock_pubkeyhash,
+            parent_block_total_burn
         }
     }
 
     pub fn run(&mut self) -> Option<TenureArtifacts> {
         info!("Node starting new tenure with VRF {:?}", self.vrf_seed);
+
+        let duration_left: u128 = self.config.burnchain.commit_anchor_block_within as u128;
+        let mut elapsed = Instant::now().duration_since(self.burnchain_tip.received_at);
+        while duration_left.saturating_sub(elapsed.as_millis()) > 0 {
+            thread::sleep(Duration::from_millis(1000));
+            elapsed = Instant::now().duration_since(self.burnchain_tip.received_at);
+        } 
+
 
         let mut chain_state = StacksChainState::open_with_block_limit(
             false, 
@@ -99,32 +81,12 @@ impl <'a> Tenure {
             &self.config.get_chainstate_path(),
             self.config.block_limit.clone()).unwrap();
 
-        let burn_header_hash = self.parent_block.metadata.burn_header_hash;
-        let block_hash= self.parent_block.block.block_hash();
-
-        let mut clarity_tx = self.block_builder.as_mut()
-            .expect("BUG: attempted to process tx in tenure that already committed")
-            .epoch_begin(&mut chain_state).unwrap();
-        let mut candidates = vec![];
-
-        self.handle_txs(&mut clarity_tx, vec![self.coinbase_tx.clone()], &mut candidates);
-
-        let duration_left: u128 = self.config.burnchain.commit_anchor_block_within as u128;
-        let mut elapsed = Instant::now().duration_since(self.burnchain_tip.received_at);
-        while duration_left.saturating_sub(elapsed.as_millis()) > 0 {
-            let txs_in_mempool = self.mem_pool.poll(&burn_header_hash, &block_hash);
-            self.handle_txs(&mut clarity_tx, txs_in_mempool, &mut candidates);
-            thread::sleep(Duration::from_millis(1000));
-            elapsed = Instant::now().duration_since(self.burnchain_tip.received_at);
-        } 
-
-        let mut block_builder = self.block_builder.take()
-            .expect("BUG: attempted to process tx in tenure that already committed");
-
-        let anchored_block = block_builder.mine_anchored_block(&mut clarity_tx);
+        let anchored_block = StacksBlockBuilder::build_anchored_block(
+            &mut chain_state, &mut self.mem_pool, &self.parent_block.metadata,
+            self.parent_block_total_burn, self.vrf_proof.clone(), self.microblock_pubkeyhash.clone(),
+            &self.coinbase_tx, self.config.block_limit.clone()).unwrap();
 
         info!("Finish tenure: {}", anchored_block.block_hash());
-        block_builder.epoch_finish(clarity_tx);
 
         let artifact = TenureArtifacts {
             anchored_block,

--- a/testnet/src/tests/integrations.rs
+++ b/testnet/src/tests/integrations.rs
@@ -720,10 +720,10 @@ fn bad_contract_tx_rollback() {
     let sk_3 = StacksPrivateKey::from_hex(SK_3).unwrap();
     let addr_3 = to_addr(&sk_3);
 
-    conf.burnchain.commit_anchor_block_within = 8000;
+    conf.burnchain.commit_anchor_block_within = 5000;
     conf.add_initial_balance(addr_3.to_string(), 100000);
 
-    let num_rounds = 3;
+    let num_rounds = 4;
 
     let mut run_loop = RunLoop::new(conf);
     run_loop.callbacks.on_new_tenure(|round, _burnchain_tip, _chain_tip, tenure| {
@@ -748,8 +748,8 @@ fn bad_contract_tx_rollback() {
             tenure.mem_pool.submit_raw(burn_header_hash, block_hash, xfer_to_contract).unwrap();
             
             // doesn't consistently get mined by the StacksBlockBuilder, because order matters!
-            // let xfer_to_contract = make_stacks_transfer(&sk_3, 2, 0, &addr_2.into(), 3000);
-            // tenure.mem_pool.submit_raw(burn_header_hash, block_hash, xfer_to_contract).unwrap();
+            let xfer_to_contract = make_stacks_transfer(&sk_3, 2, 0, &addr_2.into(), 3000);
+            tenure.mem_pool.submit_raw(burn_header_hash, block_hash, xfer_to_contract).unwrap();
             
             let publish_tx = make_contract_publish(&contract_sk, 0, 0, "faucet", FAUCET_CONTRACT);
             tenure.mem_pool.submit_raw(burn_header_hash, block_hash, publish_tx).unwrap();
@@ -796,8 +796,13 @@ fn bad_contract_tx_rollback() {
             },
             2 => {
                 assert_eq!(chain_tip.metadata.block_height, 3);
-                // Block #2 should have 4 txs -- coinbase + 1 transfers + 1 publish
+                // Block #2 should have 4 txs -- coinbase + 1 transfer + 1 publish
                 assert_eq!(chain_tip.block.txs.len(), 3);
+            },
+            3 => {
+                assert_eq!(chain_tip.metadata.block_height, 4);
+                // Block #2 should have 4 txs -- coinbase + 1 transfer
+                assert_eq!(chain_tip.block.txs.len(), 2);
             },
             _ => {},
         }

--- a/testnet/src/tests/integrations.rs
+++ b/testnet/src/tests/integrations.rs
@@ -720,7 +720,7 @@ fn bad_contract_tx_rollback() {
     let sk_3 = StacksPrivateKey::from_hex(SK_3).unwrap();
     let addr_3 = to_addr(&sk_3);
 
-    conf.burnchain.commit_anchor_block_within = 5000;
+    conf.burnchain.commit_anchor_block_within = 8000;
     conf.add_initial_balance(addr_3.to_string(), 100000);
 
     let num_rounds = 3;
@@ -747,8 +747,9 @@ fn bad_contract_tx_rollback() {
             let (burn_header_hash, block_hash) = (&tenure.parent_block.metadata.burn_header_hash, &tenure.parent_block.metadata.anchored_header.block_hash());
             tenure.mem_pool.submit_raw(burn_header_hash, block_hash, xfer_to_contract).unwrap();
             
-            let xfer_to_contract = make_stacks_transfer(&sk_3, 2, 0, &addr_2.into(), 3000);
-            tenure.mem_pool.submit_raw(burn_header_hash, block_hash, xfer_to_contract).unwrap();
+            // doesn't consistently get mined by the StacksBlockBuilder, because order matters!
+            // let xfer_to_contract = make_stacks_transfer(&sk_3, 2, 0, &addr_2.into(), 3000);
+            // tenure.mem_pool.submit_raw(burn_header_hash, block_hash, xfer_to_contract).unwrap();
             
             let publish_tx = make_contract_publish(&contract_sk, 0, 0, "faucet", FAUCET_CONTRACT);
             tenure.mem_pool.submit_raw(burn_header_hash, block_hash, publish_tx).unwrap();
@@ -795,8 +796,8 @@ fn bad_contract_tx_rollback() {
             },
             2 => {
                 assert_eq!(chain_tip.metadata.block_height, 3);
-                // Block #2 should have 4 txs -- coinbase + 2 transfers + 1 publish
-                assert_eq!(chain_tip.block.txs.len(), 4);
+                // Block #2 should have 4 txs -- coinbase + 1 transfers + 1 publish
+                assert_eq!(chain_tip.block.txs.len(), 3);
             },
             _ => {},
         }


### PR DESCRIPTION
This fixes previously bad mempool polling behavior (it would only obtain TXs accepted at exactly the current chain tip).

One test needed to be modified because of this change (it relied on the exact order of attempted applications from the block builder)