### PR TITLE
Fix/net p2p handle deadlock

### DIFF
--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -170,6 +170,8 @@ pub enum Error {
     InvalidMessage,
     /// Invalid network handle
     InvalidHandle,
+    /// Network handle is full
+    FullHandle,
     /// Invalid handshake 
     InvalidHandshake,
     /// Stale neighbor
@@ -266,6 +268,7 @@ impl fmt::Display for Error {
             Error::RecvError(ref s) => fmt::Display::fmt(s, f),
             Error::InvalidMessage => write!(f, "invalid message (malformed or bad signature)"),
             Error::InvalidHandle => write!(f, "invalid network handle"),
+            Error::FullHandle => write!(f, "network handle is full and needs to be drained"),
             Error::InvalidHandshake => write!(f, "invalid handshake from remote peer"),
             Error::StaleNeighbor => write!(f, "neighbor is too far behind the chain tip"),
             Error::NoSuchNeighbor => write!(f, "no such neighbor"),
@@ -319,6 +322,7 @@ impl error::Error for Error {
             Error::RecvError(ref _s) => None,
             Error::InvalidMessage => None,
             Error::InvalidHandle => None,
+            Error::FullHandle => None,
             Error::InvalidHandshake => None,
             Error::StaleNeighbor => None,
             Error::NoSuchNeighbor => None,

--- a/src/net/relay.rs
+++ b/src/net/relay.rs
@@ -435,7 +435,7 @@ impl Relayer {
     }
 
     pub fn from_p2p(network: &mut PeerNetwork) -> Relayer {
-        let handle = network.new_handle(1024, 1024);
+        let handle = network.new_handle(1024);
         Relayer::new(handle)
     }
 
@@ -952,13 +952,6 @@ impl Relayer {
                     }
                 }
 
-                // drain and log errors from the p2p thread's attempt to handle our request
-                while let Some(relay_result) = self.p2p.next_result() {
-                    if let Err(relay_error) = relay_result {
-                        warn!("Message relay error: {:?}", &relay_error);
-                    }
-                }
-
                 receipts
             },
             Err(e) => {
@@ -1147,11 +1140,11 @@ impl PeerNetwork {
     pub fn advertize_blocks(&mut self, availability_data: BlocksAvailableMap) -> Result<(), net_error> {
         let (mut outbound_recipients, mut inbound_recipients) = self.find_block_recipients(&availability_data)?;
         for recipient in outbound_recipients.drain(..) {
-            test_debug!("{:?}: Advertize {} blocks to outbound peer {}", &self.local_peer, availability_data.len(), &recipient);
+            debug!("{:?}: Advertize {} blocks to outbound peer {}", &self.local_peer, availability_data.len(), &recipient);
             self.advertize_to_outbound_peer(&recipient, &availability_data, false)?;
         }
         for recipient in inbound_recipients.drain(..) {
-            test_debug!("{:?}: Advertize {} blocks to inbound peer {}", &self.local_peer, availability_data.len(), &recipient);
+            debug!("{:?}: Advertize {} blocks to inbound peer {}", &self.local_peer, availability_data.len(), &recipient);
             self.advertize_to_inbound_peer(&recipient, &availability_data, |payload| StacksMessageType::BlocksAvailable(payload))?;
         }
         Ok(())
@@ -1165,11 +1158,11 @@ impl PeerNetwork {
     pub fn advertize_microblocks(&mut self, availability_data: BlocksAvailableMap) -> Result<(), net_error> {
         let (mut outbound_recipients, mut inbound_recipients) = self.find_block_recipients(&availability_data)?;
         for recipient in outbound_recipients.drain(..) {
-            test_debug!("{:?}: Advertize {} confirmed microblock streams to outbound peer {}", &self.local_peer, availability_data.len(), &recipient);
+            debug!("{:?}: Advertize {} confirmed microblock streams to outbound peer {}", &self.local_peer, availability_data.len(), &recipient);
             self.advertize_to_outbound_peer(&recipient, &availability_data, true)?;
         }
         for recipient in inbound_recipients.drain(..) {
-            test_debug!("{:?}: Advertize {} confirmed microblock streams to inbound peer {}", &self.local_peer, availability_data.len(), &recipient);
+            debug!("{:?}: Advertize {} confirmed microblock streams to inbound peer {}", &self.local_peer, availability_data.len(), &recipient);
             self.advertize_to_inbound_peer(&recipient, &availability_data, |payload| StacksMessageType::MicroblocksAvailable(payload))?;
         }
         Ok(())


### PR DESCRIPTION
To the best of my ability to tell, the testnet deadlocked over the weekend.  I _think_ this can arise if the relayer or p2p thread get too far behind one another.  Looking at the stack trace of the node's core dump, we see the following thread stoppages:

* The miner thread is blocked on trying to queue up a `RelayerDirective` to process its tenure
* The relayer thread, in turn, is blocked on a call to `advertise_blocks()`.  Crucially, _there is no trace in the recent log history of the relayer processing any request_.  So, this call has been stalled for quite some time, and the relayer thread has not been making progress.
* The p2p thread, in turn, is blocked on a call to `handle.out_channel.send()` in `PeerNetwork::dispatch_requests()`, meaning that it has been trying to send the relayer thread the result of doing some prior work but the relayer has not consumed it.  _There has been no recent p2p thread activity either_.

I think the relayer thread and p2p thread have deadlocked each other.

This fix does the following:
* It makes `PeerNetwork::send_request()` (i.e. what the relayer thread ultimately calls to send messages on the peer network) fail if the channel is full, with `net::Error::FullHandle`.
* It makes it so `PeerNetwork::send_request()` blocks on waiting for the p2p thread to reply to it if the channel is full, so it won't flood the channel with requests.
* It makes it so `PeerNetwork::dispatch_requests()` never blocks -- if a client handle's channel is full, then the peer network will drop the response to the request.
* It makes it so `PeerNetwork::send_request()` will never receive anything other than an error message -- i.e. it won't return a reply handle.  This means that the consequences of the above dropping behavior will be minimal -- at worst, the error message will be logged by the p2p thread instead of the relayer thread.

I need to run the full network test suite on this PR to make sure that nothing else has broken by this change.