### PR TITLE
Some nonce fixes

### DIFF
--- a/src/chainstate/stacks/db/blocks.rs
+++ b/src/chainstate/stacks/db/blocks.rs
@@ -164,6 +164,7 @@ pub enum MemPoolRejection {
     BadAddressVersionByte,
     NoCoinbaseViaMempool,
     NoSuchChainTip(BurnchainHeaderHash,BlockHeaderHash),
+    ConflictingNonceInMempool,
     DBError(db_error),
     Other(String),
 }
@@ -200,6 +201,7 @@ impl MemPoolRejection {
             NoSuchPublicFunction => ("NoSuchPublicFunction", None),
             BadFunctionArgument(e) => ("BadFunctionArgument",
                                        Some(json!({"message": e.to_string()}))),
+            ConflictingNonceInMempool => ("ConflictingNonceInMempool", None),
             ContractAlreadyExists(id) => ("ContractAlreadyExists",
                                           Some(json!({ "contract_identifier": id.to_string() }))),
             PoisonMicroblocksDoNotConflict => ("PoisonMicroblocksDoNotConflict", None),
@@ -3288,7 +3290,7 @@ impl StacksChainState {
     /// Check to see if a transaction can be (potentially) appended on top of a given chain tip.
     /// Note that this only checks the transaction against the _anchored chain tip_, not the
     /// unconfirmed microblock stream trailing off of it.
-    pub fn will_admit_mempool_tx(&mut self, current_burn: &BurnchainHeaderHash, current_block: &BlockHeaderHash, tx: &StacksTransaction, tx_size: u64) -> Result<(), MemPoolRejection> {
+    pub fn will_admit_mempool_tx(&mut self, mempool_conn: &DBConn, current_burn: &BurnchainHeaderHash, current_block: &BlockHeaderHash, tx: &StacksTransaction, tx_size: u64) -> Result<(), MemPoolRejection> {
         let conf = self.config();
         let staging_height = match self.get_stacks_block_height(current_burn, current_block) {
             Ok(Some(height)) => {
@@ -3318,13 +3320,15 @@ impl StacksChainState {
         };
         
         self.with_read_only_clarity_tx(current_burn, current_block, |conn| {
-            StacksChainState::can_include_tx(conn, &conf, has_microblock_pubk, tx, tx_size)
+            StacksChainState::can_include_tx(mempool_conn, conn, &conf, has_microblock_pubk, tx, tx_size)
         })
     }
 
     /// Given an outstanding clarity connection, can we append the tx to the chain state?
     /// Used when mining transactions.
-    pub fn can_include_tx<T: ClarityConnection>(clarity_connection: &mut T, chainstate_config: &DBConfig, has_microblock_pubkey: bool, tx: &StacksTransaction, tx_size: u64) -> Result<(), MemPoolRejection> {
+    pub fn can_include_tx<T: ClarityConnection>(mempool: &DBConn, clarity_connection: &mut T,
+                                                chainstate_config: &DBConfig, has_microblock_pubkey: bool,
+                                                tx: &StacksTransaction, tx_size: u64) -> Result<(), MemPoolRejection> {
         // 1: must parse (done)
 
         // 2: it must be validly signed.
@@ -3340,8 +3344,39 @@ impl StacksChainState {
         }
 
         // 4: the account nonces must be correct
-        let (origin, payer) = StacksChainState::check_transaction_nonces(clarity_connection, &tx)
-            .map_err(|e| MemPoolRejection::BadNonces(e))?;
+        let (origin, payer) = match StacksChainState::check_transaction_nonces(clarity_connection, &tx) {
+            Ok(x) => x,
+            Err((mut e, (origin, payer))) => {
+                // let's see if the tx has matching nonce in the mempool
+                //  ->  you can _only_ replace-by-fee or replace-across-fork
+                //      for nonces that increment the current chainstate's nonce.
+                //      if there are "chained" transactions in the mempool,
+                //      this check won't admit a rbf/raf for those.
+                let origin_addr = tx.origin_address();
+                let origin_nonce = tx.get_origin().nonce();
+                let origin_next_nonce = MemPoolDB::get_next_nonce_for_address(mempool, &origin_addr)?;
+                if origin_nonce != origin_next_nonce {
+                    e.is_origin = true;
+                    e.principal = origin_addr.into();
+                    e.expected = origin_next_nonce;
+                    e.actual = origin_nonce;
+                    return Err(e.into())
+                }
+
+                if let Some(sponsor_addr) = tx.sponsor_address() {
+                    let sponsor_nonce = tx.get_payer().nonce();
+                    let sponsor_next_nonce = MemPoolDB::get_next_nonce_for_address(mempool, &sponsor_addr)?;
+                    if sponsor_nonce != sponsor_next_nonce {
+                        e.is_origin = false;
+                        e.principal = sponsor_addr.into();
+                        e.expected = sponsor_next_nonce;
+                        e.actual = sponsor_nonce;
+                        return Err(e.into())
+                    }
+                }
+                (origin, payer)
+            },
+        };
 
         if !StacksChainState::is_valid_address_version(chainstate_config.mainnet, origin.principal.version())
             || !StacksChainState::is_valid_address_version(chainstate_config.mainnet, payer.principal.version()) {

--- a/src/chainstate/stacks/db/mod.rs
+++ b/src/chainstate/stacks/db/mod.rs
@@ -893,6 +893,11 @@ impl StacksChainState {
         StacksChainState::inner_clarity_tx_begin(conf, &self.headers_db, &mut self.clarity_state,
                                                  parent_burn_hash, parent_block, new_burn_hash, new_block)
     }
+
+    pub fn with_clarity_marf<F, R>(&mut self, f: F) -> R
+    where F: FnOnce(&mut MARF<StacksBlockId>) -> R {
+        self.clarity_state.with_marf(f)
+    }
     
     fn begin_read_only_clarity_tx<'a>(&'a mut self, parent_burn_hash: &BurnchainHeaderHash, parent_block: &BlockHeaderHash) -> ClarityReadOnlyConnection<'a> {
         let index_block = StacksChainState::get_parent_index_block(parent_burn_hash, parent_block);

--- a/src/core/mempool.rs
+++ b/src/core/mempool.rs
@@ -239,6 +239,11 @@ impl<'a> MemPoolTx<'a> {
             cur_burn_block, cur_stacks_block);
         let index_block = StacksBlockHeader::make_index_block_hash(
             check_burn_block, check_stacks_block);
+        // short circuit equality
+        if admitter_block == index_block {
+            return Ok(true)
+        }
+
         let height_result = self.admitter.chainstate.with_clarity_marf(|marf| {
             marf.get_block_height_of(&index_block, &admitter_block)
         });
@@ -811,7 +816,7 @@ mod tests {
 
     #[test]
     fn mempool_do_not_replace_tx() {
-        let mut chainstate = instantiate_chainstate(false, 0x80000000, "mempool_db_load_store_replace_tx");
+        let mut chainstate = instantiate_chainstate(false, 0x80000000, "mempool_do_not_replace_tx");
 
         // genesis -> b_1 -> b_2
         //      \-> b_3
@@ -854,7 +859,7 @@ mod tests {
             c_tx.commit_block();
         }
 
-        let chainstate_path = chainstate_path("mempool_db_load_store_replace_tx");
+        let chainstate_path = chainstate_path("mempool_do_not_replace_tx");
         let mut mempool = MemPoolDB::open(false, 0x80000000, &chainstate_path).unwrap();
 
         let mut txs = codec_all_transactions(&TransactionVersion::Testnet, 0x80000000, &TransactionAnchorMode::Any, &TransactionPostConditionMode::Allow);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
+#![cfg_attr(test, allow(unused_variables, unused_assignments))]
 
 extern crate rand;
 extern crate tini;

--- a/src/net/neighbors.rs
+++ b/src/net/neighbors.rs
@@ -2189,7 +2189,7 @@ mod test {
     #[ignore]
     fn test_step_walk_1_neighbor_plain() {
         let mut peer_1_config = TestPeerConfig::from_port(31990);
-        let mut peer_2_config = TestPeerConfig::from_port(31992);
+        let peer_2_config = TestPeerConfig::from_port(31992);
 
         // peer 1 crawls peer 2
         peer_1_config.add_neighbor(&peer_2_config.to_neighbor());

--- a/src/net/poll.rs
+++ b/src/net/poll.rs
@@ -496,7 +496,7 @@ mod test {
     #[test]
     fn test_register_deregister_stress() {
         let mut ns = NetworkState::new(20).unwrap();
-        let mut count = 0;
+        let count = 0;
         let mut in_use = HashSet::new();
         let mut events_in = vec![];
 

--- a/src/vm/analysis/trait_checker/tests.rs
+++ b/src/vm/analysis/trait_checker/tests.rs
@@ -970,11 +970,11 @@ fn test_contract_of_wrong_type() {
     let mut c_trait = parse(&def_contract_id, contract_defining_trait).unwrap();
     let mut c_principal = parse(&disp_contract_id, dispatching_contract_principal).unwrap();
     let mut c_int = parse(&disp_contract_id, dispatching_contract_int).unwrap();
-    let mut c_uint = parse(&disp_contract_id, dispatching_contract_uint).unwrap();
-    let mut c_bool = parse(&disp_contract_id, dispatching_contract_bool).unwrap();
-    let mut c_list = parse(&disp_contract_id, dispatching_contract_list).unwrap();
-    let mut c_buff = parse(&disp_contract_id, dispatching_contract_buff).unwrap();
-    let mut c_tuple = parse(&disp_contract_id, dispatching_contract_tuple).unwrap();
+    let c_uint = parse(&disp_contract_id, dispatching_contract_uint).unwrap();
+    let c_bool = parse(&disp_contract_id, dispatching_contract_bool).unwrap();
+    let c_list = parse(&disp_contract_id, dispatching_contract_list).unwrap();
+    let c_buff = parse(&disp_contract_id, dispatching_contract_buff).unwrap();
+    let c_tuple = parse(&disp_contract_id, dispatching_contract_tuple).unwrap();
     let mut marf = MemoryBackingStore::new();
     let mut db = marf.as_analysis_db();
 

--- a/src/vm/clarity.rs
+++ b/src/vm/clarity.rs
@@ -164,6 +164,15 @@ impl ClarityInstance {
         ClarityInstance { datastore: Some(datastore), block_limit }
     }
 
+    pub fn with_marf<F, R> (&mut self, f: F) -> R
+    where F: FnOnce(&mut MARF<StacksBlockId>) -> R {
+        let datastore = self.datastore.as_mut()
+            // this is a panicking failure, because there should be _no instance_ in which a ClarityBlockConnection
+            //   doesn't restore it's parent's datastore
+            .expect("FAIL: use of begin_block while prior block neither committed nor rolled back.");
+        f(datastore.get_marf())
+    }
+
     pub fn begin_block<'a> (&'a mut self, current: &StacksBlockId, next: &StacksBlockId,
                             header_db: &'a dyn HeadersDB) -> ClarityBlockConnection<'a> {
         let mut datastore = self.datastore.take()

--- a/testnet/stacks-node/src/node.rs
+++ b/testnet/stacks-node/src/node.rs
@@ -22,7 +22,7 @@ use stacks::chainstate::burn::operations::{
 use stacks::core::mempool::MemPoolDB;
 use stacks::net::{
     p2p::PeerNetwork, Error as NetError, db::PeerDB, PeerAddress,
-    NetworkResult, rpc::RPCHandlerArgs
+    rpc::RPCHandlerArgs
 };
 
 use stacks::util::vrf::VRFPublicKey;


### PR DESCRIPTION
This PR addresses #1686 and #1687 by doing a couple things:

1. Uniqueness changes in the mempool sqlite table -- rather than the unique property being applied to the tuple `(origin_addr, sponsor_addr, origin_nonce, sponsor_nonce)`, it is now unique in each of:
   a. `txid`
   b. `(origin_addr, origin_nonce)`
   c. `(sponsor_addr, sponsor_nonce)`
2. Replace-by-fee logic just looks at the address and nonce, regardless of the fork.
3. The mempool also allows "replace across fork" -- if prior transaction `tx'` is in a different fork than the candidate transaction `tx`, then it allows the replace in all cases.
4. Allow transaction chaining up to depth 5

It also includes a nicety for compiler warnings in our test builds:

```
#![cfg_attr(test, allow(unused_variables, unused_assignments))]
```
