### PR TITLE
Fix/miner block upload

### DIFF
--- a/src/net/relay.rs
+++ b/src/net/relay.rs
@@ -837,6 +837,13 @@ impl Relayer {
         self.p2p.advertize_blocks(available)
     }
 
+    pub fn broadcast_block(&mut self, burn_header_hash: BurnchainHeaderHash, block: StacksBlock) -> Result<(), net_error> {
+        let blocks_data = BlocksData {
+            blocks: vec![(burn_header_hash, block)]
+        };
+        self.p2p.broadcast_message(vec![], StacksMessageType::Blocks(blocks_data))
+    }
+
     pub fn broadcast_microblock(&mut self,
                                 block_header_hash: &BlockHeaderHash,
                                 block_burn_header_hash: &BurnchainHeaderHash,

--- a/testnet/stacks-node/Cargo.toml
+++ b/testnet/stacks-node/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 lazy_static = "1.4.0"
 pico-args = "0.3.1"
 rand = "=0.7.2"
-reqwest = { version = "0.10", features = ["blocking", "json", "native-tls-vendored"] }
+reqwest = { version = "0.10", features = ["blocking", "json"] }
 secp256k1 = { version = "0.11.5" }
 serde = "1"
 serde_derive = "1"

--- a/testnet/stacks-node/Cargo.toml
+++ b/testnet/stacks-node/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 lazy_static = "1.4.0"
 pico-args = "0.3.1"
 rand = "=0.7.2"
-reqwest = { version = "0.10", features = ["blocking", "json"] }
+reqwest = { version = "0.10", features = ["blocking", "json", "native-tls-vendored"] }
 secp256k1 = { version = "0.11.5" }
 serde = "1"
 serde_derive = "1"

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -108,7 +108,7 @@ fn inner_process_tenure(
     parent_burn_header_hash: &BurnchainHeaderHash, 
     burn_db: &mut BurnDB,
     chain_state: &mut StacksChainState,
-    dispatcher: &mut EventDispatcher) -> Result<(StacksHeaderInfo, Vec<StacksTransactionReceipt>), ChainstateError> {
+    dispatcher: &mut EventDispatcher) -> Result<(), ChainstateError> {
     {
         let ic = burn_db.index_conn();
 
@@ -136,22 +136,20 @@ fn inner_process_tenure(
         }
     }
 
-    // todo(ludo): yikes but good enough in the context of helium:
-    // we only expect 1 block.
-    let processed_block = match processed_blocks.last() {
-        Some(x) => x.clone().0.unwrap(),
-        None => {
-            warn!("Chainstate expected to process a new block, but we didn't");
-            return Err(ChainstateError::InvalidStacksBlock("Could not process expected block".into()));
+    if processed_blocks.len() == 0 {
+        warn!("Chainstate expected to process a new block, but we didn't");
+        return Err(ChainstateError::InvalidStacksBlock("Could not process expected block".into()));
+    }
+
+    for processed_block in processed_blocks.into_iter() {
+        match processed_block {
+            (Some((header, receipts)), _) => {
+                dispatcher_announce(&chain_state.blocks_path, dispatcher, header, receipts);
+            },
+            _ => {}
         }
-    };
-
-    // Handle events
-    let receipts = processed_block.1;
-    let metadata = processed_block.0;
-
-    dispatcher_announce(&chain_state.blocks_path, dispatcher, metadata.clone(), receipts.clone());
-    Ok((metadata, receipts))
+    }
+    Ok(())
 }
 
 fn inner_generate_coinbase_tx(keychain: &mut Keychain, nonce: u64) -> StacksTransaction {
@@ -382,23 +380,22 @@ fn spawn_miner_relayer(mut relayer: Relayer, local_peer: LocalPeer,
                                   block_header_hash,
                                   mined_burn_hh);
 
-                            let (stacks_header, _) =
-                                match inner_process_tenure(&mined_block, &burn_header_hash, &parent_block_burn_hash,
-                                                           &mut burndb, &mut chainstate, &mut event_dispatcher) {
-                                    Ok(x) => x,
-                                    Err(e) => {
-                                        warn!("Error processing my tenure, bad block produced: {}", e);
-                                        continue;
-                                    }
-                                };
+                            match inner_process_tenure(&mined_block, &burn_header_hash, &parent_block_burn_hash,
+                                                       &mut burndb, &mut chainstate, &mut event_dispatcher) {
+                                Ok(x) => x,
+                                Err(e) => {
+                                    warn!("Error processing my tenure, bad block produced: {}", e);
+                                    continue;
+                                }
+                            };
 
                             // advertize _and_ push blocks for now
-                            let blocks_available = Relayer::load_blocks_available_data(&burndb, vec![stacks_header.burn_header_hash.clone()])
+                            let blocks_available = Relayer::load_blocks_available_data(&burndb, vec![burn_header_hash.clone()])
                                 .expect("Failed to obtain block information for a block we mined.");
                             if let Err(e) = relayer.advertize_blocks(blocks_available) {
                                 warn!("Failed to advertise new block: {}", e);
                             }
-                            if let Err(e) = relayer.broadcast_block(stacks_header.burn_header_hash, mined_block) {
+                            if let Err(e) = relayer.broadcast_block(burn_header_hash.clone(), mined_block) {
                                 warn!("Failed to push new block: {}", e);
                             }
 

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -138,7 +138,7 @@ fn inner_process_tenure(
 
     // todo(ludo): yikes but good enough in the context of helium:
     // we only expect 1 block.
-    let processed_block = match processed_blocks.get(0) {
+    let processed_block = match processed_blocks.last() {
         Some(x) => x.clone().0.unwrap(),
         None => {
             warn!("Chainstate expected to process a new block, but we didn't");


### PR DESCRIPTION
This fixes #1649.  You can run a NAT'ed miner node and it will broadcast its block (in addition to a blocks-available) to the peer network, so it propagates as expected.

I tested by spinning up a local miner and confirmed that its blocks reached the Neon master node, and confirmed that the Neon node will build off of my node's blocks.