### PR TITLE
Fix/possible marf corruption

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -68,6 +68,7 @@ jobs:
       - setup_remote_docker
       - run:
           name: build docker image
+          no_output_timeout: 30m
           command: docker build . -t $IMAGE_NAME:latest
       - run:
           name: save image to workspace

--- a/src/chainstate/stacks/db/blocks.rs
+++ b/src/chainstate/stacks/db/blocks.rs
@@ -2930,7 +2930,7 @@ impl StacksChainState {
     ///
     /// Occurs as a single, atomic transaction against the (marf'ed) headers database and
     /// (un-marf'ed) staging block database, as well as against the chunk store.
-    fn process_next_staging_block(&mut self, sort_tx: &mut SortitionDBTx) -> Result<(Option<StacksEpochReceipt>, Option<TransactionPayload>), Error> {
+    pub fn process_next_staging_block(&mut self, sort_tx: &mut SortitionDBTx) -> Result<(Option<StacksEpochReceipt>, Option<TransactionPayload>), Error> {
         let (mut chainstate_tx, clarity_instance) = self.chainstate_tx_begin()?;
 
         let blocks_path = chainstate_tx.blocks_tx.get_blocks_path().clone();

--- a/src/chainstate/stacks/index/storage.rs
+++ b/src/chainstate/stacks/index/storage.rs
@@ -1317,7 +1317,7 @@ impl <T: MarfTrieId> TrieFileStorage <T> {
 
             debug!("Flush: identifier of {} is {}", flush_options, block_id);
 
-            self.cur_block_id = Some(block_id);
+            // self.cur_block_id = Some(block_id);
         }
 
         Ok(())

--- a/src/chainstate/stacks/index/trie.rs
+++ b/src/chainstate/stacks/index/trie.rs
@@ -685,7 +685,7 @@ impl Trie {
                     });
             }
 
-            test_debug!("Next root hash is {} (update_skiplist={})", h, update_skiplist);
+            debug!("Next root hash is {} (update_skiplist={})", h, update_skiplist);
 
             storage.write_nodetype(child_ptr.ptr(), &node, h)?;
         }
@@ -740,7 +740,7 @@ impl Trie {
                                         });
                                 }
             
-                                test_debug!("Next root hash is {} (update_skiplist={})", h, update_skiplist);
+                                debug!("Next root hash is {} (update_skiplist={})", h, update_skiplist);
                                 h
                             }
                             else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -300,6 +300,18 @@ fn main() {
         return
     }
 
+    if argv[1] == "process-block" {
+        use chainstate::stacks::db::StacksChainState;
+        use chainstate::burn::db::sortdb::SortitionDB;
+        let path = &argv[2];
+        let sort_path = &argv[3];
+        let mut chainstate = StacksChainState::open(false, 0x80000000, path).unwrap();
+        let mut sortition_db = SortitionDB::open(sort_path, true).unwrap();
+        let mut tx = sortition_db.tx_begin().unwrap();
+        chainstate.process_next_staging_block(&mut tx).unwrap();
+        return
+    }
+
     if argv.len() < 4 {
         eprintln!("Usage: {} blockchain network working_dir", argv[0]);
         process::exit(1);


### PR DESCRIPTION
I don't know if this fixes the current outage on testnet, but I know from process-of-elimination that the one-liner in `storage.rs` is the only place where it appears we changed the way non-persisted state gets stored in the MARF.