### PR TITLE
Event Dispatcher: Mempool txs events + parent_index_block_hash

### DIFF
--- a/docs/event-dispatcher.md
+++ b/docs/event-dispatcher.md
@@ -1,0 +1,86 @@
+# Event dispatching / observer interface
+
+The `stacks-node` supports a configurable event observer interface.
+This is enabled by adding an entry to the node's `config.toml` file:
+
+```toml
+...
+[[events_observer]]
+endpoint = "http://listener:3700"
+events_keys = [
+  "*"
+]
+...
+```
+
+The `stacks-node` will then execute HTTP POSTs to the configured
+endpoint in two events:
+
+1. A new Stacks block is processed.
+2. New mempool transactions have been received.
+
+These events are sent to the configured endpoint at two URLs:
+
+
+### `POST /new_block`
+
+This payload includes data related to a newly processed block,
+and any events emitted from Stacks transactions during the block.
+
+Example:
+
+```json
+{
+  "block_hash": "0x4eaabcd105865e471f697eff5dd5bd85d47ecb5a26a3379d74fae0ae87c40904",
+  "block_height": 3,
+  "burn_block_time": 1591301733,
+  "events": [
+    {
+      "committed": true,
+      "stx_transfer_event": {
+        "amount": "1000",
+        "recipient": "ST31DA6FTSJX2WGTZ69SFY11BH51NZMB0ZZ239N96",
+        "sender": "ST3WM51TCWMJYGZS1QFMC28DH5YP86782YGR113C1"
+      },
+      "txid": "0x738e4d44636023efa08374033428e44eca490582bd39a6e61f3b6cf749b4214c",
+      "type": "stx_transfer_event"
+    }
+  ],
+  "index_block_hash": "0x329efcbcc6daf5ac3f264522e0df50eddb5be85df6ee8a9fc2384c54274d7afc",
+  "parent_block_hash": "0xf5d4ce0efe1d42c963d615ce57f0d014f263a985175e4ece766eceff10e0a358",
+  "parent_index_block_hash": "0x0c8b38d44d6af72703a4767ff4cea683ec965346d9e9a7ded2d773fb4f257c28",
+  "parent_microblock": "0xedd15cf1e697c28df934e259f0f82970a7c9edc2d39bef04bdd0d422116235c6",
+  "transactions": [
+    {
+      "contract_abi": null,
+      "raw_result": "0x03",
+      "raw_tx": "0x808000000004008bc5147525b8f477f0bc4522a88c8339b2494db50000000000000002000000000000000001015814daf929d8700af344987681f44e913890a12e38550abe8e40f149ef5269f40f4008083a0f2e0ddf65dcd05ecfc151c7ff8a5308ad04c77c0e87b5aeadad31010200000000040000000000000000000000000000000000000000000000000000000000000000",
+      "status": "success",
+      "tx_index": 0,
+      "txid": "0x3e04ada5426332bfef446ba0a06d124aace4ade5c11840f541bf88e2e919faf6"
+    },
+    {
+      "contract_abi": null,
+      "raw_result": "0x03",
+      "raw_tx": "0x80800000000400f942874ce525e87f21bbe8c121b12fac831d02f4000000000000000000000000000003e800006ae29867aec4b0e4f776bebdcea7f6d9a24eeff370c8c739defadfcbb52659b30736ad4af021e8fb741520a6c65da419fdec01989fdf0032fc1838f427a9a36102010000000000051ac2d519faccba2e435f3272ff042b89435fd160ff00000000000003e800000000000000000000000000000000000000000000000000000000000000000000",
+      "status": "success",
+      "tx_index": 1,
+      "txid": "0x738e4d44636023efa08374033428e44eca490582bd39a6e61f3b6cf749b4214c"
+    }
+  ]
+}
+```
+
+
+### `POST /new_mempool_tx`
+
+This payload includes raw transactions newly received in the
+node's mempool.
+
+Example:
+
+```json
+[
+  "0x80800000000400f942874ce525e87f21bbe8c121b12fac831d02f4000000000000000000000000000003e800006ae29867aec4b0e4f776bebdcea7f6d9a24eeff370c8c739defadfcbb52659b30736ad4af021e8fb741520a6c65da419fdec01989fdf0032fc1838f427a9a36102010000000000051ac2d519faccba2e435f3272ff042b89435fd160ff00000000000003e800000000000000000000000000000000000000000000000000000000000000000000"
+]
+```

