### PR TITLE
PoX adjustments for Devx

### DIFF
--- a/src/chainstate/stacks/boot/mod.rs
+++ b/src/chainstate/stacks/boot/mod.rs
@@ -638,7 +638,7 @@ pub mod test {
                 }
                 if tenure_id == 2 {
                     let alice_test_tx = make_bare_contract(&alice, 1, 0, "nested-stacker", &format!(
-                        "(define-public (nested-stacks-stx)
+                        "(define-public (nested-stack-stx)
                             (contract-call? '{}.pox stack-stx u512000000 (tuple (version 0x00) (hashbytes 0xffffffffffffffffffffffffffffffffffffffff)) u1))", STACKS_BOOT_CODE_CONTRACT_ADDRESS));
 
                     block_txs.push(alice_test_tx);   
@@ -650,7 +650,7 @@ pub mod test {
                     let mut contract_call = StacksTransaction::new(TransactionVersion::Testnet, auth,
                                                                 TransactionPayload::new_contract_call(key_to_stacks_addr(&alice),
                                                                                                      "nested-stacker",
-                                                                                                     "nested-stacks-stx",
+                                                                                                     "nested-stack-stx",
                                                                                                      vec![]).unwrap());
                     contract_call.chain_id = 0x80000000;
                     contract_call.auth.set_origin_nonce(2);

--- a/src/chainstate/stacks/boot/pox-mainnet.clar
+++ b/src/chainstate/stacks/boot/pox-mainnet.clar
@@ -1,24 +1,21 @@
 ;; PoX mainnet constants
 ;; Min/max number of reward cycles uSTX can be locked for
-(define-constant MIN-POX-REWARD-CYCLES u1)
-(define-constant MAX-POX-REWARD-CYCLES u12)
+(define-constant MIN_POX_REWARD_CYCLES u1)
+(define-constant MAX_POX_REWARD_CYCLES u12)
 
 ;; Default length of the PoX registration window, in burnchain blocks.
-(define-constant REGISTRATION-WINDOW-LENGTH u250)
+(define-constant PREPARE_CYCLE_LENGTH u250)
 
 ;; Default length of the PoX reward cycle, in burnchain blocks.
-(define-constant REWARD-CYCLE-LENGTH u1000)
+(define-constant REWARD_CYCLE_LENGTH u1000)
 
 ;; Valid values for burnchain address versions.
-;; TODO: These correspond to address hash modes in Stacks 2.0,
-;;    but they should just be Bitcoin version bytes: we don't
-;;    need to constrain PoX recipient addresses the way that
-;;    we constrain other kinds of Bitcoin addresses
-(define-constant ADDRESS-VERSION-P2PKH 0x00)
-(define-constant ADDRESS-VERSION-P2SH 0x01)
-(define-constant ADDRESS-VERSION-P2WPKH 0x02)
-(define-constant ADDRESS-VERSION-P2WSH 0x03)
+;; These correspond to address hash modes in Stacks 2.0.
+(define-constant ADDRESS_VERSION_P2PKH 0x00)
+(define-constant ADDRESS_VERSION_P2SH 0x01)
+(define-constant ADDRESS_VERSION_P2WPKH 0x02)
+(define-constant ADDRESS_VERSION_P2WSH 0x03)
 
 ;; Stacking thresholds
-(define-constant STACKING-THRESHOLD-25 u20000)
-(define-constant STACKING-THRESHOLD-100 u5000)
+(define-constant STACKING_THRESHOLD_25 u20000)
+(define-constant STACKING_THRESHOLD_100 u5000)

--- a/src/chainstate/stacks/boot/pox-testnet.clar
+++ b/src/chainstate/stacks/boot/pox-testnet.clar
@@ -1,25 +1,21 @@
 ;; PoX testnet constants
 ;; Min/max number of reward cycles uSTX can be locked for
-(define-constant MIN-POX-REWARD-CYCLES u1)
-(define-constant MAX-POX-REWARD-CYCLES u12)
+(define-constant MIN_POX_REWARD_CYCLES u1)
+(define-constant MAX_POX_REWARD_CYCLES u12)
 
 ;; Default length of the PoX registration window, in burnchain blocks.
-(define-constant REGISTRATION-WINDOW-LENGTH u30)
+(define-constant PREPARE_CYCLE_LENGTH u30)
 
 ;; Default length of the PoX reward cycle, in burnchain blocks.
-(define-constant REWARD-CYCLE-LENGTH u120)
-
+(define-constant REWARD_CYCLE_LENGTH u120)
 
 ;; Valid values for burnchain address versions.
-;; TODO: These correspond to address hash modes in Stacks 2.0,
-;;    but they should just be Bitcoin version bytes: we don't
-;;    need to constrain PoX recipient addresses the way that
-;;    we constrain other kinds of Bitcoin addresses
-(define-constant ADDRESS-VERSION-P2PKH 0x00)
-(define-constant ADDRESS-VERSION-P2SH 0x01)
-(define-constant ADDRESS-VERSION-P2WPKH 0x02)
-(define-constant ADDRESS-VERSION-P2WSH 0x03)
+;; These correspond to address hash modes in Stacks 2.0.
+(define-constant ADDRESS_VERSION_P2PKH 0x00)
+(define-constant ADDRESS_VERSION_P2SH 0x01)
+(define-constant ADDRESS_VERSION_P2WPKH 0x02)
+(define-constant ADDRESS_VERSION_P2WSH 0x03)
 
 ;; Stacking thresholds
-(define-constant STACKING-THRESHOLD-25 u480)
-(define-constant STACKING-THRESHOLD-100 u120)
+(define-constant STACKING_THRESHOLD_25 u480)
+(define-constant STACKING_THRESHOLD_100 u120)

--- a/src/chainstate/stacks/boot/pox.clar
+++ b/src/chainstate/stacks/boot/pox.clar
@@ -16,35 +16,35 @@
 (define-constant ERR_NOT_ALLOWED 19)
 
 ;; Min/max number of reward cycles uSTX can be locked for
-(define-constant MIN-POX-REWARD-CYCLES u1)
-(define-constant MAX-POX-REWARD-CYCLES u12)
+(define-constant MIN_POX_REWARD_CYCLES u1)
+(define-constant MAX_POX_REWARD_CYCLES u12)
 
 ;; Default length of the PoX registration window, in burnchain blocks.
 (define-constant PREPARE_CYCLE_LENGTH u250)
 
 ;; Default length of the PoX reward cycle, in burnchain blocks.
-(define-constant REWARD-CYCLE-LENGTH u1000)
+(define-constant REWARD_CYCLE_LENGTH u1000)
 
 ;; Valid values for burnchain address versions.
 ;; These correspond to address hash modes in Stacks 2.0.
-(define-constant ADDRESS-VERSION-P2PKH 0x00)
-(define-constant ADDRESS-VERSION-P2SH 0x01)
-(define-constant ADDRESS-VERSION-P2WPKH 0x02)
-(define-constant ADDRESS-VERSION-P2WSH 0x03)
+(define-constant ADDRESS_VERSION_P2PKH 0x00)
+(define-constant ADDRESS_VERSION_P2SH 0x01)
+(define-constant ADDRESS_VERSION_P2WPKH 0x02)
+(define-constant ADDRESS_VERSION_P2WSH 0x03)
 
 ;; Stacking thresholds
-(define-constant STACKING-THRESHOLD-25 u20000)
-(define-constant STACKING-THRESHOLD-100 u5000)
+(define-constant STACKING_THRESHOLD_25 u20000)
+(define-constant STACKING_THRESHOLD_100 u5000)
 
 ;; PoX disabling threshold (a percent)
-(define-constant POX-REJECTION-FRACTION u25)
+(define-constant POX_REJECTION_FRACTION u25)
 
 ;; Data vars that store a copy of the burnchain configuration.
 ;; Implemented as data-vars, so that different configurations can be
 ;; used in e.g. test harnesses.
-(define-data-var pox-reward-cycle-length uint REWARD-CYCLE-LENGTH)
-(define-data-var pox-rejection-fraction uint POX-REJECTION-FRACTION)
 (define-data-var pox-prepare-cycle-length uint PREPARE_CYCLE_LENGTH)
+(define-data-var pox-reward-cycle-length uint REWARD_CYCLE_LENGTH)
+(define-data-var pox-rejection-fraction uint POX_REJECTION_FRACTION)
 (define-data-var first-burnchain-block-height uint u0)
 (define-data-var configured bool false)
 
@@ -317,15 +317,15 @@
 
 ;; Is the address mode valid for a PoX burn address?
 (define-private (check-pox-addr-version (version (buff 1)))
-    (or (is-eq version ADDRESS-VERSION-P2PKH)
-        (is-eq version ADDRESS-VERSION-P2SH)
-        (is-eq version ADDRESS-VERSION-P2WPKH)
-        (is-eq version ADDRESS-VERSION-P2WSH)))
+    (or (is-eq version ADDRESS_VERSION_P2PKH)
+        (is-eq version ADDRESS_VERSION_P2SH)
+        (is-eq version ADDRESS_VERSION_P2WPKH)
+        (is-eq version ADDRESS_VERSION_P2WSH)))
 
 ;; Is the given lock period valid?
 (define-private (check-pox-lock-period (lock-period uint)) 
-    (and (>= lock-period MIN-POX-REWARD-CYCLES) 
-         (<= lock-period MAX-POX-REWARD-CYCLES)))
+    (and (>= lock-period MIN_POX_REWARD_CYCLES) 
+         (<= lock-period MAX_POX_REWARD_CYCLES)))
 
 ;; Evaluate if a participant can stack an amount of STX for a given period.
 ;; This method is designed as a read-only method so that it can be used as 

--- a/src/chainstate/stacks/boot/pox.clar
+++ b/src/chainstate/stacks/boot/pox.clar
@@ -329,9 +329,9 @@
 
 ;; Evaluate if a participant can stack an amount of STX for a given period.
 ;; This method is designed as a read-only method so that it can be used as 
-;; a set of guard conditions, but also via a read-only RPC call that can be
-;; performed before hand.
-(define-read-only (can-stacks-stx (pox-addr (tuple (version (buff 1)) (hashbytes (buff 20))))
+;; a set of guard conditions and also as a read-only RPC call that can be
+;; performed beforehand.
+(define-read-only (can-stack-stx (pox-addr (tuple (version (buff 1)) (hashbytes (buff 20))))
                                   (amount-ustx uint)
                                   (first-reward-cycle uint)
                                   (num-cycles uint))
@@ -393,7 +393,7 @@
         (err ERR_STACKING_ALREADY_STACKED))
 
     ;; ensure that stacking can be performed
-    (try! (can-stacks-stx pox-addr amount-ustx first-reward-cycle lock-period))
+    (try! (can-stack-stx pox-addr amount-ustx first-reward-cycle lock-period))
 
     ;; register the PoX address with the amount stacked
     (try! (add-pox-addr-to-reward-cycles pox-addr first-reward-cycle lock-period amount-ustx))

--- a/src/chainstate/stacks/boot/pox.clar
+++ b/src/chainstate/stacks/boot/pox.clar
@@ -20,7 +20,7 @@
 (define-constant MAX-POX-REWARD-CYCLES u12)
 
 ;; Default length of the PoX registration window, in burnchain blocks.
-(define-constant REGISTRATION-WINDOW-LENGTH u250)
+(define-constant PREPARE_CYCLE_LENGTH u250)
 
 ;; Default length of the PoX reward cycle, in burnchain blocks.
 (define-constant REWARD-CYCLE-LENGTH u1000)
@@ -42,20 +42,20 @@
 ;; Data vars that store a copy of the burnchain configuration.
 ;; Implemented as data-vars, so that different configurations can be
 ;; used in e.g. test harnesses.
-(define-data-var pox-registration-window-length uint REGISTRATION-WINDOW-LENGTH)
 (define-data-var pox-reward-cycle-length uint REWARD-CYCLE-LENGTH)
 (define-data-var pox-rejection-fraction uint POX-REJECTION-FRACTION)
+(define-data-var pox-prepare-cycle-length uint PREPARE_CYCLE_LENGTH)
 (define-data-var first-burnchain-block-height uint u0)
 (define-data-var configured bool false)
 
 ;; This function can only be called once, when it boots up
-(define-public (set-burnchain-parameters (first-burn-height uint) (pox-reg-window-len uint) (pox-reward-cycle-len uint) (pox-rejection-frac uint))
+(define-public (set-burnchain-parameters (first-burn-height uint) (prepare-cycle-length uint) (reward-cycle-length uint) (rejection-fraction uint))
     (begin
         (asserts! (and is-in-regtest (not (var-get configured))) (err ERR_NOT_ALLOWED))
         (var-set first-burnchain-block-height first-burn-height)
-        (var-set pox-registration-window-length pox-reg-window-len)
-        (var-set pox-reward-cycle-length pox-reward-cycle-len)
-        (var-set pox-rejection-fraction pox-rejection-frac)
+        (var-set pox-prepare-cycle-length prepare-cycle-length)
+        (var-set pox-reward-cycle-length reward-cycle-length)
+        (var-set pox-rejection-fraction rejection-fraction)
         (var-set configured true)
         (ok true))
 )
@@ -456,7 +456,7 @@
     (ok {
         min-amount-ustx: (get-stacking-minimum),
         reward-cycle-id: (current-pox-reward-cycle),
-        registration-window-length: (var-get pox-registration-window-length),
+        prepare-cycle-length: (var-get pox-prepare-cycle-length),
         first-burnchain-block-height: (var-get first-burnchain-block-height),
         reward-cycle-length: (var-get pox-reward-cycle-length),
         rejection-fraction: (var-get pox-rejection-fraction)

--- a/src/chainstate/stacks/events.rs
+++ b/src/chainstate/stacks/events.rs
@@ -58,6 +58,12 @@ impl StacksTransactionEvent {
                 "type": "stx_burn_event",
                 "stx_burn_event": event_data.json_serialize()
             }),
+            StacksTransactionEvent::STXEvent(STXEventType::STXLockEvent(event_data)) => json!({
+                "txid": format!("0x{:?}", txid),
+                "committed": committed,
+                "type": "stx_lock_event",
+                "stx_lock_event": event_data.json_serialize()
+            }),
             StacksTransactionEvent::NFTEvent(NFTEventType::NFTTransferEvent(event_data)) => json!({
                 "txid": format!("0x{:?}", txid),
                 "committed": committed,
@@ -90,7 +96,8 @@ impl StacksTransactionEvent {
 pub enum STXEventType {
     STXTransferEvent(STXTransferEventData),
     STXMintEvent(STXMintEventData),
-    STXBurnEvent(STXBurnEventData)
+    STXBurnEvent(STXBurnEventData),
+    STXLockEvent(STXLockEventData)
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -133,6 +140,21 @@ impl STXMintEventData {
         json!({
             "recipient": format!("{}",self.recipient),
             "amount": format!("{}", self.amount),
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct STXLockEventData {
+    pub locked_amount: u128,
+    pub unlock_height: u64,
+}
+
+impl STXLockEventData {
+    pub fn json_serialize(&self) -> serde_json::Value {
+        json!({
+            "locked_amount": format!("{}",self.locked_amount),
+            "unlock_height": format!("{}", self.unlock_height),
         })
     }
 }

--- a/src/net/http.rs
+++ b/src/net/http.rs
@@ -93,6 +93,7 @@ use std::time::SystemTime;
 
 lazy_static! {
     static ref PATH_GETINFO : Regex = Regex::new(r#"^/v2/info$"#).unwrap();
+    static ref PATH_GETPOXINFO : Regex = Regex::new(r#"^/v2/pox$"#).unwrap();
     static ref PATH_GETNEIGHBORS : Regex = Regex::new(r#"^/v2/neighbors$"#).unwrap();
     static ref PATH_GETBLOCK : Regex = Regex::new(r#"^/v2/blocks/([0-9a-f]{64})$"#).unwrap();
     static ref PATH_GETMICROBLOCKS_INDEXED : Regex = Regex::new(r#"^/v2/microblocks/([0-9a-f]{64})$"#).unwrap();
@@ -1164,6 +1165,7 @@ impl HttpRequestType {
         // TODO: make this static somehow
         let REQUEST_METHODS: &[(&str, &Regex, &dyn Fn(&mut StacksHttp, &HttpRequestPreamble, &Captures, Option<&str>, &mut R) -> Result<HttpRequestType, net_error>)] = &[
             ("GET", &PATH_GETINFO, &HttpRequestType::parse_getinfo),
+            ("GET", &PATH_GETPOXINFO, &HttpRequestType::parse_getpoxinfo),
             ("GET", &PATH_GETNEIGHBORS, &HttpRequestType::parse_getneighbors),
             ("GET", &PATH_GETBLOCK, &HttpRequestType::parse_getblock),
             ("GET", &PATH_GETMICROBLOCKS_INDEXED, &HttpRequestType::parse_getmicroblocks_indexed),
@@ -1214,6 +1216,16 @@ impl HttpRequestType {
         Ok(HttpRequestType::GetInfo(HttpRequestMetadata::from_preamble(preamble)))
     }
     
+    fn parse_getpoxinfo<R: Read>(_protocol: &mut StacksHttp, preamble: &HttpRequestPreamble, _regex: &Captures, query: Option<&str>, _fd: &mut R) -> Result<HttpRequestType, net_error> {
+        if preamble.get_content_length() != 0 {
+            return Err(net_error::DeserializeError("Invalid Http request: expected 0-length body for GetInfo".to_string()));
+        }
+
+        let tip = HttpRequestType::get_chain_tip_query(query);
+
+        Ok(HttpRequestType::GetPoxInfo(HttpRequestMetadata::from_preamble(preamble), tip))
+    }
+
     fn parse_getneighbors<R: Read>(_protocol: &mut StacksHttp, preamble: &HttpRequestPreamble, _regex: &Captures, _query: Option<&str>, _fd: &mut R) -> Result<HttpRequestType, net_error> {
         if preamble.get_content_length() != 0 {
             return Err(net_error::DeserializeError("Invalid Http request: expected 0-length body for GetNeighbors".to_string()));
@@ -1502,6 +1514,7 @@ impl HttpRequestType {
     pub fn metadata(&self) -> &HttpRequestMetadata {
         match *self {
             HttpRequestType::GetInfo(ref md) => md,
+            HttpRequestType::GetPoxInfo(ref md, _) => md,
             HttpRequestType::GetNeighbors(ref md) => md,
             HttpRequestType::GetBlock(ref md, _) => md,
             HttpRequestType::GetMicroblocksIndexed(ref md, _) => md,
@@ -1523,6 +1536,7 @@ impl HttpRequestType {
     pub fn metadata_mut(&mut self) -> &mut HttpRequestMetadata {
         match *self {
             HttpRequestType::GetInfo(ref mut md) => md,
+            HttpRequestType::GetPoxInfo(ref mut md, _) => md,
             HttpRequestType::GetNeighbors(ref mut md) => md,
             HttpRequestType::GetBlock(ref mut md, _) => md,
             HttpRequestType::GetMicroblocksIndexed(ref mut md, _) => md,
@@ -1556,6 +1570,7 @@ impl HttpRequestType {
     pub fn request_path(&self) -> String {
         match self {
             HttpRequestType::GetInfo(_md) => "/v2/info".to_string(),
+            HttpRequestType::GetPoxInfo(_md, tip_opt) => format!("/v2/pox{}", HttpRequestType::make_query_string(tip_opt.as_ref(), true)),
             HttpRequestType::GetNeighbors(_md) => "/v2/neighbors".to_string(),
             HttpRequestType::GetBlock(_md, block_hash) => format!("/v2/blocks/{}", block_hash.to_hex()),
             HttpRequestType::GetMicroblocksIndexed(_md, block_hash) => format!("/v2/microblocks/{}", block_hash.to_hex()),
@@ -1798,6 +1813,7 @@ impl HttpResponseType {
         // TODO: make this static somehow
         let RESPONSE_METHODS : &[(&Regex, &dyn Fn(&mut StacksHttp, HttpVersion, &HttpResponsePreamble, &mut R, Option<usize>) -> Result<HttpResponseType, net_error>)] = &[
             (&PATH_GETINFO, &HttpResponseType::parse_peerinfo),
+            (&PATH_GETPOXINFO, &HttpResponseType::parse_poxinfo),
             (&PATH_GETNEIGHBORS, &HttpResponseType::parse_neighbors),
             (&PATH_GETBLOCK, &HttpResponseType::parse_block),
             (&PATH_GETMICROBLOCKS_INDEXED, &HttpResponseType::parse_microblocks),
@@ -1845,6 +1861,12 @@ impl HttpResponseType {
         let peer_info = HttpResponseType::parse_json(preamble, fd, len_hint, MAX_MESSAGE_LEN as u64)?;
         Ok(HttpResponseType::PeerInfo(HttpResponseMetadata::from_preamble(request_version, preamble), peer_info))
     }
+
+    fn parse_poxinfo<R: Read>(_protocol: &mut StacksHttp, request_version: HttpVersion, preamble: &HttpResponsePreamble, fd: &mut R, len_hint: Option<usize>) -> Result<HttpResponseType, net_error> {
+        let pox_info = HttpResponseType::parse_json(preamble, fd, len_hint, MAX_MESSAGE_LEN as u64)?;
+        Ok(HttpResponseType::PoxInfo(HttpResponseMetadata::from_preamble(request_version, preamble), pox_info))
+    }
+
 
     fn parse_neighbors<R: Read>(_protocol: &mut StacksHttp, request_version: HttpVersion, preamble: &HttpResponsePreamble, fd: &mut R, len_hint: Option<usize>) -> Result<HttpResponseType, net_error> {
         let neighbors_data = HttpResponseType::parse_json(preamble, fd, len_hint, MAX_MESSAGE_LEN as u64)?;
@@ -1960,6 +1982,7 @@ impl HttpResponseType {
     pub fn metadata(&self) -> &HttpResponseMetadata {
         match *self {
             HttpResponseType::PeerInfo(ref md, _) => md,
+            HttpResponseType::PoxInfo(ref md, _) => md,
             HttpResponseType::Neighbors(ref md, _) => md,
             HttpResponseType::Block(ref md, _) => md,
             HttpResponseType::BlockStream(ref md) => md,
@@ -2061,6 +2084,10 @@ impl HttpResponseType {
             HttpResponseType::PeerInfo(ref md, ref peer_info) => {
                 HttpResponsePreamble::ok_JSON_from_md(fd, md)?;
                 HttpResponseType::send_json(protocol, md, fd, peer_info)?;
+            },
+            HttpResponseType::PoxInfo(ref md, ref pox_info) => {
+                HttpResponsePreamble::ok_JSON_from_md(fd, md)?;
+                HttpResponseType::send_json(protocol, md, fd, pox_info)?;
             },
             HttpResponseType::Neighbors(ref md, ref neighbor_data) => {
                 HttpResponsePreamble::ok_JSON_from_md(fd, md)?;
@@ -2165,6 +2192,7 @@ impl MessageSequence for StacksHttpMessage {
         match *self {
             StacksHttpMessage::Request(ref req) => match req {
                 HttpRequestType::GetInfo(_) => "HTTP(GetInfo)",
+                HttpRequestType::GetPoxInfo(_, _) => "HTTP(GetPoxInfo)",
                 HttpRequestType::GetNeighbors(_) => "HTTP(GetNeighbors)",
                 HttpRequestType::GetBlock(_, _) => "HTTP(GetBlock)",
                 HttpRequestType::GetMicroblocksIndexed(_, _) => "HTTP(GetMicroblocksIndexed)",
@@ -2189,6 +2217,7 @@ impl MessageSequence for StacksHttpMessage {
                 HttpResponseType::GetContractSrc(..) => "HTTP(GetContractSrc)",
                 HttpResponseType::CallReadOnlyFunction(..) => "HTTP(CallReadOnlyFunction)",
                 HttpResponseType::PeerInfo(_, _) => "HTTP(PeerInfo)",
+                HttpResponseType::PoxInfo(_, _) => "HTTP(PeerInfo)",
                 HttpResponseType::Neighbors(_, _) => "HTTP(Neighbors)",
                 HttpResponseType::Block(_, _) => "HTTP(Block)",
                 HttpResponseType::BlockStream(_) => "HTTP(BlockStream)",

--- a/src/net/http.rs
+++ b/src/net/http.rs
@@ -1218,7 +1218,7 @@ impl HttpRequestType {
     
     fn parse_getpoxinfo<R: Read>(_protocol: &mut StacksHttp, preamble: &HttpRequestPreamble, _regex: &Captures, query: Option<&str>, _fd: &mut R) -> Result<HttpRequestType, net_error> {
         if preamble.get_content_length() != 0 {
-            return Err(net_error::DeserializeError("Invalid Http request: expected 0-length body for GetInfo".to_string()));
+            return Err(net_error::DeserializeError("Invalid Http request: expected 0-length body for GetPoxInfo".to_string()));
         }
 
         let tip = HttpRequestType::get_chain_tip_query(query);

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -947,6 +947,18 @@ pub struct RPCPeerInfoData {
     pub exit_at_block_height: Option<u64>,
 }
 
+/// The data we return on GET /v2/pox
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RPCPoxInfoData {
+    pub contract_id: String,
+    pub first_burnchain_block_height: u128,
+    pub min_amount_ustx: u128,
+    pub registration_window_length: u128,
+    pub rejection_fraction: u128,
+    pub reward_cycle_id: u128,
+    pub reward_cycle_length: u128,
+}
+
 #[derive(Debug, Clone, PartialEq, Copy, Hash)]
 #[repr(u8)]
 pub enum HttpVersion {
@@ -1078,6 +1090,7 @@ pub struct RPCNeighborsInfo {
 #[derive(Debug, Clone, PartialEq)]
 pub enum HttpRequestType {
     GetInfo(HttpRequestMetadata),
+    GetPoxInfo(HttpRequestMetadata, Option<StacksBlockId>),
     GetNeighbors(HttpRequestMetadata),
     GetBlock(HttpRequestMetadata, StacksBlockId),
     GetMicroblocksIndexed(HttpRequestMetadata, StacksBlockId),
@@ -1155,6 +1168,7 @@ impl From<&HttpRequestType> for HttpResponseMetadata {
 #[derive(Debug, Clone, PartialEq)]
 pub enum HttpResponseType {
     PeerInfo(HttpResponseMetadata, RPCPeerInfoData),
+    PoxInfo(HttpResponseMetadata, RPCPoxInfoData),
     Neighbors(HttpResponseMetadata, RPCNeighborsInfo),
     Block(HttpResponseMetadata, StacksBlock),
     BlockStream(HttpResponseMetadata),

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -953,7 +953,7 @@ pub struct RPCPoxInfoData {
     pub contract_id: String,
     pub first_burnchain_block_height: u128,
     pub min_amount_ustx: u128,
-    pub registration_window_length: u128,
+    pub prepare_cycle_length: u128,
     pub rejection_fraction: u128,
     pub reward_cycle_id: u128,
     pub reward_cycle_length: u128,

--- a/src/net/rpc.rs
+++ b/src/net/rpc.rs
@@ -231,9 +231,9 @@ impl RPCPoxInfoData {
             .to_owned()
             .expect_u128();
 
-        let registration_window_length = res
-            .get("registration-window-length")
-            .expect(&format!("FATAL: no 'registration-window-length'"))
+        let prepare_cycle_length = res
+            .get("prepare-cycle-length")
+            .expect(&format!("FATAL: no 'prepare-cycle-length'"))
             .to_owned()
             .expect_u128();
 
@@ -259,7 +259,7 @@ impl RPCPoxInfoData {
             contract_id: boot::boot_code_id("pox").to_string(),
             first_burnchain_block_height,
             min_amount_ustx,
-            registration_window_length,
+            prepare_cycle_length,
             rejection_fraction,
             reward_cycle_id,
             reward_cycle_length,

--- a/src/net/rpc.rs
+++ b/src/net/rpc.rs
@@ -37,7 +37,7 @@ use net::HttpRequestMetadata;
 use net::HttpResponseMetadata;
 use net::PeerAddress;
 use net::ClientError;
-use net::RPCPeerInfoData;
+use net::{RPCPeerInfoData, RPCPoxInfoData};
 use net::NeighborAddress;
 use net::NeighborsData;
 use net::StacksHttp;
@@ -91,6 +91,7 @@ use vm::{
     costs::{ LimitedCostTracker,
              ExecutionCost },
     types::{ PrincipalData,
+             StandardPrincipalData,
              QualifiedContractIdentifier },
     database::{ ClarityDatabase,
                 MarfedKV,
@@ -187,7 +188,81 @@ impl RPCPeerInfoData {
             stacks_tip,
             stacks_tip_consensus_hash: stacks_tip_consensus_hash.to_hex(),
             unanchored_tip: unconfirmed_tip,
-            exit_at_block_height: exit_at_block_height.cloned()
+            exit_at_block_height: exit_at_block_height.cloned(),
+        })
+    }
+}
+
+impl RPCPoxInfoData {
+
+    pub fn from_db(sortdb: &SortitionDB, chainstate: &mut StacksChainState, tip: &StacksBlockId, options: &ConnectionOptions) -> Result<RPCPoxInfoData, net_error> {
+
+        let contract_identifier = boot::boot_code_id("pox");
+        let function = "get-pox-info";
+        let cost_track = LimitedCostTracker::new(options.read_only_call_limit.clone());
+        let sender = PrincipalData::Standard(StandardPrincipalData::transient());
+
+        let data = chainstate.maybe_read_only_clarity_tx(&sortdb.index_conn(), tip, |clarity_tx| {
+            clarity_tx.with_readonly_clarity_env(sender, cost_track, |env| {
+                env.execute_contract(&contract_identifier, function, &vec![], true)
+            })
+        });
+
+        let res = match data {
+            Ok(res) => {
+                res
+                    .expect_result_ok()
+                    .expect_tuple()
+            }
+            Err(_e) => {
+                return Err(net_error::DBError(db_error::NotFoundError))
+            }
+        };
+
+        let first_burnchain_block_height = res
+            .get("first-burnchain-block-height")
+            .expect(&format!("FATAL: no 'first-burnchain-block-height'"))
+            .to_owned()
+            .expect_u128();
+
+        let min_amount_ustx = res
+            .get("min-amount-ustx")
+            .expect(&format!("FATAL: no 'min-amount-ustx'"))
+            .to_owned()
+            .expect_u128();
+
+        let registration_window_length = res
+            .get("registration-window-length")
+            .expect(&format!("FATAL: no 'registration-window-length'"))
+            .to_owned()
+            .expect_u128();
+
+        let rejection_fraction = res
+            .get("rejection-fraction")
+            .expect(&format!("FATAL: no 'rejection-fraction'"))
+            .to_owned()
+            .expect_u128();
+
+        let reward_cycle_id = res
+            .get("reward-cycle-id")
+            .expect(&format!("FATAL: no 'reward-cycle-id'"))
+            .to_owned()
+            .expect_u128();
+
+        let reward_cycle_length = res
+            .get("reward-cycle-length")
+            .expect(&format!("FATAL: no 'reward-cycle-length'"))
+            .to_owned()
+            .expect_u128();        
+
+        Ok(RPCPoxInfoData {
+            contract_id: boot::boot_code_id("pox").to_string(),
+            first_burnchain_block_height,
+            min_amount_ustx,
+            registration_window_length,
+            rejection_fraction,
+            reward_cycle_id,
+            reward_cycle_length,
         })
     }
 }
@@ -329,6 +404,24 @@ impl ConversationHttp {
         match RPCPeerInfoData::from_db(burnchain, sortdb, chainstate, peerdb, &handler_args.exit_at_block_height) {
             Ok(pi) => {
                 let response = HttpResponseType::PeerInfo(response_metadata, pi);
+                response.send(http, fd)
+            }
+            Err(e) => {
+                warn!("Failed to get peer info {:?}: {:?}", req, &e);
+                let response = HttpResponseType::ServerError(response_metadata, "Failed to query peer info".to_string());
+                response.send(http, fd)
+            }
+        }
+    }
+
+        /// Handle a GET pox info.
+    /// The response will be synchronously written to the given fd (so use a fd that can buffer!)
+    fn handle_getpoxinfo<W: Write>(http: &mut StacksHttp, fd: &mut W, req: &HttpRequestType,
+        sortdb: &SortitionDB, chainstate: &mut StacksChainState, tip: &StacksBlockId, options: &ConnectionOptions) -> Result<(), net_error> {
+        let response_metadata = HttpResponseMetadata::from(req);
+        match RPCPoxInfoData::from_db(sortdb, chainstate, tip, options) {
+            Ok(pi) => {
+                let response = HttpResponseType::PoxInfo(response_metadata, pi);
                 response.send(http, fd)
             }
             Err(e) => {
@@ -772,6 +865,13 @@ impl ConversationHttp {
                                                  sortdb, chainstate, peerdb, handler_opts)?;
                 None
             },
+            HttpRequestType::GetPoxInfo(ref _md, ref tip_opt) => {
+                if let Some(tip) = ConversationHttp::handle_load_stacks_chain_tip(&mut self.connection.protocol, &mut reply, &req, tip_opt.as_ref(), sortdb, chainstate)? {
+                    ConversationHttp::handle_getpoxinfo(&mut self.connection.protocol, &mut reply, &req,
+                                                    sortdb, chainstate, &tip, &self.connection.options)?;
+                }
+                None
+            },
             HttpRequestType::GetNeighbors(ref _md) => {
                 ConversationHttp::handle_getneighbors(&mut self.connection.protocol, &mut reply, &req, self.network_id, chain_view, peers, peerdb)?;
                 None
@@ -1192,6 +1292,11 @@ impl ConversationHttp {
     pub fn new_getinfo(&self) -> HttpRequestType {
         HttpRequestType::GetInfo(HttpRequestMetadata::from_host(self.peer_host.clone()))
     }
+
+    /// Make a new getinfo request to this endpoint
+    pub fn new_getpoxinfo(&self, tip_opt: Option<StacksBlockId>) -> HttpRequestType {
+        HttpRequestType::GetPoxInfo(HttpRequestMetadata::from_host(self.peer_host.clone()), tip_opt)
+    }    
     
     /// Make a new getneighbors request to this endpoint
     pub fn new_getneighbors(&self) -> HttpRequestType {
@@ -1582,6 +1687,38 @@ mod test {
                     }
                  });
     }
+
+    #[test]
+    #[ignore]
+    fn test_rpc_getpoxinfo() {
+        let pox_server_info = RefCell::new(None);
+        test_rpc("test_rpc_getpoxinfo", 40000, 40001, 50000, 50001,
+                 |ref mut peer_client, ref mut convo_client, ref mut peer_server, ref mut convo_server| {
+                    let mut sortdb = peer_server.sortdb.as_mut().unwrap();
+                    let chainstate = &mut peer_server.stacks_node.as_mut().unwrap().chainstate;
+                    let stacks_block_id = {
+                        let tip = chainstate.get_stacks_chain_tip(sortdb).unwrap().unwrap();
+                        StacksBlockHeader::make_index_block_hash(&tip.consensus_hash, &tip.anchored_block_hash)
+                    };
+                    let pox_info = RPCPoxInfoData::from_db(&mut sortdb, chainstate, &stacks_block_id, &ConnectionOptions::default()).unwrap();
+                    *pox_server_info.borrow_mut() = Some(pox_info);
+                    convo_client.new_getpoxinfo(None)
+                 },
+                 |ref http_request, ref http_response, ref mut peer_client, ref mut peer_server| {
+                     let req_md = http_request.metadata().clone();
+                     match http_response {
+                        HttpResponseType::PoxInfo(response_md, pox_data) => {
+                            assert_eq!(Some((*pox_data).clone()), *pox_server_info.borrow());
+                            true
+                        },
+                        _ => {
+                            error!("Invalid response: {:?}", &http_response);
+                            false
+                        }
+                    }
+                 });
+    }
+
 
     #[test]
     #[ignore]

--- a/src/vm/contexts.rs
+++ b/src/vm/contexts.rs
@@ -64,7 +64,7 @@ pub struct AssetMap {
 
 #[derive(Debug, Clone)]
 pub struct EventBatch {
-    events: Vec<StacksTransactionEvent>,        
+    pub events: Vec<StacksTransactionEvent>,        
 }
 
 /** GlobalContext represents the outermost context for a single transaction's
@@ -644,7 +644,7 @@ impl <'a,'b> Environment <'a,'b> {
             match res {
                 Ok(value) => {
                     let sender_principal = self.sender.clone().map(|v| v.expect_principal());
-                    handle_contract_call_special_cases(&mut self.global_context.database, sender_principal.as_ref(), contract_identifier, tx_name, &value)?;
+                    handle_contract_call_special_cases(&mut self.global_context, sender_principal.as_ref(), contract_identifier, tx_name, &value)?;
                     Ok(value)
                 },
                 Err(e) => Err(e)

--- a/src/vm/functions/special.rs
+++ b/src/vm/functions/special.rs
@@ -5,13 +5,14 @@ use vm::types::{Value, PrincipalData, QualifiedContractIdentifier};
 use vm::representations::{SymbolicExpression, SymbolicExpressionType};
 use vm::errors::Error;
 use vm::errors::{CheckErrors, InterpreterError, RuntimeErrorType, InterpreterResult as Result};
+use vm::contexts::GlobalContext;
 
 use chainstate::stacks::boot::boot_code_id;
 use chainstate::stacks::db::StacksChainState;
+use chainstate::stacks::events::{StacksTransactionEvent, STXEventType, STXLockEventData};
 use vm::clarity::ClarityTransactionConnection;
-use vm::database::ClarityDatabase;
 
-fn parse_pox_stacking_result(result: &Value) -> std::result::Result<(PrincipalData, u128, u128), i128> {
+fn parse_pox_stacking_result(result: &Value) -> std::result::Result<(PrincipalData, u128, u64), i128> {
     match result.clone().expect_result() {
         Ok(res) => {
             // should have gotten back (ok (tuple (stacker principal) (lock-amount uint) (unlock-burn-height uint)))
@@ -32,7 +33,9 @@ fn parse_pox_stacking_result(result: &Value) -> std::result::Result<(PrincipalDa
                 .get("unlock-burn-height")
                 .expect(&format!("FATAL: no 'unlock-burn-height'"))
                 .to_owned()
-                .expect_u128();
+                .expect_u128()
+                .try_into()
+                .expect("FATAL: 'unlock-burn-height' overflow");
 
             Ok((stacker, lock_amount, unlock_burn_height))
         }
@@ -43,7 +46,7 @@ fn parse_pox_stacking_result(result: &Value) -> std::result::Result<(PrincipalDa
 }
 
 /// Handle special cases when calling into the PoX API contract
-fn handle_pox_api_contract_call(db: &mut ClarityDatabase, sender_opt: Option<&PrincipalData>, function_name: &str, value: &Value) -> Result<()> {
+fn handle_pox_api_contract_call(global_context: &mut GlobalContext, sender_opt: Option<&PrincipalData>, function_name: &str, value: &Value) -> Result<()> {
     if function_name == "stack-stx" {
         debug!("Handle special-case contract-call to {:?} {} (which returned {:?})", boot_code_id("pox"), function_name, value);
 
@@ -56,15 +59,22 @@ fn handle_pox_api_contract_call(db: &mut ClarityDatabase, sender_opt: Option<&Pr
         };
 
         match parse_pox_stacking_result(value) {
-            Ok((stacker, lock_amount, unlock_burn_height)) => {
+            Ok((stacker, locked_amount, unlock_height)) => {
                 assert_eq!(stacker, sender, "BUG: tx-sender is not contract-call origin!");
 
                 // if this fails, then there's a bug in the contract (since it already does
                 // the necessary checks)
-                match StacksChainState::pox_lock(db, &sender, lock_amount, unlock_burn_height as u64) {
-                    Ok(_) => {},
+                match StacksChainState::pox_lock(&mut global_context.database, &sender, locked_amount, unlock_height as u64) {
+                    Ok(_) => {
+                        if let Some(batch) = global_context.event_batches.last_mut() {
+                            batch.events.push(StacksTransactionEvent::STXEvent(STXEventType::STXLockEvent(STXLockEventData {
+                                locked_amount,
+                                unlock_height
+                            })));
+                        }                
+                    },
                     Err(e) => {
-                        panic!("FATAL: failed to lock {} from {} until {}: '{:?}'", lock_amount, sender, unlock_burn_height, &e);
+                        panic!("FATAL: failed to lock {} from {} until {}: '{:?}'", locked_amount, sender, unlock_height, &e);
                     }
                 }
 
@@ -81,9 +91,9 @@ fn handle_pox_api_contract_call(db: &mut ClarityDatabase, sender_opt: Option<&Pr
 }
 
 /// Handle special cases of contract-calls -- namely, those into PoX that should lock up STX
-pub fn handle_contract_call_special_cases(db: &mut ClarityDatabase, sender: Option<&PrincipalData>, contract_id: &QualifiedContractIdentifier, function_name: &str, result: &Value) -> Result<()> {
+pub fn handle_contract_call_special_cases(global_context: &mut GlobalContext, sender: Option<&PrincipalData>, contract_id: &QualifiedContractIdentifier, function_name: &str, result: &Value) -> Result<()> {
     if *contract_id == boot_code_id("pox") {
-        return handle_pox_api_contract_call(db, sender, function_name, result);
+        return handle_pox_api_contract_call(global_context, sender, function_name, result);
     }
     // TODO: insert more special cases here, as needed
     Ok(())

--- a/testnet/stacks-node/src/event_dispatcher.rs
+++ b/testnet/stacks-node/src/event_dispatcher.rs
@@ -232,7 +232,8 @@ impl EventDispatcher {
                     },
                     StacksTransactionEvent::STXEvent(STXEventType::STXTransferEvent(_)) |
                     StacksTransactionEvent::STXEvent(STXEventType::STXMintEvent(_)) |
-                    StacksTransactionEvent::STXEvent(STXEventType::STXBurnEvent(_)) => {
+                    StacksTransactionEvent::STXEvent(STXEventType::STXBurnEvent(_)) |
+                    StacksTransactionEvent::STXEvent(STXEventType::STXLockEvent(_)) => {
                         for o_i in &self.stx_observers_lookup {
                             dispatch_matrix[*o_i as usize].insert(i);
                         }


### PR DESCRIPTION
This PR is addressing 3 requests coming from Devx:
- Mechanism to let the sidecar know that a transaction stacked some STX: this PR is introducing some events `STXLockEvent`, emitted when locking is happening
- Ability to discover PoX parameters: this PR is introducing a new RPC endpoint `v2/pox`, returning the following:
```json
{
  "contract_id": "ST000000000000000000002AMW42H.pox",
  "first_burnchain_block_height": 0,
  "min_amount_ustx": 150000000000,
  "registration_window_length": 250,
  "rejection_fraction": 25,
  "reward_cycle_id": 0,
  "reward_cycle_length": 1000
}

```
- Ability to confirm that a user is eligible to PoX: the readonly method `can-stack-stx` is now centralizing all the guard conditions evaluated when `stack-stx` was being called, to make sure that we have the same behavior.