### PR TITLE
PoX Delegation / Pooling

### DIFF
--- a/src/chainstate/stacks/boot/contract_tests.rs
+++ b/src/chainstate/stacks/boot/contract_tests.rs
@@ -347,7 +347,7 @@ fn delegation_tests() {
             env.execute_transaction(
                 (&delegator).into(),
                 POX_CONTRACT.clone(),
-                "delegator-stack-stx",
+                "delegate-stack-stx",
                 &symbols_from_values(vec![
                     (&USER_KEYS[0]).into(),
                     Value::UInt(3 * USTX_PER_HOLDER),
@@ -366,7 +366,7 @@ fn delegation_tests() {
             env.execute_transaction(
                 (&delegator).into(),
                 POX_CONTRACT.clone(),
-                "delegator-stack-stx",
+                "delegate-stack-stx",
                 &symbols_from_values(vec![
                     (&USER_KEYS[0]).into(),
                     Value::UInt(2 * USTX_PER_HOLDER),
@@ -385,7 +385,7 @@ fn delegation_tests() {
             env.execute_transaction(
                 (&delegator).into(),
                 POX_CONTRACT.clone(),
-                "delegator-stack-stx",
+                "delegate-stack-stx",
                 &symbols_from_values(vec![
                     (&USER_KEYS[0]).into(),
                     Value::UInt(*MIN_THRESHOLD - 1),
@@ -432,7 +432,7 @@ fn delegation_tests() {
             env.execute_transaction(
                 (&delegator).into(),
                 POX_CONTRACT.clone(),
-                "delegator-stack-stx",
+                "delegate-stack-stx",
                 &symbols_from_values(vec![
                     (&USER_KEYS[1]).into(),
                     Value::UInt(*MIN_THRESHOLD - 1),
@@ -451,7 +451,7 @@ fn delegation_tests() {
             env.execute_transaction(
                 (&delegator).into(),
                 POX_CONTRACT.clone(),
-                "delegator-stack-stx",
+                "delegate-stack-stx",
                 &symbols_from_values(vec![
                     (&USER_KEYS[0]).into(),
                     Value::UInt(*MIN_THRESHOLD - 1),
@@ -470,7 +470,7 @@ fn delegation_tests() {
             env.execute_transaction(
                 (&delegator).into(),
                 POX_CONTRACT.clone(),
-                "delegator-stack-stx",
+                "delegate-stack-stx",
                 &symbols_from_values(vec![
                     (&USER_KEYS[2]).into(),
                     Value::UInt(*MIN_THRESHOLD - 1),
@@ -489,7 +489,7 @@ fn delegation_tests() {
             env.execute_transaction(
                 (&delegator).into(),
                 POX_CONTRACT.clone(),
-                "delegator-stack-stx",
+                "delegate-stack-stx",
                 &symbols_from_values(vec![
                     (&USER_KEYS[2]).into(),
                     Value::UInt(*MIN_THRESHOLD - 1),
@@ -592,7 +592,7 @@ fn delegation_tests() {
             env.execute_transaction(
                 (&delegator).into(),
                 POX_CONTRACT.clone(),
-                "delegator-stack-stx",
+                "delegate-stack-stx",
                 &symbols_from_values(vec![
                     (&USER_KEYS[3]).into(),
                     Value::UInt(*MIN_THRESHOLD),
@@ -702,7 +702,7 @@ fn delegation_tests() {
             env.execute_transaction(
                 (&delegator).into(),
                 POX_CONTRACT.clone(),
-                "delegator-stack-stx",
+                "delegate-stack-stx",
                 &symbols_from_values(vec![
                     (&USER_KEYS[1]).into(),
                     Value::UInt(*MIN_THRESHOLD),
@@ -726,7 +726,7 @@ fn delegation_tests() {
                 (&USER_KEYS[4]).into(),
                 POX_CONTRACT.clone(),
                 "revoke-delegate-stx",
-                &symbols_from_values(vec![(&delegator).into()])
+                &[]
             )
             .unwrap()
             .0,
@@ -739,7 +739,7 @@ fn delegation_tests() {
                 (&USER_KEYS[4]).into(),
                 POX_CONTRACT.clone(),
                 "revoke-delegate-stx",
-                &symbols_from_values(vec![(&delegator).into()])
+                &[]
             )
             .unwrap()
             .0
@@ -751,7 +751,7 @@ fn delegation_tests() {
             env.execute_transaction(
                 (&delegator).into(),
                 POX_CONTRACT.clone(),
-                "delegator-stack-stx",
+                "delegate-stack-stx",
                 &symbols_from_values(vec![
                     (&USER_KEYS[4]).into(),
                     Value::UInt(*MIN_THRESHOLD - 1),

--- a/src/chainstate/stacks/boot/contract_tests.rs
+++ b/src/chainstate/stacks/boot/contract_tests.rs
@@ -1,0 +1,768 @@
+use std::collections::{HashMap, VecDeque};
+use std::convert::TryFrom;
+
+use vm::contracts::Contract;
+use vm::errors::{
+    CheckErrors, Error, IncomparableError, InterpreterError, InterpreterResult as Result,
+    RuntimeErrorType,
+};
+use vm::types::{
+    OptionalData, PrincipalData, QualifiedContractIdentifier, StandardPrincipalData,
+    TupleTypeSignature, TypeSignature, Value, NONE,
+};
+
+use std::convert::TryInto;
+
+use burnchains::BurnchainHeaderHash;
+use chainstate::burn::{BlockHeaderHash, ConsensusHash, VRFSeed};
+use chainstate::stacks::boot::STACKS_BOOT_CODE_CONTRACT_ADDRESS;
+use chainstate::stacks::db::{MinerPaymentSchedule, StacksHeaderInfo};
+use chainstate::stacks::index::proofs::TrieMerkleProof;
+use chainstate::stacks::index::MarfTrieId;
+use chainstate::stacks::*;
+
+use util::db::{DBConn, FromRow};
+use util::hash::{Sha256Sum, Sha512Trunc256Sum};
+use vm::contexts::OwnedEnvironment;
+use vm::costs::CostOverflowingMath;
+use vm::database::*;
+use vm::representations::SymbolicExpression;
+
+use util::hash::to_hex;
+use vm::eval;
+use vm::tests::{execute, is_committed, is_err_code, symbols_from_values};
+
+use core::{
+    FIRST_BURNCHAIN_BLOCK_HASH, FIRST_BURNCHAIN_BLOCK_HEIGHT, FIRST_BURNCHAIN_BLOCK_TIMESTAMP,
+    FIRST_BURNCHAIN_CONSENSUS_HASH, FIRST_STACKS_BLOCK_HASH, POX_REWARD_CYCLE_LENGTH,
+};
+
+const BOOT_CODE_POX_BODY: &'static str = std::include_str!("pox.clar");
+const BOOT_CODE_POX_TESTNET_CONSTS: &'static str = std::include_str!("pox-testnet.clar");
+const BOOT_CODE_POX_MAINNET_CONSTS: &'static str = std::include_str!("pox-mainnet.clar");
+const BOOT_CODE_LOCKUP: &'static str = std::include_str!("lockup.clar");
+
+const USTX_PER_HOLDER: u128 = 1_000_000;
+
+lazy_static! {
+    static ref BOOT_CODE_POX_MAINNET: String =
+        format!("{}\n{}", BOOT_CODE_POX_MAINNET_CONSTS, BOOT_CODE_POX_BODY);
+    static ref BOOT_CODE_POX_TESTNET: String =
+        format!("{}\n{}", BOOT_CODE_POX_TESTNET_CONSTS, BOOT_CODE_POX_BODY);
+    static ref FIRST_INDEX_BLOCK_HASH: StacksBlockId = StacksBlockHeader::make_index_block_hash(
+        &FIRST_BURNCHAIN_CONSENSUS_HASH,
+        &FIRST_STACKS_BLOCK_HASH
+    );
+    static ref POX_CONTRACT: QualifiedContractIdentifier =
+        QualifiedContractIdentifier::parse(&format!("{}.pox", STACKS_BOOT_CODE_CONTRACT_ADDRESS))
+            .unwrap();
+    static ref USER_KEYS: Vec<StacksPrivateKey> =
+        (0..50).map(|_| StacksPrivateKey::new()).collect();
+    static ref POX_ADDRS: Vec<Value> = (0..50u64)
+        .map(|ix| execute(&format!(
+            "{{ version: 0x00, hashbytes: 0x000000000000000000000000{} }}",
+            &to_hex(&ix.to_le_bytes())
+        )))
+        .collect();
+    static ref LIQUID_SUPPLY: u128 = USTX_PER_HOLDER * (POX_ADDRS.len() as u128);
+    static ref MIN_THRESHOLD: u128 = *LIQUID_SUPPLY / 480;
+}
+
+impl From<&StacksPrivateKey> for StandardPrincipalData {
+    fn from(o: &StacksPrivateKey) -> StandardPrincipalData {
+        let stacks_addr = StacksAddress::from_public_keys(
+            C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
+            &AddressHashMode::SerializeP2PKH,
+            1,
+            &vec![StacksPublicKey::from_private(o)],
+        )
+        .unwrap();
+        StandardPrincipalData::from(stacks_addr)
+    }
+}
+
+impl From<&StacksPrivateKey> for Value {
+    fn from(o: &StacksPrivateKey) -> Value {
+        Value::from(StandardPrincipalData::from(o))
+    }
+}
+
+struct ClarityTestSim {
+    marf: MarfedKV,
+    height: u64,
+}
+
+struct TestSimHeadersDB {
+    height: u64,
+}
+
+impl ClarityTestSim {
+    pub fn new() -> ClarityTestSim {
+        let mut marf = MarfedKV::temporary();
+        marf.begin(
+            &StacksBlockId::sentinel(),
+            &StacksBlockId(test_sim_height_to_hash(0)),
+        );
+        {
+            marf.as_clarity_db(&NULL_HEADER_DB, &NULL_BURN_STATE_DB)
+                .initialize();
+
+            let mut owned_env =
+                OwnedEnvironment::new(marf.as_clarity_db(&NULL_HEADER_DB, &NULL_BURN_STATE_DB));
+
+            for user_key in USER_KEYS.iter() {
+                owned_env.stx_faucet(
+                    &StandardPrincipalData::from(user_key).into(),
+                    USTX_PER_HOLDER,
+                );
+            }
+        }
+        marf.test_commit();
+
+        ClarityTestSim { marf, height: 0 }
+    }
+
+    pub fn execute_next_block<F, R>(&mut self, f: F) -> R
+    where
+        F: FnOnce(&mut OwnedEnvironment) -> R,
+    {
+        self.marf.begin(
+            &StacksBlockId(test_sim_height_to_hash(self.height)),
+            &StacksBlockId(test_sim_height_to_hash(self.height + 1)),
+        );
+
+        let r = {
+            let headers_db = TestSimHeadersDB {
+                height: self.height + 1,
+            };
+            let mut owned_env =
+                OwnedEnvironment::new(self.marf.as_clarity_db(&headers_db, &NULL_BURN_STATE_DB));
+            f(&mut owned_env)
+        };
+
+        self.marf.test_commit();
+        self.height += 1;
+
+        r
+    }
+}
+
+fn test_sim_height_to_hash(burn_height: u64) -> [u8; 32] {
+    let mut out = [0; 32];
+    out[0..8].copy_from_slice(&burn_height.to_le_bytes());
+    out
+}
+
+fn test_sim_hash_to_height(in_bytes: &[u8; 32]) -> Option<u64> {
+    if &in_bytes[8..] != &[0; 24] {
+        None
+    } else {
+        let mut bytes = [0; 8];
+        bytes.copy_from_slice(&in_bytes[0..8]);
+        Some(u64::from_le_bytes(bytes))
+    }
+}
+
+impl HeadersDB for TestSimHeadersDB {
+    fn get_burn_header_hash_for_block(
+        &self,
+        id_bhh: &StacksBlockId,
+    ) -> Option<BurnchainHeaderHash> {
+        if *id_bhh == *FIRST_INDEX_BLOCK_HASH {
+            Some(FIRST_BURNCHAIN_BLOCK_HASH)
+        } else {
+            self.get_burn_block_height_for_block(id_bhh)?;
+            Some(BurnchainHeaderHash(id_bhh.0.clone()))
+        }
+    }
+
+    fn get_vrf_seed_for_block(&self, _bhh: &StacksBlockId) -> Option<VRFSeed> {
+        None
+    }
+
+    fn get_stacks_block_header_hash_for_block(
+        &self,
+        id_bhh: &StacksBlockId,
+    ) -> Option<BlockHeaderHash> {
+        if *id_bhh == *FIRST_INDEX_BLOCK_HASH {
+            Some(FIRST_STACKS_BLOCK_HASH)
+        } else {
+            self.get_burn_block_height_for_block(id_bhh)?;
+            Some(BlockHeaderHash(id_bhh.0.clone()))
+        }
+    }
+
+    fn get_burn_block_time_for_block(&self, id_bhh: &StacksBlockId) -> Option<u64> {
+        if *id_bhh == *FIRST_INDEX_BLOCK_HASH {
+            Some(FIRST_BURNCHAIN_BLOCK_TIMESTAMP)
+        } else {
+            let burn_block_height = self.get_burn_block_height_for_block(id_bhh)? as u64;
+            Some(
+                FIRST_BURNCHAIN_BLOCK_TIMESTAMP + burn_block_height
+                    - FIRST_BURNCHAIN_BLOCK_HEIGHT as u64,
+            )
+        }
+    }
+    fn get_burn_block_height_for_block(&self, id_bhh: &StacksBlockId) -> Option<u32> {
+        if *id_bhh == *FIRST_INDEX_BLOCK_HASH {
+            Some(FIRST_BURNCHAIN_BLOCK_HEIGHT)
+        } else {
+            let input_height = test_sim_hash_to_height(&id_bhh.0)?;
+            if input_height > self.height {
+                eprintln!("{} > {}", input_height, self.height);
+                None
+            } else {
+                Some(
+                    (FIRST_BURNCHAIN_BLOCK_HEIGHT as u64 + input_height)
+                        .try_into()
+                        .unwrap(),
+                )
+            }
+        }
+    }
+    fn get_miner_address(&self, _id_bhh: &StacksBlockId) -> Option<StacksAddress> {
+        None
+    }
+    fn get_total_liquid_ustx(&self, _id_bhh: &StacksBlockId) -> u128 {
+        *LIQUID_SUPPLY
+    }
+}
+
+#[test]
+fn delegation_tests() {
+    let mut sim = ClarityTestSim::new();
+    let delegator = StacksPrivateKey::new();
+
+    sim.execute_next_block(|env| {
+        env.initialize_contract(POX_CONTRACT.clone(), &BOOT_CODE_POX_TESTNET)
+            .unwrap()
+    });
+    sim.execute_next_block(|env| {
+        assert_eq!(
+            env.execute_transaction(
+                (&USER_KEYS[0]).into(),
+                POX_CONTRACT.clone(),
+                "delegate-stx",
+                &symbols_from_values(vec![
+                    Value::UInt(2 * USTX_PER_HOLDER),
+                    (&delegator).into(),
+                    Value::none(),
+                    Value::none()
+                ])
+            )
+            .unwrap()
+            .0,
+            Value::okay_true()
+        );
+
+        // already delegating...
+        assert_eq!(
+            env.execute_transaction(
+                (&USER_KEYS[0]).into(),
+                POX_CONTRACT.clone(),
+                "delegate-stx",
+                &symbols_from_values(vec![
+                    Value::UInt(USTX_PER_HOLDER),
+                    (&delegator).into(),
+                    Value::none(),
+                    Value::none()
+                ])
+            )
+            .unwrap()
+            .0,
+            Value::error(Value::Int(20)).unwrap()
+        );
+
+        assert_eq!(
+            env.execute_transaction(
+                (&USER_KEYS[1]).into(),
+                POX_CONTRACT.clone(),
+                "delegate-stx",
+                &symbols_from_values(vec![
+                    Value::UInt(USTX_PER_HOLDER),
+                    (&delegator).into(),
+                    Value::none(),
+                    Value::some(POX_ADDRS[0].clone()).unwrap()
+                ])
+            )
+            .unwrap()
+            .0,
+            Value::okay_true()
+        );
+        assert_eq!(
+            env.execute_transaction(
+                (&USER_KEYS[2]).into(),
+                POX_CONTRACT.clone(),
+                "delegate-stx",
+                &symbols_from_values(vec![
+                    Value::UInt(USTX_PER_HOLDER),
+                    (&delegator).into(),
+                    Value::some(Value::UInt(300)).unwrap(),
+                    Value::none()
+                ])
+            )
+            .unwrap()
+            .0,
+            Value::okay_true()
+        );
+
+        assert_eq!(
+            env.execute_transaction(
+                (&USER_KEYS[3]).into(),
+                POX_CONTRACT.clone(),
+                "delegate-stx",
+                &symbols_from_values(vec![
+                    Value::UInt(USTX_PER_HOLDER),
+                    (&delegator).into(),
+                    Value::none(),
+                    Value::none()
+                ])
+            )
+            .unwrap()
+            .0,
+            Value::okay_true()
+        );
+
+        assert_eq!(
+            env.execute_transaction(
+                (&USER_KEYS[4]).into(),
+                POX_CONTRACT.clone(),
+                "delegate-stx",
+                &symbols_from_values(vec![
+                    Value::UInt(USTX_PER_HOLDER),
+                    (&delegator).into(),
+                    Value::none(),
+                    Value::none()
+                ])
+            )
+            .unwrap()
+            .0,
+            Value::okay_true()
+        );
+    });
+    // let's do some delegated stacking!
+    sim.execute_next_block(|env| {
+        // try to stack more than [0]'s delegated amount!
+        assert_eq!(
+            env.execute_transaction(
+                (&delegator).into(),
+                POX_CONTRACT.clone(),
+                "delegator-stack-stx",
+                &symbols_from_values(vec![
+                    (&USER_KEYS[0]).into(),
+                    Value::UInt(3 * USTX_PER_HOLDER),
+                    POX_ADDRS[1].clone(),
+                    Value::UInt(2)
+                ])
+            )
+            .unwrap()
+            .0
+            .to_string(),
+            "(err 9)".to_string()
+        );
+
+        // try to stack more than [0] has!
+        assert_eq!(
+            env.execute_transaction(
+                (&delegator).into(),
+                POX_CONTRACT.clone(),
+                "delegator-stack-stx",
+                &symbols_from_values(vec![
+                    (&USER_KEYS[0]).into(),
+                    Value::UInt(2 * USTX_PER_HOLDER),
+                    POX_ADDRS[1].clone(),
+                    Value::UInt(2)
+                ])
+            )
+            .unwrap()
+            .0
+            .to_string(),
+            "(err 1)".to_string()
+        );
+
+        // let's stack less than the threshold
+        assert_eq!(
+            env.execute_transaction(
+                (&delegator).into(),
+                POX_CONTRACT.clone(),
+                "delegator-stack-stx",
+                &symbols_from_values(vec![
+                    (&USER_KEYS[0]).into(),
+                    Value::UInt(*MIN_THRESHOLD - 1),
+                    POX_ADDRS[1].clone(),
+                    Value::UInt(2)
+                ])
+            )
+            .unwrap()
+            .0,
+            execute(&format!(
+                "(ok {{ stacker: '{}, lock-amount: {}, unlock-burn-height: {} }})",
+                Value::from(&USER_KEYS[0]),
+                Value::UInt(*MIN_THRESHOLD - 1),
+                Value::UInt(360)
+            ))
+        );
+
+        assert_eq!(
+            env.eval_read_only(
+                &POX_CONTRACT,
+                &format!("(stx-get-balance '{})", &Value::from(&USER_KEYS[0]))
+            )
+            .unwrap()
+            .0,
+            Value::UInt(USTX_PER_HOLDER - *MIN_THRESHOLD + 1)
+        );
+
+        // try to commit our partial stacking...
+        assert_eq!(
+            env.execute_transaction(
+                (&delegator).into(),
+                POX_CONTRACT.clone(),
+                "stack-aggregation-commit",
+                &symbols_from_values(vec![POX_ADDRS[1].clone(), Value::UInt(1)])
+            )
+            .unwrap()
+            .0
+            .to_string(),
+            "(err 11)".to_string()
+        );
+        // not enough! we need to stack more...
+        //   but POX_ADDR[1] cannot be used for USER_KEYS[1]...
+        assert_eq!(
+            env.execute_transaction(
+                (&delegator).into(),
+                POX_CONTRACT.clone(),
+                "delegator-stack-stx",
+                &symbols_from_values(vec![
+                    (&USER_KEYS[1]).into(),
+                    Value::UInt(*MIN_THRESHOLD - 1),
+                    POX_ADDRS[1].clone(),
+                    Value::UInt(2)
+                ])
+            )
+            .unwrap()
+            .0
+            .to_string(),
+            "(err 9)".to_string()
+        );
+
+        // And USER_KEYS[0] is already stacking...
+        assert_eq!(
+            env.execute_transaction(
+                (&delegator).into(),
+                POX_CONTRACT.clone(),
+                "delegator-stack-stx",
+                &symbols_from_values(vec![
+                    (&USER_KEYS[0]).into(),
+                    Value::UInt(*MIN_THRESHOLD - 1),
+                    POX_ADDRS[1].clone(),
+                    Value::UInt(2)
+                ])
+            )
+            .unwrap()
+            .0
+            .to_string(),
+            "(err 3)".to_string()
+        );
+
+        // USER_KEYS[2] won't want to stack past the delegation expiration...
+        assert_eq!(
+            env.execute_transaction(
+                (&delegator).into(),
+                POX_CONTRACT.clone(),
+                "delegator-stack-stx",
+                &symbols_from_values(vec![
+                    (&USER_KEYS[2]).into(),
+                    Value::UInt(*MIN_THRESHOLD - 1),
+                    POX_ADDRS[1].clone(),
+                    Value::UInt(2)
+                ])
+            )
+            .unwrap()
+            .0
+            .to_string(),
+            "(err 9)".to_string()
+        );
+
+        //  but for just one block will be fine
+        assert_eq!(
+            env.execute_transaction(
+                (&delegator).into(),
+                POX_CONTRACT.clone(),
+                "delegator-stack-stx",
+                &symbols_from_values(vec![
+                    (&USER_KEYS[2]).into(),
+                    Value::UInt(*MIN_THRESHOLD - 1),
+                    POX_ADDRS[1].clone(),
+                    Value::UInt(1)
+                ])
+            )
+            .unwrap()
+            .0,
+            execute(&format!(
+                "(ok {{ stacker: '{}, lock-amount: {}, unlock-burn-height: {} }})",
+                Value::from(&USER_KEYS[2]),
+                Value::UInt(*MIN_THRESHOLD - 1),
+                Value::UInt(240)
+            ))
+        );
+
+        assert_eq!(
+            env.eval_read_only(
+                &POX_CONTRACT,
+                &format!("(stx-get-balance '{})", &Value::from(&USER_KEYS[2]))
+            )
+            .unwrap()
+            .0,
+            Value::UInt(USTX_PER_HOLDER - *MIN_THRESHOLD + 1)
+        );
+
+        assert_eq!(
+            env.eval_read_only(
+                &POX_CONTRACT,
+                &format!("(stx-get-balance '{})", &Value::from(&USER_KEYS[0]))
+            )
+            .unwrap()
+            .0,
+            Value::UInt(USTX_PER_HOLDER - *MIN_THRESHOLD + 1)
+        );
+
+        assert_eq!(
+            env.eval_read_only(
+                &POX_CONTRACT,
+                &format!("(stx-get-balance '{})", &Value::from(&USER_KEYS[1]))
+            )
+            .unwrap()
+            .0,
+            Value::UInt(USTX_PER_HOLDER)
+        );
+
+        // try to commit our partial stacking again!
+        assert_eq!(
+            env.execute_transaction(
+                (&delegator).into(),
+                POX_CONTRACT.clone(),
+                "stack-aggregation-commit",
+                &symbols_from_values(vec![POX_ADDRS[1].clone(), Value::UInt(1)])
+            )
+            .unwrap()
+            .0
+            .to_string(),
+            "(ok true)".to_string()
+        );
+
+        assert_eq!(
+            env.eval_read_only(&POX_CONTRACT, "(get-reward-set-size u1)")
+                .unwrap()
+                .0
+                .to_string(),
+            "u1"
+        );
+        assert_eq!(
+            env.eval_read_only(&POX_CONTRACT, "(get-reward-set-pox-address u1 u0)")
+                .unwrap()
+                .0,
+            execute(&format!(
+                "(some {{ pox-addr: {}, total-ustx: {} }})",
+                &POX_ADDRS[1],
+                &Value::UInt(2 * (*MIN_THRESHOLD - 1))
+            ))
+        );
+
+        // can we double commit? I don't think so!
+        assert_eq!(
+            env.execute_transaction(
+                (&delegator).into(),
+                POX_CONTRACT.clone(),
+                "stack-aggregation-commit",
+                &symbols_from_values(vec![POX_ADDRS[1].clone(), Value::UInt(1)])
+            )
+            .unwrap()
+            .0
+            .to_string(),
+            "(err 4)".to_string()
+        );
+
+        // okay, let's try some more delegation situations...
+        // 1. we already locked user[0] up for round 2, so let's add some more stacks for round 2 from
+        //    user[3]. in the process, this will add more stacks for lockup in round 1, so lets commit
+        //    that as well.
+
+        assert_eq!(
+            env.execute_transaction(
+                (&delegator).into(),
+                POX_CONTRACT.clone(),
+                "delegator-stack-stx",
+                &symbols_from_values(vec![
+                    (&USER_KEYS[3]).into(),
+                    Value::UInt(*MIN_THRESHOLD),
+                    POX_ADDRS[1].clone(),
+                    Value::UInt(2)
+                ])
+            )
+            .unwrap()
+            .0,
+            execute(&format!(
+                "(ok {{ stacker: '{}, lock-amount: {}, unlock-burn-height: {} }})",
+                Value::from(&USER_KEYS[3]),
+                Value::UInt(*MIN_THRESHOLD),
+                Value::UInt(360)
+            ))
+        );
+
+        assert_eq!(
+            env.eval_read_only(
+                &POX_CONTRACT,
+                &format!("(stx-get-balance '{})", &Value::from(&USER_KEYS[3]))
+            )
+            .unwrap()
+            .0,
+            Value::UInt(USTX_PER_HOLDER - *MIN_THRESHOLD)
+        );
+
+        // let's commit to round 2 now.
+        assert_eq!(
+            env.execute_transaction(
+                (&delegator).into(),
+                POX_CONTRACT.clone(),
+                "stack-aggregation-commit",
+                &symbols_from_values(vec![POX_ADDRS[1].clone(), Value::UInt(2)])
+            )
+            .unwrap()
+            .0
+            .to_string(),
+            "(ok true)".to_string()
+        );
+
+        // and we can commit to round 1 again as well!
+        assert_eq!(
+            env.execute_transaction(
+                (&delegator).into(),
+                POX_CONTRACT.clone(),
+                "stack-aggregation-commit",
+                &symbols_from_values(vec![POX_ADDRS[1].clone(), Value::UInt(1)])
+            )
+            .unwrap()
+            .0
+            .to_string(),
+            "(ok true)".to_string()
+        );
+
+        // check reward sets for round 2 and round 1...
+
+        assert_eq!(
+            env.eval_read_only(&POX_CONTRACT, "(get-reward-set-size u2)")
+                .unwrap()
+                .0
+                .to_string(),
+            "u1"
+        );
+        assert_eq!(
+            env.eval_read_only(&POX_CONTRACT, "(get-reward-set-pox-address u2 u0)")
+                .unwrap()
+                .0,
+            execute(&format!(
+                "(some {{ pox-addr: {}, total-ustx: {} }})",
+                &POX_ADDRS[1],
+                &Value::UInt((*MIN_THRESHOLD))
+            ))
+        );
+
+        assert_eq!(
+            env.eval_read_only(&POX_CONTRACT, "(get-reward-set-size u1)")
+                .unwrap()
+                .0
+                .to_string(),
+            "u2"
+        );
+        assert_eq!(
+            env.eval_read_only(&POX_CONTRACT, "(get-reward-set-pox-address u1 u0)")
+                .unwrap()
+                .0,
+            execute(&format!(
+                "(some {{ pox-addr: {}, total-ustx: {} }})",
+                &POX_ADDRS[1],
+                &Value::UInt(2 * (*MIN_THRESHOLD - 1))
+            ))
+        );
+        assert_eq!(
+            env.eval_read_only(&POX_CONTRACT, "(get-reward-set-pox-address u1 u1)")
+                .unwrap()
+                .0,
+            execute(&format!(
+                "(some {{ pox-addr: {}, total-ustx: {} }})",
+                &POX_ADDRS[1],
+                &Value::UInt(*MIN_THRESHOLD)
+            ))
+        );
+
+        // 2. lets make sure we can lock up for user[1] so long as it goes to pox[0].
+
+        assert_eq!(
+            env.execute_transaction(
+                (&delegator).into(),
+                POX_CONTRACT.clone(),
+                "delegator-stack-stx",
+                &symbols_from_values(vec![
+                    (&USER_KEYS[1]).into(),
+                    Value::UInt(*MIN_THRESHOLD - 1),
+                    POX_ADDRS[0].clone(),
+                    Value::UInt(2)
+                ])
+            )
+            .unwrap()
+            .0,
+            execute(&format!(
+                "(ok {{ stacker: '{}, lock-amount: {}, unlock-burn-height: {} }})",
+                Value::from(&USER_KEYS[1]),
+                Value::UInt(*MIN_THRESHOLD),
+                Value::UInt(360)
+            ))
+        );
+
+        // 3. lets try to lock up user[4], but do some revocation first.
+        assert_eq!(
+            env.execute_transaction(
+                (&USER_KEYS[4]).into(),
+                POX_CONTRACT.clone(),
+                "revoke-delegate-stx",
+                &symbols_from_values(vec![(&delegator).into()])
+            )
+            .unwrap()
+            .0,
+            Value::okay_true()
+        );
+
+        // will run a second time, but return false
+        assert_eq!(
+            env.execute_transaction(
+                (&USER_KEYS[4]).into(),
+                POX_CONTRACT.clone(),
+                "revoke-delegate-stx",
+                &symbols_from_values(vec![(&delegator).into()])
+            )
+            .unwrap()
+            .0
+            .to_string(),
+            "(ok false)".to_string()
+        );
+
+        assert_eq!(
+            env.execute_transaction(
+                (&delegator).into(),
+                POX_CONTRACT.clone(),
+                "delegator-stack-stx",
+                &symbols_from_values(vec![
+                    (&USER_KEYS[4]).into(),
+                    Value::UInt(*MIN_THRESHOLD - 1),
+                    POX_ADDRS[0].clone(),
+                    Value::UInt(2)
+                ])
+            )
+            .unwrap()
+            .0
+            .to_string(),
+            "(err 9)".to_string()
+        );
+    });
+}

--- a/src/chainstate/stacks/boot/contract_tests.rs
+++ b/src/chainstate/stacks/boot/contract_tests.rs
@@ -664,7 +664,7 @@ fn delegation_tests() {
             execute(&format!(
                 "(some {{ pox-addr: {}, total-ustx: {} }})",
                 &POX_ADDRS[1],
-                &Value::UInt((*MIN_THRESHOLD))
+                &Value::UInt(*MIN_THRESHOLD)
             ))
         );
 

--- a/src/chainstate/stacks/boot/contract_tests.rs
+++ b/src/chainstate/stacks/boot/contract_tests.rs
@@ -664,7 +664,7 @@ fn delegation_tests() {
             execute(&format!(
                 "(some {{ pox-addr: {}, total-ustx: {} }})",
                 &POX_ADDRS[1],
-                &Value::UInt(*MIN_THRESHOLD)
+                &Value::UInt(2 * (*MIN_THRESHOLD) - 1)
             ))
         );
 
@@ -705,7 +705,7 @@ fn delegation_tests() {
                 "delegator-stack-stx",
                 &symbols_from_values(vec![
                     (&USER_KEYS[1]).into(),
-                    Value::UInt(*MIN_THRESHOLD - 1),
+                    Value::UInt(*MIN_THRESHOLD),
                     POX_ADDRS[0].clone(),
                     Value::UInt(2)
                 ])

--- a/src/chainstate/stacks/boot/contract_tests.rs
+++ b/src/chainstate/stacks/boot/contract_tests.rs
@@ -358,7 +358,7 @@ fn delegation_tests() {
             .unwrap()
             .0
             .to_string(),
-            "(err 9)".to_string()
+            "(err 22)".to_string()
         );
 
         // try to stack more than [0] has!
@@ -443,7 +443,7 @@ fn delegation_tests() {
             .unwrap()
             .0
             .to_string(),
-            "(err 9)".to_string()
+            "(err 23)".to_string()
         );
 
         // And USER_KEYS[0] is already stacking...
@@ -481,7 +481,7 @@ fn delegation_tests() {
             .unwrap()
             .0
             .to_string(),
-            "(err 9)".to_string()
+            "(err 21)".to_string()
         );
 
         //  but for just one block will be fine

--- a/src/chainstate/stacks/boot/mod.rs
+++ b/src/chainstate/stacks/boot/mod.rs
@@ -1130,7 +1130,7 @@ pub mod test {
                     chainstate.get_stacking_minimum(sortdb, &tip_index_block)
                 })
                 .unwrap();
-                assert_eq!(min_ustx, total_liquid_ustx / 20000);
+                assert_eq!(min_ustx, total_liquid_ustx / 480);
 
                 // no reward addresses
                 let reward_addrs = with_sortdb(&mut peer, |ref mut chainstate, ref sortdb| {
@@ -1196,7 +1196,7 @@ pub mod test {
                         // miner rewards increased liquid supply, so less than 25% is locked.
                         // minimum participation decreases.
                         assert!(total_liquid_ustx > 4 * 1024 * 1000000);
-                        assert_eq!(min_ustx, total_liquid_ustx / 20000);
+                        assert_eq!(min_ustx, total_liquid_ustx / 480);
                     } else {
                         // still at 25% or more locked
                         assert!(total_liquid_ustx <= 4 * 1024 * 1000000);
@@ -1323,12 +1323,11 @@ pub mod test {
                     let alice_balance = get_balance(&mut peer, &key_to_stacks_addr(&alice).into());
                     assert_eq!(alice_balance, 1024 * 1000000);
                 }
-                // stacking minimum should be floor(total-liquid-ustx / 20000)
                 let min_ustx = with_sortdb(&mut peer, |ref mut chainstate, ref sortdb| {
                     chainstate.get_stacking_minimum(sortdb, &tip_index_block)
                 })
                 .unwrap();
-                assert_eq!(min_ustx, total_liquid_ustx / 20000);
+                assert_eq!(min_ustx, total_liquid_ustx / 480);
 
                 // no reward addresses
                 let reward_addrs = with_sortdb(&mut peer, |ref mut chainstate, ref sortdb| {
@@ -1396,7 +1395,7 @@ pub mod test {
                             // miner rewards increased liquid supply, so less than 25% is locked.
                             // minimum participation decreases.
                             assert!(total_liquid_ustx > 4 * 1024 * 1000000);
-                            assert_eq!(min_ustx, total_liquid_ustx / 20000);
+                            assert_eq!(min_ustx, total_liquid_ustx / 480);
                         } else {
                             // still at 25% or more locked
                             assert!(total_liquid_ustx <= 4 * 1024 * 1000000);
@@ -1588,12 +1587,11 @@ pub mod test {
                     assert_eq!(bob_balance, 1024 * 1000000);
                 }
 
-                // stacking minimum should be floor(total-liquid-ustx / 20000)
                 let min_ustx = with_sortdb(&mut peer, |ref mut chainstate, ref sortdb| {
                     chainstate.get_stacking_minimum(sortdb, &tip_index_block)
                 })
                 .unwrap();
-                assert_eq!(min_ustx, total_liquid_ustx / 20000);
+                assert_eq!(min_ustx, total_liquid_ustx / 480);
 
                 // no reward addresses
                 let reward_addrs = with_sortdb(&mut peer, |ref mut chainstate, ref sortdb| {
@@ -1667,7 +1665,7 @@ pub mod test {
                     }
 
                     // well over 25% locked, so this is always true
-                    assert_eq!(min_ustx, total_liquid_ustx / 20000);
+                    assert_eq!(min_ustx, total_liquid_ustx / 480);
 
                     // two reward addresses, and they're Alice's and Bob's.
                     // They are present in sorted order
@@ -1990,12 +1988,11 @@ pub mod test {
                     assert_eq!(alice_balance, 1024 * 1000000);
                 }
 
-                // stacking minimum should be floor(total-liquid-ustx / 20000)
                 let min_ustx = with_sortdb(&mut peer, |ref mut chainstate, ref sortdb| {
                     chainstate.get_stacking_minimum(sortdb, &tip_index_block)
                 })
                 .unwrap();
-                assert_eq!(min_ustx, total_liquid_ustx / 20000);
+                assert_eq!(min_ustx, total_liquid_ustx / 480);
 
                 // no reward addresses
                 let reward_addrs = with_sortdb(&mut peer, |ref mut chainstate, ref sortdb| {
@@ -2059,7 +2056,7 @@ pub mod test {
                         // miner rewards increased liquid supply, so less than 25% is locked.
                         // minimum participation decreases.
                         assert!(total_liquid_ustx > 4 * 1024 * 1000000);
-                        assert_eq!(min_ustx, total_liquid_ustx / 20000);
+                        assert_eq!(min_ustx, total_liquid_ustx / 480);
                     }
 
                     if cur_reward_cycle == alice_reward_cycle {
@@ -2110,7 +2107,7 @@ pub mod test {
                         assert_eq!(reward_addrs.len(), 0);
 
                         // min STX is reset
-                        assert_eq!(min_ustx, total_liquid_ustx / 20000);
+                        assert_eq!(min_ustx, total_liquid_ustx / 480);
 
                         // Unlock is lazy
                         let alice_account =
@@ -2291,12 +2288,11 @@ pub mod test {
                     assert_eq!(charlie_balance, 0);
                 }
 
-                // stacking minimum should be floor(total-liquid-ustx / 20000)
                 let min_ustx = with_sortdb(&mut peer, |ref mut chainstate, ref sortdb| {
                     chainstate.get_stacking_minimum(sortdb, &tip_index_block)
                 })
                 .unwrap();
-                assert_eq!(min_ustx, total_liquid_ustx / 20000);
+                assert_eq!(min_ustx, total_liquid_ustx / 480);
 
                 // no reward addresses
                 assert_eq!(reward_addrs.len(), 0);
@@ -2320,13 +2316,13 @@ pub mod test {
                 assert_eq!(charlie_balance, 1024 * 1000000);
             } else if tenure_id == 11 {
                 // should have just re-locked
-                // stacking minimum should be floor(total-liquid-ustx / 20000), since we haven't
+                // stacking minimum should be minimum, since we haven't
                 // locked up 25% of the tokens yet
                 let min_ustx = with_sortdb(&mut peer, |ref mut chainstate, ref sortdb| {
                     chainstate.get_stacking_minimum(sortdb, &tip_index_block)
                 })
                 .unwrap();
-                assert_eq!(min_ustx, total_liquid_ustx / 20000);
+                assert_eq!(min_ustx, total_liquid_ustx / 480);
 
                 // no reward addresses
                 assert_eq!(reward_addrs.len(), 0);
@@ -2349,13 +2345,13 @@ pub mod test {
                 // miner rewards increased liquid supply, so less than 25% is locked.
                 // minimum participation decreases.
                 assert!(total_liquid_ustx > 4 * 1024 * 1000000);
-                assert_eq!(min_ustx, total_liquid_ustx / 20000);
+                assert_eq!(min_ustx, total_liquid_ustx / 480);
             } else if tenure_id >= 1 && cur_reward_cycle < first_reward_cycle {
                 // still at 25% or more locked
                 assert!(total_liquid_ustx <= 4 * 1024 * 1000000);
             } else if tenure_id < 1 {
                 // nothing locked yet
-                assert_eq!(min_ustx, total_liquid_ustx / 20000);
+                assert_eq!(min_ustx, total_liquid_ustx / 480);
             }
 
             if first_reward_cycle > 0 && second_reward_cycle == 0 {
@@ -2447,7 +2443,7 @@ pub mod test {
                     assert_eq!(reward_addrs.len(), 0);
 
                     // min STX is reset
-                    assert_eq!(min_ustx, total_liquid_ustx / 20000);
+                    assert_eq!(min_ustx, total_liquid_ustx / 480);
 
                     // Unlock is lazy
                     let alice_account = get_account(&mut peer, &key_to_stacks_addr(&alice).into());
@@ -2568,7 +2564,7 @@ pub mod test {
                     assert_eq!(reward_addrs.len(), 0);
 
                     // min STX is reset
-                    assert_eq!(min_ustx, total_liquid_ustx / 20000);
+                    assert_eq!(min_ustx, total_liquid_ustx / 480);
 
                     // Unlock is lazy
                     let alice_account = get_account(&mut peer, &key_to_stacks_addr(&alice).into());
@@ -2894,8 +2890,7 @@ pub mod test {
                         assert_eq!(balance, expected_balance);
                     }
                 }
-                // stacking minimum should be floor(total-liquid-ustx / 20000)
-                assert_eq!(min_ustx, total_liquid_ustx / 20000);
+                assert_eq!(min_ustx, total_liquid_ustx / 480);
 
                 // no reward addresses
                 let reward_addrs = with_sortdb(&mut peer, |ref mut chainstate, ref sortdb| {
@@ -3011,7 +3006,7 @@ pub mod test {
                     assert_eq!(reward_addrs.len(), 0);
 
                     // min STX is reset
-                    assert_eq!(min_ustx, total_liquid_ustx / 20000);
+                    assert_eq!(min_ustx, total_liquid_ustx / 480);
                 }
             }
 
@@ -3194,7 +3189,7 @@ pub mod test {
                     assert_eq!(alice_account.stx_balance.unlock_height, 0);
                 }
 
-                assert_eq!(min_ustx, total_liquid_ustx / 20000);
+                assert_eq!(min_ustx, total_liquid_ustx / 480);
 
                 // no reward addresses
                 assert_eq!(reward_addrs.len(), 0);
@@ -3254,7 +3249,7 @@ pub mod test {
                         // miner rewards increased liquid supply, so less than 25% is locked.
                         // minimum participation decreases.
                         assert!(total_liquid_ustx > 4 * 1024 * 1000000);
-                        assert_eq!(min_ustx, total_liquid_ustx / 20000);
+                        assert_eq!(min_ustx, total_liquid_ustx / 480);
                     } else {
                         // still at 25% or more locked
                         assert!(total_liquid_ustx <= 4 * 1024 * 1000000);

--- a/src/chainstate/stacks/boot/mod.rs
+++ b/src/chainstate/stacks/boot/mod.rs
@@ -262,6 +262,9 @@ impl StacksChainState {
 }
 
 #[cfg(test)]
+mod contract_tests;
+
+#[cfg(test)]
 pub mod test {
     use chainstate::burn::db::sortdb::*;
     use chainstate::burn::db::*;

--- a/src/chainstate/stacks/boot/pox.clar
+++ b/src/chainstate/stacks/boot/pox.clar
@@ -14,6 +14,7 @@
 (define-constant ERR_STACKING_ALREADY_REJECTED 17)
 (define-constant ERR_STACKING_INVALID_AMOUNT 18)
 (define-constant ERR_NOT_ALLOWED 19)
+(define-constant ERR_STACKING_ALREADY_DELEGATED 20)
 
 ;; PoX disabling threshold (a percent)
 (define-constant POX_REJECTION_FRACTION u25)
@@ -64,6 +65,22 @@
     )
 )
 
+;; Delegation relationships
+(define-map delegation-state
+    ((stacker principal))
+    ((amount-ustx uint)              ;; how many uSTX delegated?
+     (delegated-to principal)        ;; who are we delegating?
+     (until-burn-ht (optional uint)) ;; how long does the delegation last?
+     ;; does the delegator _need_ to use a specific
+     ;;   pox recipient address?
+     (pox-addr (optional { version: (buff 1),
+                           hashbytes: (buff 20) }))))
+
+;; Delegator's allowed contract-callers
+(define-map delegator-contract-callers
+    ((delegator principal) (contract-caller principal))
+    ((until-burn-ht (optional uint))))
+
 ;; How many uSTX are stacked in a given reward cycle.
 ;; Updated when a new PoX address is registered, or when more STX are granted
 ;; to it.
@@ -87,16 +104,15 @@
     ((len uint))
 )
 
-;; When is a PoX address active?
-;; Used to check of a PoX address is registered or not in a given
-;; reward cycle.
-(define-map pox-addr-reward-cycles
-    ((pox-addr (tuple (version (buff 1)) (hashbytes (buff 20)))))
-    (
-        (first-reward-cycle uint)
-        (num-cycles uint)
-    )
-)
+;; how much has been locked up for this address before
+;;   committing?
+;; this map allows stackers to stack amounts < minimum
+;;   by paying the cost of aggregation during the commit
+(define-map partial-stacked-by-cycle
+  ((pox-addr (tuple (version (buff 1)) (hashbytes (buff 20))))
+   (reward-cycle uint)
+   (sender principal))
+  ((stacked-amount uint)))
 
 ;; Amount of uSTX that reject PoX, by reward cycle
 (define-map stacking-rejection
@@ -153,8 +169,33 @@
             )
         ;; no state at all
         none
-    )
-)
+    ))
+
+(define-private (check-delegation-caller-allowed)
+    (or (is-eq tx-sender contract-caller)
+        (let ((delegation-caller-allowed 
+                 ;; if not in the delegation/caller map, return false
+                 (unwrap! (map-get? delegator-contract-callers
+                                    { delegator: tx-sender, contract-caller: contract-caller })
+                          false)))
+          ;; is the caller allowance expired?
+          (if (< burn-block-height (unwrap! (get until-burn-ht delegation-caller-allowed) true))
+              (begin (map-delete delegator-contract-callers
+                                 { delegator: tx-sender, contract-caller: contract-caller })
+                     false)
+              true))))
+
+(define-private (get-check-delegation (stacker principal))
+    (let ((delegation-info (try! (map-get? delegation-state { stacker: stacker }))))
+      ;; did the existing delegation expire?
+      (if (match (get until-burn-ht delegation-info)
+                 until-burn-ht (> burn-block-height until-burn-ht)
+                 false)
+          ;; it expired, delete the entry and return none
+          (begin (map-delete delegation-state { stacker: stacker })
+                 none)
+          ;; delegation is active
+          (some delegation-info))))
 
 ;; Get the size of the reward set for a reward cycle.
 ;; Note that this does _not_ return duplicate PoX addresses.
@@ -166,26 +207,6 @@
     (default-to
         u0
         (get len (map-get? reward-cycle-pox-address-list-len { reward-cycle: reward-cycle }))))
-
-;; Is a PoX address registered anywhere in a given range of reward cycles?
-;; Checkes the integer range [reward-cycle-start, reward-cycle-start + num-cycles)
-;; Returns true if it's registered in at least one reward cycle in the given range.
-;; Returns false if it's not registered in any reward cycle in the given range.
-(define-private (is-pox-addr-registered (pox-addr (tuple (version (buff 1)) (hashbytes (buff 20))))
-                                        (reward-cycle-start uint)
-                                        (num-cycles uint))
-    (let (
-        (pox-addr-range-opt (map-get? pox-addr-reward-cycles { pox-addr: pox-addr }))
-    )
-    (match pox-addr-range-opt
-        ;; some range
-        pox-addr-range
-            (and (>= (+ reward-cycle-start num-cycles) (get first-reward-cycle pox-addr-range))
-                    (< reward-cycle-start (+ (get first-reward-cycle pox-addr-range) (get num-cycles pox-addr-range))))
-        ;; none
-        false
-    ))
-)
 
 ;; Add a single PoX address to a single reward cycle.
 ;; Used to build up a set of per-reward-cycle PoX addresses.
@@ -230,13 +251,14 @@
                                                             (amount-ustx uint)
                                                             (i uint))))
     (let ((reward-cycle (+ (get first-reward-cycle params) (get i params)))
+          (num-cycles (get num-cycles params))
           (i (get i params)))
     {
         pox-addr: (get pox-addr params),
         first-reward-cycle: (get first-reward-cycle params),
-        num-cycles: (get num-cycles params),
+        num-cycles: num-cycles,
         amount-ustx: (get amount-ustx params),
-        i: (if (< i (get num-cycles params))
+        i: (if (< i num-cycles)
             (let ((total-ustx (get-total-ustx-stacked reward-cycle)))
               ;; record how many uSTX this pox-addr will stack for in the given reward cycle
               (append-reward-cycle-pox-addr
@@ -257,30 +279,58 @@
 ;; Add a PoX address to a given sequence of reward cycle lists.
 ;; A PoX address can be added to at most 12 consecutive cycles.
 ;; No checking is done.
-;; Returns the number of reward cycles added
 (define-private (add-pox-addr-to-reward-cycles (pox-addr (tuple (version (buff 1)) (hashbytes (buff 20))))
                                                (first-reward-cycle uint)
                                                (num-cycles uint)
                                                (amount-ustx uint))
-    (let (
-        (cycle-indexes (list u0 u1 u2 u3 u4 u5 u6 u7 u8 u9 u10 u11))
-    )
+  (let ((cycle-indexes (list u0 u1 u2 u3 u4 u5 u6 u7 u8 u9 u10 u11)))
     ;; For safety, add up the number of times (add-principal-to-ith-reward-cycle) returns 1.
     ;; It _should_ be equal to num-cycles.
     (asserts! 
-        (is-eq num-cycles (get i 
-            (fold add-pox-addr-to-ith-reward-cycle cycle-indexes 
-                { pox-addr: pox-addr, first-reward-cycle: first-reward-cycle, num-cycles: num-cycles, amount-ustx: amount-ustx, i: u0 })))
-        (err ERR_STACKING_UNREACHABLE))
+     (is-eq num-cycles 
+            (get i (fold add-pox-addr-to-ith-reward-cycle cycle-indexes 
+                         { pox-addr: pox-addr, first-reward-cycle: first-reward-cycle, num-cycles: num-cycles, amount-ustx: amount-ustx, i: u0 })))
+     (err ERR_STACKING_UNREACHABLE))
+    (ok true)))
 
-    ;; mark address in use over this range
-    (map-set pox-addr-reward-cycles
-        { pox-addr: pox-addr }
-        { first-reward-cycle: first-reward-cycle, num-cycles: num-cycles }
-    )
-    (ok true)
-    )
-)
+(define-private (add-pox-partial-stacked-to-ith-cycle
+                 (cycle-index uint)
+                 (params { pox-addr: { version: (buff 1), hashbytes: (buff 20) },
+                           reward-cycle: uint,
+                           num-cycles: uint,
+                           amount-ustx: uint }))
+  (let ((pox-addr     (get pox-addr     params))
+        (num-cycles   (get num-cycles   params))
+        (reward-cycle (get reward-cycle params))
+        (amount-ustx  (get amount-ustx  params)))
+    (let ((current-amount
+           (default-to u0
+             (get stacked-amount
+                  (map-get? partial-stacked-by-cycle { sender: tx-sender, pox-addr: pox-addr, reward-cycle: reward-cycle })))))
+      (if (>= cycle-index num-cycles)
+          ;; do not add to cycles >= cycle-index
+          false
+          ;; otherwise, add to the partial-stacked-by-cycle
+          (map-set partial-stacked-by-cycle
+                   { sender: tx-sender, pox-addr: pox-addr, reward-cycle: reward-cycle }
+                   { stacked-amount: (+ amount-ustx current-amount) }))
+      ;; produce the next params tuple
+      { pox-addr: pox-addr,
+        reward-cycle: (+ u1 reward-cycle),
+        num-cycles: num-cycles,
+        amount-ustx: amount-ustx })))
+
+;; Add a PoX address to a given sequence of partial reward cycle lists.
+;; A PoX address can be added to at most 12 consecutive cycles.
+;; No checking is done.
+(define-private (add-pox-partial-stacked (pox-addr (tuple (version (buff 1)) (hashbytes (buff 20))))
+                                         (first-reward-cycle uint)
+                                         (num-cycles uint)
+                                         (amount-ustx uint))
+  (let ((cycle-indexes (list u0 u1 u2 u3 u4 u5 u6 u7 u8 u9 u10 u11)))
+    (fold add-pox-partial-stacked-to-ith-cycle cycle-indexes 
+          { pox-addr: pox-addr, reward-cycle: first-reward-cycle, num-cycles: num-cycles, amount-ustx: amount-ustx })
+    (ok true)))
 
 ;; What is the minimum number of uSTX to be stacked in the given reward cycle?
 ;; Used internally by the Stacks node, and visible publicly.
@@ -308,37 +358,44 @@
                                   (amount-ustx uint)
                                   (first-reward-cycle uint)
                                   (num-cycles uint))
-    (let ((is-registered (is-pox-addr-registered pox-addr first-reward-cycle num-cycles)))
-      ;; amount must be valid
-      (asserts! (> amount-ustx u0)
-          (err ERR_STACKING_INVALID_AMOUNT))
+  (begin
+    ;; minimum uSTX must be met
+    (asserts! (<= (get-stacking-minimum) amount-ustx)
+              (err ERR_STACKING_THRESHOLD_NOT_MET))
 
-      ;; tx-sender principal must not have rejected in this upcoming reward cycle
-      (asserts! (is-none (get-pox-rejection tx-sender first-reward-cycle))
-          (err ERR_STACKING_ALREADY_REJECTED))
+    (minimal-can-stack-stx pox-addr amount-ustx first-reward-cycle num-cycles)))
 
-      ;; can't be registered yet
-      (asserts! (not is-registered)
-          (err ERR_STACKING_POX_ADDRESS_IN_USE))
+;; Evaluate if a participant can stack an amount of STX for a given period.
+;; This method is designed as a read-only method so that it can be used as 
+;; a set of guard conditions and also as a read-only RPC call that can be
+;; performed beforehand.
+(define-read-only (minimal-can-stack-stx 
+                   (pox-addr (tuple (version (buff 1)) (hashbytes (buff 20))))
+                   (amount-ustx uint)
+                   (first-reward-cycle uint)
+                   (num-cycles uint))
+  (begin
+    ;; amount must be valid
+    (asserts! (> amount-ustx u0)
+              (err ERR_STACKING_INVALID_AMOUNT))
 
-      ;; the Stacker must have sufficient unlocked funds
-      (asserts! (>= (stx-get-balance tx-sender) amount-ustx)
-          (err ERR_STACKING_INSUFFICIENT_FUNDS))
+    ;; tx-sender principal must not have rejected in this upcoming reward cycle
+    (asserts! (is-none (get-pox-rejection tx-sender first-reward-cycle))
+              (err ERR_STACKING_ALREADY_REJECTED))
 
-      ;; minimum uSTX must be met
-      (asserts! (<= (get-stacking-minimum) amount-ustx)
-          (err ERR_STACKING_THRESHOLD_NOT_MET))
+    ;; the Stacker must have sufficient unlocked funds
+    (asserts! (>= (stx-get-balance tx-sender) amount-ustx)
+              (err ERR_STACKING_INSUFFICIENT_FUNDS))
 
-      ;; lock period must be in acceptable range.
-      (asserts! (check-pox-lock-period num-cycles)
-          (err ERR_STACKING_INVALID_LOCK_PERIOD))
+    ;; lock period must be in acceptable range.
+    (asserts! (check-pox-lock-period num-cycles)
+              (err ERR_STACKING_INVALID_LOCK_PERIOD))
 
-      ;; address version must be valid
-      (asserts! (check-pox-addr-version (get version pox-addr))
-          (err ERR_STACKING_INVALID_POX_ADDRESS))
+    ;; address version must be valid
+    (asserts! (check-pox-addr-version (get version pox-addr))
+              (err ERR_STACKING_INVALID_POX_ADDRESS))
+    (ok true)))
 
-      (ok true))
-)
 
 ;; Lock up some uSTX for stacking!  Note that the given amount here is in micro-STX (uSTX).
 ;; The STX will be locked for the given number of reward cycles (lock-period).
@@ -357,9 +414,17 @@
     ;; this stacker's first reward cycle is the _next_ reward cycle
     (let ((first-reward-cycle (+ u1 (current-pox-reward-cycle))))
 
+      ;; must be called directly by the tx-sender
+      (asserts! (is-eq tx-sender contract-caller)
+        (err ERR_STACKING_PERMISSION_DENIED))
+
       ;; tx-sender principal must not be stacking
       (asserts! (is-none (get-stacker-info tx-sender))
         (err ERR_STACKING_ALREADY_STACKED))
+
+      ;; tx-sender must not be delegating
+      (asserts! (is-none (get-check-delegation tx-sender))
+        (err ERR_STACKING_ALREADY_DELEGATED))
 
       ;; ensure that stacking can be performed
       (try! (can-stack-stx pox-addr amount-ustx first-reward-cycle lock-period))
@@ -379,6 +444,94 @@
       ;; return the lock-up information, so the node can actually carry out the lock. 
       (ok { stacker: tx-sender, lock-amount: amount-ustx, unlock-burn-height: (reward-cycle-to-burn-height (+ first-reward-cycle lock-period)) }))
 )
+
+;; Commit partially stacked STX.
+;;   this allows a stacker/delegator to lock fewer STX than the minimal threshold in multiple transactions,
+;;   so long as the pox-addr is the same, and then this "commit" transaction is called _before_ the PoX anchor block
+;;   this ensures that each entry in the reward set returned to the stacks-node is greater than the threshold,
+;;   but does not require it be all locked up within a single transaction
+(define-public (stack-aggregation-commit (pox-addr { version: (buff 1), hashbytes: (buff 20) })
+                                         (reward-cycle uint))
+  (let ((partial-stacked
+         ;; fetch the partial commitments
+         (unwrap! (map-get? partial-stacked-by-cycle { pox-addr: pox-addr, sender: tx-sender, reward-cycle: reward-cycle })
+                  (err ERR_STACKING_NO_SUCH_PRINCIPAL))))
+    ;; must be called directly by the tx-sender or by an allowed contract-caller
+    (asserts! (check-delegation-caller-allowed)
+              (err ERR_STACKING_PERMISSION_DENIED))
+    (let ((amount-ustx (get stacked-amount partial-stacked)))
+      (try! (can-stack-stx pox-addr amount-ustx reward-cycle u1))
+      ;; add the pox addr to the reward cycle
+      (add-pox-addr-to-ith-reward-cycle
+       u0
+       { pox-addr: pox-addr,
+         first-reward-cycle: reward-cycle,
+         num-cycles: u1,
+         amount-ustx: amount-ustx,
+         i: u0
+       })
+      ;; don't update the stacking-state map,
+      ;;  because it _already has_ this stacker's state
+      ;; don't lock the STX, because the STX is already locked
+      ;;
+      ;; clear the partial-stacked state
+      (map-delete partial-stacked-by-cycle { pox-addr: pox-addr, sender: tx-sender, reward-cycle: reward-cycle })
+      (ok true))))
+
+;; As a delegator, stack the given principal's STX using partial-stacked-by-cycle
+;; Once the delegator has stacked > minimum, the delegator should call the stack-aggregation-commit
+(define-public (delegator-stack-stx (stacker principal)
+                                    (amount-ustx uint)
+                                    (pox-addr { version: (buff 1), hashbytes: (buff 20) })
+                                    (lock-period uint))
+    ;; this stacker's first reward cycle is the _next_ reward cycle
+    (let ((first-reward-cycle (+ u1 (current-pox-reward-cycle)))
+          (unlock-burn-height (reward-cycle-to-burn-height (+ (current-pox-reward-cycle) u1 lock-period))))
+
+      ;; must be called directly by the tx-sender or by an allowed contract-caller
+      (asserts! (check-delegation-caller-allowed)
+        (err ERR_STACKING_PERMISSION_DENIED))
+
+      ;; stacker must have delegated to the caller
+      (asserts! 
+        (let ((delegation-info (unwrap! (get-check-delegation stacker) (err ERR_STACKING_PERMISSION_DENIED))))
+               ;; must have delegated to tx-sender
+          (and (is-eq (get delegated-to delegation-info) tx-sender)
+               ;; must have delegated enough stx
+               (>= (get amount-ustx delegation-info) amount-ustx)
+               ;; if pox-addr is set, must be equal to pox-addr
+               (match (get pox-addr delegation-info)
+                      specified-pox-addr (is-eq pox-addr specified-pox-addr)
+                      true)
+               ;; delegation must not expire before lock period
+               (match (get until-burn-ht delegation-info)
+                      until-burn-ht (>= (+ u1 until-burn-ht)
+                                        (reward-cycle-to-burn-height unlock-burn-height))
+                      true)))
+        (err ERR_STACKING_PERMISSION_DENIED))
+
+      ;; stacker principal must not be stacking
+      (asserts! (is-none (get-stacker-info stacker))
+        (err ERR_STACKING_ALREADY_STACKED))
+
+      ;; ensure that stacking can be performed
+      (try! (minimal-can-stack-stx pox-addr amount-ustx first-reward-cycle lock-period))
+
+      ;; register the PoX address with the amount stacked
+      (try! (add-pox-addr-to-reward-cycles pox-addr first-reward-cycle lock-period amount-ustx))
+
+      ;; add stacker record
+      (map-set stacking-state
+        { stacker: stacker }
+        { amount-ustx: amount-ustx,
+          pox-addr: pox-addr,
+          first-reward-cycle: first-reward-cycle,
+          lock-period: lock-period })
+
+      ;; return the lock-up information, so the node can actually carry out the lock. 
+      (ok { stacker: stacker,
+            lock-amount: amount-ustx,
+            unlock-burn-height: unlock-burn-height })))
 
 ;; Reject Stacking for this reward cycle.
 ;; tx-sender votes all its uSTX for rejection.

--- a/src/chainstate/stacks/boot/pox.clar
+++ b/src/chainstate/stacks/boot/pox.clar
@@ -504,9 +504,10 @@
       (ok true)))
 
 ;; Commit partially stacked STX.
-;;   this allows a stacker/delegator to lock fewer STX than the minimal threshold in multiple transactions,
-;;   so long as the pox-addr is the same, and then this "commit" transaction is called _before_ the PoX anchor block
-;;   this ensures that each entry in the reward set returned to the stacks-node is greater than the threshold,
+;;   This allows a stacker/delegator to lock fewer STX than the minimal threshold in multiple transactions,
+;;   so long as: 1. The pox-addr is the same.
+;;               2. This "commit" transaction is called _before_ the PoX anchor block.
+;;   This ensures that each entry in the reward set returned to the stacks-node is greater than the threshold,
 ;;   but does not require it be all locked up within a single transaction
 (define-public (stack-aggregation-commit (pox-addr { version: (buff 1), hashbytes: (buff 20) })
                                          (reward-cycle uint))

--- a/src/chainstate/stacks/boot/pox.clar
+++ b/src/chainstate/stacks/boot/pox.clar
@@ -180,9 +180,7 @@
                           false)))
           ;; is the caller allowance expired?
           (if (< burn-block-height (unwrap! (get until-burn-ht caller-allowed) true))
-              (begin (map-delete allowance-contract-callers
-                                 { sender: tx-sender, contract-caller: contract-caller })
-                     false)
+              false
               true))))
 
 (define-private (get-check-delegation (stacker principal))
@@ -191,9 +189,8 @@
       (if (match (get until-burn-ht delegation-info)
                  until-burn-ht (> burn-block-height until-burn-ht)
                  false)
-          ;; it expired, delete the entry and return none
-          (begin (map-delete delegation-state { stacker: stacker })
-                 none)
+          ;; it expired, return none
+          none
           ;; delegation is active
           (some delegation-info))))
 

--- a/src/chainstate/stacks/boot/pox.clar
+++ b/src/chainstate/stacks/boot/pox.clar
@@ -330,7 +330,7 @@
   (let ((cycle-indexes (list u0 u1 u2 u3 u4 u5 u6 u7 u8 u9 u10 u11)))
     (fold add-pox-partial-stacked-to-ith-cycle cycle-indexes 
           { pox-addr: pox-addr, reward-cycle: first-reward-cycle, num-cycles: num-cycles, amount-ustx: amount-ustx })
-    (ok true)))
+    true))
 
 ;; What is the minimum number of uSTX to be stacked in the given reward cycle?
 ;; Used internally by the Stacks node, and visible publicly.
@@ -580,7 +580,7 @@
 
       ;; register the PoX address with the amount stacked via partial stacking
       ;;   before it can be included in the reward set, this must be committed!
-      (try! (add-pox-partial-stacked pox-addr first-reward-cycle lock-period amount-ustx))
+      (add-pox-partial-stacked pox-addr first-reward-cycle lock-period amount-ustx)
 
       ;; add stacker record
       (map-set stacking-state

--- a/src/chainstate/stacks/transaction.rs
+++ b/src/chainstate/stacks/transaction.rs
@@ -235,10 +235,10 @@ impl TransactionPayload {
         }))
     }
 
-    pub fn new_smart_contract(name: &String, contract: &String) -> Option<TransactionPayload> {
+    pub fn new_smart_contract(name: &str, contract: &str) -> Option<TransactionPayload> {
         match (
-            ContractName::try_from((*name).clone()),
-            StacksString::from_string(contract),
+            ContractName::try_from(name.to_string()),
+            StacksString::from_str(contract),
         ) {
             (Ok(s_name), Some(s_body)) => Some(TransactionPayload::SmartContract(
                 TransactionSmartContract {

--- a/src/clarity.rs
+++ b/src/clarity.rs
@@ -540,10 +540,19 @@ pub fn invoke_command(invoked_by: &str, args: &[String]) {
 
             let contract_id = QualifiedContractIdentifier::transient();
 
-            let content: String = friendly_expect(
-                fs::read_to_string(&args[1]),
-                &format!("Error reading file: {}", args[1]),
-            );
+            let content: String = if &args[1] == "-" {
+                let mut buffer = String::new();
+                friendly_expect(
+                    io::stdin().read_to_string(&mut buffer),
+                    "Error reading from stdin.",
+                );
+                buffer
+            } else {
+                friendly_expect(
+                    fs::read_to_string(&args[1]),
+                    &format!("Error reading file: {}", args[1]),
+                )
+            };
 
             let mut ast = friendly_expect(parse(&contract_id, &content), "Failed to parse program");
 

--- a/src/net/neighbors.rs
+++ b/src/net/neighbors.rs
@@ -4091,6 +4091,7 @@ mod test {
     }
 
     #[test]
+    #[ignore]
     fn test_step_walk_2_neighbors_rekey() {
         with_timeout(600, || {
             let mut peer_1_config = TestPeerConfig::from_port(32600);

--- a/src/vm/analysis/errors.rs
+++ b/src/vm/analysis/errors.rs
@@ -184,7 +184,7 @@ impl CheckError {
         self.expressions.replace(vec![expr.clone()]);
     }
 
-    pub fn set_expressions(&mut self, exprs: Vec<SymbolicExpression>) {
+    pub fn set_expressions(&mut self, exprs: &[SymbolicExpression]) {
         self.diagnostic.spans = exprs.iter().map(|e| e.span.clone()).collect();
         self.expressions.replace(exprs.clone().to_vec());
     }

--- a/src/vm/analysis/read_only_checker/mod.rs
+++ b/src/vm/analysis/read_only_checker/mod.rs
@@ -303,7 +303,10 @@ impl<'a, 'b> ReadOnlyChecker<'a, 'b> {
             .match_atom()
             .ok_or(CheckErrors::NonFunctionApplication)?;
 
-        if let Some(result) = self.try_native_function_check(function_name, args) {
+        if let Some(mut result) = self.try_native_function_check(function_name, args) {
+            if let Err(ref mut check_err) = result {
+                check_err.set_expressions(expression);
+            }
             result
         } else {
             let is_function_read_only = self

--- a/src/vm/functions/special.rs
+++ b/src/vm/functions/special.rs
@@ -48,11 +48,11 @@ fn parse_pox_stacking_result(
 /// Handle special cases when calling into the PoX API contract
 fn handle_pox_api_contract_call(
     global_context: &mut GlobalContext,
-    sender_opt: Option<&PrincipalData>,
+    _sender_opt: Option<&PrincipalData>,
     function_name: &str,
     value: &Value,
 ) -> Result<()> {
-    if function_name == "stack-stx" {
+    if function_name == "stack-stx" || function_name == "delegator-stack-stx" {
         debug!(
             "Handle special-case contract-call to {:?} {} (which returned {:?})",
             boot_code_id("pox"),
@@ -60,26 +60,13 @@ fn handle_pox_api_contract_call(
             value
         );
 
-        // sender is required
-        let sender = match sender_opt {
-            None => {
-                return Err(RuntimeErrorType::NoSenderInContext.into());
-            }
-            Some(sender) => (*sender).clone(),
-        };
-
         match parse_pox_stacking_result(value) {
             Ok((stacker, locked_amount, unlock_height)) => {
-                assert_eq!(
-                    stacker, sender,
-                    "BUG: tx-sender is not contract-call origin!"
-                );
-
                 // if this fails, then there's a bug in the contract (since it already does
                 // the necessary checks)
                 match StacksChainState::pox_lock(
                     &mut global_context.database,
-                    &sender,
+                    &stacker,
                     locked_amount,
                     unlock_height as u64,
                 ) {
@@ -96,7 +83,7 @@ fn handle_pox_api_contract_call(
                     Err(e) => {
                         panic!(
                             "FATAL: failed to lock {} from {} until {}: '{:?}'",
-                            locked_amount, sender, unlock_height, &e
+                            locked_amount, stacker, unlock_height, &e
                         );
                     }
                 }

--- a/src/vm/functions/special.rs
+++ b/src/vm/functions/special.rs
@@ -52,7 +52,7 @@ fn handle_pox_api_contract_call(
     function_name: &str,
     value: &Value,
 ) -> Result<()> {
-    if function_name == "stack-stx" || function_name == "delegator-stack-stx" {
+    if function_name == "stack-stx" || function_name == "delegate-stack-stx" {
         debug!(
             "Handle special-case contract-call to {:?} {} (which returned {:?})",
             boot_code_id("pox"),

--- a/src/vm/tests/mod.rs
+++ b/src/vm/tests/mod.rs
@@ -93,7 +93,7 @@ pub fn symbols_from_values(mut vec: Vec<Value>) -> Vec<SymbolicExpression> {
         .collect()
 }
 
-fn is_committed(v: &Value) -> bool {
+pub fn is_committed(v: &Value) -> bool {
     eprintln!("is_committed?: {}", v);
 
     match v {
@@ -102,7 +102,7 @@ fn is_committed(v: &Value) -> bool {
     }
 }
 
-fn is_err_code(v: &Value, e: u128) -> bool {
+pub fn is_err_code(v: &Value, e: u128) -> bool {
     eprintln!("is_err_code?: {}", v);
     match v {
         Value::Response(ref data) => !data.committed && *data.data == Value::UInt(e),


### PR DESCRIPTION
This PR adds delegation and pooling support to the pox contract. It does so by adding four public methods:

* `delegate-stx` - This method creates a delegation relationship between the sender and the designated principal. This _does not_ lock the corresponding STX. Rather, it allows the designated principal to perform the lock, subject to the constraints of the sender:
     * a maximum amount the delegator is allowed to lock and stack
     * optional reward address that must be used
     * optional expiration burn block height
* `revoke-delegate-stx` - This method allows the sender to revoke their designated delegator
* `delegator-stack-stx` - This method is called by a delegator to _lock_ a single stacker's STX, _but does not_ add the pox-addr to the reward cycles. Rather, when invoked, it adds the amount of locked STX to a map of "partial" rewards. Then, delegators will call the `stack-aggregation-commit` method to finalize these partial rewards. This separation of the locking and commit operations allows delegators to invoke this method multiple times with different stackers in order to build up enough STX to clear the minimum reward threshold (i.e. pooling).
* `stack-aggregation-commit` - This method checks and adds a pox-addr to a reward cycle if the corresponding partially stacked amounts clear the threshold.


In addition, this PR makes a few changes to the PoX contract's behavior:

1. Reward addresses may be used multiple times. As long as each entry clears the minimum threshold, it is fine to include a reward address multiple times. There's a few use cases where users might want to do this, e.g., a user holds STX across multiple addresses, but would like to receive Stacking rewards at a single BTC address, and I don't think there's any performance consequences to allowing this (ultimately, any cases where a reward address would be used multiple times, would instead just be a case where the same number of different addresses were used).

2. `tx-sender` must be equal to `contract-caller`, unless a contract has received an allowance. Post conditions do not protect stacking, so it's dangerous to just use `tx-sender` without the check.

3.  The minimum threshold was previously always `liquid_supply / 20000`, which isn't the case in testnet, so this was updated to use the defined constant. 