### PR TITLE
Relax trait inference

### DIFF
--- a/src/vm/analysis/trait_checker/tests.rs
+++ b/src/vm/analysis/trait_checker/tests.rs
@@ -840,3 +840,72 @@ fn test_good_call_2_with_trait() {
     }).unwrap();
 }
 
+#[test]
+fn test_dynamic_dispatch_pass_literal_principal_as_trait_in_user_defined_functions() {
+    let contract_defining_trait_src = 
+        "(define-trait trait-1 (
+            (get-1 (uint) (response uint uint))))";
+    let dispatching_contract_src =
+        "(use-trait trait-1 .contract-defining-trait.trait-1)
+        (define-public (wrapped-get-1 (contract <trait-1>)) 
+            (contract-call? contract get-1 u0))
+        (print (wrapped-get-1 .target-contract))";
+    let target_contract_src =
+        "(impl-trait .contract-defining-trait.trait-1)
+        (define-public (get-1 (x uint)) (ok u1))";
+
+    let contract_defining_trait_id = QualifiedContractIdentifier::local("contract-defining-trait").unwrap();
+    let dispatching_contract_id = QualifiedContractIdentifier::local("dispatching-contract").unwrap();
+    let target_contract_id = QualifiedContractIdentifier::local("target-contract").unwrap();
+
+    let mut contract_defining_trait = parse(&contract_defining_trait_id, contract_defining_trait_src).unwrap();
+    let mut dispatching_contract = parse(&dispatching_contract_id, dispatching_contract_src).unwrap();
+    let mut target_contract = parse(&target_contract_id, target_contract_src).unwrap();
+    let mut marf = MemoryBackingStore::new();
+    let mut db = marf.as_analysis_db();
+
+    db.execute(|db| {
+        type_check(&contract_defining_trait_id, &mut contract_defining_trait, db, true)?;
+        type_check(&target_contract_id, &mut target_contract, db, true)?;
+        type_check(&dispatching_contract_id, &mut dispatching_contract, db, true)
+    }).unwrap();
+}
+
+
+#[test]
+fn test_dynamic_dispatch_pass_binded_principal_as_trait_in_user_defined_functions() {
+    let contract_defining_trait_src = 
+        "(define-trait trait-1 (
+            (get-1 (uint) (response uint uint))))";
+    let dispatching_contract_src =
+        "(use-trait trait-1 .contract-defining-trait.trait-1)
+        (define-public (wrapped-get-1 (contract <trait-1>)) 
+            (contract-call? contract get-1 u0))
+        (let ((p .target-contract))
+            (print (wrapped-get-1 p)))";
+    let target_contract_src =
+        "(impl-trait .contract-defining-trait.trait-1)
+        (define-public (get-1 (x uint)) (ok u1))";
+
+    let contract_defining_trait_id = QualifiedContractIdentifier::local("contract-defining-trait").unwrap();
+    let dispatching_contract_id = QualifiedContractIdentifier::local("dispatching-contract").unwrap();
+    let target_contract_id = QualifiedContractIdentifier::local("target-contract").unwrap();
+
+    let mut contract_defining_trait = parse(&contract_defining_trait_id, contract_defining_trait_src).unwrap();
+    let mut dispatching_contract = parse(&dispatching_contract_id, dispatching_contract_src).unwrap();
+    let mut target_contract = parse(&target_contract_id, target_contract_src).unwrap();
+    let mut marf = MemoryBackingStore::new();
+    let mut db = marf.as_analysis_db();
+
+    let err = db.execute(|db| {
+        type_check(&contract_defining_trait_id, &mut contract_defining_trait, db, true)?;
+        type_check(&target_contract_id, &mut target_contract, db, true)?;
+        type_check(&dispatching_contract_id, &mut dispatching_contract, db, true)
+    }).unwrap_err();
+    match err.err {
+        CheckErrors::TypeError(_, _) => {},
+        _ => {
+            panic!("{:?}", err)
+        }
+    }
+}

