### PR TITLE
Update Dockerfile to produce a stacks-node bin with monitoring enabled

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,17 +7,20 @@ COPY . .
 RUN rustup target add x86_64-unknown-linux-musl && \
     apt-get update && apt-get install -y git musl-tools
 
-RUN CC=musl-gcc \
-    CC_x86_64_unknown_linux_musl=musl-gcc \
-    CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc \
-    cargo build --features "monitoring_prom" --release --target x86_64-unknown-linux-musl --workspace=./
+ENV CC musl-gcc
+ENV CC_x86_64_unknown_linux_musl musl-gcc
+ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER musl-gcc
 
-RUN cd /src/target/x86_64-unknown-linux-musl/release && \
-    mkdir /out && \
-    cp blockstack-core /out && cp blockstack-cli /out && cp clarity-cli /out && cp stacks-node /out
+RUN mkdir /out
+
+RUN cd testnet/stacks-node && cargo build --features "monitoring_prom" --release --target x86_64-unknown-linux-musl
+RUN cd testnet/bitcoin-neon-controller && cargo build --release --target x86_64-unknown-linux-musl
+
+RUN cp target/x86_64-unknown-linux-musl/release/stacks-node /out
+RUN cp target/x86_64-unknown-linux-musl/release/bitcoin-neon-controller /out
 
 FROM alpine
 
 COPY --from=build /out/ /bin/
 
-CMD ["stacks-node", "neon"]
+CMD ["stacks-node", "argon"]

--- a/testnet/stacks-node/src/monitoring/mod.rs
+++ b/testnet/stacks-node/src/monitoring/mod.rs
@@ -9,6 +9,7 @@ pub use stacks::monitoring::{
 mod prometheus;
 
 pub fn start_serving_monitoring_metrics(bind_address: String) {
+    info!("Start serving monitoring metrics");
     #[cfg(feature = "monitoring_prom")]
     prometheus::start_serving_prometheus_metrics(bind_address);
 }

--- a/testnet/stacks-node/src/monitoring/prometheus.rs
+++ b/testnet/stacks-node/src/monitoring/prometheus.rs
@@ -13,9 +13,9 @@ pub fn start_serving_prometheus_metrics(bind_address: String) {
     let addr = bind_address.clone();
 
     async_std::task::block_on(async {
-        let listener = TcpListener::bind(addr).await.expect("Prometheus monitoring: unable to bind {}", addr);
+        let listener = TcpListener::bind(addr).await.expect("Prometheus monitoring: unable to bind address");
         let addr = format!("http://{}", listener.local_addr().expect("Prometheus monitoring: unable to get addr"));
-        println!("Prometheus server listening on {}", addr);
+        info!("Prometheus monitoring: server listening on {}", addr);
     
         let mut incoming = listener.incoming();
         while let Some(stream) = incoming.next().await {
@@ -38,7 +38,7 @@ pub fn start_serving_prometheus_metrics(bind_address: String) {
 }
 
 async fn accept(addr: String, stream: TcpStream) -> http_types::Result<()> {
-    println!("starting new connection from {}", stream.peer_addr()?);
+    info!("Prometheus monitoring: starting new connection from {}", stream.peer_addr()?);
     async_h1::accept(&addr, stream.clone(), |_| async {
         let encoder = TextEncoder::new();    
         let metric_families = gather();


### PR DESCRIPTION
The command currently being used for building a stacks-node with prometheus support: 
```
cargo build --features "monitoring_prom" --release --target x86_64-unknown-linux-musl --workspace=./
```
is compiling the stacks lib with the `monitoring_prom` feature flag, but not cascading the flag to the `stacks-node` target.
As a result, when using this command, the code from the `stacks` lib behind the feature gate was included in the build, however the code in `stacks-node` behind the feature gate, was not checked / compiled / included. 
This PR is addressing this issue by revisiting the build procedure. 
A docker build (http://hub.docker.com/repository/docker/ludovic/stacks-node) was produced using the Dockerfile from this PR, and used for spawning a new follower in the `neon-staging` namespace, with a functional prometheus server
```
INFO [1594157362.332] [testnet/stacks-node/src/monitoring/mod.rs:12] [ThreadId(8)] Start serving monitoring metrics
INFO [1594157362.333] [testnet/stacks-node/src/monitoring/prometheus.rs:18] [ThreadId(8)] Prometheus monitoring: server listening on http://0.0.0.0:9153
```

```
# curl localhost:9153
# HELP stacks_node_active_miners_total Total number of active miners.
# TYPE stacks_node_active_miners_total gauge
stacks_node_active_miners_total{handler="all"} 3
# HELP stacks_node_btc_blocks_received_total Total number of blocks processed from the burnchain.
# TYPE stacks_node_btc_blocks_received_total counter
stacks_node_btc_blocks_received_total{handler="all"} 315
# HELP stacks_node_p2p_msg_authenticated_handshake_received_total Total number of authenticated Handshake messages received.
# TYPE stacks_node_p2p_msg_authenticated_handshake_received_total counter
stacks_node_p2p_msg_authenticated_handshake_received_total{handler="all"} 44
# HELP stacks_node_p2p_msg_get_neighbors_received_total Total number of GetNeighbors messages received.
# TYPE stacks_node_p2p_msg_get_neighbors_received_total counter
stacks_node_p2p_msg_get_neighbors_received_total{handler="all"} 44
# HELP stacks_node_stx_blocks_received_total Total number of Stacks blocks received.
# TYPE stacks_node_stx_blocks_received_total counter
stacks_node_stx_blocks_received_total{handler="all"} 13
# HELP stacks_node_transactions_received_total Total number of transactions received and relayed.
# TYPE stacks_node_transactions_received_total counter
stacks_node_transactions_received_total{handler="all"} 5
# HELP stacks_node_warning_emitted_total Total number of warning logs emitted by node.
# TYPE stacks_node_warning_emitted_total counter
stacks_node_warning_emitted_total{handler="all"} 62
```