### PR TITLE
a few more typos for sip-004 and sip-005

### DIFF
--- a/sip/sip-004-materialized-view.md
+++ b/sip/sip-004-materialized-view.md
@@ -22,7 +22,7 @@ validate a subsequent transaction.  The Stacks blockchain in particular not only
 maintains a materialized view of the state of every fork, but also requires
 miners to cryptographically commit to that view whenever they mine a block.
 This document describes a **Merklized Adaptive Radix Forest** (MARF), an
-authenticated index data structure structure for efficiently encoding a 
+authenticated index data structure for efficiently encoding a 
 cryptographic commitment to blockchain state.
 
 The MARF's structure is part of the consensus logic in the Stacks blockchain --
@@ -120,7 +120,7 @@ the materialized view for all forks.
 the runtime cost of calculating the materialized view must be _independent_ of the
 order in which forks are produced, as well as the order in which their blocks
 arrive.  This is required in order to avoid denial-of-service vulnerabilities,
-whereby an network attacker can control the schedules of both
+whereby a network attacker can control the schedules of both
 forks and block arrivals in a bid to force each peer to expend resources
 validating the fork.  It must be impossible for an attacker to
 significantly slow down the peer network by maliciously varying either schedule.
@@ -205,7 +205,7 @@ with is children `abcd`".
 If a leaf has a non-zero-byte path suffix, and another leaf is inserted that
 shares part of the suffix, the common bytes will be split off of the existing
 leaf to form a `node4`, whose two immediate children are the two leaves.  Each
-of the two leaves will store the path bytes that are unqiue to them.  For
+of the two leaves will store the path bytes that are unique to them.  For
 example, consider this trie with a root `node256` and a single leaf, located at
 path `aabbccddeeff00112233` and having value hash `123456`:
 
@@ -574,7 +574,7 @@ node256                                 | /* back-pointer to N - 10 */
 To generate a MARF Merkle proof, the client queries a Stacks peer for a
 particular value hash, and then requests the peer generate a proof that the key
 and value must have been included in the calculation of the current block's ART
-root hash (i.e. the digest of the materialized view of this fork. 
+root hash (i.e. the digest of the materialized view of this fork). 
 
 For example, given the key/value pair `aabbccddeeff99887766=98765` and the hash
 of the ART at block _N_, the peer would generate two segment proofs for the

--- a/sip/sip-005-blocks-and-transactions.md
+++ b/sip/sip-005-blocks-and-transactions.md
@@ -1066,9 +1066,9 @@ _fully-qualified name_ of the smart contract to:
      derive the contract account address and to query its code),
 
 The fully-qualified name of a smart contract is composed of the c32check-encoded
-standard account address that created it, as well as an ASCII-encoded string chosen by
-the standard account owner(s) when the contract is instantiated (subject to the
-constraints mentioned in the above sections).  Note that all
+standard account address that created it, followed by an ASCII period `.`, as well
+as an ASCII-encoded string chosen by the standard account owner(s) when the contract
+is instantiated (subject to the constraints mentioned in the above sections).  Note that all
 fully-qualified smart contract names are globally unique -- the same standard
 account cannot create two smart contracts with the same name.
 
@@ -1206,8 +1206,8 @@ the nonce of account `SP2RZRSEQHCFPHSBHJTKNWT86W6VSK51M7BCMY06Q`.
 
 The STX balance is encoded as follows:
 
-* Key: the string "vm-account::", a c32check-encoded address, and the string
-  "::19"
+* Key: the string "vm-account::", a Principal Address (see below), and the string
+  `"::19"`
 * Value: a serialized Clarity `UInt`
 
 Example: `"vm-account::SP2RZRSEQHCFPHSBHJTKNWT86W6VSK51M7BCMY06Q::19"` refers to
@@ -1217,7 +1217,7 @@ A fungible token balance owned by an account is encoded as follows:
 
 * Key: the string `"vm::"`, the fully-qualified contract identifier, the string `"::2::"`,
   the name of the token as defined in its Clarity contract, the string `"::"`, and the
-c32check-encoded address of the account.
+Principal Address of the account owning the token (see below).
 * Value: a serialized Clarity `UInt`
 
 Example: `"vm::SP13N5TE1FBBGRZD1FCM49QDGN32WAXM2E5F8WT2G.example-contract::2::example-token::SP2RZRSEQHCFPHSBHJTKNWT86W6VSK51M7BCMY06Q"`
@@ -1229,12 +1229,14 @@ A non-fungible token owned by an account is encoded as follows:
 * Key: the string `"vm::"`, the fully-qualified contract identifier, the string `"::4::"`,
   the name of the token as defined in its Clarity contract, the string `"::"`,
 and the serialized Clarity value that represents the token.
-* Value: a serialized Clarity standard principal
+* Value: a serialized Clarity Principal (either a Standard Principal or a Contract Principal)
 
 Example: `"vm::SP13N5TE1FBBGRZD1FCM49QDGN32WAXM2E5F8WT2G.example-contract::4::example-nft::\x02\x00\x00\x00\x0b\x68\x65\x6c\x6c\x6f\x20\x77\x6f\x72\x6c\x64"` 
 refers to the non-fungible token `"hello world"` (which has type `buff` and is
 comprised of 11 bytes), defined in Clarity contract `SP13N5TE1FBBGRZD1FCM49QDGN32WAXM2E5F8WT2G.example-contract`
 as a type of non-fungible token `example-nft`.
