### PR TITLE
PoX anchor block detection

### DIFF
--- a/src/burnchains/burnchain.rs
+++ b/src/burnchains/burnchain.rs
@@ -1295,7 +1295,7 @@ pub mod tests {
             burn_header_timestamp: 121,
             parent_burn_header_hash: first_burn_hash.clone(),
             ops_hash: block_opshash_121.clone(),
-            consensus_hash: ConsensusHash::from_ops(&block_121_hash, &block_opshash_121, 0, &block_prev_chs_121),
+            consensus_hash: ConsensusHash::from_ops(&block_121_hash, &block_opshash_121, 0, &block_prev_chs_121, &PoxId::stubbed()),
             total_burn: 0,
             sortition: false,
             sortition_hash: SortitionHash::initial()
@@ -1328,7 +1328,7 @@ pub mod tests {
             burn_header_timestamp: 122,
             parent_burn_header_hash: block_121_hash.clone(),
             ops_hash: block_opshash_122.clone(),
-            consensus_hash: ConsensusHash::from_ops(&block_122_hash, &block_opshash_122, 0, &block_prev_chs_122),
+            consensus_hash: ConsensusHash::from_ops(&block_122_hash, &block_opshash_122, 0, &block_prev_chs_122, &PoxId::stubbed()),
             total_burn: 0,
             sortition: false,
             sortition_hash: SortitionHash::initial()
@@ -1367,7 +1367,7 @@ pub mod tests {
             burn_header_timestamp: 123,
             parent_burn_header_hash: block_122_hash.clone(),
             ops_hash: block_opshash_123.clone(),
-            consensus_hash: ConsensusHash::from_ops(&block_123_hash, &block_opshash_123, 0, &block_prev_chs_123),        // user burns not included, so zero burns this block
+            consensus_hash: ConsensusHash::from_ops(&block_123_hash, &block_opshash_123, 0, &block_prev_chs_123, &PoxId::stubbed()),        // user burns not included, so zero burns this block
             total_burn: 0,
             sortition: false,
             sortition_hash: SortitionHash::initial()
@@ -1515,7 +1515,7 @@ pub mod tests {
                 burn_header_timestamp: 124,
                 parent_burn_header_hash: block_123_snapshot.burn_header_hash.clone(),
                 ops_hash: block_opshash_124.clone(),
-                consensus_hash: ConsensusHash::from_ops(&block_124_hash, &block_opshash_124, burn_total, &block_prev_chs_124),
+                consensus_hash: ConsensusHash::from_ops(&block_124_hash, &block_opshash_124, burn_total, &block_prev_chs_124, &PoxId::stubbed()),
                 total_burn: burn_total,
                 sortition: next_sortition,
                 sortition_hash: SortitionHash::initial()

--- a/src/burnchains/burnchain.rs
+++ b/src/burnchains/burnchain.rs
@@ -347,11 +347,13 @@ impl Burnchain {
     }
 
     pub fn is_reward_cycle_start(&self, block_height: u64) -> bool {
-        if block_height < self.first_block_height {
+        if block_height <= (self.first_block_height + 1) {
+            // not a reward cycle start if we're the first block after genesis.
             false
         } else {
             let effective_height = block_height - self.first_block_height;
-            (effective_height % (self.pox_constants.reward_cycle_length as u64)) == 0
+            // first block of the new reward cycle
+            (effective_height % (self.pox_constants.reward_cycle_length as u64)) == 1
         }
     }
 

--- a/src/burnchains/mod.rs
+++ b/src/burnchains/mod.rs
@@ -269,7 +269,37 @@ pub struct Burnchain {
     pub stable_confirmations: u32,
     pub first_block_height: u64,
     pub first_block_hash: BurnchainHeaderHash,
-    pub reward_cycle_period: u64,
+    pub pox_constants: PoxConstants,
+}
+
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+pub struct PoxConstants {
+    /// the length (in burn blocks) of the reward cycle
+    pub reward_cycle_length: u32,
+    /// the length (in burn blocks) of the prepare phase
+    pub prepare_length: u32,
+    /// the number of confirmations a PoX anchor block must
+    ///  receive in order to become the anchor. must be at least > prepare_length/2
+    pub anchor_threshold: u32
+}
+
+impl PoxConstants {
+    #[cfg(test)]
+    pub fn test_default() -> PoxConstants {
+        PoxConstants {
+            reward_cycle_length: 10,
+            prepare_length: 5,
+            anchor_threshold: 3
+        }
+    }
+
+    pub fn mainnet_default() -> PoxConstants {
+        PoxConstants {
+            reward_cycle_length: 1000,
+            prepare_length: 240,
+            anchor_threshold: 192
+        }
+    }
 }
 
 /// Structure for encoding our view of the network 

--- a/src/chainstate/burn/db/processing.rs
+++ b/src/chainstate/burn/db/processing.rs
@@ -133,7 +133,7 @@ impl <'a> SortitionHandleTx <'a> {
         let next_sortition_id = SortitionId::new(&this_block_hash, &next_pox);
 
         // do the cryptographic sortition and pick the next winning block.
-        let mut snapshot = BlockSnapshot::make_snapshot(&self.as_conn(), burnchain, &next_sortition_id,
+        let mut snapshot = BlockSnapshot::make_snapshot(&self.as_conn(), burnchain, &next_sortition_id, &next_pox,
                                                         parent_snapshot, block_header, &state_transition.burn_dist, &txids)
             .map_err(|e| {
                 error!("TRANSACTION ABORTED when taking snapshot at block {} ({}): {:?}", this_block_height, &this_block_hash, e);

--- a/src/chainstate/burn/db/processing.rs
+++ b/src/chainstate/burn/db/processing.rs
@@ -119,7 +119,18 @@ impl <'a> SortitionHandleTx <'a> {
 
         let txids = state_transition.accepted_ops.iter().map(|ref op| op.txid()).collect();
 
-        let next_sortition_id = SortitionId::new(&this_block_hash, &parent_pox);
+        let mut next_pox = parent_pox;
+        if let Some(ref next_pox_info) = next_pox_info {
+            if next_pox_info.anchor_block_known {
+                info!("Begin reward-cycle sortition with present anchor block={:?}", &next_pox_info.anchor_block);
+                next_pox.extend_with_present_block();
+            } else {
+                info!("Begin reward-cycle sortition with absent anchor block={:?}", &next_pox_info.anchor_block);
+                next_pox.extend_with_not_present_block();
+            }
+        };
+
+        let next_sortition_id = SortitionId::new(&this_block_hash, &next_pox);
 
         // do the cryptographic sortition and pick the next winning block.
         let mut snapshot = BlockSnapshot::make_snapshot(&self.as_conn(), burnchain, &next_sortition_id,

--- a/src/chainstate/burn/db/sortdb.rs
+++ b/src/chainstate/burn/db/sortdb.rs
@@ -1111,21 +1111,6 @@ impl PoxId {
         self.0.push(false);
     }
 
-    /// does the given pox identifier describe a child fork of the current pox identifier? this returns true if they
-    ///   are equal or child is a descendant.
-    pub fn is_pox_id_descendant(&self, child: &PoxId) -> bool {
-        if child.0.len() < self.0.len() {
-            false
-        } else {
-            for (a, b) in self.0.iter().zip(child.0.iter()) {
-                if a != b {
-                    return false;
-                }
-            }
-            true
-        }
-    }
-
     pub fn stubbed() -> PoxId {
         PoxId(vec![])
     }

--- a/src/chainstate/burn/operations/leader_block_commit.rs
+++ b/src/chainstate/burn/operations/leader_block_commit.rs
@@ -392,9 +392,7 @@ mod tests {
     use burnchains::bitcoin::keys::BitcoinPublicKey;
     use burnchains::bitcoin::address::BitcoinAddress;
     use burnchains::bitcoin::blocks::BitcoinBlockParser;
-    use burnchains::Txid;
-    use burnchains::BLOCKSTACK_MAGIC_MAINNET;
-    use burnchains::BurnchainBlockHeader;
+    use burnchains::*;
 
     use burnchains::bitcoin::BitcoinNetworkType;
 
@@ -573,7 +571,7 @@ mod tests {
         ];
         
         let burnchain = Burnchain {
-            reward_cycle_period: 10,
+            pox_constants: PoxConstants::test_default(),
             peer_version: 0x012345678,
             network_id: 0x9abcdef0,
             chain_name: "bitcoin".to_string(),

--- a/src/chainstate/burn/operations/leader_key_register.rs
+++ b/src/chainstate/burn/operations/leader_key_register.rs
@@ -253,9 +253,7 @@ pub mod tests {
     use burnchains::bitcoin::keys::BitcoinPublicKey;
     use burnchains::bitcoin::blocks::BitcoinBlockParser;
     use burnchains::bitcoin::BitcoinNetworkType;
-    use burnchains::Txid;
-    use burnchains::BurnchainBlockHeader;
-    use burnchains::BLOCKSTACK_MAGIC_MAINNET;
+    use burnchains::*;
 
     use deps::bitcoin::network::serialize::deserialize;
     use deps::bitcoin::blockdata::transaction::Transaction;
@@ -446,7 +444,7 @@ pub mod tests {
         ];
 
         let burnchain = Burnchain {
-            reward_cycle_period: 10,
+            pox_constants: PoxConstants::test_default(),
             peer_version: 0x012345678,
             network_id: 0x9abcdef0,
             chain_name: "bitcoin".to_string(),

--- a/src/chainstate/burn/operations/user_burn_support.rs
+++ b/src/chainstate/burn/operations/user_burn_support.rs
@@ -439,7 +439,7 @@ mod tests {
             block_131_hash.clone(),
         ];
         let burnchain = Burnchain {
-            reward_cycle_period: 10,
+            pox_constants: PoxConstants::test_default(),
             peer_version: 0x012345678,
             network_id: 0x9abcdef0,
             chain_name: "bitcoin".to_string(),

--- a/src/chainstate/burn/sortition.rs
+++ b/src/chainstate/burn/sortition.rs
@@ -174,7 +174,9 @@ impl BlockSnapshot {
     }
 
     /// Make the snapshot struct for the case where _no sortition_ takes place
-    fn make_snapshot_no_sortition(ic: &SortitionHandleConn, sortition_id: &SortitionId, parent_snapshot: &BlockSnapshot, block_header: &BurnchainBlockHeader, first_block_height: u64, burn_total: u64, sortition_hash: &SortitionHash, txids: &Vec<Txid>) -> Result<BlockSnapshot, db_error> {
+    fn make_snapshot_no_sortition(ic: &SortitionHandleConn, sortition_id: &SortitionId, pox_id: &PoxId,
+                                  parent_snapshot: &BlockSnapshot, block_header: &BurnchainBlockHeader, first_block_height: u64,
+                                  burn_total: u64, sortition_hash: &SortitionHash, txids: &Vec<Txid>) -> Result<BlockSnapshot, db_error> {
         let block_height = block_header.block_height;
         let block_hash = block_header.block_hash.clone();
         let parent_block_hash = block_header.parent_block_hash.clone();
@@ -184,7 +186,7 @@ impl BlockSnapshot {
 
         let ops_hash = OpsHash::from_txids(txids);
         let ch = ConsensusHash::from_parent_block_data(
-            ic, &ops_hash, block_height - 1, first_block_height, &block_hash, burn_total)?;
+            ic, &ops_hash, block_height - 1, first_block_height, &block_hash, burn_total, pox_id)?;
 
         debug!("SORTITION({}): NO BLOCK CHOSEN", block_height);
 
@@ -225,7 +227,7 @@ impl BlockSnapshot {
     /// 
     /// Call this *after* you store all of the block's transactions to the burn db.
     pub fn make_snapshot(ic: &SortitionHandleConn, burnchain: &Burnchain,
-                         my_sortition_id: &SortitionId,
+                         my_sortition_id: &SortitionId, my_pox_id: &PoxId,
                          parent_snapshot: &BlockSnapshot, block_header: &BurnchainBlockHeader,
                          burn_dist: &Vec<BurnSamplePoint>, txids: &Vec<Txid>) -> Result<BlockSnapshot, db_error> {
         assert_eq!(parent_snapshot.burn_header_hash, block_header.parent_block_hash);
@@ -241,11 +243,15 @@ impl BlockSnapshot {
         
         // next sortition hash
         let next_sortition_hash = last_sortition_hash.mix_burn_header(&block_hash);
+        let make_snapshot_no_sortition = || {
+            BlockSnapshot::make_snapshot_no_sortition(ic, my_sortition_id, my_pox_id, parent_snapshot, block_header,
+                                                      first_block_height, last_burn_total, &next_sortition_hash, &txids)
+        };
         
         if burn_dist.len() == 0 {
             // no burns happened
             debug!("No burns happened in block {} {:?}", block_height, &block_hash);
-            return BlockSnapshot::make_snapshot_no_sortition(ic, my_sortition_id, parent_snapshot, block_header, first_block_height, last_burn_total, &next_sortition_hash, &txids);
+            return make_snapshot_no_sortition();
         }
 
         // NOTE: this only counts burns from leader block commits and user burns that match them.
@@ -255,7 +261,7 @@ impl BlockSnapshot {
                 if total == 0 {
                     // no one burned, so no sortition
                     debug!("No transactions submitted burns in block {} {:?}", block_height, &block_hash);
-                    return BlockSnapshot::make_snapshot_no_sortition(ic, my_sortition_id, parent_snapshot, block_header, first_block_height, last_burn_total, &next_sortition_hash, &txids);
+                    return make_snapshot_no_sortition();
                 }
                 else {
                     total
@@ -264,7 +270,7 @@ impl BlockSnapshot {
             None => {
                 // overflow -- treat as 0 (no sortition)
                 warn!("Burn count exceeds maximum threshold");
-                return BlockSnapshot::make_snapshot_no_sortition(ic, my_sortition_id, parent_snapshot, block_header, first_block_height, last_burn_total, &next_sortition_hash, &txids);
+                return make_snapshot_no_sortition();
             }
         };
 
@@ -278,7 +284,7 @@ impl BlockSnapshot {
             None => {
                 // overflow.  Deny future sortitions
                 warn!("Cumulative sortition burn has overflown.  Subsequent sortitions will be denied.");
-                return BlockSnapshot::make_snapshot_no_sortition(ic, my_sortition_id, parent_snapshot, block_header, first_block_height, last_burn_total, &next_sortition_hash, &txids);
+                return make_snapshot_no_sortition();
             }
         };
 
@@ -291,7 +297,7 @@ impl BlockSnapshot {
         let final_sortition_hash = next_sortition_hash.mix_VRF_seed(&winning_block.new_seed);
         let next_ops_hash = OpsHash::from_txids(&txids);
         let next_ch = ConsensusHash::from_parent_block_data(
-            ic, &next_ops_hash, block_height - 1, first_block_height, &block_hash, next_burn_total)?;
+            ic, &next_ops_hash, block_height - 1, first_block_height, &block_hash, next_burn_total, my_pox_id)?;
 
         debug!("SORTITION({}): WINNER IS {:?} (from {:?})", block_height, &winning_block.block_header_hash, &winning_block.txid);
 
@@ -375,7 +381,7 @@ mod test {
             let pox_id = PoxId::stubbed();
             let sort_id = SortitionId::stubbed(&empty_block_header.block_hash);
             let ic = db.index_handle(&sort_id);
-            let sn = BlockSnapshot::make_snapshot(&ic, &burnchain, &sort_id, &initial_snapshot,
+            let sn = BlockSnapshot::make_snapshot(&ic, &burnchain, &sort_id, &pox_id, &initial_snapshot,
                                                   &empty_block_header, &vec![], &vec![]).unwrap();
             sn
         };
@@ -398,7 +404,7 @@ mod test {
             let sort_id = SortitionId::stubbed(&empty_block_header.block_hash);
             let pox_id = PoxId::stubbed();
             let ic = db.index_handle(&sort_id);
-            let sn = BlockSnapshot::make_snapshot(&ic, &burnchain, &sort_id, &initial_snapshot, &empty_block_header,
+            let sn = BlockSnapshot::make_snapshot(&ic, &burnchain, &sort_id, &pox_id, &initial_snapshot, &empty_block_header,
                                                   &vec![empty_burn_point.clone()], &vec![key.txid.clone()]).unwrap();
             sn
         };

--- a/src/chainstate/burn/sortition.rs
+++ b/src/chainstate/burn/sortition.rs
@@ -347,7 +347,7 @@ mod test {
         let first_block_height = 120;
 
         let burnchain = Burnchain {
-            reward_cycle_period: 10,
+            pox_constants: PoxConstants::test_default(),
             peer_version: 0x012345678,
             network_id: 0x9abcdef0,
             chain_name: "bitcoin".to_string(),

--- a/src/chainstate/coordinator/mod.rs
+++ b/src/chainstate/coordinator/mod.rs
@@ -268,8 +268,11 @@ impl <'a, T: BlockEventDispatcher, N: CoordinatorNotices> ChainsCoordinator <'a,
     fn get_reward_cycle_info(&self, burn_header: &BurnchainBlockHeader) -> Result<Option<RewardCycleInfo>, Error> {
         if self.burnchain.is_reward_cycle_start(burn_header.block_height) {
             info!("Beginning reward cycle. block_height={}", burn_header.block_height);
-            let ic = self.sortition_db.index_handle_at_tip();
-            if let Some((consensus_hash, stacks_block_hash)) = ic.get_reward_cycle_info(&burn_header.block_hash)? {
+            let reward_cycle_info = {
+                let ic = self.sortition_db.index_handle_at_tip();
+                ic.get_reward_cycle_info(&burn_header.parent_block_hash, &self.burnchain.pox_constants)
+            }?;
+            if let Some((consensus_hash, stacks_block_hash)) = reward_cycle_info {
                 let anchor_block_known = StacksChainState::is_stacks_block_processed(
                     &self.chain_state_db.headers_db, &consensus_hash, &stacks_block_hash)?;
                 Ok(Some(RewardCycleInfo {

--- a/src/chainstate/coordinator/tests.rs
+++ b/src/chainstate/coordinator/tests.rs
@@ -467,8 +467,15 @@ fn test_simple_setup() {
     }
 }
 
-// make it so that we can process the same block in two different pox forks
 #[test]
+// This test should panic until the MARF stability issue
+// https://github.com/blockstack/stacks-blockchain/issues/1805
+// is resolved:
+#[should_panic]
+/// Test a block that is processable in 2 PoX forks:
+///   block "11" should be processable in both `111` and `110`
+///   (because its parent is block `0`, and nobody stacks in
+///    this test, all block commits must burn)
 fn test_pox_processable_block_in_different_pox_forks() {
     let path = "/tmp/stacks-blockchain.test.pox_processable_block_in_different_pox_forks";
     // setup a second set of states that won't see the broadcasted blocks

--- a/src/chainstate/coordinator/tests.rs
+++ b/src/chainstate/coordinator/tests.rs
@@ -277,7 +277,7 @@ fn make_stacks_block(sort_db: &SortitionDB, state: &mut StacksChainState,
     let parent_vtxindex = SortitionDB::get_block_winning_vtxindex(sort_db.conn(), &parents_sortition.sortition_id)
         .unwrap().unwrap();
 
-    eprintln!("Find parents stacks header...");
+    eprintln!("Find parents stacks header: {} in sortition {}", &parent_block, &parents_sortition.sortition_id); 
     let parent_stacks_header = StacksChainState::get_anchored_block_header_info(&state.headers_db,
                                                                                 &parents_sortition.consensus_hash,
                                                                                 parent_block).unwrap().unwrap();
@@ -446,12 +446,9 @@ fn test_simple_setup() {
     let mut pox_id_string = "1".to_string();
     // now let's start revealing stacks blocks to the blinded coordinator
     for (sortition_id, block) in stacks_blocks.iter() {
-        let mut chainstate = get_chainstate(path_blinded);
-        let sortition = SortitionDB::get_block_snapshot(sort_db.conn(), &sortition_id)
-            .unwrap().unwrap();
-        preprocess_block(&mut chainstate, &sort_db_blind, &sortition, block.clone());
+        reveal_block(path_blinded, &sort_db_blind, &mut coord_blind,
+                     sortition_id, block);
 
-        coord_blind.handle_new_stacks_block().unwrap();
         let pox_id_at_tip = {
             let ic = sort_db_blind.index_handle_at_tip();
             ic.get_pox_id().unwrap()
@@ -470,13 +467,431 @@ fn test_simple_setup() {
     }
 }
 
+#[test]
+fn test_pox_no_anchor_selected() {
+    let path = "/tmp/stacks-blockchain.test.pox_fork_no_anchor_selected";
+    // setup a second set of states that won't see the broadcasted blocks
+    let path_blinded = "/tmp/stacks-blockchain.test.pox_fork_no_anchor_selected.blinded";
+    let _r = std::fs::remove_dir_all(path);
+    let _r = std::fs::remove_dir_all(path_blinded);
+
+    let vrf_keys: Vec<_> = (0..10).map(|_| VRFPrivateKey::new()).collect();
+    let committers: Vec<_> = (0..10).map(|_| StacksPrivateKey::new()).collect();
+
+    setup_states(&[path, path_blinded], &vrf_keys, &committers);
+
+    let mut coord = make_coordinator(path);
+    let mut coord_blind = make_coordinator(path_blinded);
+
+    coord.handle_new_burnchain_block().unwrap();
+    coord_blind.handle_new_burnchain_block().unwrap();
+
+    let sort_db = get_sortition_db(path);
+
+    let tip = SortitionDB::get_canonical_burn_chain_tip(sort_db.conn()).unwrap();
+    assert_eq!(tip.block_height, 1);
+    assert_eq!(tip.sortition, false);
+    let (_, ops) = sort_db.get_sortition_result(&tip.sortition_id).unwrap().unwrap();
+
+    let sort_db_blind = get_sortition_db(path_blinded);
+
+    let tip = SortitionDB::get_canonical_burn_chain_tip(sort_db_blind.conn()).unwrap();
+    assert_eq!(tip.block_height, 1);
+    assert_eq!(tip.sortition, false);
+    let (_, ops) = sort_db_blind.get_sortition_result(&tip.sortition_id).unwrap().unwrap();
+
+    // we should have all the VRF registrations accepted
+    assert_eq!(ops.accepted_ops.len(), vrf_keys.len());
+    assert_eq!(ops.consumed_leader_keys.len(), 0);
+
+    // at first, sortition_ids shouldn't have diverged
+    //  but once the first reward cycle begins, they should diverge.
+    let mut sortition_ids_diverged = false;
+    // process sequential blocks, and their sortitions...
+    let mut stacks_blocks: Vec<(SortitionId, StacksBlock)> = vec![];
+    let mut anchor_blocks = vec![];
+
+    // setup:
+    //   0 - 1 - 2 - 3 - 4 - 5 - 6
+    //    \_ 7   \_ 8 _ 9
+    for (ix, (vrf_key, miner)) in vrf_keys.iter().zip(committers.iter()).enumerate() {
+        let mut burnchain = get_burnchain_db(path);
+        let mut chainstate = get_chainstate(path);
+        eprintln!("Making block {}", ix);
+        let (op, block) =
+            if ix == 0 {
+                make_genesis_block(&sort_db, &mut chainstate, &BlockHeaderHash([0; 32]), miner, 10000, vrf_key, ix as u32)
+            } else {
+                let parent = if ix == 7 {
+                    stacks_blocks[0].1.header.block_hash()
+                } else if ix == 8 {
+                    stacks_blocks[2].1.header.block_hash()
+                } else {
+                    stacks_blocks[ix-1].1.header.block_hash()
+                };
+                make_stacks_block(&sort_db, &mut chainstate, &parent, miner, 10000, vrf_key, ix as u32)
+            };
+        let burnchain_tip = burnchain.get_canonical_chain_tip().unwrap();
+        let burnchain_blinded = get_burnchain_db(path_blinded);
+        produce_burn_block(&mut burnchain, &burnchain_tip.block_hash, vec![op], [burnchain_blinded].iter_mut());
+        // handle the sortition
+        coord.handle_new_burnchain_block().unwrap();
+        coord_blind.handle_new_burnchain_block().unwrap();
+
+        let b = get_burnchain(path);
+        let new_burnchain_tip = burnchain.get_canonical_chain_tip().unwrap();
+        if b.is_reward_cycle_start(new_burnchain_tip.block_height) {
+            eprintln!("Reward cycle start at height={}", new_burnchain_tip.block_height);
+            // processed first anchor block, not expecting a second one!
+            if anchor_blocks.len() == 1 {
+                let ic = sort_db.index_handle_at_tip();
+                assert!(ic.get_last_anchor_block_hash()
+                        .unwrap().is_none(), "No anchor block should have been chosen!");                
+            } else {
+                // the "blinded" sortition db and the one that's processed all the blocks
+                //   should have diverged in sortition_ids now...
+                sortition_ids_diverged = true;
+                // store the anchor block for this sortition for later checking
+                let ic = sort_db.index_handle_at_tip();
+                let bhh = ic.get_last_anchor_block_hash()
+                    .unwrap().unwrap();
+                eprintln!("Anchor block={}, selected at height={}", &bhh,
+                          SortitionDB::get_block_snapshot_for_winning_stacks_block(&sort_db.index_conn(),
+                                                                                   &ic.context.chain_tip,
+                                                                                   &bhh).unwrap().unwrap().block_height);
+                anchor_blocks.push(bhh);
+            }
+        }
+
+        let tip = SortitionDB::get_canonical_burn_chain_tip(sort_db.conn()).unwrap();
+        let blinded_tip = SortitionDB::get_canonical_burn_chain_tip(sort_db_blind.conn()).unwrap();
+        if sortition_ids_diverged {
+            assert_ne!(tip.sortition_id, blinded_tip.sortition_id,
+                       "Sortitions should have diverged by block height = {}", blinded_tip.block_height);
+        } else {
+            assert_eq!(tip.sortition_id, blinded_tip.sortition_id,
+                       "Sortitions should not have diverged at block height = {}", blinded_tip.block_height);
+        }
+
+        // load the block into staging
+        let block_hash = block.header.block_hash();
+        eprintln!("Block hash={}, ix={}", &block_hash, ix);
+
+        assert_eq!(&tip.winning_stacks_block_hash, &block_hash);
+        stacks_blocks.push((tip.sortition_id.clone(), block.clone()));
+
+        preprocess_block(&mut chainstate, &sort_db, &tip, block);
+
+        // handle the stacks block
+        coord.handle_new_stacks_block().unwrap();
+    }
+
+
+    let block_height = eval_at_chain_tip(path, &sort_db, "block-height");
+    assert_eq!(block_height, Value::UInt(7));
+
+    let block_height = eval_at_chain_tip(path_blinded, &sort_db_blind, "block-height");
+    assert_eq!(block_height, Value::UInt(0));
+
+    {
+        let ic = sort_db.index_handle_at_tip();
+        let pox_id = ic.get_pox_id().unwrap();
+        assert_eq!(&pox_id.to_string(),
+                   "111");
+    }
+
+    {
+        let ic = sort_db_blind.index_handle_at_tip();
+        let pox_id = ic.get_pox_id().unwrap();
+        assert_eq!(&pox_id.to_string(),
+                   "101");
+    }
+
+    for (sort_id, block) in stacks_blocks.iter() {
+        reveal_block(path_blinded, &sort_db_blind, &mut coord_blind,
+                     &sort_id, block);
+    }
+
+    {
+        let ic = sort_db_blind.index_handle_at_tip();
+        let pox_id = ic.get_pox_id().unwrap();
+        assert_eq!(&pox_id.to_string(),
+                   "111");
+    }
+
+
+    let block_height = eval_at_chain_tip(path_blinded, &sort_db_blind, "block-height");
+    assert_eq!(block_height, Value::UInt(7));
+}
+
+#[test]
+fn test_pox_fork_out_of_order() {
+    let path = "/tmp/stacks-blockchain.test.pox_fork_out_of_order";
+    // setup a second set of states that won't see the broadcasted blocks
+    let path_blinded = "/tmp/stacks-blockchain.test.pox_fork_out_of_order.blinded";
+    let _r = std::fs::remove_dir_all(path);
+    let _r = std::fs::remove_dir_all(path_blinded);
+
+    let vrf_keys: Vec<_> = (0..15).map(|_| VRFPrivateKey::new()).collect();
+    let committers: Vec<_> = (0..15).map(|_| StacksPrivateKey::new()).collect();
+
+    setup_states(&[path, path_blinded], &vrf_keys, &committers);
+
+    let mut coord = make_coordinator(path);
+    let mut coord_blind = make_coordinator(path_blinded);
+
+    coord.handle_new_burnchain_block().unwrap();
+    coord_blind.handle_new_burnchain_block().unwrap();
+
+    let sort_db = get_sortition_db(path);
+
+    let tip = SortitionDB::get_canonical_burn_chain_tip(sort_db.conn()).unwrap();
+    assert_eq!(tip.block_height, 1);
+    assert_eq!(tip.sortition, false);
+    let (_, ops) = sort_db.get_sortition_result(&tip.sortition_id).unwrap().unwrap();
+
+    let sort_db_blind = get_sortition_db(path_blinded);
+
+    let tip = SortitionDB::get_canonical_burn_chain_tip(sort_db_blind.conn()).unwrap();
+    assert_eq!(tip.block_height, 1);
+    assert_eq!(tip.sortition, false);
+    let (_, ops) = sort_db_blind.get_sortition_result(&tip.sortition_id).unwrap().unwrap();
+
+    // we should have all the VRF registrations accepted
+    assert_eq!(ops.accepted_ops.len(), vrf_keys.len());
+    assert_eq!(ops.consumed_leader_keys.len(), 0);
+
+    // at first, sortition_ids shouldn't have diverged
+    //  but once the first reward cycle begins, they should diverge.
+    let mut sortition_ids_diverged = false;
+    // process sequential blocks, and their sortitions...
+    let mut stacks_blocks: Vec<(SortitionId, StacksBlock)> = vec![];
+    let mut anchor_blocks = vec![];
+
+
+    // setup:
+    //  2 forks: 0 - 1 - 2 - 3 - 4 - 5 - 11 - 12 - 13 - 14 - 15
+    //            \_ 6 _ 7 _ 8 _ 9 _ 10
+    for (ix, (vrf_key, miner)) in vrf_keys.iter().zip(committers.iter()).enumerate() {
+        let mut burnchain = get_burnchain_db(path);
+        let mut chainstate = get_chainstate(path);
+        eprintln!("Making block {}", ix);
+        let (op, block) =
+            if ix == 0 {
+                make_genesis_block(&sort_db, &mut chainstate, &BlockHeaderHash([0; 32]), miner, 10000, vrf_key, ix as u32)
+            } else {
+                let parent = if ix == 1 {
+                    stacks_blocks[0].1.header.block_hash()
+                } else if ix == 6 {
+                    stacks_blocks[0].1.header.block_hash()
+                } else if ix == 11 {
+                    stacks_blocks[5].1.header.block_hash()
+                } else {
+                    stacks_blocks[ix-1].1.header.block_hash()
+                };
+                make_stacks_block(&sort_db, &mut chainstate, &parent, miner, 10000, vrf_key, ix as u32)
+            };
+        let burnchain_tip = burnchain.get_canonical_chain_tip().unwrap();
+        let burnchain_blinded = get_burnchain_db(path_blinded);
+        produce_burn_block(&mut burnchain, &burnchain_tip.block_hash, vec![op], [burnchain_blinded].iter_mut());
+        // handle the sortition
+        coord.handle_new_burnchain_block().unwrap();
+        coord_blind.handle_new_burnchain_block().unwrap();
+
+        let b = get_burnchain(path);
+        let new_burnchain_tip = burnchain.get_canonical_chain_tip().unwrap();
+        if b.is_reward_cycle_start(new_burnchain_tip.block_height) {
+            eprintln!("Reward cycle start at height={}", new_burnchain_tip.block_height);
+            // the "blinded" sortition db and the one that's processed all the blocks
+            //   should have diverged in sortition_ids now...
+            sortition_ids_diverged = true;
+            // store the anchor block for this sortition for later checking
+            let ic = sort_db.index_handle_at_tip();
+            let bhh = ic.get_last_anchor_block_hash()
+                .unwrap().unwrap();
+            eprintln!("Anchor block={}, selected at height={}", &bhh,
+                      SortitionDB::get_block_snapshot_for_winning_stacks_block(&sort_db.index_conn(),
+                                                                               &ic.context.chain_tip,
+                                                                               &bhh).unwrap().unwrap().block_height);
+
+            anchor_blocks.push(bhh);
+        }
+
+        let tip = SortitionDB::get_canonical_burn_chain_tip(sort_db.conn()).unwrap();
+        let blinded_tip = SortitionDB::get_canonical_burn_chain_tip(sort_db_blind.conn()).unwrap();
+        if sortition_ids_diverged {
+            assert_ne!(tip.sortition_id, blinded_tip.sortition_id,
+                       "Sortitions should have diverged by block height = {}", blinded_tip.block_height);
+        } else {
+            assert_eq!(tip.sortition_id, blinded_tip.sortition_id,
+                       "Sortitions should not have diverged at block height = {}", blinded_tip.block_height);
+        }
+
+        // load the block into staging
+        let block_hash = block.header.block_hash();
+        eprintln!("Block hash={}, ix={}", &block_hash, ix);
+
+        assert_eq!(&tip.winning_stacks_block_hash, &block_hash);
+        stacks_blocks.push((tip.sortition_id.clone(), block.clone()));
+
+        preprocess_block(&mut chainstate, &sort_db, &tip, block);
+
+        // handle the stacks block
+        coord.handle_new_stacks_block().unwrap();
+    }
+
+    let block_height = eval_at_chain_tip(path, &sort_db, "block-height");
+    assert_eq!(block_height, Value::UInt(10));
+
+    let block_height = eval_at_chain_tip(path_blinded, &sort_db_blind, "block-height");
+    assert_eq!(block_height, Value::UInt(0));
+
+    {
+        let ic = sort_db.index_handle_at_tip();
+        let pox_id = ic.get_pox_id().unwrap();
+        assert_eq!(&pox_id.to_string(),
+                   "1111");
+    }
+
+    {
+        let ic = sort_db_blind.index_handle_at_tip();
+        let pox_id = ic.get_pox_id().unwrap();
+        assert_eq!(&pox_id.to_string(),
+                   "1000");
+    }
+
+    // now, we reveal to the blinded coordinator, but out of order.
+    //  reveal block 0 first,
+    //   then the 6-7-8-9-10 fork.
+    //   then reveal 1-2-3-4-5
+    //   then reveal 11-12-13-14
+
+    reveal_block(path_blinded, &sort_db_blind, &mut coord_blind,
+                 &stacks_blocks[0].0, &stacks_blocks[0].1);
+
+    // after revealing ``0``, we should now have the anchor block for
+    //   the 6-7-8-9-10 fork
+
+    {
+        let ic = sort_db_blind.index_handle_at_tip();
+        let pox_id = ic.get_pox_id().unwrap();
+        assert_eq!(&pox_id.to_string(),
+                   "1110");
+    }
+
+    let block_height = eval_at_chain_tip(path_blinded, &sort_db_blind, "block-height");
+    assert_eq!(block_height, Value::UInt(1));
+
+    // reveal [6-10]
+    for (_sort_id, block) in stacks_blocks[6..=10].iter() {
+        // cannot use sort_id from stacks_blocks, because the blinded coordinator
+        //   has different sortition_id's for blocks 6-10 (because it's missing
+        //   the 2nd anchor block).
+        let sort_id = SortitionDB::get_block_snapshot_for_winning_stacks_block(
+            &sort_db_blind.index_conn(), 
+            &SortitionDB::get_canonical_sortition_tip(sort_db_blind.conn()).unwrap(),
+            &block.header.block_hash()).unwrap().unwrap().sortition_id;
+        reveal_block(path_blinded, &sort_db_blind, &mut coord_blind,
+                     &sort_id, block);
+    }
+
+    {
+        let ic = sort_db_blind.index_handle_at_tip();
+        let pox_id = ic.get_pox_id().unwrap();
+        assert_eq!(&pox_id.to_string(),
+                   "1110");
+    }
+
+    let block_height = eval_at_chain_tip(path_blinded, &sort_db_blind, "block-height");
+    assert_eq!(block_height, Value::UInt(6));
+
+    let block_hash = eval_at_chain_tip(path_blinded, &sort_db_blind, "(get-block-info? header-hash u5)");
+    assert_eq!(block_hash, Value::some(Value::buff_from(
+        stacks_blocks[9].1.header.block_hash()
+            .as_bytes().to_vec()).unwrap()).unwrap());
+
+    // reveal [1-5]
+    for (_sort_id, block) in stacks_blocks[1..=5].iter() {
+        // cannot use sort_id from stacks_blocks, because the blinded coordinator
+        //   has different sortition_id's for blocks 6-10 (because it's missing
+        //   the 2nd anchor block).
+        let sort_id = SortitionDB::get_block_snapshot_for_winning_stacks_block(
+            &sort_db_blind.index_conn(), 
+            &SortitionDB::get_canonical_sortition_tip(sort_db_blind.conn()).unwrap(),
+            &block.header.block_hash()).unwrap().unwrap().sortition_id;
+
+        // before processing the last of these blocks, the stacks_block[9] should still
+        //   be the canonical tip
+        let block_hash = eval_at_chain_tip(path_blinded, &sort_db_blind, "(get-block-info? header-hash u5)");
+        assert_eq!(block_hash, Value::some(Value::buff_from(
+            stacks_blocks[9].1.header.block_hash()
+                .as_bytes().to_vec()).unwrap()).unwrap());
+
+        reveal_block(path_blinded, &sort_db_blind, &mut coord_blind,
+                     &sort_id, block);
+    }
+
+    {
+        let ic = sort_db_blind.index_handle_at_tip();
+        let pox_id = ic.get_pox_id().unwrap();
+        assert_eq!(&pox_id.to_string(),
+                   "1111");
+    }
+
+    let block_height = eval_at_chain_tip(path_blinded, &sort_db_blind, "block-height");
+    assert_eq!(block_height, Value::UInt(6));
+
+    // reveal [11-14]
+    for (_sort_id, block) in stacks_blocks[11..].iter() {
+        // cannot use sort_id from stacks_blocks, because the blinded coordinator
+        //   has different sortition_id's for blocks 6-10 (because it's missing
+        //   the 2nd anchor block).
+        let sort_id = SortitionDB::get_block_snapshot_for_winning_stacks_block(
+            &sort_db_blind.index_conn(), 
+            &SortitionDB::get_canonical_sortition_tip(sort_db_blind.conn()).unwrap(),
+            &block.header.block_hash()).unwrap().unwrap().sortition_id;
+
+        reveal_block(path_blinded, &sort_db_blind, &mut coord_blind,
+                     &sort_id, block);
+    }
+
+    let block_height = eval_at_chain_tip(path_blinded, &sort_db_blind, "block-height");
+    assert_eq!(block_height, Value::UInt(10));
+
+    let block_hash = eval_at_chain_tip(path_blinded, &sort_db_blind, "(get-block-info? header-hash u9)");
+    assert_eq!(block_hash, Value::some(Value::buff_from(
+        stacks_blocks[13].1.header.block_hash()
+            .as_bytes().to_vec()).unwrap()).unwrap());
+
+}
+
+fn eval_at_chain_tip(chainstate_path: &str, sort_db: &SortitionDB, eval: &str) -> Value {
+    let stacks_tip = SortitionDB::get_canonical_stacks_chain_tip_hash(sort_db.conn()).unwrap();
+    let mut chainstate = get_chainstate(chainstate_path);
+    chainstate.with_read_only_clarity_tx(
+        &StacksBlockId::new(&stacks_tip.0, &stacks_tip.1),
+        |conn| conn.with_readonly_clarity_env(
+            PrincipalData::parse("SP3Q4A5WWZ80REGBN0ZXNE540ECJ9JZ4A765Q5K2Q").unwrap(),
+            LimitedCostTracker::new_max_limit(),
+            |env| env.eval_raw(eval)).unwrap())
+}
+
+fn reveal_block<T: BlockEventDispatcher, N: CoordinatorNotices>
+    (chainstate_path: &str, sort_db: &SortitionDB, coord: &mut ChainsCoordinator<T,N>,
+     my_sortition: &SortitionId, block: &StacksBlock) {
+    let mut chainstate = get_chainstate(chainstate_path);
+    let sortition = SortitionDB::get_block_snapshot(sort_db.conn(), &my_sortition)
+        .unwrap().unwrap();
+    preprocess_block(&mut chainstate, sort_db, &sortition, block.clone());
+    coord.handle_new_stacks_block().unwrap();
+}
+
 fn preprocess_block(chain_state: &mut StacksChainState, sort_db: &SortitionDB,
                     my_sortition: &BlockSnapshot, block: StacksBlock) {
-    let parent_sortition_id = sort_db.get_sortition_id(&my_sortition.parent_burn_header_hash, &my_sortition.sortition_id)
-        .unwrap().unwrap();
-    let parent_consensus_hash = SortitionDB::get_block_snapshot(sort_db.conn(), &parent_sortition_id)
-        .unwrap().unwrap().consensus_hash;
     let ic = sort_db.index_conn();
+    let parent_consensus_hash = SortitionDB::get_block_snapshot_for_winning_stacks_block(
+        &ic, &my_sortition.sortition_id, &block.header.parent_block)
+        .unwrap().unwrap().consensus_hash;
     // Preprocess the anchored block
     chain_state.preprocess_anchored_block(
         &ic, &my_sortition.consensus_hash, &block,

--- a/src/chainstate/coordinator/tests.rs
+++ b/src/chainstate/coordinator/tests.rs
@@ -1,0 +1,373 @@
+use util::hash::Hash160;
+use std::collections::VecDeque;
+use chainstate::coordinator::*;
+use chainstate::stacks::*;
+use chainstate::burn::operations::*;
+
+use std::sync::{ Arc, RwLock, atomic::{Ordering, AtomicU64, AtomicBool}};
+
+use crossbeam_channel::{select, bounded, Sender, Receiver, Select, TrySendError};
+use util::vrf::*;
+use core;
+use burnchains::{*, db::*};
+use chainstate::burn::*;
+use chainstate::burn::db::sortdb::{SortitionDB, PoxId, SortitionId};
+use chainstate::stacks::index::TrieHash;
+use chainstate::stacks::db::{
+    StacksHeaderInfo, StacksChainState, ClarityTx
+};
+use monitoring::{
+    increment_stx_blocks_processed_counter,
+};
+use vm::{
+    Value, types::QualifiedContractIdentifier,
+    costs::{ExecutionCost, LimitedCostTracker},
+    types::PrincipalData, clarity::ClarityConnection
+};
+
+use address;
+use chainstate;
+
+lazy_static! {
+    static ref BURN_BLOCK_HEADERS: Arc<AtomicU64> = Arc::new(AtomicU64::new(1));
+    static ref TXIDS: Arc<AtomicU64> = Arc::new(AtomicU64::new(1));
+    static ref MBLOCK_PUBKHS: Arc<AtomicU64> = Arc::new(AtomicU64::new(1));
+}
+
+pub fn next_burn_header_hash() -> BurnchainHeaderHash {
+    let cur = BURN_BLOCK_HEADERS.fetch_add(1, Ordering::SeqCst);
+    let mut bytes = vec![];
+    bytes.extend_from_slice(&cur.to_le_bytes());
+    bytes.extend_from_slice(&[0; 24]);
+    BurnchainHeaderHash::from_bytes(&bytes).unwrap()
+}
+
+pub fn next_txid() -> Txid {
+    let cur = TXIDS.fetch_add(1, Ordering::SeqCst);
+    let mut bytes = vec![];
+    bytes.extend_from_slice(&cur.to_le_bytes());
+    bytes.extend_from_slice(&[1; 24]);
+    Txid::from_bytes(&bytes).unwrap()
+}
+
+pub fn next_hash160() -> Hash160 {
+    let cur = MBLOCK_PUBKHS.fetch_add(1, Ordering::SeqCst);
+    let mut bytes = vec![];
+    bytes.extend_from_slice(&cur.to_le_bytes());
+    bytes.extend_from_slice(&[2; 12]);
+    Hash160::from_bytes(&bytes).unwrap()
+}
+
+pub fn produce_burn_block(burnchain_db: &mut BurnchainDB, par: &BurnchainHeaderHash, mut ops: Vec<BlockstackOperationType>) -> BurnchainHeaderHash {
+    let BurnchainBlockData { header: par_header, .. } = burnchain_db.get_burnchain_block(par).unwrap();
+    assert_eq!(&par_header.block_hash, par);
+    let block_height = par_header.block_height + 1;
+    let timestamp = par_header.timestamp + 1;
+    let num_txs = ops.len() as u64;
+    let block_hash = next_burn_header_hash();
+    let header = BurnchainBlockHeader {
+        block_height, timestamp, num_txs,
+        block_hash: block_hash.clone(),
+        parent_block_hash: par.clone()
+    };
+
+    for op in ops.iter_mut() {
+        op.set_block_height(block_height);
+        op.set_burn_header_hash(block_hash.clone());
+    }
+
+    burnchain_db.raw_store_burnchain_block(header, ops).unwrap();
+    block_hash
+}
+
+fn p2pkh_from(sk: &StacksPrivateKey) -> StacksAddress {
+    let pk = StacksPublicKey::from_private(sk);
+    StacksAddress::from_public_keys(
+        chainstate::stacks::C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
+        &address::AddressHashMode::SerializeP2PKH,
+        1, &vec![pk]).unwrap()
+}
+
+pub fn setup_states(path: &str, vrf_keys: &[VRFPrivateKey], committers: &[StacksPrivateKey]) {
+    let burnchain = get_burnchain(path);
+
+    let sortition_db = SortitionDB::connect(
+        &burnchain.get_db_path(), burnchain.first_block_height, &burnchain.first_block_hash,
+        0, true).unwrap();
+
+    let mut burnchain_blocks_db = BurnchainDB::connect(
+        &burnchain.get_burnchaindb_path(), burnchain.first_block_height, &burnchain.first_block_hash,
+        0, true).unwrap();
+
+    let first_sortition = SortitionDB::get_canonical_burn_chain_tip(sortition_db.conn()).unwrap();
+    let first_consensus_hash = &first_sortition.consensus_hash;
+
+    // build a bunch of VRF key registers
+
+    let mut registers = vec![];
+    for (ix, (sk, miner_sk)) in vrf_keys.iter().zip(committers.iter()).enumerate() {
+        let public_key = VRFPublicKey::from_private(sk);
+        let consensus_hash = first_consensus_hash.clone();
+        let memo = vec![0];
+        let address = p2pkh_from(miner_sk);
+        let vtxindex = 1+ix as u32;
+        let block_height = 0;
+        let burn_header_hash = BurnchainHeaderHash([0; 32]);
+        let txid = next_txid();
+
+        registers.push(BlockstackOperationType::LeaderKeyRegister(
+            LeaderKeyRegisterOp {
+                public_key, consensus_hash, memo, address, vtxindex, block_height,
+                burn_header_hash, txid
+            }));
+    }
+
+    produce_burn_block(&mut burnchain_blocks_db, &first_sortition.burn_header_hash, registers);
+
+    let initial_balances = Some(vec![]);
+    let block_limit = ExecutionCost::max_value();
+
+    let chain_state_db = StacksChainState::open_and_exec(
+        false, 0xdeadbeef, &format!("{}/chainstate/", path),
+        initial_balances, |_| {}, block_limit)
+        .unwrap();
+}
+
+pub struct NullEventDispatcher;
+
+impl BlockEventDispatcher for NullEventDispatcher {
+    fn announce_block(&self, _block: StacksBlock, _metadata: StacksHeaderInfo,
+                      _receipts: Vec<StacksTransactionReceipt>, _parent: &StacksBlockId) {
+        assert!(false, "We should never try to announce to the null dispatcher");
+    }
+}
+
+pub fn make_coordinator<'a>(path: &str) -> ChainsCoordinator<'a, NullEventDispatcher> {
+    ChainsCoordinator::test_new(&get_burnchain(path), path)
+}
+
+fn get_burnchain(path: &str) -> Burnchain {
+    let mut b = Burnchain::new(&format!("{}/burnchain/db/", path), "bitcoin", "regtest").unwrap();
+    b.reward_cycle_period = 5;
+    b
+}
+
+fn get_sortition_db(path: &str) -> SortitionDB {
+    let burnchain = get_burnchain(path);
+    SortitionDB::open(&burnchain.get_db_path(), false).unwrap()
+}
+
+fn get_burnchain_db(path: &str) -> BurnchainDB {
+    let burnchain = get_burnchain(path);
+    BurnchainDB::open(&burnchain.get_burnchaindb_path(), true).unwrap()
+}
+
+fn get_chainstate(path: &str) -> StacksChainState {
+    StacksChainState::open(false, 0xdeadbeef, &format!("{}/chainstate/", path)).unwrap()
+}
+
+/// build a stacks block with just the coinbase off of
+///  parent_block, in the canonical sortition fork.
+fn make_genesis_block(sort_db: &SortitionDB, state: &mut StacksChainState,
+                     parent_block: &BlockHeaderHash,
+                     miner: &StacksPrivateKey, my_burn: u64,
+                     vrf_key: &VRFPrivateKey, key_index: u32) -> (BlockstackOperationType, StacksBlock) {
+    let tx_auth = TransactionAuth::from_p2pkh(miner).unwrap();
+
+    let mut tx = StacksTransaction::new(
+        TransactionVersion::Testnet, 
+        tx_auth,
+        TransactionPayload::Coinbase(CoinbasePayload([0u8; 32])));
+    tx.chain_id = 0xdeadbeef;
+    tx.anchor_mode = TransactionAnchorMode::OnChainOnly;
+    let mut tx_signer = StacksTransactionSigner::new(&tx);
+    tx_signer.sign_origin(miner).unwrap();
+
+    let coinbase_op = tx_signer.get_tx().unwrap();
+
+    let sortition_tip = SortitionDB::get_canonical_burn_chain_tip(sort_db.conn()).unwrap();
+
+    let parent_stacks_header = StacksHeaderInfo::genesis_block_header_info(TrieHash([0u8; 32]));
+
+    let proof = VRF::prove(vrf_key, sortition_tip.sortition_hash.as_bytes());
+
+    let mut builder = StacksBlockBuilder::make_block_builder(
+        &parent_stacks_header, proof.clone(), 0, next_hash160()).unwrap();
+
+    let mut epoch_tx = builder.epoch_begin(state).unwrap();
+    builder.try_mine_tx(&mut epoch_tx, &coinbase_op).unwrap();
+
+    let block = builder.mine_anchored_block(&mut epoch_tx);
+    builder.epoch_finish(epoch_tx);
+
+    let commit_op = LeaderBlockCommitOp {
+        block_header_hash: block.block_hash(),
+        burn_fee: my_burn,
+        input: BurnchainSigner {
+            num_sigs: 1,
+            hash_mode: address::AddressHashMode::SerializeP2PKH,
+            public_keys: vec![ StacksPublicKey::from_private(miner) ]
+        },
+        key_block_ptr: 1, // all registers happen in block height 1
+        key_vtxindex: (1+key_index) as u16,
+        memo: vec![],
+        new_seed: VRFSeed::from_proof(&proof),
+
+        parent_block_ptr: 0,
+        parent_vtxindex: 0,
+
+        txid: next_txid(),
+        vtxindex: 1,
+        block_height: 0,
+        burn_header_hash: BurnchainHeaderHash([0; 32]),
+    };
+
+    (BlockstackOperationType::LeaderBlockCommit(commit_op), block)
+}
+
+/// build a stacks block with just the coinbase off of
+///  parent_block, in the canonical sortition fork of SortitionDB.
+/// parent_block _must_ be included in the StacksChainState
+fn make_stacks_block(sort_db: &SortitionDB, state: &mut StacksChainState,
+                     parent_block: &BlockHeaderHash,
+                     miner: &StacksPrivateKey, my_burn: u64,
+                     vrf_key: &VRFPrivateKey, key_index: u32) -> (BlockstackOperationType, StacksBlock) {
+    let tx_auth = TransactionAuth::from_p2pkh(miner).unwrap();
+
+    let mut tx = StacksTransaction::new(
+        TransactionVersion::Testnet, 
+        tx_auth,
+        TransactionPayload::Coinbase(CoinbasePayload([0u8; 32])));
+    tx.chain_id = 0xdeadbeef;
+    tx.anchor_mode = TransactionAnchorMode::OnChainOnly;
+    let mut tx_signer = StacksTransactionSigner::new(&tx);
+    tx_signer.sign_origin(miner).unwrap();
+
+    let coinbase_op = tx_signer.get_tx().unwrap();
+
+    let sortition_tip = SortitionDB::get_canonical_burn_chain_tip(sort_db.conn()).unwrap();
+    let parents_sortition = SortitionDB::get_block_snapshot_for_winning_stacks_block(
+        &sort_db.index_conn(), &sortition_tip.sortition_id, parent_block).unwrap().unwrap();
+
+    let parent_vtxindex = SortitionDB::get_block_winning_vtxindex(sort_db.conn(), &parents_sortition.sortition_id)
+        .unwrap().unwrap();
+
+    eprintln!("Find parents stacks header...");
+    let parent_stacks_header = StacksChainState::get_anchored_block_header_info(&state.headers_db,
+                                                                                &parents_sortition.consensus_hash,
+                                                                                parent_block).unwrap().unwrap();
+    let proof = VRF::prove(vrf_key, sortition_tip.sortition_hash.as_bytes());
+
+    let total_burn = parents_sortition.total_burn;
+
+    let mut builder = StacksBlockBuilder::make_block_builder(
+        &parent_stacks_header, proof.clone(), total_burn, next_hash160()).unwrap();
+    let mut epoch_tx = builder.epoch_begin(state).unwrap();
+    builder.try_mine_tx(&mut epoch_tx, &coinbase_op).unwrap();
+
+    let block = builder.mine_anchored_block(&mut epoch_tx);
+    builder.epoch_finish(epoch_tx);
+
+    let commit_op = LeaderBlockCommitOp {
+        block_header_hash: block.block_hash(),
+        burn_fee: my_burn,
+        input: BurnchainSigner {
+            num_sigs: 1,
+            hash_mode: address::AddressHashMode::SerializeP2PKH,
+            public_keys: vec![ StacksPublicKey::from_private(miner) ]
+        },
+        key_block_ptr: 1, // all registers happen in block height 1
+        key_vtxindex: (1+key_index) as u16,
+        memo: vec![],
+        new_seed: VRFSeed::from_proof(&proof),
+
+        parent_block_ptr: parents_sortition.block_height as u32,
+        parent_vtxindex,
+
+        txid: next_txid(),
+        vtxindex: 1,
+        block_height: 0,
+        burn_header_hash: BurnchainHeaderHash([0; 32]),
+    };
+
+    (BlockstackOperationType::LeaderBlockCommit(commit_op), block)
+}
+
+#[test]
+fn test_simple_setup() {
+    let path = "/tmp/stacks-blockchain-simple-setup";
+    let _r = std::fs::remove_dir_all(path);
+
+    let vrf_keys: Vec<_> = (0..50).map(|_| VRFPrivateKey::new()).collect();
+    let committers: Vec<_> = (0..50).map(|_| StacksPrivateKey::new()).collect();
+
+    setup_states(path, &vrf_keys, &committers);
+
+    let mut coord = make_coordinator(path);
+
+    coord.handle_new_burnchain_block().unwrap();
+
+    let sort_db = get_sortition_db(path);
+
+    let tip = SortitionDB::get_canonical_burn_chain_tip(sort_db.conn()).unwrap();
+    assert_eq!(tip.block_height, 1);
+    assert_eq!(tip.sortition, false);
+    let (_, ops) = sort_db.get_sortition_result(&tip.sortition_id).unwrap().unwrap();
+
+    // we should have all the VRF registrations accepted
+    assert_eq!(ops.accepted_ops.len(), vrf_keys.len());
+    assert_eq!(ops.consumed_leader_keys.len(), 0);
+
+    let mut parent = BlockHeaderHash([0; 32]);
+    // process sequential blocks, and their sortitions...
+    for (ix, (vrf_key, miner)) in vrf_keys.iter().zip(committers.iter()).enumerate() {
+        let mut burnchain = get_burnchain_db(path);
+        let mut chainstate = get_chainstate(path);
+        let (op, block) =
+            if ix == 0 {
+                make_genesis_block(&sort_db, &mut chainstate, &parent, miner, 10000, vrf_key, ix as u32)
+            } else {
+                make_stacks_block(&sort_db, &mut chainstate, &parent, miner, 10000, vrf_key, ix as u32)
+            };
+        let burnchain_tip = burnchain.get_canonical_chain_tip().unwrap();
+        produce_burn_block(&mut burnchain, &burnchain_tip.block_hash, vec![op]);
+        // handle the sortition
+        coord.handle_new_burnchain_block().unwrap();
+
+        let tip = SortitionDB::get_canonical_burn_chain_tip(sort_db.conn()).unwrap();
+        let block_hash = block.header.block_hash();
+
+        assert_eq!(&tip.winning_stacks_block_hash, &block_hash);
+        preprocess_block(&mut chainstate, &sort_db, &tip, block);
+
+        // handle the stacks block
+        coord.process_ready_blocks().unwrap();
+
+        parent = block_hash;
+    }
+
+    let stacks_tip = SortitionDB::get_canonical_stacks_chain_tip_hash(sort_db.conn())
+        .unwrap();
+    let mut chainstate = get_chainstate(path);
+    assert_eq!(
+        chainstate.with_read_only_clarity_tx(
+            &StacksBlockId::new(&stacks_tip.0, &stacks_tip.1),
+            |conn| conn.with_readonly_clarity_env(
+                PrincipalData::parse("SP3Q4A5WWZ80REGBN0ZXNE540ECJ9JZ4A765Q5K2Q").unwrap(),
+                LimitedCostTracker::new_max_limit(),
+                |env| env.eval_raw("block-height")).unwrap()),
+        Value::UInt(50));
+}
+
+fn preprocess_block(chain_state: &mut StacksChainState, sort_db: &SortitionDB,
+                    my_sortition: &BlockSnapshot, block: StacksBlock) {
+    let ic = sort_db.index_conn();
+
+    let parent_consensus_hash = SortitionDB::get_block_snapshot_for_winning_stacks_block(
+        &ic, &my_sortition.sortition_id, &block.header.parent_block).unwrap().unwrap()
+        .consensus_hash;
+    // Preprocess the anchored block
+    chain_state.preprocess_anchored_block(
+        &ic, &my_sortition.consensus_hash, &block,
+        &parent_consensus_hash).unwrap();
+}

--- a/src/chainstate/stacks/db/blocks.rs
+++ b/src/chainstate/stacks/db/blocks.rs
@@ -2792,7 +2792,6 @@ impl StacksChainState {
             };
 
             let microblock_cost = clarity_tx.cost_so_far();
-            
             debug!("\n\nAppend block {}/{} off of {}/{}\nStacks block height: {}, Total Burns: {}\nMicroblock parent: {} (seq {}) (count {})\n", 
                    chain_tip_consensus_hash, block.block_hash(), parent_consensus_hash, parent_block_hash,
                    block.header.total_work.work, block.header.total_work.burn,

--- a/src/chainstate/stacks/db/blocks.rs
+++ b/src/chainstate/stacks/db/blocks.rs
@@ -419,6 +419,7 @@ const STACKS_BLOCK_INDEX_SQL : &'static [&'static str]= &[
     CREATE TABLE staging_blocks(anchored_block_hash TEXT NOT NULL,
                                 parent_anchored_block_hash TEXT NOT NULL,
                                 consensus_hash TEXT NOT NULL,
+     -- parent_consensus_hash is the consensus hash of the parent sortition of the sortition that chose this block
                                 parent_consensus_hash TEXT NOT NULL,
                                 parent_microblock_hash TEXT NOT NULL,
                                 parent_microblock_seq INT NOT NULL,
@@ -2261,7 +2262,10 @@ impl StacksChainState {
     /// elected the given Stacks block.
     /// 
     /// If we find the same Stacks block in two or more burnchain forks, insert it there too
-    /// 
+    ///
+    /// consensus_hash: this is the consensus hash of the sortition that chose this block
+    /// parent_consensus_hash: this the consensus hash of the parent sortition of the sortition that chose this block
+    ///
     /// TODO: consider how full the block is (i.e. how much computational budget it consumes) when
     /// deciding whether or not it can be processed.
     pub fn preprocess_anchored_block(&mut self, sort_ic: &SortitionDBConn, consensus_hash: &ConsensusHash, block: &StacksBlock, parent_consensus_hash: &ConsensusHash) -> Result<bool, Error> {

--- a/src/chainstate/stacks/db/blocks.rs
+++ b/src/chainstate/stacks/db/blocks.rs
@@ -2263,8 +2263,10 @@ impl StacksChainState {
     /// 
     /// If we find the same Stacks block in two or more burnchain forks, insert it there too
     ///
+    /// sort_ic: an indexed connection to a sortition DB
     /// consensus_hash: this is the consensus hash of the sortition that chose this block
-    /// parent_consensus_hash: this the consensus hash of the parent sortition of the sortition that chose this block
+    /// block: the actual block data for this anchored Stacks block
+    /// parent_consensus_hash: this the consensus hash of the sortition that chose this Stack's block's parent
     ///
     /// TODO: consider how full the block is (i.e. how much computational budget it consumes) when
     /// deciding whether or not it can be processed.

--- a/src/chainstate/stacks/db/headers.rs
+++ b/src/chainstate/stacks/db/headers.rs
@@ -188,6 +188,16 @@ impl StacksChainState {
         Ok(())
     }
 
+    pub fn is_stacks_block_processed(conn: &Connection, consensus_hash: &ConsensusHash, block_hash: &BlockHeaderHash) -> Result<bool, Error> {
+        let sql = "SELECT 1 FROM block_headers WHERE consensus_hash = ?1 AND block_hash = ?2";
+        let args: &[&dyn ToSql] = &[&consensus_hash, &block_hash];
+        match conn.query_row(sql, args, |_| true) {
+            Ok(_) => Ok(true),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(false),
+            Err(e) => Err(Error::DBError(e.into()))
+        }
+    }
+
     /// Get a stacks header info by burn block and block hash (i.e. by primary key).
     /// Does not get back data about the parent microblock stream.
     pub fn get_anchored_block_header_info(conn: &Connection, consensus_hash: &ConsensusHash, block_hash: &BlockHeaderHash) -> Result<Option<StacksHeaderInfo>, Error> {

--- a/src/net/chat.rs
+++ b/src/net/chat.rs
@@ -1696,7 +1696,7 @@ mod test {
             stable_confirmations: 7,
             first_block_height: 12300,
             first_block_hash: first_burn_hash.clone(),
-            reward_cycle_period: 10,
+            pox_constants: PoxConstants::test_default(),
         }
     }
 

--- a/src/net/p2p.rs
+++ b/src/net/p2p.rs
@@ -2624,7 +2624,7 @@ mod test {
         let first_burn_hash = BurnchainHeaderHash::from_hex("0000000000000000000000000000000000000000000000000000000000000000").unwrap();
 
         let burnchain = Burnchain {
-            reward_cycle_period: 10,
+            pox_constants: PoxConstants::test_default(),
             peer_version: 0x012345678,
             network_id: 0x9abcdef0,
             chain_name: "bitcoin".to_string(),

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -684,8 +684,10 @@ impl InitializedNeonNode {
                     }
                 };
 
-                // the stacks block I'm mining off of's burn header hash and vtx index:
+                // the consensus hash of my Stacks block parent
                 let parent_consensus_hash = stacks_tip.consensus_hash.clone();
+
+                // the stacks block I'm mining off of's burn header hash and vtx index:
                 let parent_snapshot = SortitionDB::get_block_snapshot_consensus(burn_db.conn(), &stacks_tip.consensus_hash)
                     .expect("Failed to look up block's parent snapshot")
                     .expect("Failed to look up block's parent snapshot");


### PR DESCRIPTION
This implements PoX anchor block detection, and includes some test cases for the ChainsCoordinator that exercise that detection (the bulk of this PR is the test cases).

This PR includes a panicking test case for the desired behavior of #1805 -- when #1805 is implemented, we should remove the `should_panic` decorator from that function, and the test should pass.