### PR TITLE
Fix/net 1750

### DIFF
--- a/src/chainstate/stacks/db/blocks.rs
+++ b/src/chainstate/stacks/db/blocks.rs
@@ -1115,7 +1115,7 @@ impl StacksChainState {
 
     /// Get an anchored block's parent block header.
     /// Doesn't matter if it's staging or not.
-    pub fn load_parent_block_header(sort_ic: &SortitionDBConn, _blocks_conn: &DBConn, blocks_path: &String, 
+    pub fn load_parent_block_header(sort_ic: &SortitionDBConn, blocks_path: &String, 
                                     burn_header_hash: &BurnchainHeaderHash, anchored_block_hash: &BlockHeaderHash) -> Result<Option<(StacksBlockHeader, BurnchainHeaderHash)>, Error> {
         let header = match StacksChainState::load_block_header(blocks_path, burn_header_hash, anchored_block_hash)? {
             Some(hdr) => hdr,
@@ -5098,7 +5098,6 @@ pub mod test {
         }
     }
 
-   
     // TODO: test multiple anchored blocks confirming the same microblock stream (in the same
     // place, and different places, with/without orphans)
     // TODO: process_next_staging_block

--- a/src/chainstate/stacks/db/blocks.rs
+++ b/src/chainstate/stacks/db/blocks.rs
@@ -1128,13 +1128,13 @@ impl StacksChainState {
 
         // find all blocks that we have that could be this block's parent
         let sql = "SELECT * FROM snapshots WHERE winning_stacks_block_hash = ?1";
-        let possible_parent_snapshots = query_rows::<BlockSnapshot, _>(
-            &sort_handle, &sql, &[&header.parent_block])?;
+        let possible_parent_snapshots = query_rows::<BlockSnapshot, _>(&sort_handle, &sql, &[&header.parent_block])?;
         for possible_parent in possible_parent_snapshots.into_iter() {
             let burn_ancestor = sort_handle.get_block_snapshot(&possible_parent.burn_header_hash)?;
             if let Some(ancestor) = burn_ancestor {
                 // found!
-                let ret = StacksChainState::load_block_header(blocks_path, &ancestor.burn_header_hash, anchored_block_hash)?
+                // NOTE: this will be None if the parent block was orphaned
+                let ret = StacksChainState::load_block_header(blocks_path, &ancestor.burn_header_hash, &header.parent_block)?
                     .map(|header| { (header, ancestor.burn_header_hash) });
 
                 return Ok(ret);

--- a/src/chainstate/stacks/db/mod.rs
+++ b/src/chainstate/stacks/db/mod.rs
@@ -1089,12 +1089,10 @@ impl StacksChainState {
         ];
 
         // store each indexed field
-        test_debug!("Headers index_put_begin {}-{}", &parent_hash, &new_tip.index_block_hash(new_burn_block));
         headers_tx.put_indexed_begin(&parent_hash, &new_tip.index_block_hash(new_burn_block))
             .map_err(Error::DBError)?;
         let root_hash = headers_tx.put_indexed_all(&indexed_keys, &indexed_values)
             .map_err(Error::DBError)?;
-        test_debug!("Headers index_commit {}-{}", &parent_hash, &new_tip.index_block_hash(new_burn_block));
         
         let new_tip_info = StacksHeaderInfo {
             anchored_header: new_tip.clone(),

--- a/src/net/download.rs
+++ b/src/net/download.rs
@@ -789,7 +789,7 @@ impl PeerNetwork {
                     // does this anchor block _confirm_ a microblock stream that we don't know about?
                     let parent_header_opt = {
                         let ic = sortdb.index_conn();
-                        match StacksChainState::load_parent_block_header(&ic, &chainstate.blocks_db, &chainstate.blocks_path, &burn_header_hash, &block_hash) {
+                        match StacksChainState::load_parent_block_header(&ic, &chainstate.blocks_path, &burn_header_hash, &block_hash) {
                             Ok(header_opt) => header_opt,
                             Err(chainstate_error::DBError(db_error::NotFoundError)) => {
                                 // we don't know about this parent block yet


### PR DESCRIPTION
This fixes #1750.  This test was timing out due to a regression in the way we load a block's parent's header -- no header would ever be loaded, leading to the test spinning forever because it couldn't discover the confirmed anchored block that produced a given microblock stream.

Opening against `master` because it's a hotfix.  Will merge into `next` afterwards (will need to be modified for `next` since it depends on using the burn header hash to query the sortition DB and chainstate DB; this will need to be switched to the consensus hash in `next`).