### PR TITLE
Update `byteorder` dependency to fix failing build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ name = "block_limits"
 harness = false
 
 [dependencies]
-byteorder = "1.1"
+byteorder = "1.3.4"
 tini = "0.2"
 rand = "=0.7.2"
 serde = "1"


### PR DESCRIPTION
The old version "1.1" was causing an error with the build, updating the dependency version fixes this.