### PR TITLE
fix: typo in LogN cost function comment

### DIFF
--- a/src/vm/costs/mod.rs
+++ b/src/vm/costs/mod.rs
@@ -310,7 +310,7 @@ impl CostFunctions {
             CostFunctions::Linear(a, b) => { a.cost_overflow_mul(input)?
                                              .cost_overflow_add(*b) }
             CostFunctions::LogN(a, b) => {
-                // a*input*log(input)) + b
+                // a*log(input)) + b
                 //  and don't do log(0).
                 int_log2(cmp::max(input, 1))
                     .ok_or_else(|| CostErrors::CostOverflow)?


### PR DESCRIPTION
tiny PR fixing a typo in the comment above the `LogN` cost assessment function