### PR TITLE
Fix: Detecting dependencies in tuple constructors

### DIFF
--- a/src/vm/analysis/type_checker/tests/mod.rs
+++ b/src/vm/analysis/type_checker/tests/mod.rs
@@ -859,6 +859,29 @@ fn test_high_order_map() {
     }
 }
 
+
+#[test]
+fn test_function_order_tuples() {
+    let snippet = "
+(define-read-only (get-score)
+    (ok 
+        (tuple
+            (score (get-zero))
+        )
+    )
+)
+
+(define-private (get-zero)
+    0
+)
+
+1
+";
+
+    assert_eq!(&mem_type_check(snippet).unwrap().0.unwrap().to_string(),
+               "int");
+}
+
 #[test]
 fn test_simple_uints() {
     let good = [

--- a/src/vm/ast/definition_sorter/mod.rs
+++ b/src/vm/ast/definition_sorter/mod.rs
@@ -222,10 +222,16 @@ impl <'a> DefinitionSorter {
         }
     }
 
-    fn probe_for_dependencies_in_tuple_list(&mut self, tuples: &[PreSymbolicExpression], tle_index: usize) -> ParseResult<()> {
-        for index in 0..tuples.len() {
-            self.probe_for_dependencies_in_tuple(&tuples[index], tle_index)?;
-        } 
+    /// accept a slice of expected-pairs, e.g., [ (a b) (c d) (e f) ], and
+    ///   probe them for dependencies as if they were part of a tuple definition.
+    fn probe_for_dependencies_in_tuple_list(&mut self, pairs: &[PreSymbolicExpression], tle_index: usize) -> ParseResult<()> {
+        for pair in pairs.iter() {
+            if let Some(pair) = pair.match_list() {
+                if pair.len() == 2 {
+                    self.probe_for_dependencies(&pair[1], tle_index)?;
+                }
+            }
+        }
         Ok(())
     }
     
@@ -250,13 +256,7 @@ impl <'a> DefinitionSorter {
 
     fn probe_for_dependencies_in_tuple(&mut self, expr: &PreSymbolicExpression, tle_index: usize) -> ParseResult<()> {
         if let Some(tuple) = expr.match_list() {
-            for pair in tuple.into_iter() {
-                if let Some(pair) = pair.match_list() {
-                    if pair.len() == 2 {
-                        self.probe_for_dependencies(&pair[1], tle_index)?;
-                    }
-                }
-            }
+            self.probe_for_dependencies_in_tuple_list(tuple, tle_index)?;
         }
         Ok(())
     }

--- a/testnet/bitcoin-neon-controller/Cargo.toml
+++ b/testnet/bitcoin-neon-controller/Cargo.toml
@@ -6,9 +6,9 @@ edition = "2018"
 
 [dependencies]
 async-h1 = "1.1"
-async-std = { version = "1.4.0", features = ["attributes"] }
+async-std = { version = "<1.6", features = ["attributes"] }
 base64 = "0.12.0"
-http-types = "1.0.0"
+http-types = "1.0"
 serde = "1"
 serde_derive = "1"
 serde_json = { version = "1.0", features = ["arbitrary_precision"] }


### PR DESCRIPTION
This resolves #1625 by fixing a bug in `vm::ast::definition_sorter` --- tuple constructors weren't parsed correctly when probing for dependencies (they need to look for lists of pairs, but the previous code was looking for lists of lists of pairs).