### PR TITLE
implement withdraw-reward

### DIFF
--- a/src/chainstate/stacks/db/mod.rs
+++ b/src/chainstate/stacks/db/mod.rs
@@ -463,40 +463,12 @@ const STACKS_CHAIN_STATE_SQL : &'static [&'static str]= &[
 const STACKS_MINER_AUTH_KEY : &'static str = "a5879925788dcb3fe1f2737453e371ba04c4064e6609552ef59a126ac4fa598001";
 
 const STACKS_BOOT_CODE : &'static [&'static str] = &[
-    r#"
-    (define-constant ERR-NO-BALANCE u5)
-
-    (define-map rewards
-        ((participant principal))
-        ((available uint))
-    )
-    (define-private (get-participant-info (participant principal))
-        (default-to {available: u0} (map-get? rewards {participant: participant})))
-
-    (define-read-only (get-participant-reward (participant principal))
-        (ok (get available (get-participant-info participant))))
-
-    (define-public (withdraw-reward)
-        (let ((caller-address tx-sender) (contract-address (as-contract tx-sender)) (available (get available (get-participant-info tx-sender))))
-            (if (> available u0)
-                (match
-                    (as-contract (stx-transfer? available contract-address caller-address))
-                    value (begin (map-set rewards {participant: caller-address} {available: u0}) (ok available))
-                    err-value (err err-value))
-                (err ERR-NO-BALANCE))))
-    "#
 ];
 
 pub const STACKS_BOOT_CODE_CONTRACT_ADDRESS : &'static str = "ST000000000000000000002AMW42H";
 
 const STACKS_BOOT_CODE_CONTRACT_NAMES : &'static [&'static str] = &[
-    "miner-rewards"
 ];
-
-pub const BOOT_CODE_MINER_CONTRACT_NAME : &'static str = "miner-rewards";
-pub const BOOT_CODE_MINER_REWARDS_MAP : &'static str = "rewards";
-pub const BOOT_CODE_MINER_REWARDS_PARTICIPANT : &'static str = "participant";
-pub const BOOT_CODE_MINER_REWARDS_AVAILABLE : &'static str = "available";
 
 #[cfg(test)]
 pub const MINER_REWARD_MATURITY : u64 = 2;       // small for testing purposes

--- a/src/chainstate/stacks/db/mod.rs
+++ b/src/chainstate/stacks/db/mod.rs
@@ -458,7 +458,7 @@ const STACKS_CHAIN_STATE_SQL : &'static [&'static str]= &[
 ];
 
 /// Built-in "system-level" smart contracts that are there from the beginning.
-/// Includes BNS and the miner trust fund.
+/// Includes BNS, PoX.
 #[cfg(test)]
 const STACKS_MINER_AUTH_KEY : &'static str = "a5879925788dcb3fe1f2737453e371ba04c4064e6609552ef59a126ac4fa598001";
 

--- a/src/chainstate/stacks/miner.rs
+++ b/src/chainstate/stacks/miner.rs
@@ -1167,52 +1167,10 @@ pub mod test {
             return None;
         }
 
