### PR TITLE
Fix event ID resource leak for connecting sockets that time out

### DIFF
--- a/src/net/poll.rs
+++ b/src/net/poll.rs
@@ -106,6 +106,10 @@ impl NetworkState {
         })
     }
 
+    pub fn num_events(&self) -> usize {
+        self.event_map.len()
+    }
+
     fn bind_address(addr: &SocketAddr) -> Result<mio_net::TcpListener, net_error> {
         if !cfg!(test) {
             mio_net::TcpListener::bind(addr)


### PR DESCRIPTION
This should cause the follower node to _not_ freeze up after a few hours.