### PR TITLE
PostCondition handling in TransactionReceipts

### DIFF
--- a/src/chainstate/stacks/address.rs
+++ b/src/chainstate/stacks/address.rs
@@ -69,6 +69,15 @@ impl StacksMessageCodec for StacksAddress {
     }
 }
 
+impl From<StandardPrincipalData> for StacksAddress {
+    fn from(o: StandardPrincipalData) -> StacksAddress {
+        StacksAddress {
+            version: o.0,
+            bytes: Hash160(o.1),
+        }
+    }
+}
+
 impl StacksAddress {
     pub fn new(version: u8, hash: Hash160) -> StacksAddress {
         StacksAddress {

--- a/src/chainstate/stacks/db/transactions.rs
+++ b/src/chainstate/stacks/db/transactions.rs
@@ -100,6 +100,7 @@ impl StacksTransactionReceipt {
             events: vec![StacksTransactionEvent::STXEvent(STXEventType::STXTransferEvent(event_data))],
             result: Value::okay_true(),
             stx_burned: 0,
+            post_condition_aborted: false,
             contract_analysis: None,
             transaction: tx,
             execution_cost: cost
@@ -109,6 +110,19 @@ impl StacksTransactionReceipt {
     pub fn from_contract_call(tx: StacksTransaction, events: Vec<StacksTransactionEvent>, result: Value, burned: u128, cost: ExecutionCost) -> StacksTransactionReceipt {
         StacksTransactionReceipt {
             transaction: tx,
+            post_condition_aborted: false,
+            events,
+            result,
+            stx_burned: burned,
+            contract_analysis: None,
+            execution_cost: cost
+        }
+    }
+
+    pub fn from_condition_aborted_contract_call(tx: StacksTransaction, events: Vec<StacksTransactionEvent>, result: Value, burned: u128, cost: ExecutionCost) -> StacksTransactionReceipt {
+        StacksTransactionReceipt {
+            transaction: tx,
+            post_condition_aborted: true,
             events,
             result,
             stx_burned: burned,
@@ -121,6 +135,19 @@ impl StacksTransactionReceipt {
         StacksTransactionReceipt {
             transaction: tx,
             events,
+            post_condition_aborted: false,
+            result: Value::okay_true(),
+            stx_burned: burned,
+            contract_analysis: Some(analysis),
+            execution_cost: cost
+        }
+    }
+
+    pub fn from_condition_aborted_smart_contract(tx: StacksTransaction, events: Vec<StacksTransactionEvent>, burned: u128, analysis: ContractAnalysis, cost: ExecutionCost) -> StacksTransactionReceipt {
+        StacksTransactionReceipt {
+            transaction: tx,
+            events,
+            post_condition_aborted: true,
             result: Value::okay_true(),
             stx_burned: burned,
             contract_analysis: Some(analysis),
@@ -132,6 +159,7 @@ impl StacksTransactionReceipt {
         StacksTransactionReceipt {
             transaction: tx,
             events: vec![],
+            post_condition_aborted: false,
             result: Value::okay_true(),
             stx_burned: 0,
             contract_analysis: None,
@@ -143,6 +171,7 @@ impl StacksTransactionReceipt {
         StacksTransactionReceipt {
             transaction: tx,
             events: vec![],
+            post_condition_aborted: false,
             result: Value::err_none(),
             stx_burned: 0,
             contract_analysis: None,
@@ -519,6 +548,15 @@ impl StacksChainState {
                                 info!("Runtime error {:?} on contract-call {}.{:?} {:?}, stack trace {:?}", runtime_error, &contract_id, &contract_call.function_name, &contract_call.function_args, stack);
                                 Ok((Value::err_none(), AssetMap::new(), vec![]))
                             },
+                            clarity_error::PostConditionAbort(value, assets, events) => {
+                                let receipt = StacksTransactionReceipt::from_condition_aborted_contract_call(
+                                    tx.clone(),
+                                    events,
+                                    value.expect("BUG: Post condition contract call must provide would-have-been-returned value"),
+                                    assets.get_stx_burned_total(),
+                                    total_cost);
+                                return Ok(receipt);
+                            },
                             // log this for now
                             clarity_error::CostError(ref cost, ref budget) => {
                                 warn!("Block compute budget exceeded on {}: cost={}, budget={}", tx.txid(), cost, budget);
@@ -611,6 +649,11 @@ impl StacksChainState {
                             clarity_error::CostError(ref cost, ref budget) => {
                                 warn!("Block compute budget exceeded on {}: cost={}, budget={}", tx.txid(), cost, budget);
                                 Err(e)
+                            },
+                            clarity_error::PostConditionAbort(_, assets, events) => {
+                                let receipt = StacksTransactionReceipt::from_condition_aborted_smart_contract(
+                                    tx.clone(), events, assets.get_stx_burned_total(), contract_analysis, total_cost);
+                                return Ok(receipt);
                             },
                             // runtime errors are okay -- we just have an empty asset map
                             clarity_error::Interpreter(InterpreterError::Runtime(ref runtime_error, ref stack)) => {

--- a/src/chainstate/stacks/db/transactions.rs
+++ b/src/chainstate/stacks/db/transactions.rs
@@ -548,7 +548,7 @@ impl StacksChainState {
                                 info!("Runtime error {:?} on contract-call {}.{:?} {:?}, stack trace {:?}", runtime_error, &contract_id, &contract_call.function_name, &contract_call.function_args, stack);
                                 Ok((Value::err_none(), AssetMap::new(), vec![]))
                             },
-                            clarity_error::PostConditionAbort(value, assets, events) => {
+                            clarity_error::AbortedByCallback(value, assets, events) => {
                                 let receipt = StacksTransactionReceipt::from_condition_aborted_contract_call(
                                     tx.clone(),
                                     events,
@@ -650,7 +650,7 @@ impl StacksChainState {
                                 warn!("Block compute budget exceeded on {}: cost={}, budget={}", tx.txid(), cost, budget);
                                 Err(e)
                             },
-                            clarity_error::PostConditionAbort(_, assets, events) => {
+                            clarity_error::AbortedByCallback(_, assets, events) => {
                                 let receipt = StacksTransactionReceipt::from_condition_aborted_smart_contract(
                                     tx.clone(), events, assets.get_stx_burned_total(), contract_analysis, total_cost);
                                 return Ok(receipt);

--- a/src/chainstate/stacks/events.rs
+++ b/src/chainstate/stacks/events.rs
@@ -32,46 +32,53 @@ pub enum StacksTransactionEvent {
 }
 
 impl StacksTransactionEvent {
-
-    pub fn json_serialize(&self, txid: &Txid) -> serde_json::Value {
+    pub fn json_serialize(&self, txid: &Txid, committed: bool) -> serde_json::Value {
         match self {
             StacksTransactionEvent::SmartContractEvent(event_data) => json!({
-                    "txid": format!("0x{:?}", txid),
-                    "type": "contract_event",
-                    "contract_event": event_data.json_serialize()
+                "txid": format!("0x{:?}", txid),
+                "committed": committed,
+                "type": "contract_event",
+                "contract_event": event_data.json_serialize()
             }),
             StacksTransactionEvent::STXEvent(STXEventType::STXTransferEvent(event_data)) => json!({
                 "txid": format!("0x{:?}", txid),
+                "committed": committed,
                 "type": "stx_transfer_event",
                 "stx_transfer_event": event_data.json_serialize()
             }),
             StacksTransactionEvent::STXEvent(STXEventType::STXMintEvent(event_data)) => json!({
                 "txid": format!("0x{:?}", txid),
+                "committed": committed,
                 "type": "stx_mint_event",
                 "stx_mint_event": event_data.json_serialize()
             }),
             StacksTransactionEvent::STXEvent(STXEventType::STXBurnEvent(event_data)) => json!({
                 "txid": format!("0x{:?}", txid),
+                "committed": committed,
                 "type": "stx_burn_event",
                 "stx_burn_event": event_data.json_serialize()
             }),
             StacksTransactionEvent::NFTEvent(NFTEventType::NFTTransferEvent(event_data)) => json!({
                 "txid": format!("0x{:?}", txid),
+                "committed": committed,
                 "type": "nft_transfer_event",
                 "nft_transfer_event": event_data.json_serialize()
             }),
             StacksTransactionEvent::NFTEvent(NFTEventType::NFTMintEvent(event_data)) => json!({
                 "txid": format!("0x{:?}", txid),
+                "committed": committed,
                 "type": "nft_mint_event",
                 "nft_mint_event": event_data.json_serialize()
             }),
             StacksTransactionEvent::FTEvent(FTEventType::FTTransferEvent(event_data)) => json!({
                 "txid": format!("0x{:?}", txid),
+                "committed": committed,
                 "type": "ft_transfer_event",
                 "ft_transfer_event": event_data.json_serialize()
             }),
             StacksTransactionEvent::FTEvent(FTEventType::FTMintEvent(event_data)) => json!({
                 "txid": format!("0x{:?}", txid),
+                "committed": committed,
                 "type": "ft_mint_event",
                 "ft_mint_event": event_data.json_serialize()
             }),

--- a/src/chainstate/stacks/events.rs
+++ b/src/chainstate/stacks/events.rs
@@ -16,6 +16,7 @@ use vm::analysis::ContractAnalysis;
 pub struct StacksTransactionReceipt {
     pub transaction: StacksTransaction,
     pub events: Vec<StacksTransactionEvent>,
+    pub post_condition_aborted: bool,
     pub result: Value,
     pub stx_burned: u128,
     pub contract_analysis: Option<ContractAnalysis>,

--- a/src/vm/clarity.rs
+++ b/src/vm/clarity.rs
@@ -71,6 +71,7 @@ pub enum Error {
     Interpreter(InterpreterError),
     BadTransaction(String),
     CostError(ExecutionCost, ExecutionCost),
+    PostConditionAbort(Option<Value>, AssetMap, Vec<StacksTransactionEvent>)
 }
 
 impl From<CheckError> for Error {
@@ -111,6 +112,7 @@ impl fmt::Display for Error {
             Error::CostError(ref a, ref b) => write!(f, "Cost Error: {} cost exceeded budget of {} cost", a, b),
             Error::Analysis(ref e) => fmt::Display::fmt(e, f),
             Error::Parse(ref e) => fmt::Display::fmt(e, f),
+            Error::PostConditionAbort(_, ..) => write!(f, "Post condition aborted transaction"),
             Error::Interpreter(ref e) => fmt::Display::fmt(e, f),
             Error::BadTransaction(ref s) => fmt::Display::fmt(s, f)
         }
@@ -121,6 +123,7 @@ impl error::Error for Error {
     fn cause(&self) -> Option<&dyn error::Error> {
         match *self {
             Error::CostError(ref _a, ref _b) => None,
+            Error::PostConditionAbort(_, ..) => None,
             Error::Analysis(ref e) => Some(e),
             Error::Parse(ref e) => Some(e),
             Error::Interpreter(ref e) => Some(e),
@@ -478,7 +481,7 @@ impl <'a> ClarityTransactionConnection <'a> {
         })
     }
 
-    fn with_abort_callback<F, A, R>(&mut self, to_do: F, abort_call_back: A) -> Result<(R, AssetMap, Vec<StacksTransactionEvent>), Error>
+    fn with_abort_callback<F, A, R>(&mut self, to_do: F, abort_call_back: A) -> Result<(R, AssetMap, Vec<StacksTransactionEvent>, bool), Error>
     where A: FnOnce(&AssetMap, &mut ClarityDatabase) -> bool,
           F: FnOnce(&mut OwnedEnvironment) -> Result<(R, AssetMap, Vec<StacksTransactionEvent>), Error> {
         using!(self.log, "log", |log| {
@@ -497,12 +500,13 @@ impl <'a> ClarityTransactionConnection <'a> {
 
                 let result = match result {
                     Ok((value, asset_map, events)) => {
-                        if abort_call_back(&asset_map, &mut db) {
+                        let aborted = abort_call_back(&asset_map, &mut db);
+                        if aborted {
                             db.roll_back();
                         } else {
                             db.commit();
                         }
-                        Ok((value, asset_map, events))
+                        Ok((value, asset_map, events, aborted))
                     },
                     Err(e) => {
                         db.roll_back();
@@ -547,7 +551,7 @@ impl <'a> ClarityTransactionConnection <'a> {
         let expr_args: Vec<_> = args.iter().map(|x| SymbolicExpression::atom_value(x.clone())).collect();
 
         self.with_abort_callback(
-            |vm_env| { 
+            |vm_env| {
                 vm_env.execute_transaction(
                     Value::Principal(sender.clone()), 
                     contract.clone(), 
@@ -555,6 +559,13 @@ impl <'a> ClarityTransactionConnection <'a> {
                     &expr_args)
                 .map_err(Error::from) },
             abort_call_back)
+            .and_then(|(value, assets, events, aborted)|
+                 if aborted {
+                     Err(Error::PostConditionAbort(Some(value), assets, events))
+                 } else {
+                     Ok((value, assets, events))
+                 }
+            )
     }
 
     /// Initialize a contract in the current block.
@@ -565,11 +576,15 @@ impl <'a> ClarityTransactionConnection <'a> {
     pub fn initialize_smart_contract <F> (&mut self, identifier: &QualifiedContractIdentifier, contract_ast: &ContractAST,
                                           contract_str: &str, abort_call_back: F) -> Result<(AssetMap, Vec<StacksTransactionEvent>), Error>
     where F: FnOnce(&AssetMap, &mut ClarityDatabase) -> bool {
-        let (_, asset_map, events) = self.with_abort_callback(
+        let (_, asset_map, events, aborted) = self.with_abort_callback(
             |vm_env| { vm_env.initialize_contract_from_ast(identifier.clone(), contract_ast, contract_str)
                        .map_err(Error::from) },
             abort_call_back)?;
-        Ok((asset_map, events))
+        if aborted {
+            Err(Error::PostConditionAbort(None, asset_map, events))
+        } else {
+            Ok((asset_map, events))
+        }
     }
 
     /// Commit the changes from the edit log.
@@ -591,7 +606,7 @@ impl <'a> ClarityTransactionConnection <'a> {
     /// Evaluate a raw Clarity snippit
     #[cfg(test)]
     pub fn clarity_eval_raw(&mut self, code: &str) -> Result<Value, Error> {
-        let (result, _, _) = self.with_abort_callback(
+        let (result, _, _, _) = self.with_abort_callback(
             |vm_env| { vm_env.eval_raw(code).map_err(Error::from) },
             |_, _| { false })?;
         Ok(result)
@@ -599,7 +614,7 @@ impl <'a> ClarityTransactionConnection <'a> {
 
     #[cfg(test)]
     pub fn eval_read_only(&mut self, contract: &QualifiedContractIdentifier, code: &str) -> Result<Value, Error> {
-        let (result, _, _) = self.with_abort_callback(
+        let (result, _, _, _) = self.with_abort_callback(
             |vm_env| { vm_env.eval_read_only(contract, code).map_err(Error::from) },
             |_, _| { false })?;
         Ok(result)
@@ -826,6 +841,96 @@ mod tests {
                 Value::okay(Value::Int(1)).unwrap());
 
             
+            conn.commit_block();
+        }
+    }
+
+    #[test]
+    pub fn test_post_condition_failure_contract_publish() {
+        use chainstate::stacks::db::*;
+        use chainstate::stacks::*;
+        use util::secp256k1::MessageSignature;
+        use util::strings::StacksString;
+        use util::hash::Hash160;
+
+        let marf = MarfedKV::temporary();
+        let mut clarity_instance = ClarityInstance::new(marf, ExecutionCost::max_value());
+        let contract_identifier = QualifiedContractIdentifier::local("foo").unwrap();
+        let sender = StandardPrincipalData::transient().into();
+
+        let spending_cond = TransactionSpendingCondition::Singlesig(SinglesigSpendingCondition {
+            signer: Hash160([0x11u8; 20]),
+            hash_mode: SinglesigHashMode::P2PKH,
+            key_encoding: TransactionPublicKeyEncoding::Compressed,
+            nonce: 0,
+            fee_rate: 1,
+            signature: MessageSignature::from_raw(&vec![0xfe; 65]),
+        });
+
+        let contract = "(define-public (foo) (ok 1))";
+
+        let mut tx1 = StacksTransaction::new(
+            TransactionVersion::Mainnet,
+            TransactionAuth::Standard(spending_cond.clone()),
+            TransactionPayload::SmartContract(TransactionSmartContract {
+                name: "hello-world".into(),
+                code_body: StacksString::from_str(contract).unwrap() }).into());
+
+        let tx2 = StacksTransaction::new(
+            TransactionVersion::Mainnet,
+            TransactionAuth::Standard(spending_cond.clone()),
+            TransactionPayload::SmartContract(TransactionSmartContract {
+                name: "hello-world".into(),
+                code_body: StacksString::from_str(contract).unwrap() }).into());
+
+        tx1.post_conditions.push(TransactionPostCondition::STX(PostConditionPrincipal::Origin, FungibleConditionCode::SentEq, 100));
+
+        let mut tx3 = StacksTransaction::new(
+            TransactionVersion::Mainnet,
+            TransactionAuth::Standard(spending_cond.clone()),
+            TransactionPayload::ContractCall(TransactionContractCall {
+                address: sender,
+                contract_name: "hello-world".into(),
+                function_name: "foo".into(),
+                function_args: vec![] }));
+
+        tx3.post_conditions.push(TransactionPostCondition::STX(PostConditionPrincipal::Origin, FungibleConditionCode::SentEq, 100));
+
+        let account = StacksAccount {
+            principal: sender.into(),
+            nonce: 0,
+            stx_balance: 5000
+        };
+        {
+            let mut conn = clarity_instance.begin_block(&TrieFileStorage::block_sentinel(),
+                                                        &BlockHeaderHash::from_bytes(&[0 as u8; 32]).unwrap(),
+                                                        &NULL_HEADER_DB);
+
+            conn.as_transaction(|clarity_tx| {
+                let receipt = 
+                    StacksChainState::process_transaction_payload(
+                        clarity_tx,
+                        &tx1,
+                        &account).unwrap();
+                assert_eq!(receipt.post_condition_aborted, true);
+            });
+            conn.as_transaction(|clarity_tx| {
+                StacksChainState::process_transaction_payload(
+                    clarity_tx,
+                    &tx2,
+                    &account).unwrap();
+            });
+
+            conn.as_transaction(|clarity_tx| {
+                let receipt =
+                    StacksChainState::process_transaction_payload(
+                        clarity_tx,
+                        &tx3,
+                        &account).unwrap();
+
+                assert_eq!(receipt.post_condition_aborted, true);
+            });
+
             conn.commit_block();
         }
     }

--- a/src/vm/clarity.rs
+++ b/src/vm/clarity.rs
@@ -817,10 +817,16 @@ mod tests {
                                        |_, _| false)).unwrap().0,
                 Value::okay(Value::Int(1)).unwrap());
 
-            assert_eq!(
-                conn.as_transaction(|tx| tx.run_contract_call(&sender, &contract_identifier, "set-bar", &[Value::Int(10), Value::Int(1)],
-                                       |_, _| true)).unwrap().0,
-                Value::okay(Value::Int(10)).unwrap());
+            let e = conn.as_transaction(|tx| tx.run_contract_call(&sender, &contract_identifier, "set-bar", &[Value::Int(10), Value::Int(1)],
+                                                                  |_, _| true)).unwrap_err();
+            let result_value = if let Error::PostConditionAbort(v, ..) = e {
+                v.unwrap()
+            } else {
+                panic!("Expects a PostConditionAbort error")
+            };
+
+            assert_eq!(result_value,
+                       Value::okay(Value::Int(10)).unwrap());
 
             // prior transaction should have rolled back due to abort call back!
             assert_eq!(

--- a/src/vm/tests/large_contract.rs
+++ b/src/vm/tests/large_contract.rs
@@ -9,7 +9,7 @@ use vm::representations::SymbolicExpression;
 use vm::contracts::Contract;
 use util::hash::hex_bytes;
 use vm::database::{MemoryBackingStore, MarfedKV, NULL_HEADER_DB, ClarityDatabase};
-use vm::clarity::ClarityInstance;
+use vm::clarity::{ClarityInstance, Error as ClarityError};
 use vm::ast;
 use vm::costs::ExecutionCost;
 use vm::tests::{with_memory_environment, with_marfed_environment, execute, symbols_from_values};
@@ -203,9 +203,13 @@ pub fn fcall_memory_test() {
 
         conn.as_transaction(|conn| {
             let (ct_ast, _ct_analysis) = conn.analyze_smart_contract(&contract_identifier, &contract_ok).unwrap();
-            conn.initialize_smart_contract(
-                // initialize the ok contract without errs, but still abort.
-                &contract_identifier, &ct_ast, &contract_ok, |_,_| true).unwrap();
+            assert!(
+                match conn.initialize_smart_contract(
+                    // initialize the ok contract without errs, but still abort.
+                    &contract_identifier, &ct_ast, &contract_ok, |_,_| true).unwrap_err() {
+                    ClarityError::PostConditionAbort(..) => true,
+                    _ => false
+                });
         });
 
         conn.as_transaction(|conn| {

--- a/src/vm/tests/large_contract.rs
+++ b/src/vm/tests/large_contract.rs
@@ -207,7 +207,7 @@ pub fn fcall_memory_test() {
                 match conn.initialize_smart_contract(
                     // initialize the ok contract without errs, but still abort.
                     &contract_identifier, &ct_ast, &contract_ok, |_,_| true).unwrap_err() {
-                    ClarityError::PostConditionAbort(..) => true,
+                    ClarityError::AbortedByCallback(..) => true,
                     _ => false
                 });
         });

--- a/testnet/stacks-node/src/event_dispatcher.rs
+++ b/testnet/stacks-node/src/event_dispatcher.rs
@@ -21,9 +21,9 @@ struct EventObserver {
     endpoint: String,
 }
 
-const STATUS_RESP_TRUE = "success";
-const STATUS_RESP_NOT_COMMITTED = "abort_by_response";
-const STATUS_RESP_POST_CONDITION  = "abort_by_post_condition";
+const STATUS_RESP_TRUE: &str = "success";
+const STATUS_RESP_NOT_COMMITTED: &str = "abort_by_response";
+const STATUS_RESP_POST_CONDITION: &str  = "abort_by_post_condition";
 
 impl EventObserver {
 

--- a/testnet/stacks-node/src/event_dispatcher.rs
+++ b/testnet/stacks-node/src/event_dispatcher.rs
@@ -150,6 +150,11 @@ impl EventDispatcher {
         let mut events: Vec<(Txid, &StacksTransactionEvent)> = vec![];
         let mut i: usize = 0;
         for receipt in chain_tip.receipts.iter() {
+            if receipt.post_condition_aborted {
+                // don't include events for transactions that
+                //   were aborted by post_conditions in the block's events
+                continue;
+            }
             let tx_hash = receipt.transaction.txid();
             for event in receipt.events.iter() {
                 match event {


### PR DESCRIPTION
This PR addresses:

#1608, #1609, #1568

By doing the following:

1. Adding a new Error type to the clarity::Error enum for the event that a post condition callback aborted a transaction.
2. Modifying the TransactionReceipt struct to include a `post_condition_aborted` boolean for tracking whether or not a transaction which would have otherwise succeeded was aborted due to a PostCondition
3. Replacing `success` with `status` in `"transactions"` events. This field can (for now), take one of three values:
    a. "success" -- the transaction succeeded and was committed.
    b. "abort_by_response" -- the transaction did not succeed, because the transaction was aborted during its execution (e.g., the `contract-call` returned `(err foo)`).
    c. "abort_by_post_condition" -- the transaction would have succeeded, but was rolled back by the supplied post-condition.
