### PR TITLE
Fix/net event id tocttou

### DIFF
--- a/src/net/p2p.rs
+++ b/src/net/p2p.rs
@@ -597,11 +597,11 @@ impl PeerNetwork {
             },
             Some(ref mut network) => {
                 let sock = NetworkState::connect(&neighbor.addrbytes.to_socketaddr(neighbor.port))?;
-                let next_event_id = network.next_event_id();
-                network.register(self.p2p_network_handle, next_event_id, &sock)?;
+                let hint_event_id = network.next_event_id();
+                let registered_event_id = network.register(self.p2p_network_handle, hint_event_id, &sock)?;
 
-                self.connecting.insert(next_event_id, (sock, true, get_epoch_time_secs()));
-                next_event_id
+                self.connecting.insert(registered_event_id, (sock, true, get_epoch_time_secs()));
+                registered_event_id
             }
         };
 
@@ -1131,23 +1131,27 @@ impl PeerNetwork {
 
         let mut registered = vec![];
 
-        for (event_id, client_sock) in poll_state.new.drain() {
-            // event ID already used?
-            if self.peers.contains_key(&event_id) {
-                continue;
-            }
-
-            match self.network {
+        for (hint_event_id, client_sock) in poll_state.new.drain() {
+            let event_id = match self.network {
                 Some(ref mut network) => {
                     // add to poller
-                    if let Err(_e) = network.register(self.p2p_network_handle, event_id, &client_sock) {
-                        continue;
+                    match network.register(self.p2p_network_handle, hint_event_id, &client_sock) {
+                        Ok(event_id) => event_id,
+                        Err(e) => {
+                            warn!("Failed to register {:?}: {:?}", &client_sock, &e);
+                            continue;
+                        }
                     }
                 },
                 None => {
                     test_debug!("{:?}: network not connected", &self.local_peer);
                     return Err(net_error::NotConnected);
                 }
+            };
+            
+            // event ID already used?
+            if self.peers.contains_key(&event_id) {
+                continue;
             }
 
             // start tracking it

--- a/src/net/p2p.rs
+++ b/src/net/p2p.rs
@@ -1135,27 +1135,32 @@ impl PeerNetwork {
             let event_id = match self.network {
                 Some(ref mut network) => {
                     // add to poller
-                    match network.register(self.p2p_network_handle, hint_event_id, &client_sock) {
+                    let event_id = match network.register(self.p2p_network_handle, hint_event_id, &client_sock) {
                         Ok(event_id) => event_id,
                         Err(e) => {
                             warn!("Failed to register {:?}: {:?}", &client_sock, &e);
                             continue;
                         }
+                    };
+            
+                    // event ID already used?
+                    if self.peers.contains_key(&event_id) {
+                        warn!("Already have an event {}: {:?}", event_id, self.peers.get(&event_id));
+                        let _ = network.deregister(event_id, &client_sock);
+                        continue;
                     }
+
+                    event_id
                 },
                 None => {
                     test_debug!("{:?}: network not connected", &self.local_peer);
                     return Err(net_error::NotConnected);
                 }
             };
-            
-            // event ID already used?
-            if self.peers.contains_key(&event_id) {
-                continue;
-            }
 
             // start tracking it
             if let Err(_e) = self.register_peer(event_id, client_sock, false) {
+                // NOTE: register_peer will deregister the socket for us
                 continue;
             }
             registered.push(event_id);

--- a/src/net/poll.rs
+++ b/src/net/poll.rs
@@ -159,7 +159,7 @@ impl NetworkState {
             server_event: mio::Token(next_server_event),
         };
 
-        assert!(!self.event_map.contains_key(&next_server_event));
+        assert!(!self.event_map.contains_key(&next_server_event), "BUG: failed to generate an unused server event ID");
 
         self.servers.push(network_server);
         self.event_map.insert(next_server_event, 0);        // server events always mapped to 0
@@ -167,24 +167,43 @@ impl NetworkState {
         Ok(next_server_event)
     }
 
-    /// Register a socket for read/write notifications with this poller
-    pub fn register(&mut self, server_event_id: usize, event_id: usize, sock: &mio_net::TcpStream) -> Result<(), net_error> {
+    /// Register a socket for read/write notifications with this poller.
+    /// Try to use the given hint_event_id value, but generate a different event ID if it's been
+    /// taken.
+    /// Return the actual event ID used (it may be different than hint_event_id)
+    pub fn register(&mut self, server_event_id: usize, hint_event_id: usize, sock: &mio_net::TcpStream) -> Result<usize, net_error> {
+        let hint_event_id = hint_event_id % self.event_capacity;
+        if let Some(x) = self.event_map.get(&server_event_id) {
+            if x != &0 {
+                // not a server event
+                error!("Server event ID {} not mapped to a server token, but to {}", &server_event_id, x);
+                return Err(net_error::RegisterError);
+            }
+        }
+        else {
+            // not a server event
+            error!("Not a server event ID: {}", &server_event_id);
+            return Err(net_error::RegisterError);
+        }
+
+        // if the event ID is in use, then find another one
+        let event_id = 
+            if self.event_map.contains_key(&hint_event_id) {
+                self.next_event_id()
+            }
+            else {
+                hint_event_id
+            };
+        
         self.poll.register(sock, mio::Token(event_id), Ready::all(), PollOpt::edge())
             .map_err(|e| {
-                error!("Failed to register socket: {:?}", &e);
+                error!("Failed to register socket on server {} event ID {} ({}): {:?}", server_event_id, event_id, hint_event_id, &e);
                 net_error::RegisterError
             })?;
 
-        // this is a server event
-        assert!(self.event_map.contains_key(&server_event_id));
-        assert_eq!(self.event_map.get(&server_event_id), Some(&0));
-
-        // this event ID is not in use
-        assert!(!self.event_map.contains_key(&event_id));
-
         self.event_map.insert(event_id, server_event_id);
-        test_debug!("Register socket {:?} as event {} on server {}", sock, event_id, server_event_id);
-        Ok(())
+        test_debug!("Register socket {:?} as event {} ({}) on server {}", sock, event_id, hint_event_id, server_event_id);
+        Ok(event_id)
     }
 
     /// Deregister a socket event
@@ -194,11 +213,12 @@ impl NetworkState {
                 error!("Failed to deregister socket {}: {:?}", event_id, &e);
                 net_error::RegisterError
             })?;
+        
+        self.event_map.remove(&event_id);
 
         sock.shutdown(Shutdown::Both)
             .map_err(|_e| net_error::SocketError)?;
 
-        self.event_map.remove(&event_id);
         test_debug!("Socket deregistered: {}, {:?}", event_id, sock);
         Ok(())
     }
@@ -306,6 +326,8 @@ impl NetworkState {
                             }
                         };
 
+                        // this does the same thing as next_event_id(), but we can't borrow self
+                        // mutably here (so we'll just do the increment-mod directly).
                         let next_event_id = self.make_next_event_id(self.count, &new_events);
                         self.count = (next_event_id + 1) % self.event_capacity;
 
@@ -332,15 +354,91 @@ impl NetworkState {
                         poll_state.ready.push(event_id);
                     }
                     else {
-                        panic!("Unknown server event ID {}", server_event_id);
+                        warn!("Unknown server event ID {}", server_event_id);
                     }
                 },
                 None => {
-                    panic!("Surreptitious readiness event {}", event_id);
+                    warn!("Surreptitious readiness event {}", event_id);
                 }
             }
         }
 
         Ok(poll_states)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use mio;
+    use mio::net as mio_net;
+    use mio::Ready;
+    use mio::Token;
+    use mio::PollOpt;
+    
+    use std::collections::HashSet;
+
+    #[test]
+    fn test_bind() {
+        let mut ns = NetworkState::new(100).unwrap();
+        let mut server_events = HashSet::new();
+        for port in 49000..49010 {
+            let addr = format!("127.0.0.1:{}", &port).parse::<SocketAddr>().unwrap();
+            let event_id = ns.bind(&addr).unwrap();
+            assert!(!server_events.contains(&event_id));
+            server_events.insert(event_id);
+        }
+    }
+
+    #[test]
+    fn test_register_deregister() {
+        let mut ns = NetworkState::new(100).unwrap();
+        let mut server_events = vec![];
+        let mut event_ids = HashSet::new();
+        for port in 49010..49020 {
+            let addr = format!("127.0.0.1:{}", &port).parse::<SocketAddr>().unwrap();
+            let event_id = ns.bind(&addr).unwrap();
+            server_events.push(event_id);
+            event_ids.insert(event_id);
+        }
+
+        let mut client_events = vec![];
+        for port in 49010..49020 {
+            let addr = format!("127.0.0.1:{}", &port).parse::<SocketAddr>().unwrap();
+            let sock = NetworkState::connect(&addr).unwrap();
+
+            let event_id = ns.register(server_events[port - 49010], 1, &sock).unwrap();
+            assert!(event_id != 0);
+            assert!(!event_ids.contains(&event_id));
+            ns.deregister(event_id, &sock).unwrap();
+
+            let event_id = ns.register(server_events[port - 49010], 101, &sock).unwrap();
+            assert!(event_id != 0);
+            assert!(!event_ids.contains(&event_id));
+            ns.deregister(event_id, &sock).unwrap();
+            
+            let event_id = ns.register(server_events[port - 49010], server_events[port - 49010], &sock).unwrap();
+            assert!(event_id != 0);
+            assert!(!event_ids.contains(&event_id));
+            ns.deregister(event_id, &sock).unwrap();
+
+            let event_id = ns.register(server_events[port - 49010], 11, &sock).unwrap();
+            assert!(!event_ids.contains(&event_id));
+
+            event_ids.insert(event_id);
+            client_events.push(event_id);
+        }
+
+        test_debug!("=====");
+        for port in 49010..49020 {
+            let addr = format!("127.0.0.1:{}", &port).parse::<SocketAddr>().unwrap();
+            let sock = NetworkState::connect(&addr).unwrap();
+
+            // can't use non-server events
+            assert_eq!(Err(net_error::RegisterError), ns.register(client_events[port - 49010], port - 49010 + 1, &sock));
+            
+            // can'te use non-registered events
+            assert_eq!(Err(net_error::RegisterError), ns.register(99, port - 49010 + 1, &sock));
+        }
     }
 }

--- a/src/net/poll.rs
+++ b/src/net/poll.rs
@@ -182,8 +182,7 @@ impl NetworkState {
         }
         else {
             // not a server event
-            error!("Not a server event ID: {}", &server_event_id);
-            return Err(net_error::RegisterError);
+            panic!("Not a server event ID: {}", &server_event_id);
         }
 
         // if the event ID is in use, then find another one
@@ -436,9 +435,6 @@ mod test {
 
             // can't use non-server events
             assert_eq!(Err(net_error::RegisterError), ns.register(client_events[port - 49010], port - 49010 + 1, &sock));
-            
-            // can'te use non-registered events
-            assert_eq!(Err(net_error::RegisterError), ns.register(99, port - 49010 + 1, &sock));
         }
     }
 }

--- a/src/net/server.rs
+++ b/src/net/server.rs
@@ -313,10 +313,13 @@ impl HttpPeer {
             
             // event ID already used?
             if self.peers.contains_key(&event_id) {
+                warn!("Already have an event {}: {:?}", event_id, self.peers.get(&event_id));
+                let _ = network_state.deregister(event_id, &client_sock);
                 continue;
             }
 
             if let Err(_e) = self.register_http(network_state, chainstate, event_id, client_sock, None, None) {
+                // NOTE: register_http will deregister the socket for us
                 continue;
             }
             registered.push(event_id);


### PR DESCRIPTION
This PR fixes a TOCTTOU bug in the way we allocate event IDs in the poller.  What could happen is that an event ID allocated on `NetworkState::poll()` could get consumed in the p2p thread by a call to `register()`, which can happen if the p2p thread tries to open a connection to another node.  It doesn't happen very often, but when it does, it causes a runtime panic.

This PR removes these runtime panics, and fixes event ID allocation so that it can only happen when registering a socket.  It changes the `NetworkState::register()` method to return the allocated event ID, which both the HTTP server and P2P node will use to identify readiness on the socket (as opposed to the event ID hint given by the poller when it accepts new connections).