### PR TITLE
fix for clarity-transaction-js-92

### DIFF
--- a/src/chainstate/stacks/db/blocks.rs
+++ b/src/chainstate/stacks/db/blocks.rs
@@ -3380,8 +3380,7 @@ impl StacksChainState {
                     .map_err(|_e| MemPoolRejection::NoSuchContract)?
                     .ok_or_else(|| MemPoolRejection::NoSuchPublicFunction)?;
 
-                let arg_types: Vec<_> = function_args.iter().map(|x| TypeSignature::type_of(x)).collect();
-                function_type.check_args(&mut (), &arg_types)
+                function_type.check_args_by_allowing_trait_cast(&function_args)
                     .map_err(|e| MemPoolRejection::BadFunctionArgument(e))?;
             },
             TransactionPayload::SmartContract(TransactionSmartContract { name, code_body: _ }) => {

--- a/src/chainstate/stacks/db/blocks.rs
+++ b/src/chainstate/stacks/db/blocks.rs
@@ -3374,14 +3374,13 @@ impl StacksChainState {
 
                 let contract_identifier = QualifiedContractIdentifier::new(address.clone().into(), contract_name.clone());
 
-                let function_type = clarity_connection.with_analysis_db_readonly(|db| {
-                        db.get_public_function_type(&contract_identifier, &function_name)
-                    })
-                    .map_err(|_e| MemPoolRejection::NoSuchContract)?
-                    .ok_or_else(|| MemPoolRejection::NoSuchPublicFunction)?;
-
-                function_type.check_args_by_allowing_trait_cast(&function_args)
-                    .map_err(|e| MemPoolRejection::BadFunctionArgument(e))?;
+                clarity_connection.with_analysis_db_readonly(|db| {
+                    let function_type = db.get_public_function_type(&contract_identifier, &function_name)
+                        .map_err(|_e| MemPoolRejection::NoSuchContract)?
+                        .ok_or_else(|| MemPoolRejection::NoSuchPublicFunction)?;
+                    function_type.check_args_by_allowing_trait_cast(db, &function_args)
+                        .map_err(|e| MemPoolRejection::BadFunctionArgument(e))
+                })?;
             },
             TransactionPayload::SmartContract(TransactionSmartContract { name, code_body: _ }) => {
                 let contract_identifier = QualifiedContractIdentifier::new(tx.origin_address().into(), name.clone());

--- a/src/vm/analysis/type_checker/mod.rs
+++ b/src/vm/analysis/type_checker/mod.rs
@@ -186,8 +186,8 @@ impl FunctionType {
                     contract_to_check.check_trait_compliance(trait_id, &trait_definition)?;
                 },
                 (expected_type, value) => {
-                    let actual_type = TypeSignature::type_of(&value);
-                    if !expected_type.admits_type(&actual_type) {
+                    if !expected_type.admits(&value) {
+                        let actual_type = TypeSignature::type_of(&value);
                         return Err(CheckErrors::TypeError(expected_type.clone(), actual_type.clone()).into())
                     }
                 }

--- a/src/vm/functions/database.rs
+++ b/src/vm/functions/database.rs
@@ -39,7 +39,7 @@ pub fn special_contract_call(args: &[SymbolicExpression],
         },
         SymbolicExpressionType::Atom(contract_ref) => {
             // Dynamic dispatch
-            match context.callable_contracts.get(contract_ref) {
+            match context.lookup_callable_contract(contract_ref) {
                 Some((ref contract_identifier, trait_identifier)) => {
                     // Ensure that contract-call is used for inter-contract calls only 
                     if *contract_identifier == env.contract_context.contract_identifier {

--- a/src/vm/functions/mod.rs
+++ b/src/vm/functions/mod.rs
@@ -384,7 +384,7 @@ fn special_contract_of(args: &[SymbolicExpression], env: &mut Environment, conte
         _ => return Err(CheckErrors::ContractOfExpectsTrait.into())
     };
 
-    let contract_identifier = match context.callable_contracts.get(contract_ref) {
+    let contract_identifier = match context.lookup_callable_contract(contract_ref) {
         Some((ref contract_identifier, _trait_identifier)) => {
             env.global_context.database.get_contract(contract_identifier)
                 .map_err(|_e| CheckErrors::NoSuchContract(contract_identifier.to_string()))?;

--- a/src/vm/types/signatures.rs
+++ b/src/vm/types/signatures.rs
@@ -433,10 +433,6 @@ impl TypeSignature {
                     false
                 }
             },
-            TraitReferenceType(ref candidate) => {
-                debug!("admits trait ref {:?} / {:?}", candidate, other);
-                true
-            },
             NoType => panic!("NoType should never be asked to admit."),
             _ => other == self
         }

--- a/src/vm/types/signatures.rs
+++ b/src/vm/types/signatures.rs
@@ -433,6 +433,10 @@ impl TypeSignature {
                     false
                 }
             },
+            TraitReferenceType(ref candidate) => {
+                debug!("admits trait ref {:?} / {:?}", candidate, other);
+                true
+            },
             NoType => panic!("NoType should never be asked to admit."),
             _ => other == self
         }

--- a/testnet/stacks-node/src/tests/mempool.rs
+++ b/testnet/stacks-node/src/tests/mempool.rs
@@ -346,7 +346,7 @@ fn mempool_setup_chainstate() {
 
             let tx_bytes = make_contract_call(&contract_sk, 3, 200, &contract_addr, "use-trait-contract", "baz", &[Value::Principal(contract_principal)]);
             let tx = StacksTransaction::consensus_deserialize(&mut tx_bytes.as_slice()).unwrap();
-            chain_state.will_admit_mempool_tx(mempool_conn, burn_hash, block_hash, &tx, tx_bytes.len() as u64).unwrap();
+            chain_state.will_admit_mempool_tx(mempool_conn, consensus_hash, block_hash, &tx, tx_bytes.len() as u64).unwrap();
         }
     });
 


### PR DESCRIPTION
Fix https://github.com/blockstack/stacks-transactions-js/issues/92

The current code is obviously not enough as it would need to check that `other` is a `PrincipalType` that implements the trait.

Anything else that should be checked?  Is this opening the door for other potential problems when it should not return `true` for a `TraitReferenceType`?  And is `other == self` also a valid case for a `TraitReferenceType`?  I would think so.

Any suggestion on how to write tests for this, except by calling `admits_type` directly with various combinations?  I'm also curious why the fix done for https://github.com/blockstack/stacks-blockchain/pull/1679 would not address this case?

The full fix also requires https://github.com/blockstack/stacks-blockchain/pull/1817 from @lgalabru.
