### PR TITLE
Fix #1591: as-max-len should update runtime type annotation

### DIFF
--- a/src/vm/docs/mod.rs
+++ b/src/vm/docs/mod.rs
@@ -407,8 +407,11 @@ const ASSERTS_MAX_LEN_API: SpecialAPI = SpecialAPI {
     signature: "(as-max-len? buffer u10)",
     description: "The `as-max-len?` function takes a length N (must be a literal) and a buffer or list argument, which must be typed as a list
 or buffer of length M and outputs that same list or buffer, but typed with max length N.
-At runtime, a check is performed, which if it fails, returns a (none) option.",
-    example: "(as-max-len? (list 2 2 2) u3) ;; Returns (some (list 2 2 2))"
+
+This function returns an optional type with the resulting iterable. If the inputt iterable is less than
+or equal to the supplied max-len, it returns `(some <iterable>)`, otherwise it returns `none`.",
+    example: "(as-max-len? (list 2 2 2) u3) ;; Returns (some (list 2 2 2))
+(as-max-len? (list 1 2 3) u2) ;; Returns none"
 };
 
 const LEN_API: SpecialAPI = SpecialAPI {

--- a/src/vm/docs/mod.rs
+++ b/src/vm/docs/mod.rs
@@ -408,7 +408,7 @@ const ASSERTS_MAX_LEN_API: SpecialAPI = SpecialAPI {
     description: "The `as-max-len?` function takes a length N (must be a literal) and a buffer or list argument, which must be typed as a list
 or buffer of length M and outputs that same list or buffer, but typed with max length N.
 
-This function returns an optional type with the resulting iterable. If the inputt iterable is less than
+This function returns an optional type with the resulting iterable. If the input iterable is less than
 or equal to the supplied max-len, it returns `(some <iterable>)`, otherwise it returns `none`.",
     example: "(as-max-len? (list 2 2 2) u3) ;; Returns (some (list 2 2 2))
 (as-max-len? (list 1 2 3) u2) ;; Returns none"

--- a/src/vm/functions/iterables.rs
+++ b/src/vm/functions/iterables.rs
@@ -186,7 +186,7 @@ pub fn special_concat(args: &[SymbolicExpression], env: &mut Environment, contex
 pub fn special_as_max_len(args: &[SymbolicExpression], env: &mut Environment, context: &LocalContext) -> Result<Value> {
     check_argument_count(2, args)?;
 
-    let iterable = eval(&args[0], env, context)?;
+    let mut iterable = eval(&args[0], env, context)?;
 
     runtime_cost!(cost_functions::AS_MAX_LEN, env, 0)?;
 
@@ -199,6 +199,9 @@ pub fn special_as_max_len(args: &[SymbolicExpression], env: &mut Environment, co
         if iterable_len as u128 > *expected_len {
             Ok(Value::none())
         } else {
+            if let Value::List(ref mut list) = iterable {
+                list.type_signature.reduce_max_len(*expected_len as u32);
+            }
             Ok(Value::some(iterable)?)
         }
     } else {

--- a/src/vm/tests/contracts.rs
+++ b/src/vm/tests/contracts.rs
@@ -684,6 +684,19 @@ fn test_at_unknown_block() {
 }
 
 #[test]
+fn test_as_max_len() {
+    fn test(owned_env: &mut OwnedEnvironment) {
+        let contract = "(define-data-var token-ids (list 10 uint) (list))
+                        (var-set token-ids 
+                           (unwrap! (as-max-len? (append (var-get token-ids) u1) u10) (err 10)))";
+
+        owned_env.initialize_contract(QualifiedContractIdentifier::local("contract").unwrap(), &contract).unwrap();
+    }
+
+    with_marfed_environment(test, true);
+}
+
+#[test]
 fn test_ast_stack_depth() {
     let program = "(+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ 
                        (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ 

--- a/src/vm/types/signatures.rs
+++ b/src/vm/types/signatures.rs
@@ -215,6 +215,14 @@ impl ListTypeData {
         (*self.entry_type, self.max_len)
     }
 
+    // if checks like as-max-len pass, they may _reduce_
+    //   but should not increase the type signatures max length
+    pub fn reduce_max_len(&mut self, new_max_len: u32) {
+        if new_max_len <= self.max_len {
+            self.max_len = new_max_len;
+        }
+    }
+
     pub fn get_max_len(&self) -> u32 {
         self.max_len
     }


### PR DESCRIPTION
`as-max-len` needs to update the returned iterable's runtime type.