### PR TITLE
Discussion: Structured logging via `slog`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,12 +31,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85bb70cc08ec97ca5450e6eba421deeea5f172c0fc61f78b5357b2a8e8be195f"
 
 [[package]]
-name = "arc-swap"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d25d88fd6b8041580a654f9d0c581a047baee2b3efee13275f2fc392fc75034"
-
-[[package]]
 name = "arrayref"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -257,7 +251,6 @@ dependencies = [
  "sha2-asm",
  "sha3",
  "slog",
- "slog-async",
  "slog-json",
  "slog-term",
  "time 0.2.16",
@@ -2173,18 +2166,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1cc9c640a4adbfbcc11ffb95efe5aa7af7309e002adab54b185507dbf2377b99"
 
 [[package]]
-name = "slog-async"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b3336ce47ce2f96673499fc07eb85e3472727b9a7a2959964b002c2ce8fbbb"
-dependencies = [
- "crossbeam-channel",
- "slog",
- "take_mut",
- "thread_local",
-]
-
-[[package]]
 name = "slog-json"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2193,17 +2174,6 @@ dependencies = [
  "chrono",
  "serde",
  "serde_json",
- "slog",
-]
-
-[[package]]
-name = "slog-scope"
-version = "4.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c44c89dd8b0ae4537d1ae318353eaf7840b4869c536e31c41e963d1ea523ee6"
-dependencies = [
- "arc-swap",
- "lazy_static",
  "slog",
 ]
 
@@ -2269,9 +2239,6 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "slog",
- "slog-json",
- "slog-scope",
- "slog-term",
  "tokio",
  "toml",
  "warp",
@@ -2362,12 +2329,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "take_mut"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,6 +31,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85bb70cc08ec97ca5450e6eba421deeea5f172c0fc61f78b5357b2a8e8be195f"
 
 [[package]]
+name = "arc-swap"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d25d88fd6b8041580a654f9d0c581a047baee2b3efee13275f2fc392fc75034"
+
+[[package]]
+name = "arrayref"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
+
+[[package]]
+name = "arrayvec"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
+
+[[package]]
 name = "assert-json-diff"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -182,6 +200,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
+name = "blake2b_simd"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8fb2d74254a3a0b5cac33ac9f8ed0e44aa50378d9dbb2e5d83bd21ed1dc2c8a"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "constant_time_eq",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -227,6 +256,10 @@ dependencies = [
  "sha2",
  "sha2-asm",
  "sha3",
+ "slog",
+ "slog-async",
+ "slog-json",
+ "slog-term",
  "time 0.2.16",
  "tini",
  "url",
@@ -324,6 +357,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
+name = "chrono"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+dependencies = [
+ "libc",
+ "num-integer",
+ "num-traits",
+ "time 0.1.43",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "clap"
 version = "2.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -351,6 +397,12 @@ checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 dependencies = [
  "bitflags",
 ]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "cookie"
@@ -514,6 +566,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "dirs"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3"
+dependencies = [
+ "cfg-if",
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e93d7f5705de3e49895a2b5e0b8855a1c27f080192ae9c32a6432d50741a57a"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1209,6 +1282,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-integer"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d59457e662d541ba17869cf51cf177c0b5f0cbf476c66bdc90bf1edac4f875b"
+dependencies = [
+ "autocfg 1.0.0",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1694,6 +1777,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
+name = "redox_users"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d"
+dependencies = [
+ "getrandom",
+ "redox_syscall",
+ "rust-argon2",
+]
+
+[[package]]
 name = "regex"
 version = "1.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1803,6 +1897,18 @@ dependencies = [
  "lru-cache",
  "serde_json",
  "time 0.1.43",
+]
+
+[[package]]
+name = "rust-argon2"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dab61250775933275e84053ac235621dfb739556d5c54a2f2e9313b7cf43a19"
+dependencies = [
+ "base64 0.12.3",
+ "blake2b_simd",
+ "constant_time_eq",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -2061,6 +2167,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 
 [[package]]
+name = "slog"
+version = "2.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cc9c640a4adbfbcc11ffb95efe5aa7af7309e002adab54b185507dbf2377b99"
+
+[[package]]
+name = "slog-async"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51b3336ce47ce2f96673499fc07eb85e3472727b9a7a2959964b002c2ce8fbbb"
+dependencies = [
+ "crossbeam-channel",
+ "slog",
+ "take_mut",
+ "thread_local",
+]
+
+[[package]]
+name = "slog-json"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddc0d2aff1f8f325ef660d9a0eb6e6dcd20b30b3f581a5897f58bf42d061c37a"
+dependencies = [
+ "chrono",
+ "serde",
+ "serde_json",
+ "slog",
+]
+
+[[package]]
+name = "slog-scope"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c44c89dd8b0ae4537d1ae318353eaf7840b4869c536e31c41e963d1ea523ee6"
+dependencies = [
+ "arc-swap",
+ "lazy_static",
+ "slog",
+]
+
+[[package]]
+name = "slog-term"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bab1d807cf71129b05ce36914e1dbb6fbfbdecaf686301cb457f4fa967f9f5b6"
+dependencies = [
+ "atty",
+ "chrono",
+ "slog",
+ "term",
+ "thread_local",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2108,6 +2268,10 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
+ "slog",
+ "slog-json",
+ "slog-scope",
+ "slog-term",
  "tokio",
  "toml",
  "warp",
@@ -2200,6 +2364,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "take_mut"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
+
+[[package]]
 name = "tempfile"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2210,6 +2380,16 @@ dependencies = [
  "rand 0.7.2",
  "redox_syscall",
  "remove_dir_all",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "term"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0863a3345e70f61d613eab32ee046ccd1bcc5f9105fe402c61fcd0c13eeb8b5"
+dependencies = [
+ "dirs",
  "winapi 0.3.9",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ prometheus = { version = "0.9", optional = true }
 integer-sqrt = "0.1.3"
 slog = "2.5.2"
 slog-term = "2.6.0"
-slog-json = "2.3.0"
+slog-json = { version = "2.3.0", optional = true }
 
 [dependencies.serde_json]
 version = "1.0"
@@ -91,10 +91,11 @@ assert-json-diff = "1.0.0"
 criterion = "0.3"
 
 [features]
-developer-mode = []
 default = ["developer-mode"]
+developer-mode = []
 monitoring_prom = ["prometheus"]
 tx_log = []
+slog_json = ["slog-json"]
 
 [target.'cfg(all(target_arch = "x86_64", not(target_env = "msvc")))'.dependencies]
 sha2-asm = "0.5.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,10 @@ percent-encoding = "2.1.0"
 sha2 = "0.8.0"
 prometheus = { version = "0.9", optional = true }
 integer-sqrt = "0.1.3"
+slog = "2.5.2"
+slog-term = "2.6.0"
+slog-json = "2.3.0"
+slog-async = "2.5.0"
 
 [dependencies.serde_json]
 version = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,6 @@ integer-sqrt = "0.1.3"
 slog = "2.5.2"
 slog-term = "2.6.0"
 slog-json = "2.3.0"
-slog-async = "2.5.0"
 
 [dependencies.serde_json]
 version = "1.0"

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apk add --no-cache musl-dev
 
 RUN mkdir /out
 
-RUN cd testnet/stacks-node && cargo build --features "monitoring_prom" --release
+RUN cd testnet/stacks-node && cargo build --features monitoring_prom,slog_json --release
 RUN cd testnet/bitcoin-neon-controller && cargo build --release
 
 RUN cp target/release/stacks-node /out

--- a/Dockerfile.stretch
+++ b/Dockerfile.stretch
@@ -6,7 +6,7 @@ COPY . .
 
 RUN mkdir /out
 
-RUN cd testnet/stacks-node && cargo build --features monitoring_prom slog_json --release
+RUN cd testnet/stacks-node && cargo build --features monitoring_prom,slog_json --release
 RUN cd testnet/bitcoin-neon-controller && cargo build --release
 
 RUN cp target/release/stacks-node /out

--- a/Dockerfile.stretch
+++ b/Dockerfile.stretch
@@ -6,7 +6,7 @@ COPY . .
 
 RUN mkdir /out
 
-RUN cd testnet/stacks-node && cargo build --features "monitoring_prom" --release
+RUN cd testnet/stacks-node && cargo build --features monitoring_prom slog_json --release
 RUN cd testnet/bitcoin-neon-controller && cargo build --release
 
 RUN cp target/release/stacks-node /out

--- a/src/blockstack_cli.rs
+++ b/src/blockstack_cli.rs
@@ -453,7 +453,6 @@ fn generate_secret_key(args: &[String], version: TransactionVersion) -> Result<S
 }
 
 fn main() {
-    log::set_loglevel(log::LOG_DEBUG).unwrap();
     let mut argv: Vec<String> = env::args().collect();
 
     argv.remove(0);

--- a/src/chainstate/stacks/index/marf.rs
+++ b/src/chainstate/stacks/index/marf.rs
@@ -216,7 +216,7 @@ impl<'a, T: MarfTrieId> MarfTransaction<'a, T> {
         if !is_parent_sentinel {
             debug!("Extending off of existing node {}", chain_tip);
         } else {
-            info!("First-ever block {}", next_chain_tip);
+            info!("First-ever block {}", next_chain_tip; "block" => %next_chain_tip);
         }
 
         self.storage.open_block(chain_tip)?;

--- a/src/clarity_cli.rs
+++ b/src/clarity_cli.rs
@@ -29,7 +29,6 @@ use blockstack_lib::{clarity, util::log};
 use std::env;
 
 fn main() {
-    log::set_loglevel(log::LOG_DEBUG).unwrap();
     let argv: Vec<String> = env::args().collect();
 
     clarity::invoke_command(&argv[0], &argv[1..]);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,12 @@ extern crate sha3;
 extern crate time;
 extern crate url;
 
+#[macro_use(o, slog_log, slog_trace, slog_debug, slog_info, slog_warn, slog_error)]
+extern crate slog;
+extern crate slog_term;
+extern crate slog_json;
+extern crate slog_async;
+
 #[macro_use]
 extern crate serde_derive;
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,9 +46,9 @@ extern crate url;
 
 #[macro_use(o, slog_log, slog_trace, slog_debug, slog_info, slog_warn, slog_error)]
 extern crate slog;
-extern crate slog_term;
-extern crate slog_json;
 extern crate slog_async;
+extern crate slog_json;
+extern crate slog_term;
 
 #[macro_use]
 extern crate serde_derive;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,7 @@ extern crate url;
 
 #[macro_use(o, slog_log, slog_trace, slog_debug, slog_info, slog_warn, slog_error)]
 extern crate slog;
+#[cfg(feature = "slog_json")]
 extern crate slog_json;
 extern crate slog_term;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,6 @@ extern crate url;
 
 #[macro_use(o, slog_log, slog_trace, slog_debug, slog_info, slog_warn, slog_error)]
 extern crate slog;
-extern crate slog_async;
 extern crate slog_json;
 extern crate slog_term;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,9 @@
 extern crate blockstack_lib;
 extern crate rusqlite;
 
+#[macro_use(o, slog_log, slog_trace, slog_debug, slog_info, slog_warn, slog_error)]
+extern crate slog;
+
 use blockstack_lib::burnchains::db::BurnchainBlockData;
 use blockstack_lib::*;
 
@@ -57,8 +60,6 @@ use rusqlite::Connection;
 use rusqlite::OpenFlags;
 
 fn main() {
-    log::set_loglevel(log::LOG_INFO).unwrap();
-
     let mut argv: Vec<String> = env::args().collect();
     if argv.len() < 2 {
         eprintln!("Usage: {} command [args...]", argv[0]);

--- a/src/util/log.rs
+++ b/src/util/log.rs
@@ -17,8 +17,8 @@
  along with Blockstack. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use std::env;
 use slog::{Drain, Logger};
+use std::env;
 use std::sync::Mutex;
 
 lazy_static! {

--- a/src/util/log.rs
+++ b/src/util/log.rs
@@ -17,153 +17,76 @@
  along with Blockstack. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use std::cell::RefCell;
 use std::env;
+use slog::{Drain, Logger};
+use std::sync::Mutex;
 
-// Message Priorities/Levels
-// Apache Conventions defined here: https://commons.apache.org/proper/commons-logging/guide.html#Message_PrioritiesLevels
-//
-// Severe errors that cause premature termination.
-// Expect these to be immediately visible on a status console.
-pub const LOG_FATAL: u8 = 6;
-// Other runtime errors or unexpected conditions.
-// Expect these to be immediately visible on a status console.
-pub const LOG_ERROR: u8 = 5;
-// Use of deprecated APIs, poor use of API, 'almost' errors, other runtime situations that are undesirable or unexpected, but not necessarily "wrong".
-// Expect these to be immediately visible on a status console.
-pub const LOG_WARN: u8 = 4;
-// Interesting runtime events (startup/shutdown).
-// Expect these to be immediately visible on a console, so be conservative and keep to a minimum
-pub const LOG_INFO: u8 = 3;
-// Detailed information on the flow through the system.
-// Expect these to be written to logs only.
-pub const LOG_DEBUG: u8 = 2;
-// More detailed information.
-// Expect these to be written to logs only.
-pub const LOG_TRACE: u8 = 1;
-
-// per-thread log level and log format
-thread_local!(static loglevel: RefCell<u8> = RefCell::new(LOG_INFO));
-
-pub fn set_loglevel(ll: u8) -> Result<(), String> {
-    loglevel.with(move |level| match ll {
-        LOG_TRACE..=LOG_FATAL => {
-            *level.borrow_mut() = ll;
-            Ok(())
-        }
-        _ => Err("Invalid log level".to_string()),
-    })
+lazy_static! {
+    pub static ref LOGGER: Logger = make_logger();
 }
 
-pub fn get_loglevel() -> u8 {
-    let mut res = 0;
-    loglevel.with(|lvl| {
-        res = *lvl.borrow();
-    });
-
-    if env::var("BLOCKSTACK_DEBUG") == Ok("1".into()) && res > LOG_DEBUG {
-        set_loglevel(LOG_DEBUG).unwrap();
-        LOG_DEBUG
-    } else if env::var("BLOCKSTACK_TRACE") == Ok("1".into()) && res > LOG_TRACE {
-        set_loglevel(LOG_TRACE).unwrap();
-        LOG_TRACE
+fn make_logger() -> Logger {
+    if env::var("BLOCKSTACK_LOG_JSON") == Ok("1".into()) {
+        let drain = Mutex::new(slog_json::Json::default(std::io::stderr())).map(slog::Fuse);
+        let filtered_drain = slog::LevelFilter::new(drain, get_loglevel()).fuse();
+        slog::Logger::root(filtered_drain, o!())
     } else {
-        res
+        let decorator = slog_term::TermDecorator::new().build();
+        let drain = slog_term::CompactFormat::new(decorator).build().fuse();
+        let drain = slog_async::Async::new(drain).build().fuse();
+        let filtered_drain = slog::LevelFilter::new(drain, get_loglevel()).fuse();
+        slog::Logger::root(filtered_drain, o!())
+    }
+}
+
+fn get_loglevel() -> slog::Level {
+    if env::var("BLOCKSTACK_TRACE") == Ok("1".into()) {
+        slog::Level::Trace
+    } else if env::var("BLOCKSTACK_DEBUG") == Ok("1".into()) {
+        slog::Level::Debug
+    } else {
+        slog::Level::Info
     }
 }
 
 #[macro_export]
 macro_rules! trace {
     ($($arg:tt)*) => ({
-        if ::util::log::get_loglevel() <= ::util::log::LOG_TRACE {
-            use std::time::SystemTime;
-            use std::thread;
-            let (ts_sec, ts_msec) = match SystemTime::now().duration_since(SystemTime::UNIX_EPOCH) {
-                Ok(n) => (n.as_secs(), n.subsec_nanos() / 1_000_000),
-                Err(_) => (0, 0)
-            };
-            eprintln!("TRACE [{}.{:03}] [{}:{}] [{:?}] {}", ts_sec, ts_msec, file!(), line!(), thread::current().id(), format!($($arg)*));
-        }
-    })
-}
-
-#[macro_export]
-macro_rules! debug {
-    ($($arg:tt)*) => ({
-        if ::util::log::get_loglevel() <= ::util::log::LOG_DEBUG {
-            use std::time::SystemTime;
-            use std::thread;
-            let (ts_sec, ts_msec) = match SystemTime::now().duration_since(SystemTime::UNIX_EPOCH) {
-                Ok(n) => (n.as_secs(), n.subsec_nanos() / 1_000_000),
-                Err(_) => (0, 0)
-            };
-            eprintln!("DEBUG [{}.{:03}] [{}:{}] [{:?}] {}", ts_sec, ts_msec, file!(), line!(), thread::current().id(), format!($($arg)*));
-        }
-    })
-}
-
-#[macro_export]
-macro_rules! info {
-    ($($arg:tt)*) => ({
-        if ::util::log::get_loglevel() <= ::util::log::LOG_INFO {
-            use std::time::SystemTime;
-            use std::thread;
-            let (ts_sec, ts_msec) = match SystemTime::now().duration_since(SystemTime::UNIX_EPOCH) {
-                Ok(n) => (n.as_secs(), n.subsec_nanos() / 1_000_000),
-                Err(_) => (0, 0)
-            };
-            eprintln!("INFO [{}.{:03}] [{}:{}] [{:?}] {}", ts_sec, ts_msec, file!(), line!(), thread::current().id(), format!($($arg)*));
-        }
-    })
-}
-
-#[macro_export]
-macro_rules! warn {
-    ($($arg:tt)*) => ({
-        if ::util::log::get_loglevel() <= ::util::log::LOG_WARN {
-            use std::time::SystemTime;
-            use std::thread;
-            use crate::monitoring::increment_warning_emitted_counter;
-            let (ts_sec, ts_msec) = match SystemTime::now().duration_since(SystemTime::UNIX_EPOCH) {
-                Ok(n) => (n.as_secs(), n.subsec_nanos() / 1_000_000),
-                Err(_) => (0, 0)
-            };
-            eprintln!("WARN [{}.{:03}] [{}:{}] [{:?}] {}", ts_sec, ts_msec, file!(), line!(), thread::current().id(), format!($($arg)*));
-
-            increment_warning_emitted_counter();
-        }
+        slog_trace!($crate::util::log::LOGGER, $($arg)*)
     })
 }
 
 #[macro_export]
 macro_rules! error {
     ($($arg:tt)*) => ({
-        if ::util::log::get_loglevel() <= ::util::log::LOG_ERROR {
-            use std::time::SystemTime;
-            use std::thread;
-            use crate::monitoring::increment_errors_emitted_counter;
-            let (ts_sec, ts_msec) = match SystemTime::now().duration_since(SystemTime::UNIX_EPOCH) {
-                Ok(n) => (n.as_secs(), n.subsec_nanos() / 1_000_000),
-                Err(_) => (0, 0)
-            };
-            eprintln!("ERROR [{}.{:03}] [{}:{}] [{:?}] {}", ts_sec, ts_msec, file!(), line!(), thread::current().id(), format!($($arg)*));
+        slog_error!($crate::util::log::LOGGER, $($arg)*)
+    })
+}
 
-            increment_errors_emitted_counter();
-        }
+#[macro_export]
+macro_rules! warn {
+    ($($arg:tt)*) => ({
+        slog_warn!($crate::util::log::LOGGER, $($arg)*)
+    })
+}
+
+#[macro_export]
+macro_rules! info {
+    ($($arg:tt)*) => ({
+        slog_info!($crate::util::log::LOGGER, $($arg)*)
+    })
+}
+
+#[macro_export]
+macro_rules! debug {
+    ($($arg:tt)*) => ({
+        slog_debug!($crate::util::log::LOGGER, $($arg)*)
     })
 }
 
 #[macro_export]
 macro_rules! fatal {
     ($($arg:tt)*) => ({
-        if ::util::log::get_loglevel() <= ::util::log::LOG_FATAL {
-            use std::time::SystemTime;
-            use std::thread;
-            let (ts_sec, ts_msec) = match SystemTime::now().duration_since(SystemTime::UNIX_EPOCH) {
-                Ok(n) => (n.as_secs(), n.subsec_nanos() / 1_000_000),
-                Err(_) => (0, 0)
-            };
-            eprintln!("FATAL [{}.{:03}] [{}:{}] [{:?}] {}", ts_sec, ts_msec, file!(), line!(), thread::current().id(), format!($($arg)*));
-        }
+        slog_crit!($crate::util::log::LOGGER, $($arg)*)
     })
 }

--- a/src/util/log.rs
+++ b/src/util/log.rs
@@ -14,29 +14,114 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use slog::{Drain, Logger};
+use slog::{Drain, Logger, FnValue, Record, KV, BorrowedKV, OwnedKVList};
+use slog_term::{Decorator, Serializer, RecordDecorator};
 use std::env;
 use std::sync::Mutex;
+use std::io;
+use std::time::{SystemTime, Duration};
+use std::thread;
 
 lazy_static! {
     pub static ref LOGGER: Logger = make_logger();
 }
 
-fn make_logger() -> Logger {
-    if env::var("BLOCKSTACK_LOG_JSON") == Ok("1".into()) {
-        let drain = Mutex::new(slog_json::Json::default(std::io::stderr())).map(slog::Fuse);
-        let filtered_drain = slog::LevelFilter::new(drain, get_loglevel()).fuse();
-        slog::Logger::root(filtered_drain, o!())
-    } else {
-        let decorator = slog_term::TermDecorator::new().build();
-        let drain = slog_term::CompactFormat::new(decorator).build().fuse();
-        let drain = slog_async::Async::new(drain).build().fuse();
-        let filtered_drain = slog::LevelFilter::new(drain, get_loglevel()).fuse();
-        slog::Logger::root(filtered_drain, o!())
+struct TermFormat<D: Decorator> {
+    decorator: D,
+}
+
+fn print_msg_header(rd: &mut dyn RecordDecorator, record: &Record) -> io::Result<bool> {
+    rd.start_level()?;
+    write!(rd, "{}", record.level().as_short_str())?;
+    rd.start_whitespace()?;
+    write!(rd, " ")?;
+
+    rd.start_timestamp()?;
+    let elapsed = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap_or(Duration::from_secs(0));
+    write!(rd, "[{:5}.{:06}]", elapsed.as_secs(), elapsed.subsec_nanos()/1000)?;
+    write!(rd, " ")?;
+    write!(rd, "[{}:{}]", record.file(), record.line())?;
+    write!(rd, " ")?;
+    write!(rd, "[{:?}]", thread::current().id())?;
+
+    rd.start_whitespace()?;
+    write!(rd, " ")?;
+
+    rd.start_msg()?;
+    write!(rd, "{}", record.msg())?;
+    Ok(false)
+}
+
+impl<D: Decorator> Drain for TermFormat<D> {
+    type Ok = ();
+    type Err = io::Error;
+
+    fn log(&self, record: &Record, values: &OwnedKVList) -> Result<Self::Ok, Self::Err> {
+        self.format_full(record, values)
     }
 }
 
-fn get_loglevel() -> slog::Level {
+impl<D: Decorator> TermFormat<D> {
+    pub fn new(decorator: D) -> TermFormat<D> {
+        TermFormat { decorator }
+    }
+
+    fn format_full(&self, record: &Record, values: &OwnedKVList) -> io::Result<()> {
+        self.decorator.with_record(record, values, |decorator| {
+            let comma_needed =
+                print_msg_header(decorator, record)?;
+            {
+                let mut serializer = Serializer::new(
+                    decorator,
+                    comma_needed,
+                    true
+                );
+
+                record.kv().serialize(record, &mut serializer)?;
+
+                values.serialize(record, &mut serializer)?;
+
+                serializer.finish()?;
+            }
+
+            decorator.start_whitespace()?;
+            writeln!(decorator)?;
+
+            decorator.flush()?;
+
+            Ok(())
+        })
+    }
+}
+
+fn make_logger() -> Logger {
+    if env::var("BLOCKSTACK_LOG_JSON") == Ok("1".into()) {
+        let def_keys = o!("file" =>
+                          FnValue(move |info| {
+                              info.file()
+                          }),
+                          "line" => FnValue(move |info| {
+                              info.line()
+                          }),
+                          "thread" =>
+                          FnValue(move |_| {
+                              format!("{:?}", thread::current().id())
+                          }),
+        );
+
+        let drain = Mutex::new(slog_json::Json::default(std::io::stderr())).map(slog::Fuse);
+        let filtered_drain = slog::LevelFilter::new(drain, get_loglevel()).fuse();
+        slog::Logger::root(filtered_drain, def_keys)
+    } else {
+        let plain = slog_term::PlainSyncDecorator::new(std::io::stdout());
+        let drain = TermFormat::new(plain);
+
+        let logger = Logger::root(drain.fuse(), o!());
+        logger
+    }
+}
+
+pub fn get_loglevel() -> slog::Level {
     if env::var("BLOCKSTACK_TRACE") == Ok("1".into()) {
         slog::Level::Trace
     } else if env::var("BLOCKSTACK_DEBUG") == Ok("1".into()) {
@@ -49,41 +134,59 @@ fn get_loglevel() -> slog::Level {
 #[macro_export]
 macro_rules! trace {
     ($($arg:tt)*) => ({
-        slog_trace!($crate::util::log::LOGGER, $($arg)*)
+        let cur_level = ::util::log::get_loglevel();
+        if slog::Level::Trace.is_at_least(cur_level) {
+            slog_trace!($crate::util::log::LOGGER, $($arg)*)
+        }
     })
 }
 
 #[macro_export]
 macro_rules! error {
     ($($arg:tt)*) => ({
-        slog_error!($crate::util::log::LOGGER, $($arg)*)
+        let cur_level = ::util::log::get_loglevel();
+        if slog::Level::Error.is_at_least(cur_level) {
+            slog_error!($crate::util::log::LOGGER, $($arg)*)
+        }
     })
 }
 
 #[macro_export]
 macro_rules! warn {
     ($($arg:tt)*) => ({
-        slog_warn!($crate::util::log::LOGGER, $($arg)*)
+        let cur_level = ::util::log::get_loglevel();
+        if slog::Level::Warning.is_at_least(cur_level) {
+            slog_warn!($crate::util::log::LOGGER, $($arg)*)
+        }
     })
 }
 
 #[macro_export]
 macro_rules! info {
     ($($arg:tt)*) => ({
-        slog_info!($crate::util::log::LOGGER, $($arg)*)
+        let cur_level = ::util::log::get_loglevel();
+        if slog::Level::Info.is_at_least(cur_level) {
+            slog_info!($crate::util::log::LOGGER, $($arg)*)
+        }
     })
 }
 
 #[macro_export]
 macro_rules! debug {
     ($($arg:tt)*) => ({
-        slog_debug!($crate::util::log::LOGGER, $($arg)*)
+        let cur_level = ::util::log::get_loglevel();
+        if slog::Level::Debug.is_at_least(cur_level) {
+            slog_debug!($crate::util::log::LOGGER, $($arg)*)
+        }
     })
 }
 
 #[macro_export]
 macro_rules! fatal {
     ($($arg:tt)*) => ({
-        slog_crit!($crate::util::log::LOGGER, $($arg)*)
+        let cur_level = ::util::log::get_loglevel();
+        if slog::Level::Critical.is_at_least(cur_level) {
+            slog_crit!($crate::util::log::LOGGER, $($arg)*)
+        }
     })
 }

--- a/testnet/stacks-node/Cargo.toml
+++ b/testnet/stacks-node/Cargo.toml
@@ -19,6 +19,10 @@ http-types = "1.0"
 base64 = "0.12.0"
 backtrace = "0.3.50"
 libc = "0.2"
+slog = "2.5.2"
+slog-term = "2.6.0"
+slog-json = "2.3.0"
+slog-scope = "4.3.0"
 
 [dev-dependencies]
 warp = "0.2"

--- a/testnet/stacks-node/Cargo.toml
+++ b/testnet/stacks-node/Cargo.toml
@@ -32,5 +32,6 @@ path = "src/main.rs"
 
 [features]
 monitoring_prom = ["stacks/monitoring_prom"]
+slog_json = ["stacks/slog_json"]
 tx-log = ["stacks/tx_log"]
 default = []

--- a/testnet/stacks-node/Cargo.toml
+++ b/testnet/stacks-node/Cargo.toml
@@ -20,9 +20,6 @@ base64 = "0.12.0"
 backtrace = "0.3.50"
 libc = "0.2"
 slog = "2.5.2"
-slog-term = "2.6.0"
-slog-json = "2.3.0"
-slog-scope = "4.3.0"
 
 [dev-dependencies]
 warp = "0.2"

--- a/testnet/stacks-node/src/main.rs
+++ b/testnet/stacks-node/src/main.rs
@@ -11,6 +11,7 @@ extern crate serde_json;
 #[macro_use]
 extern crate stacks;
 
+#[allow(unused_imports)]
 #[macro_use(o, slog_log, slog_trace, slog_debug, slog_info, slog_warn, slog_error)]
 extern crate slog;
 

--- a/testnet/stacks-node/src/main.rs
+++ b/testnet/stacks-node/src/main.rs
@@ -11,6 +11,9 @@ extern crate serde_json;
 #[macro_use]
 extern crate stacks;
 
+#[macro_use(o, slog_log, slog_trace, slog_debug, slog_info, slog_warn, slog_error)]
+extern crate slog;
+
 pub use stacks::util;
 
 pub mod monitoring;


### PR DESCRIPTION
This PR does an initial port of our logging macros to [slog](https://github.com/slog-rs/slog). This allows us to add key-value pairs to our logs which could be parsed immediately by tools like kibana. Eventually, we could also support scoped/contextual logging, which would allow us to filter logs from different subsystems (e.g., logs from the net module could have a different logging backend), and out-of-thread logging which could improve performance when logging lots of data. This would also allow us to plug into syslog if we wanted to do that.

The only potential downside here is that this does involve including a few crates from `slog-rs`, and there's a fair bit of code there. This could _perhaps_ be remedied by something like a feature gate, but that would require that we implement a compatible macro for the k-v pairs.

To see the key-value pairs in action, this PR changed one of the log lines in `src/chainstate/stacks/index/marf.rs`:

```rust
...
    fn inner_get_extension_height(
        &mut self,
        chain_tip: &T,
        next_chain_tip: &T,
    ) -> Result<u32, Error> {
        // current chain tip must exist if it's not the "sentinel"
        let is_parent_sentinel = chain_tip == &T::sentinel();
        if !is_parent_sentinel {
            debug!("Extending off of existing node {}", chain_tip);
        } else {
            info!("First-ever block {}", next_chain_tip; "block" => %next_chain_tip);
        }
...
```

And you can see it in JSON logs:

```
$ BLOCKSTACK_LOG_JSON=1 BITCOIND_TEST=1 cargo test --workspace --bin=stacks-node  -- --nocapture --test-threads 1 --ignored

...

{"msg":"First-ever block 55c9861be5cff984a20ce6d99d4aa65941412889bdc665094136429b84f8c2ee","level":"INFO","ts":"2020-10-02T16:51:37.157992-05:00","block":"55c9861be5cff984a20ce6d99d4aa65941412889bdc665094136429b84f8c2ee"}
{"msg":"ST2VHM28V9E5QCRD6C73215KAPSBKQGPWTEE5CMQT credited (genesis): 10000 uSTX","level":"INFO","ts":"2020-10-02T16:51:40.487250-05:00"}
{"msg":"First-ever block 55c9861be5cff984a20ce6d99d4aa65941412889bdc665094136429b84f8c2ee","level":"INFO","ts":"2020-10-02T16:51:40.494040-05:00","block":"55c9861be5cff984a20ce6d99d4aa65941412889bdc665094136429b84f8c2ee"}
```


Now, this PR would need some changes to include all the same information in the log records that we had previously (e.g., thread id), but I wanted to open this first to see if this is a direction we want to go before making any more changes.

Issue: https://github.com/blockstack/stacks-blockchain/issues/1796