### PR TITLE
Feature: Store all transactions as they are processed for debugging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,7 @@ criterion = "0.3"
 developer-mode = []
 default = ["developer-mode"]
 monitoring_prom = ["prometheus"]
+tx_log = []
 
 [target.'cfg(all(target_arch = "x86_64", not(target_env = "msvc")))'.dependencies]
 sha2-asm = "0.5.3"

--- a/src/chainstate/stacks/db/blocks.rs
+++ b/src/chainstate/stacks/db/blocks.rs
@@ -2904,6 +2904,8 @@ impl StacksChainState {
                                                     &block_execution_cost)
             .expect("FATAL: failed to advance chain tip");
 
+        chainstate_tx.log_transactions_processed(&new_tip.index_block_hash(), &txs_receipts);
+
         let epoch_receipt = StacksEpochReceipt {
             header: new_tip, 
             tx_receipts: txs_receipts,

--- a/testnet/stacks-node/Cargo.toml
+++ b/testnet/stacks-node/Cargo.toml
@@ -31,4 +31,5 @@ path = "src/main.rs"
 
 [features]
 monitoring_prom = ["stacks/monitoring_prom"]
+tx-log = ["stacks/tx_log"]
 default = []


### PR DESCRIPTION
This adds a compile-enabled feature for storing to a table a copy of the transaction ID and transaction data whenever a transaction is processed. This lets you figure out whether or not a particular TXID was processed, and if so, what the result of it was.

```
$  cargo build --workspace --features tx_log
$ ./target/debug/stacks-node krypton
```

And then to find a transaction...

```
$ echo 'SELECT index_block_hash, result FROM transactions WHERE txid = "9e4ef900f521dd7c07c1c22e4b58b33df656880c8035bdb5e2b0c44ba8356af6"' | sqlite3 -separator ", " /tmp/stacks-testnet-f7c1618951418340/chainstate/chain-00000080-testnet/vm/index
87cbab207957c48bcb5b56943b26ef78c30ae4d6110dbdc7af21b9d93ca3946d, (ok true)
```