### PR TITLE
Fix/remove downloader index hash cache

### DIFF
--- a/src/net/download.rs
+++ b/src/net/download.rs
@@ -717,7 +717,7 @@ impl PeerNetwork {
 
     /// Create block request keys for a range of blocks that are available but that we don't have in a given range of
     /// sortitions.  The same keys can be used to fetch confirmed microblock streams.
-    fn make_requests(&mut self, sortdb: &SortitionDB, chainstate: &StacksChainState, _downloader: &BlockDownloader, start_sortition_height: u64, microblocks: bool) -> Result<HashMap<u64, VecDeque<BlockRequestKey>>, net_error> {
+    fn make_requests(&mut self, sortdb: &SortitionDB, chainstate: &StacksChainState, start_sortition_height: u64, microblocks: bool) -> Result<HashMap<u64, VecDeque<BlockRequestKey>>, net_error> {
         let scan_batch_size = self.burnchain.pox_constants.reward_cycle_length as u64;
         let mut blocks_to_try : HashMap<u64, VecDeque<BlockRequestKey>> = HashMap::new();
 
@@ -873,13 +873,13 @@ impl PeerNetwork {
     }
 
     /// Make requests for missing anchored blocks
-    fn make_block_requests(&mut self, sortdb: &SortitionDB, chainstate: &mut StacksChainState, downloader: &BlockDownloader, start_sortition_height: u64) -> Result<HashMap<u64, VecDeque<BlockRequestKey>>, net_error> {
-        self.make_requests(sortdb, chainstate, downloader, start_sortition_height, false)
+    fn make_block_requests(&mut self, sortdb: &SortitionDB, chainstate: &mut StacksChainState, start_sortition_height: u64) -> Result<HashMap<u64, VecDeque<BlockRequestKey>>, net_error> {
+        self.make_requests(sortdb, chainstate, start_sortition_height, false)
     }
 
     /// Make requests for missing confirmed microblocks 
-    fn make_confirmed_microblock_requests(&mut self, sortdb: &SortitionDB, chainstate: &mut StacksChainState, downloader: &BlockDownloader, start_sortition_height: u64) -> Result<HashMap<u64, VecDeque<BlockRequestKey>>, net_error> {
-        self.make_requests(sortdb, chainstate, downloader, start_sortition_height, true)
+    fn make_confirmed_microblock_requests(&mut self, sortdb: &SortitionDB, chainstate: &mut StacksChainState, start_sortition_height: u64) -> Result<HashMap<u64, VecDeque<BlockRequestKey>>, net_error> {
+        self.make_requests(sortdb, chainstate, start_sortition_height, true)
     }
 
     /// Prioritize block requests -- ask for the rarest blocks first
@@ -919,10 +919,10 @@ impl PeerNetwork {
                 while next_block_sortition_height <= network.chain_view.burn_block_height - sortdb.first_block_height || next_microblock_sortition_height <= network.chain_view.burn_block_height - sortdb.first_block_height {
 
                     debug!("{:?}: Make block requests from sortition height {}", &network.local_peer, next_block_sortition_height);
-                    let mut next_blocks_to_try = network.make_block_requests(sortdb, chainstate, downloader, next_block_sortition_height)?;
+                    let mut next_blocks_to_try = network.make_block_requests(sortdb, chainstate, next_block_sortition_height)?;
                     
                     debug!("{:?}: Make microblock requests from sortition height {}", &network.local_peer, next_microblock_sortition_height);
-                    let mut next_microblocks_to_try = network.make_confirmed_microblock_requests(sortdb, chainstate, downloader, next_microblock_sortition_height)?;
+                    let mut next_microblocks_to_try = network.make_confirmed_microblock_requests(sortdb, chainstate, next_microblock_sortition_height)?;
 
                     let mut height = next_block_sortition_height;
                     let mut mblock_height = next_microblock_sortition_height;
@@ -1023,7 +1023,7 @@ impl PeerNetwork {
                     debug!("{:?}: block download scan now at ({},{}) (was ({},{}))", &network.local_peer, height, mblock_height, block_sortition_height, microblock_sortition_height);
                     
                     if max_height <= next_block_sortition_height && max_mblock_height <= next_microblock_sortition_height {
-                        debug!("{:?}: no more download requests requests to make", &network.local_peer);
+                        debug!("{:?}: no more download requests to make", &network.local_peer);
                         break;
                     }
 

--- a/src/net/inv.rs
+++ b/src/net/inv.rs
@@ -1006,7 +1006,7 @@ impl InvState {
             // No block is available here anyway, even though the peer agrees with us on the
             // consensus hash.
             // This is bad behavior on the peer's part.
-            test_debug!("No sortition for consensus hash {}", consensus_hash);
+            debug!("No sortition for consensus hash {}", consensus_hash);
             return Err(net_error::InvalidMessage);
         }
 
@@ -1049,7 +1049,7 @@ impl InvState {
                 }
             },
             None => {
-                test_debug!("No inv stats for neighbor {:?}", neighbor_key);
+                debug!("No inv stats for neighbor {:?}", neighbor_key);
                 Ok(None)
             }
         }
@@ -1620,7 +1620,7 @@ impl PeerNetwork {
         self.tip_sort_id = new_tip_sort_id;
         self.pox_id = new_pox_id;
 
-        test_debug!("{:?}: PoX bit vector is {:?}", &self.local_peer, &self.pox_id);
+        debug!("{:?}: PoX bit vector is {:?}", &self.local_peer, &self.pox_id);
 
         Ok(())
     }

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -736,9 +736,9 @@ impl InitializedNeonNode {
                         }
                     };
 
-                debug!("Mining tenure's last consensus hash: {}, stacks tip consensus hash: {}",
-                       &burn_block.consensus_hash,
-                       &stacks_tip.consensus_hash);
+                debug!("Mining tenure's last consensus hash: {} (height {}), stacks tip consensus hash: {} (height {})",
+                       &burn_block.consensus_hash, burn_block.block_height,
+                       &stacks_tip.consensus_hash, parent_snapshot.block_height);
 
                 let coinbase_nonce = {
                     let principal = keychain.origin_address().unwrap().into();


### PR DESCRIPTION
This removes the index hash cache from the block downloader.  This had been used to prevent blocks from being re-downloaded, but this functionality is already checked by simply looking at the staging DB and seeing if a block or microblock stream is already stored.  The presence of this cache seems to be interfering with the relayer discarding blocks in the event the PoX bit vector gets invalidated -- the act of discarding the downloaded block does _not_ clear this cache.  This, in turn, seems to be causing nodes unlucky enough to experience a PoX bit vector invalidation to download blocks and never re-download them if they were truly necessary for the chainstate.