### PR TITLE
PoX Krypton Fixes

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -65,10 +65,12 @@ workflows:
     jobs:
       - unit_tests
       - test_demo
-      - all_tests:
-          filters:
-            branches:
-              only:
-                - master
-                - /.*net.*/
-                - /.*marf.*/
+# disable `all_tests` for now, because the circle builder
+#   OOMs on compile...
+#      - all_tests:
+#          filters:
+#            branches:
+#              only:
+#                - master
+#                - /.*net.*/
+#                - /.*marf.*/

--- a/src/chainstate/coordinator/tests.rs
+++ b/src/chainstate/coordinator/tests.rs
@@ -165,13 +165,13 @@ impl BlockEventDispatcher for NullEventDispatcher {
 }
 
 pub fn make_coordinator<'a>(path: &str) -> ChainsCoordinator<'a, NullEventDispatcher, (), OnChainRewardSetProvider> {
-    ChainsCoordinator::test_new(&get_burnchain(path), path, OnChainRewardSetProvider::new())
+    ChainsCoordinator::test_new(&get_burnchain(path), path, OnChainRewardSetProvider())
 }
 
 struct StubbedRewardSetProvider(Vec<StacksAddress>);
 
 impl RewardSetProvider for StubbedRewardSetProvider {
-    fn get_reward_set(&self, chainstate: &mut StacksChainState,
+    fn get_reward_set(&self, _current_burn_height: u64, chainstate: &mut StacksChainState,
         burnchain: &Burnchain, sortdb: &SortitionDB, block_id: &StacksBlockId) -> Result<Vec<StacksAddress>, chainstate::coordinator::Error> {
         Ok(self.0.clone())
     }

--- a/src/chainstate/stacks/boot/mod.rs
+++ b/src/chainstate/stacks/boot/mod.rs
@@ -51,13 +51,28 @@ use std::boxed::Box;
 
 pub const STACKS_BOOT_CODE_CONTRACT_ADDRESS : &'static str = "ST000000000000000000002AMW42H";
 
-pub const STACKS_BOOT_CODE : &'static [(&'static str, &'static str)] = &[
-    ("pox", std::include_str!("pox.clar")),
-    ("lookup", std::include_str!("lockup.clar"))
-];
+const BOOT_CODE_POX_BODY: &'static str = std::include_str!("pox.clar");
+const BOOT_CODE_POX_TESTNET_CONSTS: &'static str = std::include_str!("pox-testnet.clar");
+const BOOT_CODE_POX_MAINNET_CONSTS: &'static str = std::include_str!("pox-mainnet.clar");
+const BOOT_CODE_LOCKUP: &'static str = std::include_str!("lockup.clar");
+
+lazy_static! {
+    static ref BOOT_CODE_POX_MAINNET: String = format!("{}\n{}", BOOT_CODE_POX_MAINNET_CONSTS, BOOT_CODE_POX_BODY);
+    static ref BOOT_CODE_POX_TESTNET: String = format!("{}\n{}", BOOT_CODE_POX_TESTNET_CONSTS, BOOT_CODE_POX_BODY);
+
+    pub static ref STACKS_BOOT_CODE_MAINNET : [(&'static str, &'static str); 2] = [
+        ("pox", &BOOT_CODE_POX_MAINNET),
+        ("lockup", BOOT_CODE_LOCKUP)
+    ];
+
+    pub static ref STACKS_BOOT_CODE_TESTNET : [(&'static str, &'static str); 2] = [
+        ("pox", &BOOT_CODE_POX_TESTNET),
+        ("lockup", BOOT_CODE_LOCKUP)
+    ];
+}
 
 pub fn boot_code_addr() -> StacksAddress {
-    StacksAddress::from_string(&STACKS_BOOT_CODE_CONTRACT_ADDRESS.clone()).unwrap()
+    StacksAddress::from_string(STACKS_BOOT_CODE_CONTRACT_ADDRESS).unwrap()
 }    
 
 pub fn boot_code_id(name: &str) -> QualifiedContractIdentifier {
@@ -66,14 +81,6 @@ pub fn boot_code_id(name: &str) -> QualifiedContractIdentifier {
 
 pub fn make_contract_id(addr: &StacksAddress, name: &str) -> QualifiedContractIdentifier {
     QualifiedContractIdentifier::new(StandardPrincipalData::from(addr.clone()), ContractName::try_from(name.to_string()).unwrap())
-}
-
-pub fn pox_boot_code_constants(mainnet: bool) -> &'static str {
-    if mainnet {
-        std::include_str!("pox-mainnet.clar")
-    } else {
-        std::include_str!("pox-testnet.clar")
-    }
 }
 
 /// Extract a PoX address from its tuple representation

--- a/src/chainstate/stacks/boot/mod.rs
+++ b/src/chainstate/stacks/boot/mod.rs
@@ -1165,15 +1165,15 @@ pub mod test {
                     assert_eq!(min_ustx, total_liquid_ustx / 20000);
 
                     // two reward addresses, and they're Alice's and Bob's.
-                    // They are present in insertion order
+                    // They are present in sorted order
                     assert_eq!(reward_addrs.len(), 2);
-                    assert_eq!((reward_addrs[0].0).version, AddressHashMode::SerializeP2PKH.to_version_testnet());
-                    assert_eq!((reward_addrs[0].0).bytes, key_to_stacks_addr(&alice).bytes);
-                    assert_eq!(reward_addrs[0].1, 1024 * 1000000);
-                    
                     assert_eq!((reward_addrs[1].0).version, AddressHashMode::SerializeP2PKH.to_version_testnet());
-                    assert_eq!((reward_addrs[1].0).bytes, key_to_stacks_addr(&bob).bytes);
-                    assert_eq!(reward_addrs[1].1, (4 * 1024 * 1000000) / 5);
+                    assert_eq!((reward_addrs[1].0).bytes, key_to_stacks_addr(&alice).bytes);
+                    assert_eq!(reward_addrs[1].1, 1024 * 1000000);
+                    
+                    assert_eq!((reward_addrs[0].0).version, AddressHashMode::SerializeP2PKH.to_version_testnet());
+                    assert_eq!((reward_addrs[0].0).bytes, key_to_stacks_addr(&bob).bytes);
+                    assert_eq!(reward_addrs[0].1, (4 * 1024 * 1000000) / 5);
                 }
                 else {
                     // no reward addresses
@@ -1633,15 +1633,15 @@ pub mod test {
                     assert_eq!(first_reward_cycle, first_pox_reward_cycle);
                     assert_eq!(lock_period, 1);
 
-                    // two reward address, and it's Alice's and Charlie's
+                    // two reward address, and it's Alice's and Charlie's in sorted order
                     assert_eq!(reward_addrs.len(), 2);
-                    assert_eq!((reward_addrs[0].0).version, AddressHashMode::SerializeP2PKH.to_version_testnet());
-                    assert_eq!((reward_addrs[0].0).bytes, key_to_stacks_addr(&alice).bytes);
-                    assert_eq!(reward_addrs[0].1, 1024 * 1000000);
-                    
                     assert_eq!((reward_addrs[1].0).version, AddressHashMode::SerializeP2PKH.to_version_testnet());
-                    assert_eq!((reward_addrs[1].0).bytes, key_to_stacks_addr(&charlie).bytes);
+                    assert_eq!((reward_addrs[1].0).bytes, key_to_stacks_addr(&alice).bytes);
                     assert_eq!(reward_addrs[1].1, 1024 * 1000000);
+                    
+                    assert_eq!((reward_addrs[0].0).version, AddressHashMode::SerializeP2PKH.to_version_testnet());
+                    assert_eq!((reward_addrs[0].0).bytes, key_to_stacks_addr(&charlie).bytes);
+                    assert_eq!(reward_addrs[0].1, 1024 * 1000000);
                
                     // All of Alice's and Charlie's tokens are locked
                     assert_eq!(alice_balance, 0);
@@ -1711,13 +1711,13 @@ pub mod test {
                     // one reward address, and it's Alice's
                     // either way, there's a single reward address
                     assert_eq!(reward_addrs.len(), 2);
-                    assert_eq!((reward_addrs[0].0).version, AddressHashMode::SerializeP2PKH.to_version_testnet());
-                    assert_eq!((reward_addrs[0].0).bytes, key_to_stacks_addr(&alice).bytes);
-                    assert_eq!(reward_addrs[0].1, 512 * 1000000);
-
                     assert_eq!((reward_addrs[1].0).version, AddressHashMode::SerializeP2PKH.to_version_testnet());
-                    assert_eq!((reward_addrs[1].0).bytes, key_to_stacks_addr(&charlie).bytes);
+                    assert_eq!((reward_addrs[1].0).bytes, key_to_stacks_addr(&alice).bytes);
                     assert_eq!(reward_addrs[1].1, 512 * 1000000);
+
+                    assert_eq!((reward_addrs[0].0).version, AddressHashMode::SerializeP2PKH.to_version_testnet());
+                    assert_eq!((reward_addrs[0].0).bytes, key_to_stacks_addr(&charlie).bytes);
+                    assert_eq!(reward_addrs[0].1, 512 * 1000000);
                
                     // Half of Alice's tokens are locked
                     assert_eq!(alice_balance, 512 * 1000000);
@@ -1971,11 +1971,16 @@ pub mod test {
                     // in reward cycle
                     assert_eq!(reward_addrs.len(), expected_pox_addrs.len());
 
+                    // in sorted order
+                    let mut sorted_expected_pox_info: Vec<_> = expected_pox_addrs.iter().zip(balances_stacked.iter())
+                        .collect();
+                    sorted_expected_pox_info.sort_by_key(|(pox_addr, _)| (pox_addr.1).0);
+
                     // in stacker order
-                    for ((i, pox_addr), expected_stacked) in expected_pox_addrs.iter().enumerate().zip(balances_stacked.iter()) {
+                    for (i, (pox_addr, expected_stacked)) in sorted_expected_pox_info.iter().enumerate() {
                         assert_eq!((reward_addrs[i].0).version, pox_addr.0);
                         assert_eq!((reward_addrs[i].0).bytes, pox_addr.1);
-                        assert_eq!(reward_addrs[i].1, *expected_stacked);
+                        assert_eq!(reward_addrs[i].1, **expected_stacked);
                     }
 
                     // all stackers are present

--- a/src/chainstate/stacks/boot/mod.rs
+++ b/src/chainstate/stacks/boot/mod.rs
@@ -68,6 +68,14 @@ pub fn make_contract_id(addr: &StacksAddress, name: &str) -> QualifiedContractId
     QualifiedContractIdentifier::new(StandardPrincipalData::from(addr.clone()), ContractName::try_from(name.to_string()).unwrap())
 }
 
+pub fn pox_boot_code_constants(mainnet: bool) -> &'static str {
+    if mainnet {
+        std::include_str!("pox-mainnet.clar")
+    } else {
+        std::include_str!("pox-testnet.clar")
+    }
+}
+
 /// Extract a PoX address from its tuple representation
 fn tuple_to_pox_addr(tuple_data: TupleData) -> (AddressHashMode, Hash160) {
     let version_value = tuple_data.get("version").expect("FATAL: no 'version' field in pox-addr").to_owned();
@@ -169,6 +177,8 @@ impl StacksChainState {
 
             ret.push((StacksAddress::new(version, hash), total_ustx));
         }
+
+        ret.sort_by_key(|k| k.0.bytes.0);
 
         Ok(ret)
     }

--- a/src/chainstate/stacks/boot/pox-mainnet.clar
+++ b/src/chainstate/stacks/boot/pox-mainnet.clar
@@ -1,0 +1,24 @@
+;; PoX mainnet constants
+;; Min/max number of reward cycles uSTX can be locked for
+(define-constant MIN-POX-REWARD-CYCLES u1)
+(define-constant MAX-POX-REWARD-CYCLES u12)
+
+;; Default length of the PoX registration window, in burnchain blocks.
+(define-constant REGISTRATION-WINDOW-LENGTH u250)
+
+;; Default length of the PoX reward cycle, in burnchain blocks.
+(define-constant REWARD-CYCLE-LENGTH u1000)
+
+;; Valid values for burnchain address versions.
+;; TODO: These correspond to address hash modes in Stacks 2.0,
+;;    but they should just be Bitcoin version bytes: we don't
+;;    need to constrain PoX recipient addresses the way that
+;;    we constrain other kinds of Bitcoin addresses
+(define-constant ADDRESS-VERSION-P2PKH 0x00)
+(define-constant ADDRESS-VERSION-P2SH 0x01)
+(define-constant ADDRESS-VERSION-P2WPKH 0x02)
+(define-constant ADDRESS-VERSION-P2WSH 0x03)
+
+;; Stacking thresholds
+(define-constant STACKING-THRESHOLD-25 u20000)
+(define-constant STACKING-THRESHOLD-100 u5000)

--- a/src/chainstate/stacks/boot/pox-testnet.clar
+++ b/src/chainstate/stacks/boot/pox-testnet.clar
@@ -1,0 +1,25 @@
+;; PoX testnet constants
+;; Min/max number of reward cycles uSTX can be locked for
+(define-constant MIN-POX-REWARD-CYCLES u1)
+(define-constant MAX-POX-REWARD-CYCLES u12)
+
+;; Default length of the PoX registration window, in burnchain blocks.
+(define-constant REGISTRATION-WINDOW-LENGTH u30)
+
+;; Default length of the PoX reward cycle, in burnchain blocks.
+(define-constant REWARD-CYCLE-LENGTH u120)
+
+
+;; Valid values for burnchain address versions.
+;; TODO: These correspond to address hash modes in Stacks 2.0,
+;;    but they should just be Bitcoin version bytes: we don't
+;;    need to constrain PoX recipient addresses the way that
+;;    we constrain other kinds of Bitcoin addresses
+(define-constant ADDRESS-VERSION-P2PKH 0x00)
+(define-constant ADDRESS-VERSION-P2SH 0x01)
+(define-constant ADDRESS-VERSION-P2WPKH 0x02)
+(define-constant ADDRESS-VERSION-P2WSH 0x03)
+
+;; Stacking thresholds
+(define-constant STACKING-THRESHOLD-25 u480)
+(define-constant STACKING-THRESHOLD-100 u120)

--- a/src/chainstate/stacks/boot/pox.clar
+++ b/src/chainstate/stacks/boot/pox.clar
@@ -15,27 +15,6 @@
 (define-constant ERR_STACKING_INVALID_AMOUNT 18)
 (define-constant ERR_NOT_ALLOWED 19)
 
-;; Min/max number of reward cycles uSTX can be locked for
-(define-constant MIN-POX-REWARD-CYCLES u1)
-(define-constant MAX-POX-REWARD-CYCLES u12)
-
-;; Default length of the PoX registration window, in burnchain blocks.
-(define-constant REGISTRATION-WINDOW-LENGTH u250)
-
-;; Default length of the PoX reward cycle, in burnchain blocks.
-(define-constant REWARD-CYCLE-LENGTH u1000)
-
-;; Valid values for burnchain address versions.
-;; These correspond to address hash modes in Stacks 2.0.
-(define-constant ADDRESS-VERSION-P2PKH 0x00)
-(define-constant ADDRESS-VERSION-P2SH 0x01)
-(define-constant ADDRESS-VERSION-P2WPKH 0x02)
-(define-constant ADDRESS-VERSION-P2WSH 0x03)
-
-;; Stacking thresholds
-(define-constant STACKING-THRESHOLD-25 u20000)
-(define-constant STACKING-THRESHOLD-100 u5000)
-
 ;; PoX disabling threshold (a percent)
 (define-constant POX-REJECTION-FRACTION u25)
 

--- a/src/chainstate/stacks/boot/pox.clar
+++ b/src/chainstate/stacks/boot/pox.clar
@@ -229,36 +229,30 @@
                                                             (num-cycles uint)
                                                             (amount-ustx uint)
                                                             (i uint))))
-    (let (
-        (reward-cycle (+ (get first-reward-cycle params) (get i params)))
-        (i (get i params))
-    )
+    (let ((reward-cycle (+ (get first-reward-cycle params) (get i params)))
+          (i (get i params)))
     {
         pox-addr: (get pox-addr params),
         first-reward-cycle: (get first-reward-cycle params),
         num-cycles: (get num-cycles params),
         amount-ustx: (get amount-ustx params),
         i: (if (< i (get num-cycles params))
-            (let (
-                (total-ustx (get-total-ustx-stacked reward-cycle))
-            )
-            ;; record how many uSTX this pox-addr will stack for in the given reward cycle
-            (append-reward-cycle-pox-addr
+            (let ((total-ustx (get-total-ustx-stacked reward-cycle)))
+              ;; record how many uSTX this pox-addr will stack for in the given reward cycle
+              (append-reward-cycle-pox-addr
                 (get pox-addr params)
                 reward-cycle
                 (get amount-ustx params))
 
-            ;; update running total
-            (map-set reward-cycle-total-stacked
-                { reward-cycle: reward-cycle }
-                { total-ustx: (+ (get amount-ustx params) total-ustx) }
-            )
-            
-            ;; updated _this_ reward cycle
-            (+ i u1))
+              ;; update running total
+              (map-set reward-cycle-total-stacked
+                 { reward-cycle: reward-cycle }
+                 { total-ustx: (+ (get amount-ustx params) total-ustx) })
+
+              ;; updated _this_ reward cycle
+              (+ i u1))
             (+ i u0))
-    })
-)
+    }))
 
 ;; Add a PoX address to a given sequence of reward cycle lists.
 ;; A PoX address can be added to at most 12 consecutive cycles.
