### PR TITLE
Fix/testnet thread debugging fixes

### DIFF
--- a/src/net/p2p.rs
+++ b/src/net/p2p.rs
@@ -2764,15 +2764,15 @@ impl PeerNetwork {
     pub fn run(&mut self, burndb: &BurnDB, chainstate: &mut StacksChainState, mempool: &mut MemPoolDB,
                dns_client_opt: Option<&mut DNSClient>, download_backpressure: bool,
                poll_timeout: u64, handler_args: &RPCHandlerArgs) -> Result<NetworkResult, net_error> {
+        
+        debug!(">>>>>>>>>>>>>>>>>>>>>>> Begin Network Dispatch (poll for {}) >>>>>>>>>>>>>>>>>>>>>>>>>>>>", poll_timeout);
         let mut poll_states = match self.network {
             None => {
-                test_debug!("{:?}: network not connected", &self.local_peer);
+                debug!("{:?}: network not connected", &self.local_peer);
                 Err(net_error::NotConnected)
             },
             Some(ref mut network) => {
-                debug!(">>>>>>>>>>>>>>>>>>>>>>> Begin Poll {}ms >>>>>>>>>>>>>>>>>>>>>>>>>>>>", poll_timeout);
                 let poll_result = network.poll(poll_timeout);
-                debug!("<<<<<<<<<<<<<<<<<<<<<<<<<< End Poll <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<");
                 poll_result
             }
         }?;
@@ -2792,6 +2792,7 @@ impl PeerNetwork {
         
         self.dispatch_network(&mut result, burndb, chainstate, dns_client_opt, download_backpressure, p2p_poll_state)?;
 
+        debug!(">>>>>>>>>>>>>>>>>>>>>>> End Network Dispatch >>>>>>>>>>>>>>>>>>>>>>>>>>>>");
         Ok(result)
     }
 }

--- a/testnet/stacks-node/src/main.rs
+++ b/testnet/stacks-node/src/main.rs
@@ -32,7 +32,15 @@ pub use self::run_loop::{neon, helium};
 use pico_args::Arguments;
 use std::env;
 
+use std::panic;
+use std::process;
+
 fn main() {
+
+    panic::set_hook(Box::new(|_| {
+        eprintln!("Process abort due to thread panic");
+        process::exit(1);
+    }));
 
     let mut args = Arguments::from_env();
     let subcommand = args.subcommand().unwrap().unwrap_or_default();

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -256,22 +256,27 @@ fn spawn_peer(mut this: PeerNetwork, p2p_sock: &SocketAddr, rpc_sock: &SocketAdd
         let handler_args = RPCHandlerArgs { exit_at_block_height: exit_at_block_height.as_ref(),
                                             .. RPCHandlerArgs::default() };
 
-        loop {
+        let mut disconnected = false;
+        while !disconnected {
             let download_backpressure = results_with_data.len() > 0;
             let poll_ms = 
                 if !download_backpressure && this.has_more_downloads() {
                     // keep getting those blocks -- drive the downloader state-machine
-                    debug!("backpressure: {}, more downloads: {}", download_backpressure, this.has_more_downloads());
+                    debug!("P2P: backpressure: {}, more downloads: {}", download_backpressure, this.has_more_downloads());
                     100
                 }
                 else {
                     poll_timeout
                 };
 
-            let network_result = this.run(&burndb, &mut chainstate, &mut mem_pool, Some(&mut dns_client),
-                                          download_backpressure, poll_ms,
-                                          &handler_args)
-                .unwrap();
+            let network_result = match this.run(&burndb, &mut chainstate, &mut mem_pool, Some(&mut dns_client),
+                                                 download_backpressure, poll_ms, &handler_args) {
+                Ok(res) => res,
+                Err(e) => {
+                    error!("P2P: Failed to process network dispatch: {:?}", &e);
+                    panic!();
+                }
+            };
 
             if network_result.has_data_to_store() {
                 results_with_data.push_back(RelayerDirective::HandleNetResult(network_result));
@@ -280,7 +285,7 @@ fn spawn_peer(mut this: PeerNetwork, p2p_sock: &SocketAddr, rpc_sock: &SocketAdd
             while let Some(next_result) = results_with_data.pop_front() {
                 // have blocks, microblocks, and/or transactions (don't care about anything else),
                 if let Err(e) = relay_channel.try_send(next_result) {
-                    debug!("{:?}: download backpressure detected", &this.local_peer);
+                    debug!("P2P: {:?}: download backpressure detected", &this.local_peer);
                     match e {
                         TrySendError::Full(directive) => {
                             // don't lose this data -- just try it again
@@ -288,13 +293,18 @@ fn spawn_peer(mut this: PeerNetwork, p2p_sock: &SocketAddr, rpc_sock: &SocketAdd
                             break;
                         },
                         TrySendError::Disconnected(_) => {
-                            info!("Relayer hang up with p2p channel");
+                            info!("P2P: Relayer hang up with p2p channel");
+                            disconnected = true;
                             break;
                         }
                     }
                 }
+                else {
+                    debug!("P2P: Dispatched result to Relayer!");
+                }
             }
         }
+        debug!("P2P thread exit!");
     });
 
     let _jh = thread::spawn(move || {
@@ -352,6 +362,8 @@ fn spawn_miner_relayer(mut relayer: Relayer, local_peer: LocalPeer,
             block_on_recv = false;
             match directive {
                 RelayerDirective::TryProcessAttachable => {
+                    debug!("Relayer: Try process attacheable blocks");
+
                     // process any attachable blocks
                     let block_receipts = chainstate.process_blocks(&mut burndb, 1).expect("BUG: failure processing chainstate");
                     let mut num_processed = 0;
@@ -370,6 +382,7 @@ fn spawn_miner_relayer(mut relayer: Relayer, local_peer: LocalPeer,
                     }
                 },
                 RelayerDirective::HandleNetResult(ref mut net_result) => {
+                    debug!("Relayer: Handle network result");
                     let net_receipts = relayer.process_network_result(&local_peer, net_result,
                                                                         &mut burndb, &mut chainstate, &mut mem_pool)
                         .expect("BUG: failure processing network results");
@@ -386,6 +399,7 @@ fn spawn_miner_relayer(mut relayer: Relayer, local_peer: LocalPeer,
                     }
                 },
                 RelayerDirective::ProcessTenure(burn_header_hash, parent_burn_header_hash, block_header_hash) => {
+                    debug!("Relayer: Process tenure");
                     if let Some(my_mined) = last_mined_block.take() {
                         let AssembledAnchorBlock {
                             parent_block_burn_hash,
@@ -463,17 +477,20 @@ fn spawn_miner_relayer(mut relayer: Relayer, local_peer: LocalPeer,
                     }
                 },
                 RelayerDirective::RunTenure(registered_key, last_burn_block) => {
+                    debug!("Relayer: Run tenure");
                     last_mined_block = InitializedNeonNode::relayer_run_tenure(
                         registered_key, &mut chainstate, &burndb, last_burn_block,
                         &mut keychain, &mut mem_pool, burn_fee_cap, &mut bitcoin_controller);
                     bump_processed_counter(&blocks_processed);
                 },
                 RelayerDirective::RegisterKey(ref last_burn_block) => {
+                    debug!("Relayer: Register key");
                     rotate_vrf_and_register(&mut keychain, last_burn_block, &mut bitcoin_controller);
                     bump_processed_counter(&blocks_processed);
                 }
             }
         }
+        debug!("Relayer exit!");
     });
 
     Ok(())


### PR DESCRIPTION
Recently, the Argon master node's p2p thread stalled.  It did not die -- it still held open the channel linking it to the relayer thread, and it still held the sockets -- but it stopped looping.  This PR does the following:

* Sets a panic handler to force the process to abort on thread panic
* Adds better-placed debug messages to the top-level p2p dispatcher, so we can see that the p2p dispatcher is doing something
* Adds better-placed debug messages to the top-level p2p thread and relay thread, so we can see that they are still alive