-        pub fn get_miner_status<'a>(clarity_tx: &mut ClarityTx<'a>, addr: &StacksAddress) -> Option<u128> {
-            let boot_code_address = StacksAddress::from_string(&STACKS_BOOT_CODE_CONTRACT_ADDRESS.to_string()).unwrap();
-            let miner_contract_id = QualifiedContractIdentifier::new(StandardPrincipalData::from(boot_code_address.clone()), ContractName::try_from(BOOT_CODE_MINER_CONTRACT_NAME.to_string()).unwrap());
-            
-            let miner_participant_principal = ClarityName::try_from(BOOT_CODE_MINER_REWARDS_PARTICIPANT.to_string()).unwrap();
-            let miner_available_name = ClarityName::try_from(BOOT_CODE_MINER_REWARDS_AVAILABLE.to_string()).unwrap();
-            
-            let miner_principal = Value::Tuple(TupleData::from_data(vec![
-                    (miner_participant_principal, Value::Principal(PrincipalData::Standard(StandardPrincipalData::from(addr.clone()))))])
-                .expect("FATAL: failed to construct miner principal key"));
-
-            let miner_status = clarity_tx.with_clarity_db_readonly(|db| {
-                let miner_status_opt = db.fetch_entry(&miner_contract_id, BOOT_CODE_MINER_REWARDS_MAP, &miner_principal)
-                    .expect("FATAL: Clarity DB Error");
-                let miner_status = match miner_status_opt {
-                    Value::Optional(ref optional_data) => {
-                        match optional_data.data {
-                            None => None,
-                            Some(ref miner_status) => {
-                                match **miner_status {
-                                    Value::Tuple(ref tuple) => {
-                                        let available = match tuple.get(&miner_available_name).expect("FATAL: no miner available in tuple") {
-                                            Value::UInt(ref available) => *available,
-                                            _ => {
-                                                panic!("FATAL: miner reward data map is malformed");
-                                            }
-                                        };
-                                        
-                                        Some(available)
-                                    },
-                                    ref x => {
-                                        panic!("FATAL: miner status is not a tuple: {:?}", &x);
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    ref x => {
-                        panic!("FATAL: fetched miner status it not an optional: {:?}", &x);
-                    }
-                };
-            
-                miner_status
-            });
-
-            miner_status
+        pub fn get_miner_balance<'a>(clarity_tx: &mut ClarityTx<'a>, addr: &StacksAddress) -> u128 {
+            clarity_tx.with_clarity_db_readonly(|db| {
+                db.get_account_stx_balance(&StandardPrincipalData::from(addr.clone()).into())
+            })
         }
 
         pub fn make_tenure_commitment(&mut self, 
@@ -1370,20 +1328,16 @@ pub mod test {
             }
         }
 
-        let miner_status_opt = TestStacksNode::get_miner_status(clarity_tx, &miner.origin_address().unwrap());
-        match miner_status_opt {
-            None => {
-                test_debug!("Miner {} '{}' has no mature funds in this fork", miner.id, miner.origin_address().unwrap().to_string());
-                return total == 0;
+        let amount = TestStacksNode::get_miner_balance(clarity_tx, &miner.origin_address().unwrap());
+        if amount == 0 {
+            test_debug!("Miner {} '{}' has no mature funds in this fork", miner.id, miner.origin_address().unwrap().to_string());
+            return total == 0;
+        } else {
+            if amount != total {
+                test_debug!("Amount {} != {}", amount, total);
+                return false;
             }
-            Some(amount) => {
-                test_debug!("Miner {} '{}' with amount: {} in this fork", miner.id, miner.origin_address().unwrap().to_string(), amount);
-                if amount != total {
-                    test_debug!("Amount {} != {}", amount, total);
-                    return false;
-                }
-                return true;
-            }
+            return true;
         }
     }
 


### PR DESCRIPTION
This is a  possible implementation of the `withdraw reward` functionality for the `miner-rewards` contract.  It also removes the `authorized` part as discussed with @jcnelson via discord.

Unexpectedly, meaning I had originally not thought that part through, for the contract to be able to disburse STX to miners, not only does the reward code need to update the amount `available` for a given miner, it also needs to credit the contract with the corresponding STX so the contract can transfer them when requested.  Would there be a different way to approach this?

Also, having a miner withdraw by sending a transaction, if that miner also mines the block, will mean we have 2 transactions for the same address in a block, and the admission checks in `mempool.submit` will fail if you send in the *correct* nonce value.  The admission check wants the 2 nonces to be equal, but the execution code wants them to be consecutive (rightfully).
This would mean that in practice, the miner would need to stop mining to be able to withdraw (this is related to https://github.com/blockstack/stacks-blockchain/issues/1719, but may require a separate fix as this is related to adding to the mempool (not sure if this is used when receiving transactions by the api, or via peers), but that was a problem for the test).

I tried to use the simplest possible approach while still checking for possible errors.  The contract could gather all sort of stats (this can be done by analyzing the stacks chain), and maybe allow the miner to withdraw to a different address, but not sure that's really needed.

With all this said... and done, I'm not so sure anymore that using a contract is really necessary here.  Sure, this is pretty cool, and it works, but maybe things would be simpler if the miner's address was directly credited when the reward becomes available?  Unless there are other things planned for the `miner-rewards` contract?
