### PR TITLE
fix: wrap <trait-alias> as code in description

### DIFF
--- a/src/vm/docs/mod.rs
+++ b/src/vm/docs/mod.rs
@@ -1102,7 +1102,7 @@ const USE_TRAIT_API: DefineAPI = DefineAPI {
     output_type: "Not Applicable",
     signature: "(use-trait trait-alias trait-identifier)",
     description: "`use-trait` is used to bring a trait, defined in another contract, to the current contract. Subsequent
-references to an imported trait are signaled with the syntax <trait-alias>.
+references to an imported trait are signaled with the syntax `<trait-alias>`.
 
 Traits import are defined with a name, used as an alias, and a trait identifier. Trait identifiers can either be
 using the sugared syntax (.token-a.token-trait), or be fully qualified ('SPAXYA5XS51713FDTQ8H94EJ4V579CXMTRNBZKSF.token-a.token-trait).


### PR DESCRIPTION
Working on the new docs, this line caused an issue with rendering the content of the reference descriptions, it thought that <trait-alias> was a JSX element. This PR wraps that so it will render as inline-code.