### PR TITLE
Feat/fix 1748

### DIFF
--- a/sip/sip-003-peer-network.md
+++ b/sip/sip-003-peer-network.md
@@ -804,21 +804,20 @@ The peer may take an operator-given public IP address.  If no public IP address
 is given, the peer will learn the IP address using the `NatPunchRequest` and
 `NatPunchReply` messages as follows:
 
-1. The peer sends a `NatPunchRequest` to a randomly-chosen neighbor it has
+1. The peer sends a `NatPunchRequest` to a randomly-chosen initial neighbor it has
    already handshaked with.  It uses a random nonce value.
 2. The remote neighbor replies with a (signed) `NatPunchReply` message, with its
    `addrbytes` and `port` set to what it believes the public IP is (based on the
    underlying socket's peer address).
-3. The peer, upon receipt and authentication of the `NatPunchReply`, will
-   confirm the public IP address by attempting to connect to itself.  To do so,
-   it sends a `NatPunchRequest` to the public IP address it learned (with a
-   random nonce).
-4. If the peer successfully connects to itself via the public IP address, it
-   will send a `NatPunchReply` back to itself with the nonce used in step 3.
-5. Upon receipt of the `NatPunchReply`, the peer will have confirmed its public
+3. Upon receipt of the `NatPunchReply`, the peer will have confirmed its public
    IP address, and will send it in all future `HandshakeAccept` messages.  It
    will periodically re-learn its IP address, if it was not given by the
    operator.
+
+Because the peer's initial neighbors are chosen by the operator as being
+sufficiently trustworthy to supply network information for network walks, it is
+reasonable to assume that they can also be trusted to tell a bootstrapping peer
+its public IP address.
 
 ### Checking a Peer's Liveness
 

--- a/src/burnchains/burnchain.rs
+++ b/src/burnchains/burnchain.rs
@@ -723,7 +723,7 @@ impl Burnchain {
                 let ipc_block = downloader.download(&ipc_header)?;
                 let download_end = get_epoch_time_ms();
 
-                debug!("Downloaded block {} in {}ms", ipc_block.height(), download_end - download_start);
+                debug!("Downloaded block {} in {}ms", ipc_block.height(), download_end.saturating_sub(download_start));
 
                 parser_send.send(Some(ipc_block))
                     .map_err(|_e| burnchain_error::ThreadChannelError)?;
@@ -741,7 +741,7 @@ impl Burnchain {
                 let burnchain_block = parser.parse(&ipc_block)?;
                 let parse_end = get_epoch_time_ms();
 
-                debug!("Parsed block {} in {}ms", burnchain_block.block_height(), parse_end - parse_start);
+                debug!("Parsed block {} in {}ms", burnchain_block.block_height(), parse_end.saturating_sub(parse_start));
 
                 db_send.send(Some(burnchain_block))
                     .map_err(|_e| burnchain_error::ThreadChannelError)?;
@@ -765,7 +765,7 @@ impl Burnchain {
                 last_processed = (tip, Some(transition));
                 let insert_end = get_epoch_time_ms();
 
-                debug!("Inserted block {} in {}ms", burnchain_block.block_height(), insert_end - insert_start);
+                debug!("Inserted block {} in {}ms", burnchain_block.block_height(), insert_end.saturating_sub(insert_start));
             }
             Ok(last_processed)
         });

--- a/src/net/neighbors.rs
+++ b/src/net/neighbors.rs
@@ -2191,7 +2191,8 @@ mod test {
         let mut peer_1_config = TestPeerConfig::from_port(31990);
         let peer_2_config = TestPeerConfig::from_port(31992);
 
-        // peer 1 crawls peer 2
+        // peer 1 crawls peer 2, but not vice versa
+        // (so only peer 1 will learn its public IP)
         peer_1_config.add_neighbor(&peer_2_config.to_neighbor());
 
         let mut peer_1 = TestPeer::new(peer_1_config);
@@ -2201,7 +2202,7 @@ mod test {
         let mut walk_1_count = 0;
         let mut walk_2_count = 0;
         
-        while walk_1_count < 20 || walk_2_count < 20 || (!peer_1.network.public_ip_confirmed || !peer_2.network.public_ip_confirmed) {
+        while walk_1_count < 20 || walk_2_count < 20 || (!peer_1.network.public_ip_confirmed) {
             let _ = peer_1.step();
             let _ = peer_2.step();
 
@@ -2264,11 +2265,10 @@ mod test {
         assert!(peer_1.network.public_ip_learned);
         assert!(peer_1.network.public_ip_confirmed);
 
-        // peer 2 learned and confirmed its public IP address from peer 1
-        assert!(peer_2.network.local_peer.public_ip_address.is_some());
-        assert_eq!(peer_2.network.local_peer.public_ip_address.clone().unwrap(), (PeerAddress::from_socketaddr(&format!("127.0.0.1:1").parse::<SocketAddr>().unwrap()), 31992)); 
+        // peer 2 learned nothing, despite trying
+        assert!(peer_2.network.local_peer.public_ip_address.is_none());
         assert!(peer_2.network.public_ip_learned);
-        assert!(peer_2.network.public_ip_confirmed);
+        assert!(!peer_2.network.public_ip_confirmed);
     }
     
     #[test]

--- a/testnet/stacks-node/src/main.rs
+++ b/testnet/stacks-node/src/main.rs
@@ -37,8 +37,13 @@ use std::process;
 
 fn main() {
 
-    panic::set_hook(Box::new(|_| {
-        eprintln!("Process abort due to thread panic");
+    panic::set_hook(Box::new(|panic_info| {
+        if let Some(s) = panic_info.payload().downcast_ref::<&str>() {
+            eprintln!("panic occurred: {:?}", s);
+        }
+        else {
+            eprintln!("panic occurred");
+        }
         process::exit(1);
     }));
 


### PR DESCRIPTION
This fixes #1748.  It removes the "confirm IP address" step of the public IP-learning protocol, which doesn't appear to work on most NATs (even when port-forwarding is enabled on the router).  Instead, the IP-learning protocol just asks one of the initial seed nodes given to the peer DB for the peer IP address.