### PR TITLE
Fix: Github action: open PR against the _correct_ docs.blockstack repository

### DIFF
--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -12,9 +12,9 @@ name: Open Docs PR
 env:
   ROBOT_OWNER: kantai-robot
   ROBOT_REPO: docs.blockstack
-  TARGET_OWNER: kantai
+  TARGET_OWNER: blockstack
   TARGET_REPO: docs.blockstack
-  TARGET_REPOSITORY: kantai/docs.blockstack
+  TARGET_REPOSITORY: blockstack/docs.blockstack
 on:
   push:
     branches: [master]


### PR DESCRIPTION
I fat finger merged the github action with the repo I was using for testing. This patch corrects that.