### PR TITLE
Use alpine in primary docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,22 @@
-FROM rust:latest as build
+FROM rust:stretch as build
 
 WORKDIR /src
 
 COPY . .
 
-RUN cargo build --release --workspace=./
-RUN cd /src/target/release && \
+RUN rustup target add x86_64-unknown-linux-musl && \
+    apt-get update && apt-get install -y musl-tools
+
+RUN CC=musl-gcc \
+    CC_x86_64_unknown_linux_musl=musl-gcc \
+    CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc \
+    cargo build --release --target x86_64-unknown-linux-musl --workspace=./
+
+RUN cd /src/target/x86_64-unknown-linux-musl/release && \
     mkdir /out && \
     cp blockstack-core /out && cp blockstack-cli /out && cp clarity-cli /out && cp stacks-node /out
 
-FROM debian:stable-slim
+FROM alpine
 
 COPY --from=build /out/ /bin/
 

--- a/testnet/bitcoin-neon-controller/Dockerfile
+++ b/testnet/bitcoin-neon-controller/Dockerfile
@@ -1,24 +1,19 @@
-FROM rust as builder
-WORKDIR /src/bitcoin-neon-controller
+FROM rust:stretch as builder
+
+WORKDIR /src
 COPY . .
-RUN cd /src/bitcoin-neon-controller && cargo build --target x86_64-unknown-linux-gnu --release
-RUN cargo install --target x86_64-unknown-linux-gnu --path /src/bitcoin-neon-controller
+
+RUN rustup target add x86_64-unknown-linux-musl && \
+    apt-get update && apt-get install -y musl-tools
+
+RUN CC=musl-gcc \
+    CC_x86_64_unknown_linux_musl=musl-gcc \
+    CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc \
+    cargo build --release --target x86_64-unknown-linux-musl
 
 FROM alpine
-ARG GLIBC_VERSION="2.31-r0"
-ARG GLIBC_URL="https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-${GLIBC_VERSION}.apk"
-ARG GLIBC_BIN_URL="https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-bin-${GLIBC_VERSION}.apk"
-ARG GLIBC_I18N_URL="https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-i18n-${GLIBC_VERSION}.apk"
 WORKDIR /
-RUN apk --no-cache add --update ca-certificates curl libgcc \
-    && curl -L -s -o /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub \
-    && curl -L -s -o /tmp/glibc-${GLIBC_VERSION}.apk ${GLIBC_URL} \
-    && curl -L -s -o /tmp/glibc-bin-${GLIBC_VERSION}.apk ${GLIBC_BIN_URL} \
-    && curl -L -s -o /tmp/glibc-i18n-${GLIBC_VERSION}.apk ${GLIBC_I18N_URL} \
-    && apk --no-cache add /tmp/glibc-${GLIBC_VERSION}.apk /tmp/glibc-bin-${GLIBC_VERSION}.apk /tmp/glibc-i18n-${GLIBC_VERSION}.apk \
-    && /usr/glibc-compat/sbin/ldconfig /usr/lib /lib \
-    && rm /tmp/glibc-${GLIBC_VERSION}.apk /tmp/glibc-bin-${GLIBC_VERSION}.apk /tmp/glibc-i18n-${GLIBC_VERSION}.apk
-COPY --from=builder /usr/local/cargo/bin/bitcoin-neon-controller /usr/local/bin/bitcoin-neon-controller
+COPY --from=builder /src/target/x86_64-unknown-linux-musl/release/bitcoin-neon-controller /bin/
 COPY config.toml.default /etc/bitcoin-neon-controller/Config.toml
 EXPOSE 3000
-CMD ["/usr/local/bin/bitcoin-neon-controller /etc/bitcoin-neon-controller/Config.toml"]
+CMD ["/bin/bitcoin-neon-controller", "/etc/bitcoin-neon-controller/Config.toml"]


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1447546/81305949-386aef80-907f-11ea-89f8-a4fd6c38b811.png)

Requested by devops. Also simplifies a bunch of glibc lib curls in the `bitcoin-neon-controller` dockerfile. 