@@ -341,33 +335,28 @@
 (define-read-only (can-stacks-stx (amount-ustx uint)
                                   (pox-addr (tuple (version (buff 1)) (hashbytes (buff 20))))
                                   (lock-period uint))
-    (let (        
-        ;; this stacker's first reward cycle is the _next_ reward cycle
-        (first-reward-cycle (+ u1 (current-pox-reward-cycle)))
-    )
-    ;; amount must be valid
-    (asserts! (> amount-ustx u0)
+    ;; this stacker's first reward cycle is the _next_ reward cycle
+    (let ((first-reward-cycle (+ u1 (current-pox-reward-cycle))))
+      ;; amount must be valid
+      (asserts! (> amount-ustx u0)
         (err ERR_STACKING_INVALID_AMOUNT))
 
-    ;; tx-sender principal must not have rejected in this upcoming reward cycle
-    (asserts! (is-none (get-pox-rejection tx-sender first-reward-cycle))
+      ;; tx-sender principal must not have rejected in this upcoming reward cycle
+      (asserts! (is-none (get-pox-rejection tx-sender first-reward-cycle))
         (err ERR_STACKING_ALREADY_REJECTED))
 
-    ;; tx-sender principal must not be stacking
-    (asserts! (is-none (get-stacker-info tx-sender))
+      ;; tx-sender principal must not be stacking
+      (asserts! (is-none (get-stacker-info tx-sender))
         (err ERR_STACKING_ALREADY_STACKED))
 
-    ;; the Stacker must have sufficient unlocked funds
-    (asserts! (>= (stx-get-balance tx-sender) amount-ustx)
+      ;; the Stacker must have sufficient unlocked funds
+      (asserts! (>= (stx-get-balance tx-sender) amount-ustx)
         (err ERR_STACKING_INSUFFICIENT_FUNDS))
 
-    (ok {
-        amount-ustx: amount-ustx,
-        pox-addr: pox-addr,
-        first-reward-cycle: first-reward-cycle,
-        lock-period: lock-period
-    }))
-)
+      (ok { amount-ustx: amount-ustx,
+            pox-addr: pox-addr,
+            first-reward-cycle: first-reward-cycle,
+            lock-period: lock-period })))
 
 ;; Lock up some uSTX for stacking!  Note that the given amount here is in micro-STX (uSTX).
 ;; The STX will be locked for the given number of reward cycles (lock-period).

--- a/src/chainstate/stacks/db/mod.rs
+++ b/src/chainstate/stacks/db/mod.rs
@@ -609,11 +609,20 @@ impl StacksChainState {
         {
             let mut clarity_tx = chainstate.block_begin(&NULL_BURN_STATE_DB, &BURNCHAIN_BOOT_CONSENSUS_HASH, &BOOT_BLOCK_HASH, &FIRST_BURNCHAIN_CONSENSUS_HASH, &FIRST_STACKS_BLOCK_HASH);
             for (boot_code_name, boot_code_contract) in STACKS_BOOT_CODE.iter() {
+                let boot_code_contract_string = 
+                    if *boot_code_name == "pox" {
+                        debug!("Instantiating PoX contract parameters for {}", if mainnet { "mainnet" } else { "testnet" });
+                        format!("{}\n{}", pox_boot_code_constants(mainnet), boot_code_contract)
+                    } else {
+                        boot_code_contract.to_string()
+                    };
+
                 debug!("Instantiate boot code contract '{}.{}' ({} bytes)...", &STACKS_BOOT_CODE_CONTRACT_ADDRESS, boot_code_name, boot_code_contract.len());
+
                 let smart_contract = TransactionPayload::SmartContract(
                     TransactionSmartContract {
                         name: ContractName::try_from(boot_code_name.to_string()).expect("FATAL: invalid boot-code contract name"),
-                        code_body: StacksString::from_str(&boot_code_contract.to_string()).expect("FATAL: invalid boot code body"),
+                        code_body: StacksString::from_string(&boot_code_contract_string).expect("FATAL: invalid boot code body"),
                     }
                 );
 

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -2010,7 +2010,7 @@ pub mod test {
                 },
                 ExecutionCost::max_value()).unwrap();
 
-            let mut coord = ChainsCoordinator::test_new(&burnchain, &test_path, OnChainRewardSetProvider::new());
+            let mut coord = ChainsCoordinator::test_new(&burnchain, &test_path, OnChainRewardSetProvider());
             coord.handle_new_burnchain_block().unwrap();
 
             let mut stacks_node = TestStacksNode::from_chainstate(chainstate);
@@ -2479,7 +2479,7 @@ pub mod test {
             let leader_key_op = stacks_node.add_key_register(&mut burn_block, &mut self.miner);
 
             // patch in reward set info
-            match get_next_recipients(&last_sortition_block, &mut stacks_node.chainstate, &mut sortdb, &self.config.burnchain, &OnChainRewardSetProvider::new()) {
+            match get_next_recipients(&last_sortition_block, &mut stacks_node.chainstate, &mut sortdb, &self.config.burnchain, &OnChainRewardSetProvider()) {
                 Ok(recipients) => {
                     block_commit_op.commit_outs = match recipients {
                         Some(info) => vec![info.recipient.0],

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -774,7 +774,7 @@ impl InitializedNeonNode {
 
         // let's figure out the recipient set!
         let recipients = match get_next_recipients(&burn_block, chain_state, burn_db,
-                                                   burnchain, &OnChainRewardSetProvider::new()) {
+                                                   burnchain, &OnChainRewardSetProvider()) {
             Ok(x) => x,
             Err(e) => {
                 error!("Failure fetching recipient set: {:?}", e);

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -1,12 +1,16 @@
 use super::{make_stacks_transfer_mblock_only, SK_1, ADDR_4, to_addr, make_microblock,
+            make_contract_call,
             make_contract_publish, make_contract_publish_microblock_only};
 use stacks::burnchains::{ Address, PublicKey };
+use stacks::util::secp256k1::Secp256k1PublicKey;
 use stacks::chainstate::stacks::{
     StacksTransaction, StacksPrivateKey, StacksPublicKey, StacksAddress, db::StacksChainState, StacksBlock, StacksBlockHeader };
 use stacks::chainstate::burn::ConsensusHash;
 use stacks::net::StacksMessageCodec;
-use stacks::vm::types::PrincipalData;
+use stacks::vm::types::{PrincipalData};
 use stacks::vm::costs::ExecutionCost;
+use stacks::vm::Value;
+use stacks::vm::execute;
 
 use crate::{
     neon, Config, Keychain, config::InitialBalance, BitcoinRegtestController, BurnchainController,
@@ -27,6 +31,8 @@ fn neon_integration_test_conf() -> (Config, StacksAddress) {
     let keychain = Keychain::default(conf.node.seed.clone());
 
     conf.node.miner = true;
+    conf.node.wait_time_for_microblocks = 500;
+
     conf.burnchain.mode = "neon".into(); 
     conf.burnchain.username = Some("neon-tester".into());
     conf.burnchain.password = Some("neon-tester-pass".into());
@@ -556,6 +562,141 @@ fn size_check_integration_test() {
 
     assert_eq!(anchor_block_txs, 2);
     assert_eq!(micro_block_txs, 1);
+
+    channel.stop_chains_coordinator();
+}
+
+
+#[test]
+#[ignore]
+fn pox_integration_test() {
+    if env::var("BITCOIND_TEST") != Ok("1".into()) {
+        return
+    }
+
+    let spender_sk = StacksPrivateKey::new();
+    let spender_addr: PrincipalData = to_addr(&spender_sk).into();
+
+    let pox_pubkey = Secp256k1PublicKey::from_hex("02f006a09b59979e2cb8449f58076152af6b124aa29b948a3714b8d5f15aa94ede").unwrap();
+    let pox_pubkey_hash = bytes_to_hex(&Hash160::from_data(&pox_pubkey.to_bytes()).to_bytes().to_vec());
+
+    let (mut conf, miner_account) = neon_integration_test_conf();
+
+    let total_bal = 10_000_000_000;
+    let stacked_bal = 1_000_000_000;
+
+    conf.initial_balances.push(InitialBalance { 
+        address: spender_addr.clone(),
+        amount: total_bal,
+    });
+
+    let mut btcd_controller = BitcoinCoreController::new(conf.clone());
+    btcd_controller.start_bitcoind().map_err(|_e| ()).expect("Failed starting bitcoind");
+
+    let mut btc_regtest_controller = BitcoinRegtestController::new(conf.clone(), None);
+    let http_origin = format!("http://{}", &conf.node.rpc_bind);
+
+    btc_regtest_controller.bootstrap_chain(201);
+
+    eprintln!("Chain bootstrapped...");
+
+    let mut run_loop = neon::RunLoop::new(conf);
+    let blocks_processed = run_loop.get_blocks_processed_arc();
+    let client = reqwest::blocking::Client::new();
+    let channel = run_loop.get_coordinator_channel().unwrap();
+
+    thread::spawn(move || {
+        run_loop.start(0)
+    });
+
+    // give the run loop some time to start up!
+    wait_for_runloop(&blocks_processed);
+
+    // first block wakes up the run loop
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+
+    // first block will hold our VRF registration
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+
+    // second block will be the first mined Stacks block
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+
+    // let's query the miner's account nonce:
+
+    eprintln!("Miner account: {}", miner_account);
+
+    let path = format!("{}/v2/accounts/{}?proof=0",
+                       &http_origin, &miner_account);
+    eprintln!("Test: GET {}", path);
+    let res = client.get(&path).send().unwrap().json::<AccountEntryResponse>().unwrap();
+    assert_eq!(u128::from_str_radix(&res.balance[2..], 16).unwrap(), 0);
+    assert_eq!(res.nonce, 1);
+
+    // and our potential spenders:
+
+    let path = format!("{}/v2/accounts/{}?proof=0",
+                       &http_origin, spender_addr);
+    let res = client.get(&path).send().unwrap().json::<AccountEntryResponse>().unwrap();
+    assert_eq!(u128::from_str_radix(&res.balance[2..], 16).unwrap(), total_bal as u128);
+    assert_eq!(res.nonce, 0);
+
+    let tx = make_contract_call(&spender_sk, 0, 243, &StacksAddress::from_string("ST000000000000000000002AMW42H").unwrap(),
+                                "pox", "stack-stx", &[Value::UInt(stacked_bal),
+                                                      execute(&format!("{{ hashbytes: 0x{}, version: 0x00 }}", pox_pubkey_hash)).unwrap().unwrap(),
+                                                      Value::UInt(3)]);
+
+    // okay, let's push that stacking transaction!
+    let path = format!("{}/v2/transactions", &http_origin);
+    let res = client.post(&path)
+        .header("Content-Type", "application/octet-stream")
+        .body(tx.clone())
+        .send()
+        .unwrap();
+    eprintln!("{:#?}", res);
+    if res.status().is_success() {
+        let res: String = res
+            .json()
+            .unwrap();
+        assert_eq!(res, StacksTransaction::consensus_deserialize(&mut &tx[..]).unwrap().txid().to_string());
+    } else {
+        eprintln!("{}", res.text().unwrap());
+        panic!("");
+    }
+
+    // now let's mine a couple blocks, and then check the sender's nonce.
+    //  at the end of mining three blocks, there should be _one_ transaction from the microblock
+    //  only set that got mined (since the block before this one was empty, a microblock can
+    //  be added),
+    //  and _two_ transactions from the two anchor blocks that got mined (and processed)
+    //
+    // this one wakes up our node, so that it'll mine a microblock _and_ an anchor block.
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+    // this one will contain the sortition from above anchor block,
+    //    which *should* have also confirmed the microblock.
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+
+    // let's figure out how many micro-only and anchor-only txs got accepted
+    //   by examining our account nonces:
+    let path = format!("{}/v2/accounts/{}?proof=0",
+                       &http_origin, spender_addr);
+    let res = client.get(&path).send().unwrap().json::<AccountEntryResponse>().unwrap();
+    if res.nonce != 1 {        
+        assert_eq!(res.nonce, 1, "Spender address nonce should be 1");
+    }
+
+    // now let's mine until the next reward cycle starts ...
+    for _i in 0..35 {
+        next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+    }
+
+    // we should have received a Bitcoin commitment
+    let utxos = btc_regtest_controller.get_utxos(
+        &pox_pubkey, 1).expect("Should have been able to retrieve UTXOs for PoX recipient");
+
+    eprintln!("Got UTXOs: {}", utxos.len());
+    assert!(utxos.len() > 0, "Should have received an output during PoX");
 
     channel.stop_chains_coordinator();
 }


### PR DESCRIPTION
This addresses a few things:

1. `chainstate.get_reward_addresses` needs to take the current burnchain block height as an additional argument. The reward cycle being queried is the current block height, even though it is evaluated at the anchor block.
2. The default constants in the `pox.clar` change depending on the mainnet flag. I think this could be DRY'd a bit with the Burnchain config object, but I think we can leave that to a future issue (will open an issue for that).
3. The reward set is sorted by address. This ensures that every node has the same ordering of the reward set (resolving #1860).

This also adds a new bitcoind integration test for PoX which sets up an address, issues a contract call to the pox contract and checks that the registered address receives BTC after the subsequent reward cycle has started.