### PR TITLE
Fix/detect marf corruption

### DIFF
--- a/src/burnchains/bitcoin/indexer.rs
+++ b/src/burnchains/bitcoin/indexer.rs
@@ -645,6 +645,9 @@ impl BurnchainIndexer for BitcoinIndexer {
         let mut indexer = BitcoinIndexer::from_file(bitcoin_network_id, &conf_path_str)
             .map_err(burnchain_error::Bitcoin)?;
 
+        SpvClient::new(&indexer.config.spv_headers_path, 0, None, indexer.runtime.network_id, true, false)
+            .map_err(burnchain_error::Bitcoin)?;
+
         indexer.connect()?;
         Ok(indexer)
     }

--- a/src/burnchains/burnchain.rs
+++ b/src/burnchains/burnchain.rs
@@ -361,7 +361,7 @@ impl Burnchain {
         Ok(())
     }
 
-    fn make_indexer<I: BurnchainIndexer>(&self) -> Result<I, burnchain_error> {
+    pub fn make_indexer<I: BurnchainIndexer>(&self) -> Result<I, burnchain_error> {
         Burnchain::setup_chainstate_dirs(&self.working_dir, &self.chain_name, &self.network_name)?;
 
         let indexer : I = BurnchainIndexer::init(&self.working_dir, &self.network_name)?;
@@ -409,7 +409,7 @@ impl Burnchain {
         db_path
     }
 
-    fn connect_db<I: BurnchainIndexer>(&self, indexer: &I, readwrite: bool) -> Result<(SortitionDB, BurnchainDB), burnchain_error> {
+    pub fn connect_db<I: BurnchainIndexer>(&self, indexer: &I, readwrite: bool) -> Result<(SortitionDB, BurnchainDB), burnchain_error> {
         Burnchain::setup_chainstate_dirs(&self.working_dir, &self.chain_name, &self.network_name)?;
 
         let first_block_height = indexer.get_first_block_height();

--- a/src/chainstate/burn/db/sortdb.rs
+++ b/src/chainstate/burn/db/sortdb.rs
@@ -1131,6 +1131,12 @@ impl SortitionDB {
         db_tx.commit()?;
         Ok(())
     }
+
+    /// Load up all snapshots, in ascending order by block height.  Great for testing!
+    pub fn get_all_snapshots(&self) -> Result<Vec<BlockSnapshot>, db_error> {
+        let qry = "SELECT * FROM snapshots ORDER BY block_height ASC";
+        query_rows(self.conn(), qry, NO_PARAMS)
+    }
 }
 
 impl <'a> SortitionDBConn <'a> {
@@ -1472,7 +1478,6 @@ impl SortitionDB {
         }
         Ok(burn_total)
     }
-
 
     /// Get all user burns registered in a block on is fork.
     /// Returns list of user burns in order by vtxindex.

--- a/src/chainstate/burn/operations/leader_block_commit.rs
+++ b/src/chainstate/burn/operations/leader_block_commit.rs
@@ -262,11 +262,9 @@ impl StacksMessageCodec for LeaderBlockCommitOp {
         write_next(fd, &self.parent_vtxindex)?;
         write_next(fd, &self.key_block_ptr)?;
         write_next(fd, &self.key_vtxindex)?;
-        let memo = match self.memo.len() > 0 {
-            true => self.memo[0],
-            false => 0x00,
-        };
-        write_next(fd, &memo)?;
+        if self.memo.len() > 0 {
+            write_next(fd, &self.memo[0])?;
+        }
         Ok(())
     }
 

--- a/src/chainstate/stacks/db/blocks.rs
+++ b/src/chainstate/stacks/db/blocks.rs
@@ -296,7 +296,7 @@ impl FromRow<StagingBlock> for StagingBlock {
 
         let processed = processed_i64 != 0;
         let attachable = attachable_i64 != 0;
-        let orphaned = orphaned_i64 == 0;
+        let orphaned = orphaned_i64 != 0;
 
         Ok(StagingBlock {
             anchored_block_hash,
@@ -482,7 +482,8 @@ impl StacksChainState {
             // instantiate!
             StacksChainState::instantiate_blocks_db(&mut conn)?;
         }
-        
+       
+        debug!("Opened blocks DB {}", db_path);
         Ok(conn)
     }
     
@@ -695,6 +696,13 @@ impl StacksChainState {
             .map_err(Error::DBError)?;
 
         Ok(blocks.drain(..).map(|b| (b.burn_header_hash, b.anchored_block_hash)).collect())
+    }
+
+    /// Get all stacks block headers.  Great for testing!
+    pub fn get_all_staging_block_headers(blocks_conn: &DBConn) -> Result<Vec<StagingBlock>, Error> {
+        let sql = "SELECT * FROM staging_blocks ORDER BY height".to_string();
+        query_rows::<StagingBlock, _>(blocks_conn, &sql, NO_PARAMS)
+            .map_err(Error::DBError)
     }
 
     /// Get a list of all microblocks' hashes, and their anchored blocks' hashes
@@ -2385,6 +2393,7 @@ impl StacksChainState {
     }
 
     /// Given a burnchain snapshot, a Stacks block and a microblock stream, preprocess them all.
+    /// This does not work when forking
     #[cfg(test)]
     pub fn preprocess_stacks_epoch(&mut self, sort_ic: &SortitionDBConn, snapshot: &BlockSnapshot, block: &StacksBlock, microblocks: &Vec<StacksMicroblock>) -> Result<(), Error> {
         self.preprocess_anchored_block(sort_ic, &snapshot.burn_header_hash, snapshot.burn_header_timestamp, block, &snapshot.parent_burn_header_hash)?;

--- a/src/chainstate/stacks/index/storage.rs
+++ b/src/chainstate/stacks/index/storage.rs
@@ -1324,6 +1324,8 @@ impl <T: MarfTrieId> TrieFileStorage <T> {
             tx.commit()?;
 
             debug!("Flush: identifier of {} is {}", flush_options, block_id);
+
+            self.cur_block_id = None;
         }
 
         Ok(())
@@ -1358,6 +1360,8 @@ impl <T: MarfTrieId> TrieFileStorage <T> {
                     .expect("Corruption: Failed to drop the extended trie");
             }
             self.last_extended = None;
+            self.cur_block_id = None;
+            self.trie_ancestor_hash_bytes_cache = None;
         }
     }
 
@@ -1373,6 +1377,8 @@ impl <T: MarfTrieId> TrieFileStorage <T> {
             tx.commit()
                 .expect("Corruption: Failed to drop the extended trie");
             self.last_extended = None;
+            self.cur_block_id = None;
+            self.trie_ancestor_hash_bytes_cache = None;
         }
     }
 

--- a/src/chainstate/stacks/index/storage.rs
+++ b/src/chainstate/stacks/index/storage.rs
@@ -581,6 +581,8 @@ pub struct TrieFileStorage <T: MarfTrieId> {
 
     db: Connection,
     cur_block: T,
+    /// Tracking the row_id for the cur_block. If cur_block == last_extended,
+    ///   this value should always be None
     cur_block_id: Option<u32>,
 
     read_count: u64,
@@ -980,7 +982,7 @@ impl <T: MarfTrieId> TrieFileStorage <T> {
         }
 
         if let Some((ref last_extended, _)) = self.last_extended {
-            if !self.unconfirmed && last_extended == bhh {
+            if last_extended == bhh {
                 panic!("BUG: passed id of a currently building block");
             }
         }
@@ -1025,7 +1027,16 @@ impl <T: MarfTrieId> TrieFileStorage <T> {
         Ok(())
     }
 
+    /// Return the block_identifier / row_id for a given bhh. If that bhh
+    ///  is currently being extended, return None, since the row_id won't
+    ///  be known until the extended trie is flushed.
     pub fn get_block_identifier(&self, bhh: &T) -> Option<u32> {
+        if let Some((ref last_extended, _)) = self.last_extended {
+            if bhh == last_extended {
+                return None
+            }
+        }
+
         trie_sql::get_block_identifier(&self.db, bhh).ok()
     }
 
@@ -1324,8 +1335,6 @@ impl <T: MarfTrieId> TrieFileStorage <T> {
             tx.commit()?;
 
             debug!("Flush: identifier of {} is {}", flush_options, block_id);
-
-            self.cur_block_id = None;
         }
 
         Ok(())

--- a/src/chainstate/stacks/index/trie.rs
+++ b/src/chainstate/stacks/index/trie.rs
@@ -680,6 +680,7 @@ impl Trie {
                 let node_hash = my_hash.clone();
                 let _ = Trie::get_trie_root_ancestor_hashes_bytes(storage, &node_hash)
                     .and_then(|_hs| {
+                        storage.clear_cached_ancestor_hashes_bytes();
                         trace!("update_root_hash: Updated {:?} with {:?} from {} to {} + {:?} = {} (fixed root)", &node, &child_ptr, &_cur_hash, &node_hash, &_hs[1..].to_vec(), &h);
                         Ok(())
                     });
@@ -735,6 +736,7 @@ impl Trie {
                                 if is_trace() {
                                     let _ = Trie::get_trie_root_ancestor_hashes_bytes(storage, &content_hash)
                                         .and_then(|_hs| {
+                                            storage.clear_cached_ancestor_hashes_bytes();
                                             trace!("update_root_hash: Updated {:?} with {:?} from {:?} to {:?} + {:?} = {:?}", &node, &child_ptr, &_cur_hash, &content_hash, &_hs[1..].to_vec(), &h);
                                             Ok(())
                                         });

--- a/src/chainstate/stacks/miner.rs
+++ b/src/chainstate/stacks/miner.rs
@@ -4076,6 +4076,200 @@ pub mod test {
             // assert_eq!(stacks_block.txs.len(), 1);
         }
     }
+    
+    #[test]
+    fn test_build_anchored_blocks_invalid() {
+        let peer_config = TestPeerConfig::new("test_build_anchored_blocks_invalid", 2014, 2015);
+        let mut peer = TestPeer::new(peer_config);
+
+        let chainstate_path = peer.chainstate_path.clone();
+
+        let num_blocks = 10;
+        let first_stacks_block_height = {
+            let sn = SortitionDB::get_canonical_burn_chain_tip_stubbed(&peer.sortdb.as_ref().unwrap().conn()).unwrap();
+            sn.block_height
+        };
+
+        let mut last_block : Option<StacksBlock> = None;
+        let mut last_valid_block : Option<StacksBlock> = None;
+        let mut last_tip : Option<BlockSnapshot> = None;
+        let mut last_parent : Option<StacksBlock> = None;
+        let mut last_parent_tip : Option<StacksHeaderInfo> = None;
+
+        let bad_block_tenure = 6;
+        let bad_block_ancestor_tenure = 3;
+        let resume_parent_tenure = 5;
+
+        let mut bad_block_tip : Option<BlockSnapshot> = None;
+        let mut bad_block_parent : Option<StacksBlock> = None;
+        let mut bad_block_parent_tip : Option<StacksHeaderInfo> = None;
+        let mut bad_block_parent_commit : Option<LeaderBlockCommitOp> = None;
+
+        let mut resume_tenure_parent_commit : Option<LeaderBlockCommitOp> = None;
+        let mut resume_tip : Option<BlockSnapshot> = None;
+
+        for tenure_id in 0..num_blocks {
+            // send transactions to the mempool
+            let mut tip = SortitionDB::get_canonical_burn_chain_tip_stubbed(&peer.sortdb.as_ref().unwrap().conn()).unwrap();
+            
+            if tenure_id == bad_block_ancestor_tenure {
+                bad_block_tip = Some(tip.clone());
+            }
+            else if tenure_id == bad_block_tenure {
+                tip = bad_block_tip.clone().unwrap();
+            }
+            else if tenure_id == resume_parent_tenure {
+                resume_tip = Some(tip.clone());
+            }
+            else if tenure_id == bad_block_tenure + 1 {
+                tip = resume_tip.clone().unwrap();
+            }
+
+            last_tip = Some(tip.clone());
+
+            let (mut burn_ops, stacks_block, microblocks) = peer.make_tenure(|ref mut miner, ref mut sortdb, ref mut chainstate, vrf_proof, ref parent_opt, ref parent_microblock_header_opt| {
+                let parent_opt = 
+                    if tenure_id != bad_block_tenure {
+                        if let Some(p) = &last_parent {
+                            assert!(tenure_id == bad_block_tenure + 1);
+                            Some(p.clone())
+                        }
+                        else {
+                            assert!(tenure_id != bad_block_tenure + 1);
+                            match parent_opt {
+                                Some(p) => Some((*p).clone()),
+                                None => None
+                            }
+                        }
+                    }
+                    else {
+                        bad_block_parent.clone()
+                    };
+
+                let parent_tip = 
+                    if tenure_id != bad_block_tenure {
+                        if let Some(tip) = &last_parent_tip {
+                            assert!(tenure_id == bad_block_tenure + 1);
+                            tip.clone()
+                        }
+                        else {
+                            assert!(tenure_id != bad_block_tenure + 1);
+                            match parent_opt {
+                                None => {
+                                    StacksChainState::get_genesis_header_info(&chainstate.headers_db).unwrap()
+                                }
+                                Some(ref block) => {
+                                    let ic = sortdb.index_conn();
+                                    let parent_block_hash = 
+                                        if let Some(ref block) = last_valid_block.as_ref() {
+                                            block.block_hash()
+                                        }
+                                        else {
+                                            block.block_hash()
+                                        };
+
+                                    let snapshot = SortitionDB::get_block_snapshot_for_winning_stacks_block(&ic, &tip.sortition_id, &parent_block_hash).unwrap().unwrap();      // succeeds because we don't fork
+                                    StacksChainState::get_anchored_block_header_info(&chainstate.headers_db, &snapshot.burn_header_hash, &snapshot.winning_stacks_block_hash).unwrap().unwrap()
+                                }
+                            }
+                        }
+                    }
+                    else {
+                        bad_block_parent_tip.clone().unwrap()
+                    };
+
+                if tenure_id == resume_parent_tenure {
+                    // resume here
+                    last_parent = parent_opt.clone();
+                    last_parent_tip = Some(parent_tip.clone());
+
+                    eprintln!("\n\nat resume parent tenure:\nlast_parent: {:?}\nlast_parent_tip: {:?}\n\n", &last_parent, &last_parent_tip);
+                }
+                else if tenure_id >= bad_block_tenure + 1 {
+                    last_parent = None;
+                    last_parent_tip = None;
+                }
+
+                if tenure_id == bad_block_ancestor_tenure {
+                    bad_block_parent_tip = Some(parent_tip.clone());
+                    bad_block_parent = parent_opt.clone();
+
+                    eprintln!("\n\nancestor of corrupt block: {:?}\n", &parent_tip);
+                }
+                
+                if tenure_id == bad_block_tenure + 1 {
+                    // prior block was invalid; reset nonce
+                    miner.set_nonce(resume_parent_tenure as u64);
+                }
+                else if tenure_id == bad_block_tenure {
+                    // building off of a long-gone snapshot
+                    miner.set_nonce(miner.get_nonce() - ((bad_block_tenure - bad_block_ancestor_tenure) as u64));
+                }
+
+                let parent_header_hash = parent_tip.anchored_header.block_hash();
+                let parent_tip_bhh = parent_tip.burn_header_hash.clone();
+
+                let mempool = MemPoolDB::open(false, 0x80000000, &chainstate_path).unwrap();
+
+                let coinbase_tx = make_coinbase(miner, tenure_id as usize);
+
+                let mut anchored_block = StacksBlockBuilder::build_anchored_block(chainstate, &mempool, &parent_tip, tip.total_burn, vrf_proof, Hash160([tenure_id as u8; 20]), &coinbase_tx, ExecutionCost::max_value()).unwrap();
+
+                if tenure_id == bad_block_tenure {
+                    // corrupt the block
+                    eprintln!("\n\ncorrupt block {:?}\nparent: {:?}\n", &anchored_block.0.header, &parent_tip.anchored_header);
+                    anchored_block.0.header.state_index_root = TrieHash([0xff; 32]);
+                }
+
+                (anchored_block.0, vec![])
+            });
+
+            if tenure_id == bad_block_tenure + 1 {
+                // adjust
+                for i in 0..burn_ops.len() {
+                    if let BlockstackOperationType::LeaderBlockCommit(ref mut opdata) = burn_ops[i] {
+                        opdata.parent_block_ptr = (resume_tenure_parent_commit.as_ref().unwrap().block_height as u32) - 1;
+                    }
+                }
+            }
+            else if tenure_id == bad_block_tenure {
+                // adjust
+                for i in 0..burn_ops.len() {
+                    if let BlockstackOperationType::LeaderBlockCommit(ref mut opdata) = burn_ops[i] {
+                        opdata.parent_block_ptr = (bad_block_parent_commit.as_ref().unwrap().block_height as u32) - 1;
+                        eprintln!("\n\ncorrupt block commit is now {:?}\n", opdata);
+                    }
+                }
+            }
+            else if tenure_id == bad_block_ancestor_tenure {
+                // find
+                for i in 0..burn_ops.len() {
+                    if let BlockstackOperationType::LeaderBlockCommit(ref mut opdata) = burn_ops[i] {
+                        bad_block_parent_commit = Some(opdata.clone());
+                    }
+                }
+            }
+            else if tenure_id == resume_parent_tenure {
+                // find 
+                for i in 0..burn_ops.len() {
+                    if let BlockstackOperationType::LeaderBlockCommit(ref mut opdata) = burn_ops[i] {
+                        resume_tenure_parent_commit = Some(opdata.clone());
+                    }
+                }
+            }
+
+            if tenure_id != bad_block_tenure { 
+                last_block = Some(stacks_block.clone());
+                last_valid_block = last_block.clone();
+            }
+            else {
+                last_block = last_valid_block.clone();
+            }
+
+            let (_, burn_header_hash) = peer.next_burnchain_block(burn_ops.clone());
+            peer.process_stacks_epoch(&stacks_block, &burn_header_hash, &microblocks);
+        }
+    }
 
     // TODO: invalid block with duplicate microblock public key hash (okay between forks, but not
     // within the same fork)

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -2150,6 +2150,38 @@ pub mod test {
             self.sortdb = Some(sortdb);
             self.stacks_node = Some(node);
         }
+        
+        pub fn process_stacks_epoch(&mut self, block: &StacksBlock, burn_header_hash: &BurnchainHeaderHash, microblocks: &Vec<StacksMicroblock>) -> () {
+            let mut sortdb = self.sortdb.take().unwrap();
+            let mut node = self.stacks_node.take().unwrap();
+            {
+                let ic = sortdb.index_conn();
+                Relayer::process_new_anchored_block(&ic, &mut node.chainstate, burn_header_hash, block).unwrap();
+                
+                let block_hash = block.block_hash();
+                for mblock in microblocks.iter() {
+                    node.chainstate.preprocess_streamed_microblock(burn_header_hash, &block_hash, mblock).unwrap();
+                }
+            }
+    
+            loop {
+                let processed = node.chainstate.process_blocks(&mut sortdb, 1).unwrap();
+                if processed.len() == 0 {
+                    break;
+                }
+                match processed[0] {
+                    (Some(ref header_info), _) => {
+                        continue;
+                    },
+                    (None, _) => {
+                        break;
+                    }
+                }
+            }
+
+            self.sortdb = Some(sortdb);
+            self.stacks_node = Some(node);
+        }
 
         pub fn add_empty_burnchain_block(&mut self) -> (u64, BurnchainHeaderHash) {
             self.next_burnchain_block(vec![])

--- a/src/net/relay.rs
+++ b/src/net/relay.rs
@@ -470,7 +470,7 @@ impl Relayer {
     }
 
     /// Insert a staging block
-    fn process_new_anchored_block(sort_ic: &SortitionDBConn, chainstate: &mut StacksChainState, burn_header_hash: &BurnchainHeaderHash, block: &StacksBlock) -> Result<bool, chainstate_error> {
+    pub fn process_new_anchored_block(sort_ic: &SortitionDBConn, chainstate: &mut StacksChainState, burn_header_hash: &BurnchainHeaderHash, block: &StacksBlock) -> Result<bool, chainstate_error> {
         let db_handle = SortitionHandleConn::open_reader_stubbed(sort_ic, burn_header_hash)?;
 
         let sn = match db_handle.get_block_snapshot(burn_header_hash)? {

--- a/testnet/stacks-node/Cargo.toml
+++ b/testnet/stacks-node/Cargo.toml
@@ -18,6 +18,7 @@ async-h1 = "=1.0"
 async-std = { version = "<1.6", features = ["attributes"] }
 http-types = "1.0"
 base64 = "0.12.0"
+backtrace = "0.3.50"
 
 [dev-dependencies]
 warp = "0.2"

--- a/testnet/stacks-node/src/main.rs
+++ b/testnet/stacks-node/src/main.rs
@@ -35,10 +35,14 @@ use std::env;
 use std::panic;
 use std::process;
 
+use backtrace::Backtrace;
+
 fn main() {
 
     panic::set_hook(Box::new(|_| {
         eprintln!("Process abort due to thread panic");
+        let bt = Backtrace::new();
+        eprintln!("{:?}", &bt);
         process::exit(1);
     }));
 


### PR DESCRIPTION
This PR includes #1763, and adds two additional goodies:

* It adds a high-level testcase in which we confirm that it is possible to render a StacksChainState in an unusable state by processing a block with an invalid state root, and then processing a valid but non-sibling block.  This was due to the fact that on processing an invalid block, the cached ancestor trie root hashes in the inner Clarity MARF's storage were not getting cleared (which in turn would cause subsequent attempts to process blocks to produce invalid trie root hashes).

* It adds another low-level tool to `blockstack-core` to replay a chainstate's blocks and sortitions.  This was crucial in ruling out possible causes for the above bug.