### PR TITLE
Additional logs

### DIFF
--- a/src/burnchains/burnchain.rs
+++ b/src/burnchains/burnchain.rs
@@ -225,6 +225,10 @@ impl BurnchainSigner {
         }
     }
 
+    pub fn to_address(&self) -> String { 
+        to_hex(&self.to_address_bits()[..])
+    }
+
     pub fn to_address_bits(&self) -> Vec<u8> { 
         let h = public_keys_to_address_hash(&self.hash_mode, self.num_sigs, &self.public_keys);
         h.as_bytes().to_vec()

--- a/src/burnchains/burnchain.rs
+++ b/src/burnchains/burnchain.rs
@@ -51,6 +51,9 @@ use burnchains::BurnchainStateTransition;
 use burnchains::bitcoin::{BitcoinTxInput, BitcoinTxOutput, BitcoinInputType};
 use burnchains::bitcoin::address::to_c32_version_byte;
 use burnchains::bitcoin::address::address_type_to_version_byte;
+use burnchains::bitcoin::address::BitcoinAddress;
+use burnchains::bitcoin::address::BitcoinAddressType;
+use burnchains::bitcoin::BitcoinNetworkType;
 
 use chainstate::burn::Opcodes;
 
@@ -225,8 +228,14 @@ impl BurnchainSigner {
         }
     }
 