--- a/src/burnchains/burnchain.rs
+++ b/src/burnchains/burnchain.rs
@@ -1715,7 +1715,7 @@ pub mod tests {
                     block_header_hash: BlockHeaderHash::from_bytes(&vec![i,i,i,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]).unwrap(),
                     new_seed: VRFSeed::from_bytes(&vec![i,i,i,i,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]).unwrap(),
                     parent_block_ptr: (if i == 1 { 0 } else { first_block_height + (i as u64) }) as u32,
-                    parent_vtxindex: (if i == 1 { 0 } else { (2 * (i - 1)) }) as u16,
+                    parent_vtxindex: (if i == 1 { 0 } else { 2 * (i - 1) }) as u16,
                     key_block_ptr: (first_block_height + (i as u64)) as u32,
                     key_vtxindex: (2 * (i - 1) + 1) as u16,
                     memo: vec![i],

--- a/src/chainstate/burn/mod.rs
+++ b/src/chainstate/burn/mod.rs
@@ -65,6 +65,7 @@ pub struct BlockHeaderHash(pub [u8; 32]);
 impl_array_newtype!(BlockHeaderHash, u8, 32);
 impl_array_hexstring_fmt!(BlockHeaderHash);
 impl_byte_array_newtype!(BlockHeaderHash, u8, 32);
+impl_byte_array_serde!(BlockHeaderHash);
 pub const BLOCK_HEADER_HASH_ENCODED_SIZE : usize = 32;
 
 pub struct VRFSeed(pub [u8; 32]);

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -1382,6 +1382,12 @@ impl NetworkResult {
         self.pushed_transactions.len() > 0 || self.uploaded_transactions.len() > 0
     }
 
+    pub fn transactions(&self) -> Vec<StacksTransaction> {
+        self.pushed_transactions.values()
+            .flat_map(|pushed_txs| pushed_txs.iter().map(|(_, tx)| tx.clone()))
+            .chain(self.uploaded_transactions.iter().map(|x| x.clone())).collect()
+    }
+
     pub fn has_data_to_store(&self) -> bool {
         self.has_blocks() || self.has_microblocks() || self.has_transactions()
     }

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -851,14 +851,18 @@ impl PeerHost {
 /// The data we return on GET /v2/info
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct RPCPeerInfoData {
-    peer_version: u32,
-    burn_consensus: ConsensusHash,
-    burn_block_height: u64,
-    stable_burn_consensus: ConsensusHash,
-    stable_burn_block_height: u64,
-    server_version: String,
-    network_id: u32,
-    parent_network_id: u32,
+    pub peer_version: u32,
+    pub burn_consensus: ConsensusHash,
+    pub burn_block_height: u64,
+    pub stable_burn_consensus: ConsensusHash,
+    pub stable_burn_block_height: u64,
+    pub server_version: String,
+    pub network_id: u32,
+    pub parent_network_id: u32,
+    pub stacks_tip_height: u64,
+    pub stacks_tip: BlockHeaderHash,
+    pub stacks_tip_burn_block: String,
+    pub exit_at_block_height: Option<u64>,
 }
 
 #[derive(Debug, Clone, PartialEq, Copy, Hash)]
@@ -1916,7 +1920,7 @@ pub mod test {
             let mut stacks_node = self.stacks_node.take().unwrap();
             let mut mempool = self.mempool.take().unwrap();
 
-            let ret = self.network.run(&mut burndb, &mut stacks_node.chainstate, &mut mempool, None, false, 10);
+            let ret = self.network.run(&mut burndb, &mut stacks_node.chainstate, &mut mempool, None, false, 10, None);
 
             self.burndb = Some(burndb);
             self.stacks_node = Some(stacks_node);
@@ -1930,7 +1934,7 @@ pub mod test {
             let mut stacks_node = self.stacks_node.take().unwrap();
             let mut mempool = self.mempool.take().unwrap();
 
-            let ret = self.network.run(&mut burndb, &mut stacks_node.chainstate, &mut mempool, Some(dns_client), false, 10);
+            let ret = self.network.run(&mut burndb, &mut stacks_node.chainstate, &mut mempool, Some(dns_client), false, 10, None);
 
             self.burndb = Some(burndb);
             self.stacks_node = Some(stacks_node);

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -1463,6 +1463,7 @@ pub mod test {
     use net::db::*;
     use net::neighbors::*;
     use net::p2p::*;
+    use net::rpc::RPCHandlerArgs;
     use net::poll::*;
     use net::relay::*;
     use net::Error as net_error;
@@ -1920,7 +1921,7 @@ pub mod test {
             let mut stacks_node = self.stacks_node.take().unwrap();
             let mut mempool = self.mempool.take().unwrap();
 
-            let ret = self.network.run(&mut burndb, &mut stacks_node.chainstate, &mut mempool, None, false, 10, None);
+            let ret = self.network.run(&mut burndb, &mut stacks_node.chainstate, &mut mempool, None, false, 10, &RPCHandlerArgs::default());
 
             self.burndb = Some(burndb);
             self.stacks_node = Some(stacks_node);
@@ -1934,7 +1935,7 @@ pub mod test {
             let mut stacks_node = self.stacks_node.take().unwrap();
             let mut mempool = self.mempool.take().unwrap();
 
-            let ret = self.network.run(&mut burndb, &mut stacks_node.chainstate, &mut mempool, Some(dns_client), false, 10, None);
+            let ret = self.network.run(&mut burndb, &mut stacks_node.chainstate, &mut mempool, Some(dns_client), false, 10, &RPCHandlerArgs::default());
 
             self.burndb = Some(burndb);
             self.stacks_node = Some(stacks_node);

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -357,10 +357,20 @@ impl PartialEq for Error {
 
 /// Helper trait for various primitive types that make up Stacks messages
 pub trait StacksMessageCodec {
+    /// serialize implementors _should never_ error unless there is an underlying
+    ///   failure in writing to the `fd`
     fn consensus_serialize<W: Write>(&self, fd: &mut W) -> Result<(), Error>
         where Self: Sized;
     fn consensus_deserialize<R: Read>(fd: &mut R) -> Result<Self, Error>
         where Self: Sized;
+    /// Convenience for serialization to a vec.
+    ///  this function unwraps any underlying serialization error
+    fn serialize_to_vec(&self) -> Vec<u8> where Self: Sized {
+        let mut bytes = vec![];
+        self.consensus_serialize(&mut bytes)
+            .expect("BUG: serialization to buffer failed.");
+        bytes
+    }
 }
 
 /// A container for an IPv4 or IPv6 address.

--- a/src/net/p2p.rs
+++ b/src/net/p2p.rs
@@ -94,6 +94,7 @@ use mio::net as mio_net;
 
 use net::inv::*;
 use net::relay::*;
+use net::rpc::RPCHandlerArgs;
 
 /// inter-thread request to send a p2p message from another thread in this program.
 pub enum NetworkRequest {
@@ -2219,7 +2220,7 @@ impl PeerNetwork {
     /// that sent them (i.e. keyed by their event IDs)
     pub fn run(&mut self, burndb: &BurnDB, chainstate: &mut StacksChainState, mempool: &mut MemPoolDB,
                dns_client_opt: Option<&mut DNSClient>, download_backpressure: bool,
-               poll_timeout: u64, exit_at_block_height: Option<u64>) -> Result<NetworkResult, net_error> {
+               poll_timeout: u64, handler_args: &RPCHandlerArgs) -> Result<NetworkResult, net_error> {
         let mut poll_states = match self.network {
             None => {
                 test_debug!("{:?}: network not connected", &self.local_peer);
@@ -2241,7 +2242,7 @@ impl PeerNetwork {
         PeerNetwork::with_network_state(self, |ref mut network, ref mut network_state| {
             let http_stacks_msgs = network.http.run(
                 network_state, network.chain_view.clone(), &network.peers, burndb,
-                &network.peerdb, chainstate, mempool, http_poll_state, exit_at_block_height)?;
+                &network.peerdb, chainstate, mempool, http_poll_state, handler_args)?;
             result.consume_http_uploads(http_stacks_msgs);
             Ok(())
         })?;

--- a/src/net/p2p.rs
+++ b/src/net/p2p.rs
@@ -2217,7 +2217,9 @@ impl PeerNetwork {
     /// -- runs the p2p and http peer main loop
     /// Returns the table of unhandled network messages to be acted upon, keyed by the neighbors
     /// that sent them (i.e. keyed by their event IDs)
-    pub fn run(&mut self, burndb: &BurnDB, chainstate: &mut StacksChainState, mempool: &mut MemPoolDB, dns_client_opt: Option<&mut DNSClient>, download_backpressure: bool, poll_timeout: u64) -> Result<NetworkResult, net_error> {
+    pub fn run(&mut self, burndb: &BurnDB, chainstate: &mut StacksChainState, mempool: &mut MemPoolDB,
+               dns_client_opt: Option<&mut DNSClient>, download_backpressure: bool,
+               poll_timeout: u64, exit_at_block_height: Option<u64>) -> Result<NetworkResult, net_error> {
         let mut poll_states = match self.network {
             None => {
                 test_debug!("{:?}: network not connected", &self.local_peer);
@@ -2237,7 +2239,9 @@ impl PeerNetwork {
         let mut result = NetworkResult::new();
 
         PeerNetwork::with_network_state(self, |ref mut network, ref mut network_state| {
-            let http_stacks_msgs = network.http.run(network_state, network.chain_view.clone(), &network.peers, burndb, &network.peerdb, chainstate, mempool, http_poll_state)?;
+            let http_stacks_msgs = network.http.run(
+                network_state, network.chain_view.clone(), &network.peers, burndb,
+                &network.peerdb, chainstate, mempool, http_poll_state, exit_at_block_height)?;
             result.consume_http_uploads(http_stacks_msgs);
             Ok(())
         })?;

--- a/src/net/relay.rs
+++ b/src/net/relay.rs
@@ -82,6 +82,11 @@ pub struct RelayerStats {
     next_priority: u64
 }
 
+pub struct ProcessedNetReceipts {
+    pub blocks_processed: Vec<(StacksHeaderInfo, Vec<StacksTransactionReceipt>)>,
+    pub mempool_txs_added: Vec<StacksTransaction>
+}
+
 /// Private trait for keeping track of messages that can be relayed, so we can identify the peers
 /// who frequently send us duplicates.
 pub trait RelayPayload {
@@ -864,8 +869,8 @@ impl Relayer {
     /// Mask errors from invalid data -- all errors due to invalid blocks and invalid data should be captured, and
     /// turned into peer bans.
     pub fn process_network_result(&mut self, _local_peer: &LocalPeer, network_result: &mut NetworkResult, burndb: &mut BurnDB, chainstate: &mut StacksChainState, mempool: &mut MemPoolDB)
-                                  -> Result<Vec<(StacksHeaderInfo, Vec<StacksTransactionReceipt>)>, net_error> {
-        let receipts = match Relayer::process_new_blocks(network_result, burndb, chainstate) {
+                                  -> Result<ProcessedNetReceipts, net_error> {
+        let blocks_processed = match Relayer::process_new_blocks(network_result, burndb, chainstate) {
             Ok((new_blocks, new_confirmed_microblocks, mut new_microblocks, bad_block_neighbors, receipts)) => {
                 // attempt to relay messages (note that this is all best-effort).
                 // punish bad peers
@@ -915,19 +920,26 @@ impl Relayer {
 
         // store all transactions, and forward the novel ones to neighbors
         test_debug!("{:?}: Process {} transaction(s)", &_local_peer, network_result.pushed_transactions.len());
-        let mut new_txs = Relayer::process_transactions(network_result, burndb, chainstate, mempool)?;
+        let new_txs = Relayer::process_transactions(network_result, burndb, chainstate, mempool)?;
 
         if new_txs.len() > 0 {
             debug!("{:?}: Send {} transactions to neighbors", &_local_peer, new_txs.len());
         }
 
-        for (relayers, tx) in new_txs.drain(..) {
+        let mut mempool_txs_added = vec![];
+        for (relayers, tx) in new_txs.into_iter() {
             debug!("{:?}: Broadcast tx {}", &_local_peer, &tx.txid());
+            mempool_txs_added.push(tx.clone());
             let msg = StacksMessageType::Transaction(tx);
             if let Err(e) = self.p2p.broadcast_message(relayers, msg) {
                 warn!("Failed to broadcast transaction: {:?}", &e);
             }
         }
+
+        let receipts = ProcessedNetReceipts {
+            blocks_processed,
+            mempool_txs_added
+        };
 
         Ok(receipts)
     }

--- a/src/net/rpc.rs
+++ b/src/net/rpc.rs
@@ -76,6 +76,8 @@ use util::get_epoch_time_secs;
 use util::hash::to_hex;
 use util::hash::Hash160;
 
+use crate::{version_string};
+
 use vm::{
     clarity::ClarityConnection,
     ClarityName,
@@ -135,9 +137,9 @@ impl fmt::Debug for ConversationHttp {
 }
 
 impl RPCPeerInfoData {
-    pub fn from_db(burnchain: &Burnchain, burndb: &BurnDB, peerdb: &PeerDB) -> Result<RPCPeerInfoData, net_error> {
-        let burnchain_tip = BurnDB::get_canonical_burn_chain_tip(burndb.conn()).map_err(net_error::DBError)?;
-        let local_peer = PeerDB::get_local_peer(peerdb.conn()).map_err(net_error::DBError)?;
+    pub fn from_db(burnchain: &Burnchain, burndb: &BurnDB, peerdb: &PeerDB, exit_at_block_height: Option<u64>) -> Result<RPCPeerInfoData, net_error> {
+        let burnchain_tip = BurnDB::get_canonical_burn_chain_tip(burndb.conn())?;
+        let local_peer = PeerDB::get_local_peer(peerdb.conn())?;
         let stable_burnchain_tip = {
             let ic = burndb.index_conn();
             let stable_height = 
@@ -148,10 +150,16 @@ impl RPCPeerInfoData {
                     burnchain_tip.block_height - (burnchain.stable_confirmations as u64)
                 };
 
-            BurnDB::get_block_snapshot_in_fork(&ic, stable_height, &burnchain_tip.burn_header_hash)
-                .map_err(net_error::DBError)?
+            BurnDB::get_block_snapshot_in_fork(&ic, stable_height, &burnchain_tip.burn_header_hash)?
                 .ok_or(net_error::DBError(db_error::NotFoundError))?
         };
+
+        let server_version = version_string(
+            option_env!("CARGO_PKG_NAME").unwrap_or("stacks-node"),
+            option_env!("CARGO_PKG_VERSION").unwrap_or("0.0.0.0"));
+        let stacks_tip_burn_block = burnchain_tip.canonical_stacks_tip_burn_hash;
+        let stacks_tip = burnchain_tip.canonical_stacks_tip_hash;
+        let stacks_tip_height = burnchain_tip.canonical_stacks_tip_height;
 
         Ok(RPCPeerInfoData {
             peer_version: burnchain.peer_version,
@@ -159,9 +167,13 @@ impl RPCPeerInfoData {
             burn_block_height: burnchain_tip.block_height,
             stable_burn_consensus: stable_burnchain_tip.consensus_hash,
             stable_burn_block_height: stable_burnchain_tip.block_height,
-            server_version: "TODO".to_string(),
+            server_version,
             network_id: local_peer.network_id,
             parent_network_id: local_peer.parent_network_id,
+            stacks_tip_height,
+            stacks_tip,
+            stacks_tip_burn_block: stacks_tip_burn_block.to_hex(),
+            exit_at_block_height
         })
     }
 }
@@ -297,9 +309,10 @@ impl ConversationHttp {
 
     /// Handle a GET peer info.
     /// The response will be synchronously written to the given fd (so use a fd that can buffer!)
-    fn handle_getinfo<W: Write>(http: &mut StacksHttp, fd: &mut W, req: &HttpRequestType, burnchain: &Burnchain, burndb: &BurnDB, peerdb: &PeerDB) -> Result<(), net_error> {
+    fn handle_getinfo<W: Write>(http: &mut StacksHttp, fd: &mut W, req: &HttpRequestType, burnchain: &Burnchain,
+                                burndb: &BurnDB, peerdb: &PeerDB, exit_at_block_height: Option<u64>) -> Result<(), net_error> {
         let response_metadata = HttpResponseMetadata::from(req);
-        match RPCPeerInfoData::from_db(burnchain, burndb, peerdb) {
+        match RPCPeerInfoData::from_db(burnchain, burndb, peerdb, exit_at_block_height) {
             Ok(pi) => {
                 let response = HttpResponseType::PeerInfo(response_metadata, pi);
                 response.send(http, fd)
@@ -659,7 +672,7 @@ impl ConversationHttp {
     /// Returns a StacksMessageType option -- it's Some(...) if we need to forward a message to the
     /// peer network (like a transaction or a block or microblock)
     pub fn handle_request(&mut self, req: HttpRequestType, chain_view: &BurnchainView, peers: &PeerMap, burndb: &BurnDB, peerdb: &PeerDB,
-                          chainstate: &mut StacksChainState, mempool: &mut MemPoolDB) -> Result<Option<StacksMessageType>, net_error> {
+                          chainstate: &mut StacksChainState, mempool: &mut MemPoolDB, exit_at_block_height: Option<u64>) -> Result<Option<StacksMessageType>, net_error> {
 
         let mut reply = self.connection.make_relay_handle(self.conn_id)?;
         let keep_alive = req.metadata().keep_alive;
@@ -667,7 +680,8 @@ impl ConversationHttp {
 
         let stream_opt = match req {
             HttpRequestType::GetInfo(ref _md) => {
-                ConversationHttp::handle_getinfo(&mut self.connection.protocol, &mut reply, &req, &self.burnchain, burndb, peerdb)?;
+                ConversationHttp::handle_getinfo(&mut self.connection.protocol, &mut reply, &req, &self.burnchain,
+                                                 burndb, peerdb, exit_at_block_height)?;
                 None
             },
             HttpRequestType::GetNeighbors(ref _md) => {
@@ -957,7 +971,7 @@ impl ConversationHttp {
     /// Make progress on in-flight requests and replies.
     /// Returns the list of transactions we'll need to forward to the peer network
     pub fn chat(&mut self, chain_view: &BurnchainView, peers: &PeerMap, burndb: &BurnDB, peerdb: &PeerDB,
-                chainstate: &mut StacksChainState, mempool: &mut MemPoolDB) -> Result<Vec<StacksMessageType>, net_error> {
+                chainstate: &mut StacksChainState, mempool: &mut MemPoolDB, exit_at_block_height: Option<u64>) -> Result<Vec<StacksMessageType>, net_error> {
 
         // if we have an in-flight error, then don't take any more requests.
         if self.pending_error_response.is_some() {
@@ -982,7 +996,8 @@ impl ConversationHttp {
                     // new request
                     self.total_request_count += 1;
                     self.last_request_timestamp = get_epoch_time_secs();
-                    let msg_opt = self.handle_request(req, chain_view, peers, burndb, peerdb, chainstate, mempool)?;
+                    let msg_opt = self.handle_request(req, chain_view, peers, burndb,
+                                                      peerdb, chainstate, mempool, exit_at_block_height)?;
                     if let Some(msg) = msg_opt {
                         ret.push(msg);
                     }
@@ -1192,7 +1207,7 @@ mod test {
         let mut peer_1_stacks_node = peer_1.stacks_node.take().unwrap();
         let mut peer_1_mempool = peer_1.mempool.take().unwrap();
 
-        convo_1.chat(&view_1, &PeerMap::new(), &mut peer_1_burndb, &peer_1.network.peerdb, &mut peer_1_stacks_node.chainstate, &mut peer_1_mempool).unwrap();
+        convo_1.chat(&view_1, &PeerMap::new(), &mut peer_1_burndb, &peer_1.network.peerdb, &mut peer_1_stacks_node.chainstate, &mut peer_1_mempool, None).unwrap();
 
         peer_1.burndb = Some(peer_1_burndb);
         peer_1.stacks_node = Some(peer_1_stacks_node);
@@ -1205,7 +1220,7 @@ mod test {
         let mut peer_2_stacks_node = peer_2.stacks_node.take().unwrap();
         let mut peer_2_mempool = peer_2.mempool.take().unwrap();
 
-        convo_2.chat(&view_2, &PeerMap::new(), &mut peer_2_burndb, &peer_2.network.peerdb, &mut peer_2_stacks_node.chainstate, &mut peer_2_mempool).unwrap();
+        convo_2.chat(&view_2, &PeerMap::new(), &mut peer_2_burndb, &peer_2.network.peerdb, &mut peer_2_stacks_node.chainstate, &mut peer_2_mempool, None).unwrap();
         
         peer_2.burndb = Some(peer_2_burndb);
         peer_2.stacks_node = Some(peer_2_stacks_node);
@@ -1222,7 +1237,7 @@ mod test {
         let mut peer_1_stacks_node = peer_1.stacks_node.take().unwrap();
         let mut peer_1_mempool = peer_1.mempool.take().unwrap();
 
-        convo_1.chat(&view_1, &PeerMap::new(), &mut peer_1_burndb, &peer_1.network.peerdb, &mut peer_1_stacks_node.chainstate, &mut peer_1_mempool).unwrap();
+        convo_1.chat(&view_1, &PeerMap::new(), &mut peer_1_burndb, &peer_1.network.peerdb, &mut peer_1_stacks_node.chainstate, &mut peer_1_mempool, None).unwrap();
         
         peer_1.burndb = Some(peer_1_burndb);
         peer_1.stacks_node = Some(peer_1_stacks_node);
@@ -1244,7 +1259,7 @@ mod test {
         let peer_server_info = RefCell::new(None);
         test_rpc("test_rpc_getinfo", 40000, 40001, 50000, 50001,
                  |ref mut peer_client, ref mut convo_client, ref mut peer_server, ref mut convo_server| {
-                     let peer_info = RPCPeerInfoData::from_db(&peer_server.config.burnchain, peer_server.burndb.as_mut().unwrap(), &peer_server.network.peerdb).unwrap();
+                     let peer_info = RPCPeerInfoData::from_db(&peer_server.config.burnchain, peer_server.burndb.as_mut().unwrap(), &peer_server.network.peerdb, None).unwrap();
                      *peer_server_info.borrow_mut() = Some(peer_info);
                      
                      convo_client.new_getinfo()

--- a/src/net/server.rs
+++ b/src/net/server.rs
@@ -336,7 +336,8 @@ impl HttpPeer {
                                  burndb: &BurnDB, peerdb: &PeerDB,
                                  chainstate: &mut StacksChainState, mempool: &mut MemPoolDB,
                                  event_id: usize, client_sock: &mut mio_net::TcpStream,
-                                 convo: &mut ConversationHttp) -> Result<(bool, Vec<StacksMessageType>), net_error> {
+                                 convo: &mut ConversationHttp,
+                                 exit_at_block_height: Option<u64>) -> Result<(bool, Vec<StacksMessageType>), net_error> {
         // get incoming bytes and update the state of this conversation.
         let mut convo_dead = false;
         let recv_res = convo.recv(client_sock);
@@ -380,7 +381,7 @@ impl HttpPeer {
         // react to inbound messages -- do we need to send something out, or fulfill requests
         // to other threads?  Try to chat even if the recv() failed, since we'll want to at
         // least drain the conversation inbox.
-        let msgs = match convo.chat(chain_view, peers, burndb, peerdb, chainstate, mempool) {
+        let msgs = match convo.chat(chain_view, peers, burndb, peerdb, chainstate, mempool, exit_at_block_height) {
             Ok(msgs) => msgs,
             Err(e) => {
                 debug!("Failed to converse HTTP on event {} (socket {:?}): {:?}", event_id, &client_sock, &e);
@@ -428,7 +429,7 @@ impl HttpPeer {
     /// Return the list of events that correspond to failed conversations, as well as the list of
     /// peer network messages we'll need to forward
     fn process_ready_sockets(&mut self, poll_state: &mut NetworkPollState, peers: &PeerMap, burndb: &BurnDB, peerdb: &PeerDB,
-                             chainstate: &mut StacksChainState, mempool: &mut MemPoolDB) -> (Vec<StacksMessageType>, Vec<usize>) {
+                             chainstate: &mut StacksChainState, mempool: &mut MemPoolDB, exit_at_block_height: Option<u64>) -> (Vec<StacksMessageType>, Vec<usize>) {
         let mut to_remove = vec![];
         let mut msgs = vec![];
         for event_id in &poll_state.ready {
@@ -451,7 +452,7 @@ impl HttpPeer {
                     // activity on a http socket
                     test_debug!("Process HTTP data from {:?}", convo);
                     match HttpPeer::process_http_conversation(&self.chain_view, peers, burndb, peerdb, chainstate, mempool,
-                                                              *event_id, client_sock, convo) {
+                                                              *event_id, client_sock, convo, exit_at_block_height) {
                         Ok((alive, mut new_msgs)) => {
                             if !alive {
                                 to_remove.push(*event_id);
@@ -505,8 +506,10 @@ impl HttpPeer {
     /// -- receive data on ready sockets
     /// -- clear out timed-out requests
     /// Returns the list of messages to forward along to the peer network.
-    pub fn run(&mut self, network_state: &mut NetworkState, new_chain_view: BurnchainView, p2p_peers: &PeerMap, burndb: &BurnDB, peerdb: &PeerDB,
-               chainstate: &mut StacksChainState, mempool: &mut MemPoolDB, mut poll_state: NetworkPollState) -> Result<Vec<StacksMessageType>, net_error> {
+    pub fn run(&mut self, network_state: &mut NetworkState, new_chain_view: BurnchainView,
+               p2p_peers: &PeerMap, burndb: &BurnDB, peerdb: &PeerDB,
+               chainstate: &mut StacksChainState, mempool: &mut MemPoolDB,
+               mut poll_state: NetworkPollState, exit_at_block_height: Option<u64>) -> Result<Vec<StacksMessageType>, net_error> {
 
         // update burnchain snapshot
         self.chain_view = new_chain_view;
@@ -518,7 +521,8 @@ impl HttpPeer {
         self.process_connecting_sockets(network_state, chainstate, &mut poll_state);
 
         // run existing conversations, clear out broken ones, and get back messages forwarded to us
-        let (stacks_msgs, error_events) = self.process_ready_sockets(&mut poll_state, p2p_peers, burndb, peerdb, chainstate, mempool);
+        let (stacks_msgs, error_events) = self.process_ready_sockets(
+            &mut poll_state, p2p_peers, burndb, peerdb, chainstate, mempool, exit_at_block_height);
         for error_event in error_events {
             debug!("Failed HTTP connection on event {}", error_event);
             self.deregister_http(network_state, error_event);

--- a/testnet/stacks-node/Cargo.toml
+++ b/testnet/stacks-node/Cargo.toml
@@ -16,6 +16,10 @@ serde_json = { version = "1.0", features = ["arbitrary_precision", "raw_value"] 
 stacks = { package = "blockstack-core", path = "../../." }
 toml = "0.5.6"
 
+[dev-dependencies]
+warp = "0.2"
+tokio = "0.2.21"
+
 [[bin]]
 name = "stacks-node"
 path = "src/main.rs"

--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -703,6 +703,7 @@ pub enum EventKeyType {
     SmartContractEvent((QualifiedContractIdentifier, String)),
     AssetEvent(AssetIdentifier),
     STXEvent,
+    MemPoolTransactions,
     AnyEvent,
 }
 
@@ -716,6 +717,10 @@ impl EventKeyType {
             return Some(EventKeyType::STXEvent);
         } 
         
+        if raw_key == "memtx" {
+            return Some(EventKeyType::MemPoolTransactions);
+        }
+
         let comps: Vec<_> = raw_key.split("::").collect();
         if comps.len() ==  1 {
             let split: Vec<_> = comps[0].split(".").collect();

--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -334,8 +334,14 @@ impl Config {
                         .map(|e| EventKeyType::from_string(e).unwrap())
                         .collect();
 
+                    let endpoint = if observer.endpoint.ends_with("/") {
+                        observer.endpoint
+                    } else {
+                        format!("{}/", observer.endpoint)
+                    };
+
                     observers.push(EventObserverConfig {
-                        endpoint: observer.endpoint,
+                        endpoint,
                         events_keys
                     });
                 }

--- a/testnet/stacks-node/src/event_dispatcher.rs
+++ b/testnet/stacks-node/src/event_dispatcher.rs
@@ -34,9 +34,8 @@ pub const PATH_BLOCK_PROCESSED: &str = "new_block";
 impl EventObserver {
 
     fn send_payload(&self, payload: &serde_json::Value, path: &str) {
-        let endpoint = format!("{}{}{}",
+        let endpoint = format!("{}{}",
                                &self.endpoint,
-                               if self.endpoint.ends_with("/") { "" } else { "/" },
                                path);
 
         let mut backoff: f64 = 1.0;

--- a/testnet/stacks-node/src/event_dispatcher.rs
+++ b/testnet/stacks-node/src/event_dispatcher.rs
@@ -9,9 +9,12 @@ use serde_json::json;
 
 use stacks::burnchains::Txid;
 use stacks::chainstate::stacks::events::{StacksTransactionEvent, STXEventType, FTEventType, NFTEventType};
+use stacks::chainstate::stacks::StacksTransaction;
 use stacks::net::StacksMessageCodec;
 use stacks::vm::types::{Value, QualifiedContractIdentifier, AssetIdentifier};
 use stacks::vm::analysis::{contract_interface_builder::build_contract_interface};
+use stacks::util::hash::{bytes_to_hex};
+use stacks::chainstate::burn::BlockHeaderHash;
 
 use super::config::{EventObserverConfig, EventKeyType};
 use super::node::{ChainTip};
@@ -25,9 +28,59 @@ const STATUS_RESP_TRUE: &str = "success";
 const STATUS_RESP_NOT_COMMITTED: &str = "abort_by_response";
 const STATUS_RESP_POST_CONDITION: &str  = "abort_by_post_condition";
 
+pub const PATH_MEMPOOL_TX_SUBMIT: &str = "new_mempool_tx";
+pub const PATH_BLOCK_PROCESSED: &str = "new_block";
+
 impl EventObserver {
 
-    fn send(&mut self, filtered_events: Vec<&(bool, Txid, &StacksTransactionEvent)>, chain_tip: &ChainTip) {
+    fn send_payload(&self, payload: &serde_json::Value, path: &str) {
+        let endpoint = format!("{}{}{}",
+                               &self.endpoint,
+                               if self.endpoint.ends_with("/") { "" } else { "/" },
+                               path);
+
+        let mut backoff: f64 = 1.0;
+        let mut rng = thread_rng();
+        loop {
+            let response = Client::new()
+                .post(&endpoint)
+                .json(payload)
+                .send();
+
+            match response {
+                Ok(response) => {
+                    if response.status().is_success() {
+                        break;
+                    }
+                    error!("Event dispatcher: POST {} failed with error {:?}", self.endpoint, response);
+                },
+                Err(e) => {
+                    error!("Event dispatcher: POST {} failed with error {:?}", self.endpoint, e);
+                }
+            };
+
+            backoff = (2.0 * backoff + (backoff * rng.gen_range(0.0, 1.0))).min(60.0);
+            let duration = Duration::from_millis((backoff * 1_000.0) as u64);
+            info!("Event dispatcher will retry posting in {:?}", duration);
+            sleep(duration);
+        };
+    }
+
+    fn make_new_mempool_txs_payload(transactions: Vec<StacksTransaction>) -> serde_json::Value {
+        let raw_txs = transactions.into_iter().map(|tx| {
+            serde_json::Value::String(
+                format!("0x{}", &bytes_to_hex(&tx.serialize_to_vec())))
+        }).collect();
+
+        serde_json::Value::Array(raw_txs)
+    }
+
+    fn send_new_mempool_txs(&self, payload: &serde_json::Value) {
+        self.send_payload(payload, PATH_MEMPOOL_TX_SUBMIT);
+    }
+
+    fn send(&mut self, filtered_events: Vec<&(bool, Txid, &StacksTransactionEvent)>, chain_tip: &ChainTip,
+            parent_index_hash: &BlockHeaderHash) {
         // Serialize events to JSON
         let serialized_events: Vec<serde_json::Value> = filtered_events.iter().map(|(committed, txid, event)|
             event.json_serialize(txid, *committed)
@@ -85,42 +138,19 @@ impl EventObserver {
         
         // Wrap events
         let payload = json!({
-            "block_hash": format!("0x{:?}", chain_tip.block.block_hash()),
+            "block_hash": format!("0x{}", chain_tip.block.block_hash()),
             "block_height": chain_tip.metadata.block_height,
             "burn_block_time": chain_tip.metadata.burn_header_timestamp,
-            "index_block_hash": format!("0x{:?}", chain_tip.metadata.index_block_hash()),
-            "parent_block_hash": format!("0x{:?}", chain_tip.block.header.parent_block),
-            "parent_microblock": format!("0x{:?}", chain_tip.block.header.parent_microblock),
+            "index_block_hash": format!("0x{}", chain_tip.metadata.index_block_hash()),
+            "parent_block_hash": format!("0x{}", chain_tip.block.header.parent_block),
+            "parent_index_block_hash": format!("0x{}", parent_index_hash),
+            "parent_microblock": format!("0x{}", chain_tip.block.header.parent_microblock),
             "events": serialized_events,
             "transactions": serialized_txs,
         });
 
         // Send payload
-        let mut backoff: f64 = 1.0;
-        let mut rng = thread_rng();
-        loop {
-            let response = Client::new()
-                .post(&self.endpoint)
-                .json(&payload)
-                .send();
-
-            match response {
-                Ok(response) => {
-                    if response.status().is_success() {
-                        break;
-                    }
-                    error!("Event dispatcher: POST {:?} failed with error {:?}", self.endpoint, response);
-                },
-                Err(e) => {
-                    error!("Event dispatcher: POST {:?} failed with error {:?}", self.endpoint, e);
-                }
-            };
-
-            backoff = (2.0 * backoff + (backoff * rng.gen_range(0.0, 1.0))).min(60.0);
-            let duration = Duration::from_millis((backoff * 1_000.0) as u64);
-            info!("Event dispatcher will retry posting in {:?}", duration);
-            sleep(duration);
-        };
+        self.send_payload(&payload, PATH_BLOCK_PROCESSED);
     }
 }
 
@@ -128,6 +158,7 @@ pub struct EventDispatcher {
     registered_observers: Vec<EventObserver>,
     contract_events_observers_lookup: HashMap<(QualifiedContractIdentifier, String), HashSet<u16>>,
     assets_observers_lookup: HashMap<AssetIdentifier, HashSet<u16>>,
+    mempool_observers_lookup: HashSet<u16>,
     stx_observers_lookup: HashSet<u16>,
     any_event_observers_lookup: HashSet<u16>,
 }
@@ -141,10 +172,11 @@ impl EventDispatcher {
             assets_observers_lookup: HashMap::new(),
             stx_observers_lookup: HashSet::new(),
             any_event_observers_lookup: HashSet::new(),
+            mempool_observers_lookup: HashSet::new(),
         }
     }
 
-    pub fn process_chain_tip(&mut self, chain_tip: &ChainTip) {
+    pub fn process_chain_tip(&mut self, chain_tip: &ChainTip, parent_index_hash: &BlockHeaderHash) {
 
         let mut dispatch_matrix: Vec<HashSet<usize>> = self.registered_observers.iter().map(|_| HashSet::new()).collect();
         let mut events: Vec<(bool, Txid, &StacksTransactionEvent)> = vec![];
@@ -193,7 +225,25 @@ impl EventDispatcher {
             let filtered_events: Vec<_> = filtered_events_ids.iter()
                 .map(|event_id| &events[*event_id]).collect();
 
-            self.registered_observers[observer_id].send(filtered_events, chain_tip);
+            self.registered_observers[observer_id].send(filtered_events, chain_tip, parent_index_hash);
+        }
+    }
+
+    pub fn process_new_mempool_txs(&mut self, txs: Vec<StacksTransaction>) {
+        // lazily assemble payload only if we have observers
+        let interested_observers: Vec<_> = self.registered_observers.iter().enumerate().filter(
+            |(obs_id, _observer)| {
+                self.mempool_observers_lookup.contains(&(*obs_id as u16)) ||
+                    self.any_event_observers_lookup.contains(&(*obs_id as u16))
+            }).collect();
+        if interested_observers.len() < 1 {
+            return;
+        }
+
+        let payload = EventObserver::make_new_mempool_txs_payload(txs);
+
+        for (_, observer) in interested_observers.iter() {
+            observer.send_new_mempool_txs(&payload);
         }
     }
 
@@ -227,6 +277,9 @@ impl EventDispatcher {
                             v.insert(observer_indexes);
                         }
                     };
+                },
+                EventKeyType::MemPoolTransactions => {
+                    self.mempool_observers_lookup.insert(observer_index);
                 },
                 EventKeyType::STXEvent => {
                     self.stx_observers_lookup.insert(observer_index);

--- a/testnet/stacks-node/src/event_dispatcher.rs
+++ b/testnet/stacks-node/src/event_dispatcher.rs
@@ -19,7 +19,7 @@ use stacks::chainstate::burn::BlockHeaderHash;
 use super::config::{EventObserverConfig, EventKeyType};
 use super::node::{ChainTip};
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 struct EventObserver {
     endpoint: String,
 }
@@ -154,6 +154,7 @@ impl EventObserver {
     }
 }
 
+#[derive(Clone)]
 pub struct EventDispatcher {
     registered_observers: Vec<EventObserver>,
     contract_events_observers_lookup: HashMap<(QualifiedContractIdentifier, String), HashSet<u16>>,
@@ -229,7 +230,7 @@ impl EventDispatcher {
         }
     }
 
-    pub fn process_new_mempool_txs(&mut self, txs: Vec<StacksTransaction>) {
+    pub fn process_new_mempool_txs(&self, txs: Vec<StacksTransaction>) {
         // lazily assemble payload only if we have observers
         let interested_observers: Vec<_> = self.registered_observers.iter().enumerate().filter(
             |(obs_id, _observer)| {

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -10,7 +10,10 @@ use stacks::burnchains::{Burnchain, BurnchainHeaderHash, Txid, PublicKey};
 use stacks::chainstate::burn::db::burndb::{BurnDB};
 use stacks::chainstate::stacks::db::{StacksChainState, StacksHeaderInfo, ClarityTx};
 use stacks::chainstate::stacks::events::StacksTransactionReceipt;
-use stacks::chainstate::stacks::{ StacksBlock, TransactionPayload, StacksAddress, StacksTransactionSigner, StacksTransaction, TransactionVersion, StacksMicroblock, CoinbasePayload, TransactionAnchorMode};
+use stacks::chainstate::stacks::{
+    StacksBlock, TransactionPayload, StacksAddress, StacksTransactionSigner,
+    StacksTransaction, TransactionVersion, StacksMicroblock, CoinbasePayload,
+    TransactionAnchorMode, StacksBlockHeader };
 use stacks::chainstate::burn::{ConsensusHash, VRFSeed, BlockHeaderHash};
 use stacks::chainstate::burn::operations::{
     LeaderBlockCommitOp,
@@ -144,7 +147,8 @@ fn inner_process_tenure(
     for processed_block in processed_blocks.into_iter() {
         match processed_block {
             (Some((header, receipts)), _) => {
-                dispatcher_announce(&chain_state.blocks_path, dispatcher, header, receipts);
+                dispatcher_announce_block(&chain_state.blocks_path, dispatcher,
+                                          header, Some(parent_burn_header_hash), burn_db, receipts);
             },
             _ => {}
         }
@@ -261,7 +265,7 @@ fn spawn_peer(mut this: PeerNetwork, p2p_sock: &SocketAddr, rpc_sock: &SocketAdd
             let network_result = this.run(&burndb, &mut chainstate, &mut mem_pool, Some(&mut dns_client), download_backpressure, poll_ms)
                 .unwrap();
 
-            if network_result.has_blocks() || network_result.has_microblocks() {
+            if network_result.has_data_to_store() {
                 results_with_data.push_back(RelayerDirective::HandleNetResult(network_result));
             }
 
@@ -346,7 +350,7 @@ fn spawn_miner_relayer(mut relayer: Relayer, local_peer: LocalPeer,
                     for (headers_and_receipts_opt, _poison_microblock_opt) in block_receipts.into_iter() {
                         // TODO: pass the poison microblock transaction off to the miner!
                         if let Some((header_info, receipts)) = headers_and_receipts_opt {
-                            dispatcher_announce(&blocks_path, &mut event_dispatcher, header_info, receipts);
+                            dispatcher_announce_block(&blocks_path, &mut event_dispatcher, header_info, None, &mut burndb, receipts);
                             num_processed += 1;
                         }
                     }
@@ -356,14 +360,18 @@ fn spawn_miner_relayer(mut relayer: Relayer, local_peer: LocalPeer,
                     }
                 },
                 RelayerDirective::HandleNetResult(ref mut net_result) => {
-                    let block_receipts = relayer.process_network_result(&local_peer, net_result,
+                    let net_receipts = relayer.process_network_result(&local_peer, net_result,
                                                                         &mut burndb, &mut chainstate, &mut mem_pool)
                         .expect("BUG: failure processing network results");
 
                     // TODO: extricate the poison block transaction(s) from the relayer and feed
                     // them to the miner
-                    for (stacks_header, tx_receipts) in block_receipts {
-                        dispatcher_announce(&blocks_path, &mut event_dispatcher, stacks_header, tx_receipts);
+                    for (stacks_header, tx_receipts) in net_receipts.blocks_processed {
+                        dispatcher_announce_block(&blocks_path, &mut event_dispatcher, stacks_header, None, &mut burndb, tx_receipts);
+                    }
+
+                    if net_receipts.mempool_txs_added.len() > 0 {
+                        event_dispatcher.process_new_mempool_txs(net_receipts.mempool_txs_added);
                     }
                 },
                 RelayerDirective::ProcessTenure(burn_header_hash, parent_burn_header_hash, block_header_hash) => {
@@ -458,14 +466,28 @@ fn spawn_miner_relayer(mut relayer: Relayer, local_peer: LocalPeer,
     Ok(())
 }
 
-fn dispatcher_announce(blocks_path: &str, event_dispatcher: &mut EventDispatcher,
-                       metadata: StacksHeaderInfo, receipts: Vec<StacksTransactionReceipt>) {
-    let block = {
+fn dispatcher_announce_block(blocks_path: &str, event_dispatcher: &mut EventDispatcher,
+                             metadata: StacksHeaderInfo,
+                             parent_burn_header_hash: Option<&BurnchainHeaderHash>,
+                             burndb: &mut BurnDB,
+                             receipts: Vec<StacksTransactionReceipt>) {
+    let block: StacksBlock = {
         let block_path = StacksChainState::get_block_path(
             blocks_path, 
             &metadata.burn_header_hash, 
             &metadata.anchored_header.block_hash()).unwrap();
         StacksChainState::consensus_load(&block_path).unwrap()
+    };
+
+    let parent_index_hash = match parent_burn_header_hash {
+        Some(x) => StacksBlockHeader::make_index_block_hash(x, &block.header.parent_block),
+        None => {
+            let parent_burn_header_hash = StacksChainState::get_parent_burn_header_hash(
+                &burndb.index_conn(), &block.header.parent_block, &metadata.burn_header_hash)
+                .expect("Failed to get parent burn header hash for processed block")
+                .expect("Failed to get parent burn header hash for processed block");
+            StacksBlockHeader::make_index_block_hash(&parent_burn_header_hash, &block.header.parent_block)
+        }
     };
 
     let chain_tip = ChainTip {
@@ -474,7 +496,7 @@ fn dispatcher_announce(blocks_path: &str, event_dispatcher: &mut EventDispatcher
         receipts
     };
 
-    event_dispatcher.process_chain_tip(&chain_tip);
+    event_dispatcher.process_chain_tip(&chain_tip, &parent_index_hash);
 }
 
 impl InitializedNeonNode {

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -232,6 +232,7 @@ fn spawn_peer(mut this: PeerNetwork, p2p_sock: &SocketAddr, rpc_sock: &SocketAdd
     let burn_db_path = config.get_burn_db_file_path();
     let stacks_chainstate_path = config.get_chainstate_path();
     let block_limit = config.block_limit;
+    let exit_at_block_height = config.burnchain.process_exit_at_block_height;
 
     this.bind(p2p_sock, rpc_sock).unwrap();
     let (mut dns_resolver, mut dns_client) = DNSResolver::new(10);
@@ -262,7 +263,8 @@ fn spawn_peer(mut this: PeerNetwork, p2p_sock: &SocketAddr, rpc_sock: &SocketAdd
                     poll_timeout
                 };
 
-            let network_result = this.run(&burndb, &mut chainstate, &mut mem_pool, Some(&mut dns_client), download_backpressure, poll_ms)
+            let network_result = this.run(&burndb, &mut chainstate, &mut mem_pool, Some(&mut dns_client),
+                                          download_backpressure, poll_ms, exit_at_block_height.clone())
                 .unwrap();
 
             if network_result.has_data_to_store() {

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -197,7 +197,7 @@ fn microblock_integration_test() {
 
     conf.events_observers.push(
         EventObserverConfig {
-            endpoint: format!("http://localhost:{}", test_observer::EVENT_OBSERVER_PORT),
+            endpoint: format!("http://localhost:{}/", test_observer::EVENT_OBSERVER_PORT),
             events_keys: vec![ EventKeyType::AnyEvent ],
         });
 
@@ -283,6 +283,9 @@ fn microblock_integration_test() {
     let path = format!("{}/v2/info", &http_origin);
     let tip_info = client.get(&path).send().unwrap().json::<RPCPeerInfoData>().unwrap();
     assert!(tip_info.stacks_tip_height >= 3);
+
+    eprintln!("{:#?}", client.get(&path).send().unwrap().json::<serde_json::Value>().unwrap());
+
 
     let memtx_events = test_observer::get_memtxs();
     assert_eq!(memtx_events.len(), 1);


### PR DESCRIPTION
This implements #1547 and #1653:

1. It requires a new event observer endpoint for mempool transactions. Previously the event dispatcher just posted to a single endpoint, now there are two endpoints:
   a. `/new_block`, which POSTs the same JSON object it previously posted to the root.
   b. `/new_mempool_tx` which POSTs a JSON array containing new raw transactions.
2. It adds a `parent_index_block_hash` field to the "new block" JSON object.
3. It adds support for integration testing the event dispatcher in `neon_integrations.rs` -- this uses `warp` as the test event observer.