+
+A Principal Address is either a 32check-encoded address in the case of standard principal, or a c32check-encoded address, followed by an ASCII period `.`0, and an ASCII-encoded string for a contract principal.
 
 #### Calculating the State of a Smart Contract
 

--- a/sip/sip-005-blocks-and-transactions.md
+++ b/sip/sip-005-blocks-and-transactions.md
@@ -1236,7 +1236,7 @@ refers to the non-fungible token `"hello world"` (which has type `buff` and is
 comprised of 11 bytes), defined in Clarity contract `SP13N5TE1FBBGRZD1FCM49QDGN32WAXM2E5F8WT2G.example-contract`
 as a type of non-fungible token `example-nft`.
 
-A Principal Address is either a 32check-encoded address in the case of standard principal, or a c32check-encoded address, followed by an ASCII period `.`0, and an ASCII-encoded string for a contract principal.
+A Principal Address is either a c32check-encoded address in the case of standard principal, or a c32check-encoded address, followed by an ASCII period `.`, and an ASCII-encoded string for a contract principal.
 
 #### Calculating the State of a Smart Contract
 

--- a/sip/sip-005-blocks-and-transactions.md
+++ b/sip/sip-005-blocks-and-transactions.md
@@ -816,7 +816,7 @@ A _block header_ is encoded as follows:
   chain (in particular, it must hash to its VRF seed), described below.
 * A 32-byte **parent block hash**, which must be the SHA512/256 hash of the last _anchored_ block
   that precedes this block in the fork to which this block is to be appended.
-* A 32-byte **parent microblock hash**, which must be the SHA512/256 hash of the last _stremead_
+* A 32-byte **parent microblock hash**, which must be the SHA512/256 hash of the last _streamed_
   block that precedes this block in the fork to which this block is to be appended.
 * A 2-byte **parent microblock sequence number**, which indicates the sequence
   number of the parent microblock to which this anchored block is attached.

--- a/sip/sip-005-blocks-and-transactions.md
+++ b/sip/sip-005-blocks-and-transactions.md
@@ -168,7 +168,7 @@ Moreover, transactions are processed in the same total order by all Stacks
 nodes.
 
 At its core, a transaction is an authorization statement (see below),
-a snippit of executable Clarity code, and a list of
+a snippet of executable Clarity code, and a list of
 _post-conditions_ that must be true before the transaction is accepted.  The
 transaction body supplies the Stacks blockchain this code, as well as all of
 the necessary metadata to describe how the transaction should be executed.
@@ -461,7 +461,7 @@ An _uncompressed secp256k1 public key_ has the following encoding:
 
 A _recoverable ECDSA secp256k1 signature_ has the following encoding:
 
-* A 1-byte **recovery ID**, which can have the value `0x00`, `0x01, `0x02`, or
+* A 1-byte **recovery ID**, which can have the value `0x00`, `0x01`, `0x02`, or
   `0x03`.
 * A 32-byte `r` curve coordinate
 * A 32-byte `s` curve coordinate.  Of the two possible `s` values that may be
@@ -816,7 +816,7 @@ A _block header_ is encoded as follows:
   chain (in particular, it must hash to its VRF seed), described below.
 * A 32-byte **parent block hash**, which must be the SHA512/256 hash of the last _anchored_ block
   that precedes this block in the fork to which this block is to be appended.
-* A 32-byte **parent microblock hash**, which must be the SHA512/256 hash of the last _stremaed_
+* A 32-byte **parent microblock hash**, which must be the SHA512/256 hash of the last _stremead_
   block that precedes this block in the fork to which this block is to be appended.
 * A 2-byte **parent microblock sequence number**, which indicates the sequence
   number of the parent microblock to which this anchored block is attached.
@@ -839,7 +839,7 @@ The _cumulative tunable proof score_ contains the following two fields:
 * An 8-byte unsigned integer that encodes the total proof-of-work done in this
   fork of the burn chain.
 
-In-between two consecuritve anchored blocks in the same fork there can exist
+In-between two consecutive anchored blocks in the same fork there can exist
 zero or more Stacks microblocks.
 
 A _microblock_ is comprised of two fields:
@@ -1257,7 +1257,7 @@ commitment is serialized as follows:
 * Bytes 65-72: the ASCII-encoding of the block height, itself as a big-endian
   unsigned 32-bit integer.
 
-Example: The contract commentment of a contract whose code's SHA512/256 hash is
+Example: The contract commitment of a contract whose code's SHA512/256 hash is
 `d8faa525ecb3661e7f88f0bd18b8f6676ec3c96fcd5915cf47d48778da1b7ce0` at block
 height 123456 would be `"d8faa525ecb3661e7f88f0bd18b8f6676ec3c96fcd5915cf47d48778da1b7ce0402e0100"`.
 


### PR DESCRIPTION
Very interesting and useful read.  I learned a lot by reading in details, and will probably need to re-read many times...  Thank you for writing these SIPs, it helps in understanding the code further and how things are supposed to work.

I do have one question on https://github.com/psq/stacks-blockchain/blob/sip/sip-typos-2/sip/sip-005-blocks-and-transactions.md#calculating-the-state-of-an-account

instead of being just a `c32check-encoded address`, shouldn't this be either that, or a contract address, as contract can have balances as well.  Plus the implementation of `make_key_for_account` takes a `PrincipalData`, which supports both types.