### PR TITLE
Fix trait lookup

### DIFF
--- a/src/vm/analysis/trait_checker/tests.rs
+++ b/src/vm/analysis/trait_checker/tests.rs
@@ -1049,3 +1049,81 @@ fn test_contract_of_wrong_type() {
         }
     }
 }
+
+#[test]
+fn test_return_trait_with_contract_of() {
+    let dispatching_contract_src =
+        "(define-trait trait-1 (
+            (get-1 (uint) (response uint uint))))
+        (define-public (wrapped-get-1 (contract <trait-1>))
+            (begin
+                (contract-call? contract get-1 u0)
+                (ok (contract-of contract))))";
+    let target_contract_src =
+        "(define-public (get-1 (x uint)) (ok u1))";
+
+    let dispatching_contract_id = QualifiedContractIdentifier::local("dispatching-contract").unwrap();
+    let target_contract_id = QualifiedContractIdentifier::local("target-contract").unwrap();
+
+    let mut dispatching_contract = parse(&dispatching_contract_id, dispatching_contract_src).unwrap();
+    let mut target_contract = parse(&target_contract_id, target_contract_src).unwrap();
+    let mut marf = MemoryBackingStore::new();
+    let mut db = marf.as_analysis_db();
+
+    db.execute(|db| {
+        type_check(&dispatching_contract_id, &mut dispatching_contract, db, true)?;
+        type_check(&target_contract_id, &mut target_contract, db, true)
+    }).unwrap();
+}
+
+#[test]
+fn test_return_trait_with_contract_of_wrapped_in_begin() {
+    let dispatching_contract_src =
+        "(define-trait trait-1 (
+            (get-1 (uint) (response uint uint))))
+        (define-public (wrapped-get-1 (contract <trait-1>))
+            (begin
+                (contract-call? contract get-1 u0)
+                (ok (contract-of contract))))";
+    let target_contract_src =
+        "(define-public (get-1 (x uint)) (ok u1))";
+
+    let dispatching_contract_id = QualifiedContractIdentifier::local("dispatching-contract").unwrap();
+    let target_contract_id = QualifiedContractIdentifier::local("target-contract").unwrap();
+
+    let mut dispatching_contract = parse(&dispatching_contract_id, dispatching_contract_src).unwrap();
+    let mut target_contract = parse(&target_contract_id, target_contract_src).unwrap();
+    let mut marf = MemoryBackingStore::new();
+    let mut db = marf.as_analysis_db();
+
+    db.execute(|db| {
+        type_check(&dispatching_contract_id, &mut dispatching_contract, db, true)?;
+        type_check(&target_contract_id, &mut target_contract, db, true)
+    }).unwrap();
+}
+
+#[test]
+fn test_return_trait_with_contract_of_wrapped_in_let() {
+    let dispatching_contract_src =
+        "(define-trait trait-1 (
+            (get-1 (uint) (response uint uint))))
+        (define-public (wrapped-get-1 (contract <trait-1>))
+            (let ((val u0))
+                (contract-call? contract get-1 val)
+                (ok (contract-of contract))))";
+    let target_contract_src =
+        "(define-public (get-1 (x uint)) (ok u1))";
+
+    let dispatching_contract_id = QualifiedContractIdentifier::local("dispatching-contract").unwrap();
+    let target_contract_id = QualifiedContractIdentifier::local("target-contract").unwrap();
+
+    let mut dispatching_contract = parse(&dispatching_contract_id, dispatching_contract_src).unwrap();
+    let mut target_contract = parse(&target_contract_id, target_contract_src).unwrap();
+    let mut marf = MemoryBackingStore::new();
+    let mut db = marf.as_analysis_db();
+
+    db.execute(|db| {
+        type_check(&dispatching_contract_id, &mut dispatching_contract, db, true)?;
+        type_check(&target_contract_id, &mut target_contract, db, true)
+    }).unwrap();
+}

--- a/src/vm/functions/database.rs
+++ b/src/vm/functions/database.rs
@@ -39,7 +39,7 @@ pub fn special_contract_call(args: &[SymbolicExpression],
         },
         SymbolicExpressionType::Atom(contract_ref) => {
             // Dynamic dispatch
-            match context.callable_contracts.get(contract_ref) {
+            match context.lookup_callable_contract(contract_ref) {
                 Some((ref contract_identifier, trait_identifier)) => {
                     // Ensure that contract-call is used for inter-contract calls only 
                     if *contract_identifier == env.contract_context.contract_identifier {

--- a/src/vm/functions/mod.rs
+++ b/src/vm/functions/mod.rs
@@ -384,7 +384,7 @@ fn special_contract_of(args: &[SymbolicExpression], env: &mut Environment, conte
         _ => return Err(CheckErrors::ContractOfExpectsTrait.into())
     };
 
-    let contract_identifier = match context.callable_contracts.get(contract_ref) {
+    let contract_identifier = match context.lookup_callable_contract(contract_ref) {
         Some((ref contract_identifier, _trait_identifier)) => {
             env.global_context.database.get_contract(contract_identifier)
                 .map_err(|_e| CheckErrors::NoSuchContract(contract_identifier.to_string()))?;


### PR DESCRIPTION
Address https://github.com/blockstack/stacks-blockchain/issues/1815

When optimising for O(1) retrieval in https://github.com/blockstack/stacks-blockchain/pull/1644/commits/084ec6e3222e1ad5bd8c44775484acdfc79b6323, I should have cascade the fact that the `lookup_callable_contract ` method should be used, instead of accessing the hashmap directly.