--- a/src/vm/analysis/trait_checker/tests.rs
+++ b/src/vm/analysis/trait_checker/tests.rs
@@ -873,7 +873,7 @@ fn test_dynamic_dispatch_pass_literal_principal_as_trait_in_user_defined_functio
 
 
 #[test]
-fn test_dynamic_dispatch_pass_binded_principal_as_trait_in_user_defined_functions() {
+fn test_dynamic_dispatch_pass_bound_principal_as_trait_in_user_defined_functions() {
     let contract_defining_trait_src = 
         "(define-trait trait-1 (
             (get-1 (uint) (response uint uint))))";

--- a/src/vm/analysis/type_checker/mod.rs
+++ b/src/vm/analysis/type_checker/mod.rs
@@ -437,9 +437,16 @@ impl <'a, 'b> TypeChecker <'a, 'b> {
         if let Some(type_result) = self.try_native_function_check(function_name, args, context) {
             type_result
         } else {
-            let function_type = self.get_function_type(function_name)
-                .ok_or(CheckErrors::UnknownFunction(function_name.to_string()))?;
-            self.type_check_function_type(&function_type, args, context)
+            let function = match self.get_function_type(function_name) {
+                Some(FunctionType::Fixed(function)) => Ok(function),
+                _ => Err(CheckErrors::UnknownFunction(function_name.to_string()))
+            }?;
+
+            for (expected_type, found_type) in function.args.iter().map(|x| &x.signature).zip(args) {
+                self.type_check_expects(found_type, context, &expected_type)?;
+            }
+
+            Ok(function.returns)
         }
     }
 

--- a/src/vm/tests/traits.rs
+++ b/src/vm/tests/traits.rs
@@ -29,6 +29,7 @@ fn test_all() {
         test_good_call_with_trait,
         test_good_call_2_with_trait,
         test_dynamic_dispatch_by_implementing_imported_trait_mul_funcs,
+        test_dynamic_dispatch_pass_literal_principal_as_trait_in_user_defined_functions,
         ];
     for test in to_test.iter() {
         with_memory_environment(test, false);
@@ -541,3 +542,33 @@ fn test_good_call_2_with_trait(owned_env: &mut OwnedEnvironment) {
     }
 }
 
+fn test_dynamic_dispatch_pass_literal_principal_as_trait_in_user_defined_functions(owned_env: &mut OwnedEnvironment) {
+    let contract_defining_trait = 
+        "(define-trait trait-1 (
+            (get-1 (uint) (response uint uint))))";
+    let dispatching_contract =
+        "(use-trait trait-1 .contract-defining-trait.trait-1)
+        (define-public (wrapped-get-1 (contract <trait-1>)) 
+            (contract-call? contract get-1 u0))
+        (print (wrapped-get-1 .target-contract))";
+    let target_contract =
+        "(impl-trait .contract-defining-trait.trait-1)
+        (define-public (get-1 (x uint)) (ok u1))";
+
+    let p1 = execute("'SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR");
+
+    {
+        let mut env = owned_env.get_exec_environment(None);
+        env.initialize_contract(QualifiedContractIdentifier::local("contract-defining-trait").unwrap(), contract_defining_trait).unwrap();
+        env.initialize_contract(QualifiedContractIdentifier::local("target-contract").unwrap(), target_contract).unwrap();
+        env.initialize_contract(QualifiedContractIdentifier::local("dispatching-contract").unwrap(), dispatching_contract).unwrap();
+    }
+
+    {
+        let target_contract = Value::from(PrincipalData::Contract(QualifiedContractIdentifier::local("target-contract").unwrap()));
+        let mut env = owned_env.get_exec_environment(Some(p1.clone()));
+        assert_eq!(
+            env.execute_contract(&QualifiedContractIdentifier::local("dispatching-contract").unwrap(), "wrapped-get-1", &symbols_from_values(vec![target_contract]), false).unwrap(),
+            Value::okay(Value::UInt(1)).unwrap());
+    }
+}


### PR DESCRIPTION
This PR is addressing #1621, by allowing trait inference when a principal is being passed (as a literal) to a user defined function.