-    pub fn to_address(&self) -> String { 
-        to_hex(&self.to_address_bits()[..])
+    pub fn to_testnet_address(&self) -> String { 
+        let addr_type = match &self.hash_mode {
+            AddressHashMode::SerializeP2PKH | AddressHashMode::SerializeP2WPKH => BitcoinAddressType::PublicKeyHash,
+            _ => BitcoinAddressType::ScriptHash,
+        };
+        BitcoinAddress::from_bytes(BitcoinNetworkType::Testnet,
+                                   addr_type, 
+                                   &self.to_address_bits()).unwrap().to_string()
     }
 
     pub fn to_address_bits(&self) -> Vec<u8> { 

--- a/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
+++ b/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
@@ -314,7 +314,9 @@ impl BitcoinRegtestController {
             utxos,
             signer);
 
-        Some(tx)   
+        info!("Miner node: submitting leader_key_register op - {}", public_key.to_hex());
+
+        Some(tx)
     }
 
     fn build_leader_block_commit_tx(&mut self, payload: LeaderBlockCommitOp, signer: &mut BurnchainOpSigner) -> Option<Transaction> {
@@ -360,7 +362,9 @@ impl BitcoinRegtestController {
             utxos,
             signer);
 
-        Some(tx)    
+        info!("Miner node: submitting leader_block_commit op - {}", public_key.to_hex());
+
+        Some(tx)
     }
 
     fn prepare_tx(&self, public_key: &Secp256k1PublicKey, ops_fee: u64) -> Option<(Transaction, Vec<UTXO>)> {

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -650,7 +650,7 @@ impl InitializedNeonNode {
             .expect("Unexpected BurnDB error fetching block commits");
         for op in block_commits.into_iter() {
             if op.txid == block_snapshot.winning_block_txid {
-                info!("Received burnchain block #{} including block_commit_op (winning) - {}", block_height, op.input.to_address());
+                info!("Received burnchain block #{} including block_commit_op (winning) - {}", block_height, op.input.to_testnet_address());
                 last_sortitioned_block = Some((block_snapshot.clone(), op.vtxindex));
                 // Release current registered key if leader won the sortition
                 // This will trigger a new registration
@@ -658,7 +658,7 @@ impl InitializedNeonNode {
                     won_sortition = true;
                 }    
             } else {
-                info!("Received burnchain block #{} including block_commit_op - {}", block_height, op.input.to_address());
+                info!("Received burnchain block #{} including block_commit_op - {}", block_height, op.input.to_testnet_address());
             }
         }
 

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -650,18 +650,22 @@ impl InitializedNeonNode {
             .expect("Unexpected BurnDB error fetching block commits");
         for op in block_commits.into_iter() {
             if op.txid == block_snapshot.winning_block_txid {
+                info!("Received burnchain block #{} including winning block_commit_op - {}", block_height, op.input.to_address());
                 last_sortitioned_block = Some((block_snapshot.clone(), op.vtxindex));
                 // Release current registered key if leader won the sortition
                 // This will trigger a new registration
                 if op.input == self.burnchain_signer {
                     won_sortition = true;
                 }    
-            }            
+            } else {
+                info!("Received burnchain block #{} including block_commit_op - {}", block_height, op.input.to_address());
+            }
         }
 
         let key_registers = BurnDB::get_leader_keys_by_block(&ic, block_height, burn_hash)
             .expect("Unexpected BurnDB error fetching key registers");
         for op in key_registers.into_iter() {
+            info!("Received burnchain block #{} including key_register_op - {}", block_height, op.address);
             if op.address == Keychain::address_from_burnchain_signer(&self.burnchain_signer) {
                 // Registered key has been mined
                 self.active_keys.push(

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -650,7 +650,7 @@ impl InitializedNeonNode {
             .expect("Unexpected BurnDB error fetching block commits");
         for op in block_commits.into_iter() {
             if op.txid == block_snapshot.winning_block_txid {
-                info!("Received burnchain block #{} including winning block_commit_op - {}", block_height, op.input.to_address());
+                info!("Received burnchain block #{} including block_commit_op (winning) - {}", block_height, op.input.to_address());
                 last_sortitioned_block = Some((block_snapshot.clone(), op.vtxindex));
                 // Release current registered key if leader won the sortition
                 // This will trigger a new registration

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -658,14 +658,18 @@ impl InitializedNeonNode {
                     won_sortition = true;
                 }    
             } else {
-                info!("Received burnchain block #{} including block_commit_op - {}", block_height, op.input.to_testnet_address());
+                if self.is_miner {
+                    info!("Received burnchain block #{} including block_commit_op - {}", block_height, op.input.to_testnet_address());
+                }
             }
         }
 
         let key_registers = BurnDB::get_leader_keys_by_block(&ic, block_height, burn_hash)
             .expect("Unexpected BurnDB error fetching key registers");
         for op in key_registers.into_iter() {
-            info!("Received burnchain block #{} including key_register_op - {}", block_height, op.address);
+            if self.is_miner {
+                info!("Received burnchain block #{} including key_register_op - {}", block_height, op.address);
+            }
             if op.address == Keychain::address_from_burnchain_signer(&self.burnchain_signer) {
                 // Registered key has been mined
                 self.active_keys.push(

--- a/testnet/stacks-node/src/run_loop/neon.rs
+++ b/testnet/stacks-node/src/run_loop/neon.rs
@@ -59,8 +59,6 @@ impl RunLoop {
             false
         };
 
-        // self.callbacks.invoke_burn_chain_initialized(&mut burnchain);
-
         let mut burnchain_tip = burnchain.start();
 
         let mut block_height = burnchain_tip.block_snapshot.block_height;

--- a/testnet/stacks-node/src/run_loop/neon.rs
+++ b/testnet/stacks-node/src/run_loop/neon.rs
@@ -47,18 +47,19 @@ impl RunLoop {
                 BitcoinAddressType::PublicKeyHash,
                 &Keychain::address_from_burnchain_signer(&keychain.get_burnchain_signer()).to_bytes())
                 .unwrap();
-            info!("Configured as a miner: checking if we have UTXOs at address: {}", btc_addr);
+            info!("Miner node: checking UTXOs at address: {}", btc_addr);
 
             let utxos = burnchain.get_utxos(
                 &keychain.generate_op_signer().get_public_key(), 1);
             if utxos.is_none() {
-                error!("I have no UTXOs... spawning as a follower. Restart node when you get some UTXOs.");
+                error!("Miner node: UTXOs not found. Switching to Follower node. Restart node when you get some UTXOs.");
                 false
             } else {
-                info!("Have UTXOs, starting up as miner");
+                info!("Miner node: starting up, UTXOs found.");
                 true
             }
         } else {
+            info!("Follower node: starting up");
             false
         };
 

--- a/testnet/stacks-node/src/run_loop/neon.rs
+++ b/testnet/stacks-node/src/run_loop/neon.rs
@@ -36,10 +36,6 @@ impl RunLoop {
         // Initialize and start the burnchain.
         let mut burnchain = BitcoinRegtestController::new(self.config.clone());
 
-        // self.callbacks.invoke_burn_chain_initialized(&mut burnchain);
-
-        let mut burnchain_tip = burnchain.start();
-
         let is_miner = if self.config.node.miner {
             let mut keychain = Keychain::default(self.config.node.seed.clone());
             let btc_addr = BitcoinAddress::from_bytes(
@@ -62,6 +58,10 @@ impl RunLoop {
             info!("Follower node: starting up");
             false
         };
+
+        // self.callbacks.invoke_burn_chain_initialized(&mut burnchain);
+
+        let mut burnchain_tip = burnchain.start();
 
         let mut block_height = burnchain_tip.block_snapshot.block_height;
 


### PR DESCRIPTION
Adding some high level logs so that testnet participations can be visible upfront.

Include a minor miner experience enhancement - we're now hitting the listunspent endpoint before the block syncing, so that you can terminate your node / hit the faucet / restart the node without having to wait for the sync, when you're out of UTXOs.