### PR TITLE
Fixes on event dispatcher

### DIFF
--- a/testnet/bitcoin-neon-controller/src/main.rs
+++ b/testnet/bitcoin-neon-controller/src/main.rs
@@ -304,7 +304,6 @@ fn build_request(config: &ConfigFile, body: Vec<u8>) -> Request {
     let mut req = Request::new(Method::Post, url);
     req.append_header("Authorization", config.neon.authorization_token()).unwrap();
     req.append_header("Content-Type", "application/json").unwrap();
-    req.append_header("Content-Length", format!("{}", body.len())).unwrap();
     req.append_header("Host", format!("{}", config.neon.bitcoind_rpc_host)).unwrap();
     req.set_body(body);
     req

--- a/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
+++ b/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
@@ -941,7 +941,6 @@ impl BitcoinRPCRequest {
             }
         };
         request.append_header("Content-Type", "application/json").expect("Unable to set header");
-        request.append_header("Content-Length", format!("{}", body.len())).expect("Unable to set header");
         request.set_body(body);
 
         let mut response = async_std::task::block_on(async move {

--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -335,11 +335,7 @@ impl Config {
                         .map(|e| EventKeyType::from_string(e).unwrap())
                         .collect();
 
-                    let endpoint = if observer.endpoint.ends_with("/") {
-                        observer.endpoint
-                    } else {
-                        format!("{}/", observer.endpoint)
-                    };
+                    let endpoint = format!("{}", observer.endpoint);
 
                     observers.push(EventObserverConfig {
                         endpoint,

--- a/testnet/stacks-node/src/event_dispatcher.rs
+++ b/testnet/stacks-node/src/event_dispatcher.rs
@@ -47,8 +47,8 @@ impl EventObserver {
 
         let url = {
             let joined_components = match path.starts_with("/") {
-                true => format!("{}{}", &self.endpoint, &path[1..]),
-                false => format!("{}{}", &self.endpoint, path)
+                true => format!("{}{}", &self.endpoint, path),
+                false => format!("{}/{}", &self.endpoint, path)
             };
             let url = format!("http://{}", joined_components);
             Url::parse(&url).expect(&format!("Event dispatcher: unable to parse {} as a URL", url))

--- a/testnet/stacks-node/src/event_dispatcher.rs
+++ b/testnet/stacks-node/src/event_dispatcher.rs
@@ -60,7 +60,6 @@ impl EventObserver {
             let body = body.clone();
             let mut req = Request::new(Method::Post, url.clone());
             req.append_header("Content-Type", "application/json").expect("Unable to set header");
-            req.append_header("Content-Length", format!("{}", body.len())).expect("Unable to set header");
             req.set_body(body);
 
             let response = async_std::task::block_on(async {

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -197,7 +197,7 @@ fn microblock_integration_test() {
 
     conf.events_observers.push(
         EventObserverConfig {
-            endpoint: format!("http://localhost:{}/", test_observer::EVENT_OBSERVER_PORT),
+            endpoint: format!("localhost:{}", test_observer::EVENT_OBSERVER_PORT),
             events_keys: vec![ EventKeyType::AnyEvent ],
         });
 


### PR DESCRIPTION
I should have clicked with this feedback: https://github.com/blockstack/stacks-blockchain/pull/1718#discussion_r450489368
Since we are creating the connection manually:
```rust
let stream = match TcpStream::connect(self.endpoint.clone())
```
We don't want to suffix the endpoint with `/` anymore, and we should produce a parsing error when such a value is provided in the settings (mimicking the behaviour of `rpc_bind`, `p2p_bind`, `prometheus_bind`).
This PR is fixing this.

While testing this PR with a local sidecar, I noticed that the `Content-type` header was being added twice:
```
POST /new_block HTTP/1.1
host: 127.0.0.1:3000
content-length: 979
date: Tue, 07 Jul 2020 03:50:10 GMT
content-type: application/json
content-length: 979
```
This PR is also addressing this issue.