### PR TITLE
Fix/1623

### DIFF
--- a/src/chainstate/stacks/db/mod.rs
+++ b/src/chainstate/stacks/db/mod.rs
@@ -1056,6 +1056,19 @@ pub mod test {
         StacksChainState::open(mainnet, chain_id, &path).unwrap()
     }
 
+    pub fn instantiate_chainstate_with_balances(mainnet: bool, chain_id: u32, test_name: &str, balances: Vec<(StacksAddress, u64)>) -> StacksChainState {
+        let path = chainstate_path(test_name);
+        match fs::metadata(&path) {
+            Ok(_) => {
+                fs::remove_dir_all(&path).unwrap();
+            },
+            Err(_) => {}
+        };
+
+        let initial_balances = Some(balances.into_iter().map(|(addr, balance)| (PrincipalData::from(addr), balance)).collect());
+        StacksChainState::open_and_exec(mainnet, chain_id, &path, initial_balances, |_| {}, ExecutionCost::max_value()).unwrap()
+    }
+
     pub fn open_chainstate(mainnet: bool, chain_id: u32, test_name: &str) -> StacksChainState {
         let path = chainstate_path(test_name);
         StacksChainState::open(mainnet, chain_id, &path).unwrap()

--- a/src/chainstate/stacks/db/transactions.rs
+++ b/src/chainstate/stacks/db/transactions.rs
@@ -181,6 +181,21 @@ impl From<TransactionNonceMismatch> for MemPoolRejection {
 }
 
 impl StacksChainState {
+    /// Get the payer account
+    fn get_payer_account<T: ClarityConnection>(clarity_tx: &mut T, tx: &StacksTransaction) -> StacksAccount {
+        // who's paying the fee?
+        let payer_account =
+            if let Some(sponsor_address) = tx.sponsor_address() {
+                let payer_account = StacksChainState::get_account(clarity_tx, &sponsor_address.into());
+                payer_account
+            } else {
+                let origin_account = StacksChainState::get_account(clarity_tx, &tx.origin_address().into());
+                origin_account
+            };
+
+        payer_account
+    }
+
     /// Check the account nonces for the supplied stacks transaction,
     ///   returning the origin and payer accounts if valid.
     pub fn check_transaction_nonces<T: ClarityConnection>(clarity_tx: &mut T, tx: &StacksTransaction) -> Result<(StacksAccount, StacksAccount), TransactionNonceMismatch> {
@@ -669,10 +684,15 @@ impl StacksChainState {
         let tx_receipt = StacksChainState::process_transaction_payload(&mut transaction, tx, &origin_account)?;
 
         // pay fee borne by runtime costs.
-        // TODO: this is the fee *rate*, not the absolute fee.  This code is broken until we have
+        // NOTE: the fee must be paid _after_ we run the payload, because we will (eventually) be
+        // debiting the account a fee equal to its transaction's runtime cost (which can only be
+        // determined by running the code).  Hence, we need to refresh the payer account after the
+        // transaction body runs.
+        // TODO: this field is the fee *rate*, not the absolute fee.  This code is broken until we have
         // the true block reward system built.
+        let new_payer_account = StacksChainState::get_payer_account(&mut transaction, tx);
         let fee = tx.get_fee_rate();
-        StacksChainState::pay_transaction_fee(&mut transaction, fee, &payer_account)?;
+        StacksChainState::pay_transaction_fee(&mut transaction, fee, &new_payer_account)?;
 
         // update the account nonces
         StacksChainState::update_account_nonce(&mut transaction, &origin_account);
@@ -3171,5 +3191,57 @@ pub mod test {
         }
     }
 
+    #[test]
+    fn process_smart_contract_fee_check() {
+        let contract = r#"
+        (define-public (send-stx (amount uint) (recipient principal))
+            (stx-transfer? amount tx-sender recipient))
+        "#;
+        
+        let privk = StacksPrivateKey::from_hex("6d430bb91222408e7706c9001cfaeb91b08c2be6d5ac95779ab52c6b431950e001").unwrap();
+        let auth = TransactionAuth::from_p2pkh(&privk).unwrap();
+        let addr = auth.origin().address_testnet();
+
+        let balances = vec![(addr.clone(), 1000000000)];
+
+        let mut chainstate = instantiate_chainstate_with_balances(false, 0x80000000, "process-smart-contract-fee_check", balances);
+
+        let mut tx_contract_create = StacksTransaction::new(TransactionVersion::Testnet,
+                                                            auth.clone(),
+                                                            TransactionPayload::new_smart_contract(&"hello-world".to_string(), &contract.to_string()).unwrap());
+
+        tx_contract_create.chain_id = 0x80000000;
+        tx_contract_create.set_fee_rate(0);
+
+        let mut signer = StacksTransactionSigner::new(&tx_contract_create);
+        signer.sign_origin(&privk).unwrap();
+
+        let signed_contract_tx = signer.get_tx().unwrap();
+
+        let mut tx_contract_call = StacksTransaction::new(TransactionVersion::Testnet,
+                                                          auth.clone(),
+                                                          TransactionPayload::new_contract_call(
+                                                              addr.clone(), 
+                                                              "hello-world", 
+                                                              "send-stx", vec![Value::UInt(1000000000), Value::Principal(PrincipalData::from(StacksAddress::from_string("ST1H1B54MY50RMBRRKS7GV2ZWG79RZ1RQ1ETW4E01").unwrap()))]).unwrap());
+
+        tx_contract_call.chain_id = 0x80000000;
+        tx_contract_call.set_fee_rate(1);
+        tx_contract_call.set_origin_nonce(1);
+        tx_contract_call.post_condition_mode = TransactionPostConditionMode::Allow;
+
+        let mut signer = StacksTransactionSigner::new(&tx_contract_call);
+        signer.sign_origin(&privk).unwrap();
+
+        let signed_contract_call_tx = signer.get_tx().unwrap();
+
+        let mut conn = chainstate.block_begin(&FIRST_BURNCHAIN_BLOCK_HASH, &FIRST_STACKS_BLOCK_HASH, &BurnchainHeaderHash([1u8; 32]), &BlockHeaderHash([1u8; 32]));
+        let (fee, _) = StacksChainState::process_transaction(&mut conn, &signed_contract_tx).unwrap();
+        let err = StacksChainState::process_transaction(&mut conn, &signed_contract_call_tx).unwrap_err();
+        conn.commit_block();
+
+        eprintln!("{:?}", &err);
+        assert_eq!(fee, 0);
+    }
     // TODO: test poison microblock
 }

--- a/src/chainstate/stacks/db/transactions.rs
+++ b/src/chainstate/stacks/db/transactions.rs
@@ -3242,6 +3242,7 @@ pub mod test {
 
         eprintln!("{:?}", &err);
         assert_eq!(fee, 0);
+        if let Error::InvalidFee = err {} else { assert!(false) };
     }
     // TODO: test poison microblock
 }

--- a/testnet/stacks-node/src/tests/integrations.rs
+++ b/testnet/stacks-node/src/tests/integrations.rs
@@ -843,13 +843,13 @@ fn bad_contract_tx_rollback() {
             },
             2 => {
                 assert_eq!(chain_tip.metadata.block_height, 3);
-                // Block #2 should have 4 txs -- coinbase + 1 transfer + 1 publish
-                assert_eq!(chain_tip.block.txs.len(), 3);
+                // Block #2 should have 4 txs -- coinbase + 2 transfer + 1 publish
+                assert_eq!(chain_tip.block.txs.len(), 4);
             },
             3 => {
                 assert_eq!(chain_tip.metadata.block_height, 4);
-                // Block #2 should have 4 txs -- coinbase + 1 transfer
-                assert_eq!(chain_tip.block.txs.len(), 2);
+                // Block #2 should have 1 txs -- coinbase
+                assert_eq!(chain_tip.block.txs.len(), 1);
             },
             _ => {},
         }


### PR DESCRIPTION
This PR fixes #1623.  The problem arises because we need to bill accounts for their transaction fees _after_ we run their payloads, because (eventually) we only want to bill them for the resources they actually used.  If a payload is a `contract-call` that liquidates the account's STX, then the act of paying the transaction fee would cause a runtime panic.  This PR ultimately fixes it by re-loading the payer account after running the transaction payload and using that account's balance to decide if it can pay.

While trying to reproduce the issue, I noticed a small bug in the mempool scanning logic that could cause transactions to get mined out-of-order.  This PR also adjusts the mempool scanning logic to sort all transactions by origin nonce, instead of by fee.  This way, if there are multiple transactions in the mempool from the same origin account, but with different nonces, they'll be mined in the right order in the same block (otherwise, they would have been spaced out across multiple blocks as they became eligible).