### PR TITLE
BTC Faucet support

### DIFF
--- a/testnet/bitcoin-neon-controller/Cargo.toml
+++ b/testnet/bitcoin-neon-controller/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Ludo Galabru <ludovic@blockstack.com>"]
 edition = "2018"
 
 [dependencies]
-async-h1 = "1.0.2"
+async-h1 = "1.1"
 async-std = { version = "1.4.0", features = ["attributes"] }
 base64 = "0.12.0"
 http-types = "1.0.0"

--- a/testnet/bitcoin-neon-controller/config.toml.default
+++ b/testnet/bitcoin-neon-controller/config.toml.default
@@ -7,3 +7,10 @@ bitcoind_rpc_host = "127.0.0.1:18443"
 bitcoind_rpc_user = "helium-node"
 bitcoind_rpc_pass = "secret"
 genesis_timestamp = 1588615296
+whitelisted_rpc_calls = [
+    "listunspent",
+    "importaddress",
+    "sendrawtransaction",
+    "getrawtransaction",
+    "scantxoutset"
+]

--- a/testnet/bitcoin-neon-controller/local-leader.toml.default
+++ b/testnet/bitcoin-neon-controller/local-leader.toml.default
@@ -7,6 +7,13 @@ bitcoind_rpc_host = "127.0.0.1:18443"
 bitcoind_rpc_user = "helium-node"
 bitcoind_rpc_pass = "secret"
 genesis_timestamp = 1588615296
+whitelisted_rpc_calls = [
+    "listunspent",
+    "importaddress",
+    "sendrawtransaction",
+    "getrawtransaction",
+    "scantxoutset"
+]
 
 # Faucet:
 # Private Key          cTYqAVPS7uJTAcxyzkXWjmRGoCjkPcb38wZVRjyXov1RiRDWPQj3

--- a/testnet/bitcoin-neon-controller/local-leader.toml.default
+++ b/testnet/bitcoin-neon-controller/local-leader.toml.default
@@ -2,11 +2,11 @@
 rpc_bind = "0.0.0.0:28443"
 block_time = 7000
 miner_address = "mtFzK54XtpktHj7fKonFExEPEGkUMsiXdy"
-faucet_address = "n3k15aVS4rEWhVYn4YfAFjD8Em5mmsducg"
+faucet_address = "mrzLDS7LT3otAnpiRWGYkWipdnAZJaXAZQ"
 bitcoind_rpc_host = "127.0.0.1:18443"
 bitcoind_rpc_user = "helium-node"
 bitcoind_rpc_pass = "secret"
-genesis_timestamp = 1588615296
+genesis_timestamp = 1588902103
 whitelisted_rpc_calls = [
     "listunspent",
     "importaddress",

--- a/testnet/bitcoin-neon-controller/src/main.rs
+++ b/testnet/bitcoin-neon-controller/src/main.rs
@@ -143,7 +143,19 @@ async fn accept(addr: String, stream: TcpStream, config: &ConfigFile) -> http_ty
                 let stream = TcpStream::connect(config.neon.bitcoind_rpc_host.clone()).await?;
                 let body = serde_json::to_vec(&rpc_req).unwrap();
                 let req = build_request(&config, body);
-                client::connect(stream.clone(), req).await
+                let response = match client::connect(stream.clone(), req).await {
+                    Ok(ref mut res) => {
+                        let mut response = Response::new(res.status());
+                        let _ = response.append_header("Content-Type", "application/json");
+                        response.set_body(res.take_body());
+                        response
+                    },
+                    Err(err) => {
+                        println!("Unable to reach host: {:?}", err);
+                        return Ok(Response::new(StatusCode::MethodNotAllowed))
+                    }
+                };
+                Ok(response)
             },
             _ => {
                 Ok(Response::new(StatusCode::MethodNotAllowed))
@@ -229,11 +241,11 @@ pub struct RPCRequest {
     /// The name of the RPC call
     pub method: String,
     /// Parameters to the RPC call
-    pub params: Vec<serde_json::Value>,
+    pub params: serde_json::Value,
     /// Identifier for this Request, which should appear in the response
     pub id: serde_json::Value,
     /// jsonrpc field, MUST be "2.0"
-    pub jsonrpc: String,
+    pub jsonrpc: serde_json::Value,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -249,18 +261,18 @@ impl RPCRequest {
     pub fn generate_next_block_req(blocks_count: u64, address: String) -> RPCRequest {
         RPCRequest {
             method: "generatetoaddress".to_string(),
-            params: vec![blocks_count.into(), address.into()],
+            params: serde_json::Value::Array(vec![blocks_count.into(), address.into()]),
             id: 0.into(),
-            jsonrpc: "2.0".to_string()
+            jsonrpc: "2.0".to_string().into()
         }
     }
 
     pub fn is_chain_bootstrapped() -> RPCRequest {
         RPCRequest {
             method: "getblockhash".to_string(),
-            params: vec![200.into()],
+            params: serde_json::Value::Array(vec![200.into()]),
             id: 0.into(),
-            jsonrpc: "2.0".to_string()
+            jsonrpc: "2.0".to_string().into()
         }
     }
 }

--- a/testnet/bitcoin-neon-controller/src/main.rs
+++ b/testnet/bitcoin-neon-controller/src/main.rs
@@ -132,13 +132,10 @@ async fn accept(addr: String, stream: TcpStream, config: &ConfigFile) -> http_ty
 
                 println!("{:?}", rpc_req);
 
-                let authorized_methods = vec![
-                    "listunspent",
-                    "importaddress",
-                    "sendrawtransaction"];
+                let authorized_methods = &config.neon.whitelisted_rpc_calls;
                 
                 // Guard: unauthorized method
-                if !authorized_methods.contains(&rpc_req.method.as_str()) {
+                if !authorized_methods.contains(&rpc_req.method) {
                     return Ok(Response::new(StatusCode::MethodNotAllowed))
                 }
 
@@ -303,6 +300,8 @@ pub struct RegtestConfig {
     bitcoind_rpc_pass: String,
     /// Used for deducting the right amount of blocks
     genesis_timestamp: u64,
+    /// List of whitelisted RPC calls
+    whitelisted_rpc_calls: Vec<String>, 
 }
 
 impl RegtestConfig {


### PR DESCRIPTION
Per devx request, the faucet is using 2 additional RPC methods that needs to be whitelisted.
This will be a config from now on - we should not have to recompile the project for updating the whitelist.