### PR TITLE
Fix/neon fixes 20200507

### DIFF
--- a/src/burnchains/bitcoin/indexer.rs
+++ b/src/burnchains/bitcoin/indexer.rs
@@ -272,7 +272,7 @@ impl BitcoinIndexerRuntime {
             block_height: 0,
             last_getdata_send_time: 0,
             last_getheaders_send_time: 0,
-            timeout: 30,
+            timeout: 300,
         }
     }
 }

--- a/src/burnchains/bitcoin/spv.rs
+++ b/src/burnchains/bitcoin/spv.rs
@@ -55,7 +55,8 @@ use util::db::{
     Error as db_error,
     FromColumn,
     FromRow,
-    tx_begin_immediate
+    tx_begin_immediate,
+    tx_busy_handler,
 };
 
 const BLOCK_HEADER_SIZE: u64 = 81;
@@ -206,6 +207,8 @@ impl SpvClient {
 
         let mut conn = Connection::open_with_flags(headers_path, open_flags)
             .map_err(db_error::SqliteError)?;
+        
+        conn.busy_handler(Some(tx_busy_handler)).map_err(db_error::SqliteError)?;
 
         if create_flag {
             SpvClient::db_instantiate(&mut conn)?;

--- a/src/chainstate/stacks/db/blocks.rs
+++ b/src/chainstate/stacks/db/blocks.rs
@@ -2536,7 +2536,7 @@ impl StacksChainState {
     pub fn has_attacheable_staging_blocks(blocks_conn: &DBConn) -> Result<bool, Error> {
         // go through staging blocks and see if any of them match headers and are attacheable.
         // pick randomly -- don't allow the network sender to choose the processing order!
-        let sql = "SELECT 1 FROM staging_blocks WHERE processed = 0 AND attacheable = 1 AND orphaned = 0".to_string();
+        let sql = "SELECT 1 FROM staging_blocks WHERE processed = 0 AND attacheable = 1 AND orphaned = 0 LIMIT 1".to_string();
         let available = blocks_conn.query_row(&sql, NO_PARAMS, |_row| ()).optional().map_err(|e| Error::DBError(db_error::SqliteError(e)))?.is_some();
         Ok(available)
     }

--- a/src/chainstate/stacks/db/mod.rs
+++ b/src/chainstate/stacks/db/mod.rs
@@ -73,7 +73,8 @@ use util::db::{
     FromRow,
     FromColumn,
     db_mkdirs,
-    tx_begin_immediate
+    tx_begin_immediate,
+    tx_busy_handler,
 };
 
 use util::hash::to_hex;
@@ -530,6 +531,7 @@ impl StacksChainState {
             };
 
         let mut conn = DBConn::open_with_flags(headers_path, open_flags).map_err(|e| Error::DBError(db_error::SqliteError(e)))?;
+        conn.busy_handler(Some(tx_busy_handler)).map_err(|e| Error::DBError(db_error::SqliteError(e)))?;
 
         if create_flag {
             // instantiate!

--- a/src/core/mempool.rs
+++ b/src/core/mempool.rs
@@ -52,6 +52,7 @@ use util::db::query_row;
 use util::db::Error as db_error;
 use util::get_epoch_time_secs;
 use util::db::tx_begin_immediate;
+use util::db::tx_busy_handler;
 
 use core::FIRST_STACKS_BLOCK_HASH;
 use core::FIRST_BURNCHAIN_BLOCK_HASH;
@@ -271,6 +272,7 @@ impl MemPoolDB {
             };
 
         let mut conn = DBConn::open_with_flags(&db_path, open_flags).map_err(db_error::SqliteError)?;
+        conn.busy_handler(Some(tx_busy_handler)).map_err(db_error::SqliteError)?;
 
         if create_flag {
             // instantiate!

--- a/src/net/chat.rs
+++ b/src/net/chat.rs
@@ -886,8 +886,7 @@ impl ConversationP2P {
         // update cache
         BurnDB::merge_block_header_cache(chainstate.borrow_block_header_cache(), &block_hashes);
 
-        let inv_query : Vec<(BurnchainHeaderHash, Option<BlockHeaderHash>)> = block_hashes.into_iter().map(|(bhh, _, hh_opt)| (bhh, hh_opt)).collect();
-        let blocks_inv_data : BlocksInvData = chainstate.get_blocks_inventory(&inv_query).map_err(|e| net_error::from(e))?;
+        let blocks_inv_data : BlocksInvData = chainstate.get_blocks_inventory(&block_hashes).map_err(|e| net_error::from(e))?;
 
         debug!("{:?}: Handle GetBlocksInv from {:?}. Reply {:?} to request {:?}", &local_peer, &self, &blocks_inv_data, get_blocks_inv);
 

--- a/src/net/connection.rs
+++ b/src/net/connection.rs
@@ -334,6 +334,7 @@ pub struct ConnectionOptions {
     pub walk_interval: u64,
     pub inv_sync_interval: u64,
     pub download_interval: u64,
+    pub download_retry_interval: u64,
     pub dns_timeout: u128,
     pub max_inflight_blocks: u64,
     pub read_only_call_limit: ExecutionCost,
@@ -373,6 +374,7 @@ impl std::default::Default for ConnectionOptions {
             walk_interval: NEIGHBOR_WALK_INTERVAL,              // how often to do a neighbor walk.  Note that this should be _smaller_ than inv_sync_interval
             inv_sync_interval: INV_SYNC_INTERVAL,               // how often to synchronize block inventories
             download_interval: BLOCK_DOWNLOAD_INTERVAL,         // how often to synchronize blocks
+            download_retry_interval: 60,                        // how often to retry blocks we already tried to download
             dns_timeout: 15_000,            // DNS timeout, in millis
             max_inflight_blocks: 6,         // number of parallel block downloads
             read_only_call_limit: ExecutionCost { write_length: 0, write_count: 0,

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -1317,6 +1317,22 @@ impl NetworkResult {
         }
     }
 
+    pub fn has_blocks(&self) -> bool {
+        self.blocks.len() > 0 || self.pushed_blocks.len() > 0
+    }
+
+    pub fn has_microblocks(&self) -> bool {
+        self.confirmed_microblocks.len() > 0 || self.pushed_microblocks.len() > 0
+    }
+
+    pub fn has_transactions(&self) -> bool {
+        self.pushed_transactions.len() > 0 || self.uploaded_transactions.len() > 0
+    }
+
+    pub fn has_data_to_store(&self) -> bool {
+        self.has_blocks() || self.has_microblocks() || self.has_transactions()
+    }
+
     pub fn consume_unsolicited(&mut self, mut unhandled_messages: HashMap<NeighborKey, Vec<StacksMessage>>) -> () {
         for (neighbor_key, mut messages) in unhandled_messages.drain() {
             for message in messages.drain(..) {

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -1857,7 +1857,7 @@ pub mod test {
             let mut stacks_node = self.stacks_node.take().unwrap();
             let mut mempool = self.mempool.take().unwrap();
 
-            let ret = self.network.run(&mut burndb, &mut stacks_node.chainstate, &mut mempool, None, 10);
+            let ret = self.network.run(&mut burndb, &mut stacks_node.chainstate, &mut mempool, None, false, 10);
 
             self.burndb = Some(burndb);
             self.stacks_node = Some(stacks_node);
@@ -1871,7 +1871,7 @@ pub mod test {
             let mut stacks_node = self.stacks_node.take().unwrap();
             let mut mempool = self.mempool.take().unwrap();
 
-            let ret = self.network.run(&mut burndb, &mut stacks_node.chainstate, &mut mempool, Some(dns_client), 10);
+            let ret = self.network.run(&mut burndb, &mut stacks_node.chainstate, &mut mempool, Some(dns_client), false, 10);
 
             self.burndb = Some(burndb);
             self.stacks_node = Some(stacks_node);

--- a/src/net/p2p.rs
+++ b/src/net/p2p.rs
@@ -1628,7 +1628,8 @@ impl PeerNetwork {
     fn do_network_work(&mut self, 
                        burndb: &BurnDB, 
                        chainstate: &mut StacksChainState, 
-                       mut dns_client_opt: Option<&mut DNSClient>, 
+                       mut dns_client_opt: Option<&mut DNSClient>,
+                       download_backpressure: bool,
                        network_result: &mut NetworkResult) -> Result<bool, net_error> {
 
         // do some Actual Work(tm)
@@ -1642,8 +1643,14 @@ impl PeerNetwork {
                 PeerNetworkWorkState::BlockInvSync => {
                     // synchronize peer block inventories 
                     if self.do_network_inv_sync(burndb)? {
-                        // proceed to get blocks
-                        self.work_state = PeerNetworkWorkState::BlockDownload;
+                        if !download_backpressure {
+                            // proceed to get blocks, if we're not backpressured
+                            self.work_state = PeerNetworkWorkState::BlockDownload;
+                        }
+                        else {
+                            // skip downloads for now
+                            self.work_state = PeerNetworkWorkState::Prune;
+                        }
 
                         // pass along hints
                         if let Some(ref inv_sync) = self.inv_state {
@@ -1968,8 +1975,17 @@ impl PeerNetwork {
         }
         Ok(unhandled)
     }
-    
 
+    /// Are we in the process of downloading blocks?
+    pub fn has_more_downloads(&self) -> bool {
+        if let Some(ref dl) = self.block_downloader {
+            !dl.is_download_idle() || dl.is_initial_download()
+        }
+        else {
+            false
+        }
+    }
+    
     /// Update p2p networking state.
     /// -- accept new connections
     /// -- send data on ready sockets
@@ -1979,7 +1995,8 @@ impl PeerNetwork {
                         network_result: &mut NetworkResult,
                         burndb: &BurnDB, 
                         chainstate: &mut StacksChainState, 
-                        dns_client_opt: Option<&mut DNSClient>, 
+                        dns_client_opt: Option<&mut DNSClient>,
+                        download_backpressure: bool,
                         mut poll_state: NetworkPollState) -> Result<(), net_error> {
 
         if self.network.is_none() {
@@ -2024,7 +2041,7 @@ impl PeerNetwork {
         // do some Actual Work(tm)
         // do this _after_ processing new sockets, so the act of opening a socket doesn't trample
         // an already-used network ID.
-        let do_prune = self.do_network_work(burndb, chainstate, dns_client_opt, network_result)?;
+        let do_prune = self.do_network_work(burndb, chainstate, dns_client_opt, download_backpressure, network_result)?;
         if do_prune {
             // prune back our connections if it's been a while
             // (only do this if we're done with all other tasks).
@@ -2086,7 +2103,7 @@ impl PeerNetwork {
     /// -- runs the p2p and http peer main loop
     /// Returns the table of unhandled network messages to be acted upon, keyed by the neighbors
     /// that sent them (i.e. keyed by their event IDs)
-    pub fn run(&mut self, burndb: &BurnDB, chainstate: &mut StacksChainState, mempool: &mut MemPoolDB, dns_client_opt: Option<&mut DNSClient>, poll_timeout: u64) -> Result<NetworkResult, net_error> {
+    pub fn run(&mut self, burndb: &BurnDB, chainstate: &mut StacksChainState, mempool: &mut MemPoolDB, dns_client_opt: Option<&mut DNSClient>, download_backpressure: bool, poll_timeout: u64) -> Result<NetworkResult, net_error> {
         let mut poll_states = match self.network {
             None => {
                 test_debug!("{:?}: network not connected", &self.local_peer);
@@ -2111,7 +2128,7 @@ impl PeerNetwork {
             Ok(())
         })?;
         
-        self.dispatch_network(&mut result, burndb, chainstate, dns_client_opt, p2p_poll_state)?;
+        self.dispatch_network(&mut result, burndb, chainstate, dns_client_opt, download_backpressure, p2p_poll_state)?;
 
         Ok(result)
     }

--- a/src/net/relay.rs
+++ b/src/net/relay.rs
@@ -750,9 +750,9 @@ impl Relayer {
         if new_blocks.len() > 0 {
             info!("Processing newly received blocks: {}", new_blocks.len());
         }
+        
         // process as many epochs as we can.
-        // Try to process at least a few epochs
-        let max_epochs = if new_blocks.len() < 3 { 3 } else { new_blocks.len() };
+        let max_epochs = if new_blocks.len() < 1024 { 1024 } else { new_blocks.len() };
         let receipts: Vec<_> = chainstate.process_blocks(burndb, max_epochs)?.into_iter()
             .filter_map(|block_result| block_result.0).collect();
 

--- a/src/net/rpc.rs
+++ b/src/net/rpc.rs
@@ -106,8 +106,8 @@ pub struct ConversationHttp {
     keep_alive: bool,
     total_request_count: u64,       // number of messages taken from the inbox
     total_reply_count: u64,         // number of messages responsed to
-    last_request_timestamp: u64,    // absolute timestamp of last inbound request, in seconds
-    last_response_timestamp: u64,   // absolute timestamp of the last time we sent at least 1 byte in response
+    last_request_timestamp: u64,    // absolute timestamp of the last time we received at least 1 byte in a request
+    last_response_timestamp: u64,   // absolute timestamp of the last time we sent at least 1 byte in a response
     connection_time: u64,           // when this converation was instantiated
 
     // ongoing block streams
@@ -994,7 +994,10 @@ impl ConversationHttp {
             };
 
             total_recv += nrecv;
-            if nrecv == 0 {
+            if nrecv > 0 {
+                self.last_request_timestamp = get_epoch_time_secs();
+            }
+            else {
                 break;
             }
         }

--- a/src/vm/database/sqlite.rs
+++ b/src/vm/database/sqlite.rs
@@ -3,6 +3,8 @@ use rusqlite::types::{ToSql, FromSql};
 
 use chainstate::burn::BlockHeaderHash;
 
+use util::db::tx_busy_handler;
+
 use vm::contracts::Contract;
 use vm::errors::{Error, InterpreterError, RuntimeErrorType, InterpreterResult as Result, IncomparableError};
 
@@ -145,6 +147,9 @@ impl SqliteConnection {
 
     pub fn inner_open(filename: &str) -> Result<Self> {
         let conn = Connection::open(filename)
+            .map_err(|x| InterpreterError::SqliteError(IncomparableError{ err: x }))?;
+        
+        conn.busy_handler(Some(tx_busy_handler))
             .map_err(|x| InterpreterError::SqliteError(IncomparableError{ err: x }))?;
 
         Ok(SqliteConnection { conn })

--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -458,7 +458,7 @@ impl BurnchainConfig {
             rpc_ssl: false,
             username: None,
             password: None,
-            timeout: 30,
+            timeout: 300,
             spv_headers_path: "./spv-headers.dat".to_string(),
             first_block: FIRST_BLOCK_MAINNET,
             magic_bytes: BLOCKSTACK_MAGIC_MAINNET.clone(),

--- a/testnet/stacks-node/src/node.rs
+++ b/testnet/stacks-node/src/node.rs
@@ -99,7 +99,7 @@ fn spawn_peer(mut this: PeerNetwork, p2p_sock: &SocketAddr, rpc_sock: &SocketAdd
                 }
             };
 
-            this.run(&burndb, &mut chainstate, &mut mem_pool, None, poll_timeout)
+            this.run(&burndb, &mut chainstate, &mut mem_pool, None, false, poll_timeout)
                 .unwrap();
         }
     });


### PR DESCRIPTION
This PR does the following:

* Fixes #1543 by adding a busy-handler to all SQLite connections that will implement exponential backoff

* Fixes the stacks block header hash cache logic, which previously had been constantly missing hits.  Speed-up on a spinning rust disk is at least 10x.

* Adds relayer back-pressure awareness to the Neon p2p thread.  If the relayer is lagging behind in receiving downloaded blocks, the p2p thread will buffer them up and ask the p2p network to stop asking for them until the relayer's pressure is releaved.  At the same time, the p2p thread will wake up the relayer more frequently if there are pending blocks to process, so idle network activity won't delay block processing.  Also, the p2p thread will wake _itself_ up more frequently if it detects that it's doing its initial block download, so it will more quickly transition to fetching the next batch of blocks (but, it will take the relayer's back-pressure into account when doing so).

* (TODO) speed up querying the scheduled miner payments.  This currently takes 1-2 seconds on my spinning rust disk.  We can and should cache the `MinerPaymentSchedule` instances into the `StacksChainState` for the last `MINER_REWARD_WINDOW` blocks.