### PR TITLE
Nicer RPC deserialization errors

### DIFF
--- a/src/net/connection.rs
+++ b/src/net/connection.rs
@@ -578,7 +578,7 @@ impl<P: ProtocolFamily> ConnectionInbox<P> {
                     Some(message)
                 },
                 Err(e) => {
-                    // will never be valid, even if underflowed, since the premable ought to have
+                    // will never be valid, even if underflowed, since the preamble ought to have
                     // told us the message length
                     debug!("Invalid message payload: {:?}.  Preamble was {:?}", &e, &preamble);
                     return Err(net_error::InvalidMessage);

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -126,7 +126,7 @@ pub enum Error {
     ReadError(io::Error),
     /// Failed to decode 
     DeserializeError(String),
-    /// Filaed to write
+    /// Failed to write
     WriteError(io::Error),
     /// Underflow -- not enough bytes to form the message
     UnderflowError(String),
@@ -210,6 +210,32 @@ pub enum Error {
     ClarityError(clarity_error),
     /// Catch-all for chainstate errors that don't map cleanly into network errors
     ChainstateError(String),
+    /// Catch-all for errors that a client should receive more information about
+    ClientError(ClientError),
+}
+
+/// Enum for passing data for ClientErrors
+#[derive(Debug, Clone, PartialEq)]
+pub enum ClientError {
+    /// Catch-all
+    Message(String),
+    /// 404
+    NotFound(String),
+}
+
+impl error::Error for ClientError {
+    fn cause(&self) -> Option<&dyn error::Error> {
+        None
+    }
+}
+
+impl fmt::Display for ClientError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            ClientError::Message(s) => write!(f, "{}", s),
+            ClientError::NotFound(s) => write!(f, "HTTP path not matched: {}", s),
+        }
+    }
 }
 
 impl fmt::Display for Error {
@@ -260,6 +286,7 @@ impl fmt::Display for Error {
             Error::ChainstateError(ref s) => fmt::Display::fmt(s, f),
             Error::ClarityError(ref e) => fmt::Display::fmt(e, f),
             Error::MARFError(ref e) => fmt::Display::fmt(e, f),
+            Error::ClientError(ref e) => write!(f, "ClientError: {}", e),
         }
     }
 }
@@ -310,6 +337,7 @@ impl error::Error for Error {
             Error::PeerThrottled => None,
             Error::LookupError(ref _s) => None,
             Error::ChainstateError(ref _s) => None,
+            Error::ClientError(ref e) => Some(e),
             Error::ClarityError(ref e) => Some(e),
             Error::MARFError(ref e) => Some(e),
         }
@@ -1025,7 +1053,8 @@ pub enum HttpRequestType {
     GetContractSrc(HttpRequestMetadata, StacksAddress, ContractName, bool),
     GetContractABI(HttpRequestMetadata, StacksAddress, ContractName),
     OptionsPreflight(HttpRequestMetadata, String),
-    Unmatched(HttpRequestMetadata, String),     // catch-all if we can't parse the request
+    /// catch-all for any errors we should surface from parsing
+    ClientError(HttpRequestMetadata, ClientError),
 }
 
 /// The fields that Actually Matter to http responses

--- a/testnet/stacks-node/src/tests/integrations.rs
+++ b/testnet/stacks-node/src/tests/integrations.rs
@@ -15,6 +15,7 @@ use stacks::net::{AccountEntryResponse, ContractSrcResponse, CallReadOnlyRequest
 use stacks::net::StacksMessageCodec;
 use stacks::vm::clarity::ClarityConnection;
 use stacks::core::mempool::MAXIMUM_MEMPOOL_TX_CHAINING;
+use stacks::util::hash::hex_bytes;
 
 use crate::config::InitialBalance;
 use crate::helium::RunLoop;
@@ -556,6 +557,21 @@ fn integration_test_get_info() {
                     .unwrap();
 
                 assert_eq!(res, format!("{}", StacksTransaction::consensus_deserialize(&mut &tx_xfer[..]).unwrap().txid()));
+
+                // let's test a posttransaction call that fails to deserialize,
+                //   making sure we get a nicer error message
+                let tx_hex = "80800000000400f942874ce525e87f21bbe8c121b12fac831d02f4000000000000000000000000000003e80001031734446f0870af42bb0cafad27f405e5d9eba441375eada8607a802b875fbb7ba7c4da3474f2bfd76851fb6314a48fe98b57440b8ccec6c9b8362c843a89f303020000000001047465737400000007282b2031203129";
+                let tx_xfer = hex_bytes(tx_hex).unwrap();
+
+                let res: String = client.post(&path)
+                    .header("Content-Type", "application/octet-stream")
+                    .body(tx_xfer.clone())
+                    .send()
+                    .unwrap()
+                    .json()
+                    .unwrap();
+
+                assert!(res.contains("contract name: too short"));
                 
                 // let's submit an invalid transaction!
                 let path = format!("{}/v2/transactions", &http_origin);


### PR DESCRIPTION
Previously, if the RPC handler failed while parsing a request from HTTP to a RequestType, the RPC server would return 400 and an empty HTTP body. This led to some not very friendly error messages (e.g., #1703)

This PR adds a test for that case, as well as introducing an error handling scheme for cases like these (currently only used for deserialization errors and 404s).

This change is relatively straight-forward, though there's one tricky part -- the StacksHttp::read_payload error handling needs to return to its caller as if it read the full content-length of the socket. Without that, the RPC server would continue reading the prior request's body when trying to process a subsequent request on the same socket.