### PR TITLE
Percent decode URL paths in RPC requests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ mio = "0.6"
 libc = "0.2"
 lazy_static = "1.4.0"
 url = "2.1.1"
+percent-encoding = "2.1.0"
 sha2 = "0.8.0"
 
 [dependencies.serde_json]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ regex = "1"
 mio = "0.6"
 libc = "0.2"
 lazy_static = "1.4.0"
-url = "2.1.1"
+url = "2.1.0"
 percent-encoding = "2.1.0"
 sha2 = "0.8.0"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@ extern crate time;
 extern crate byteorder;
 extern crate mio;
 extern crate url;
+extern crate percent_encoding;
 
 #[macro_use] extern crate serde_derive;
 #[macro_use] extern crate serde_json;

--- a/testnet/stacks-node/src/tests/integrations.rs
+++ b/testnet/stacks-node/src/tests/integrations.rs
@@ -476,7 +476,7 @@ fn integration_test_get_info() {
                                                                        "(get-exotic-data-info u1)");
                 assert_eq!(result_data, expected_data);
 
-                // how about a read-only function call!
+                // let's try a call with a url-encoded string.
                 let path = format!("{}/v2/contracts/call-read/{}/{}/{}", &http_origin, &contract_addr, "get-info",
                                    "get-exotic-data-info%3F");
                 eprintln!("Test: POST {}", path);
@@ -489,17 +489,14 @@ fn integration_test_get_info() {
                 let res = client.post(&path)
                     .json(&body)
                     .send()
-                    .unwrap();
-                eprintln!("{:?}", res);
-
-                let res = res
+                    .unwrap()
                     .json::<serde_json::Value>().unwrap();
                 assert!(res.get("cause").is_none());
                 assert!(res["okay"].as_bool().unwrap());
 
                 let result_data = Value::try_deserialize_hex_untyped(&res["result"].as_str().unwrap()[2..]).unwrap();
                 let expected_data = chain_state.clarity_eval_read_only(bhh, &contract_identifier,
-                                                                       "(get-exotic-data-info u1)");
+                                                                       "(get-exotic-data-info? u1)");
                 assert_eq!(result_data, expected_data);
 
                 // let's have a runtime error!


### PR DESCRIPTION
This adds percent-decoding to the RPC request handler --

This is necessary for resolving #1622 (from the stacks-blockchain node's perspective -- separately, clarity-js-sdk will need to add support for encoding this URL).