### PR TITLE
PoX: Threshold Adjustment and Reward Address Repetition

### DIFF
--- a/src/burnchains/mod.rs
+++ b/src/burnchains/mod.rs
@@ -308,6 +308,10 @@ impl PoxConstants {
         PoxConstants::new(10, 5, 3, 25)
     }
 
+    pub fn reward_slots(&self) -> u32 {
+        self.reward_cycle_length
+    }
+
     pub fn mainnet_default() -> PoxConstants {
         PoxConstants::new(1000, 240, 192, 25)
     }

--- a/src/chainstate/coordinator/mod.rs
+++ b/src/chainstate/coordinator/mod.rs
@@ -1,7 +1,5 @@
 use std::collections::VecDeque;
-use std::convert::{
-    TryInto, TryFrom
-};
+use std::convert::{TryFrom, TryInto};
 use std::time::Duration;
 
 use burnchains::{
@@ -14,14 +12,18 @@ use chainstate::burn::{
     BlockHeaderHash, BlockSnapshot, ConsensusHash,
 };
 use chainstate::stacks::{
-    db::{ClarityTx, StacksChainState, StacksHeaderInfo},
     boot::STACKS_BOOT_CODE_CONTRACT_ADDRESS,
+    db::{ClarityTx, StacksChainState, StacksHeaderInfo},
     events::StacksTransactionReceipt,
     Error as ChainstateError, StacksAddress, StacksBlock, StacksBlockHeader, StacksBlockId,
 };
 use monitoring::increment_stx_blocks_processed_counter;
 use util::db::Error as DBError;
-use vm::{costs::ExecutionCost, Value, types::{PrincipalData, QualifiedContractIdentifier}};
+use vm::{
+    costs::ExecutionCost,
+    types::{PrincipalData, QualifiedContractIdentifier},
+    Value,
+};
 
 pub mod comm;
 use chainstate::stacks::index::MarfTrieId;
@@ -169,16 +171,21 @@ impl RewardSetProvider for OnChainRewardSetProvider {
 
         let liquid_ustx = StacksChainState::get_stacks_block_header_info_by_index_block_hash(
             chainstate.headers_db(),
-            block_id)?
-            .expect("CORRUPTION: Failed to look up block header info for PoX anchor block")
-            .total_liquid_ustx;
+            block_id,
+        )?
+        .expect("CORRUPTION: Failed to look up block header info for PoX anchor block")
+        .total_liquid_ustx;
 
         let threshold = StacksChainState::get_reward_threshold(
             &burnchain.pox_constants,
             &registered_addrs,
-            liquid_ustx);
+            liquid_ustx,
+        );
 
-        Ok(StacksChainState::make_reward_set(threshold, registered_addrs))
+        Ok(StacksChainState::make_reward_set(
+            threshold,
+            registered_addrs,
+        ))
     }
 }
 
@@ -212,21 +219,27 @@ impl<'a, T: BlockEventDispatcher>
             initial_balances,
             |clarity_tx| {
                 let burnchain = burnchain.clone();
-                let contract = QualifiedContractIdentifier::parse(&format!("{}.pox", STACKS_BOOT_CODE_CONTRACT_ADDRESS))
-                    .expect("Failed to construct boot code contract address");
+                let contract = QualifiedContractIdentifier::parse(&format!(
+                    "{}.pox",
+                    STACKS_BOOT_CODE_CONTRACT_ADDRESS
+                ))
+                .expect("Failed to construct boot code contract address");
                 let sender = PrincipalData::from(contract.clone());
-                
+
                 clarity_tx.connection().as_transaction(|conn| {
                     conn.run_contract_call(
                         &sender,
                         &contract,
                         "set-burnchain-parameters",
-                        &[Value::UInt(burnchain.first_block_height as u128),
-                          Value::UInt(burnchain.pox_constants.prepare_length as u128),
-                          Value::UInt(burnchain.pox_constants.reward_cycle_length as u128),
-                          Value::UInt(burnchain.pox_constants.pox_rejection_fraction as u128)],
-                        |_,_| false)
-                        .expect("Failed to set burnchain parameters in PoX contract");
+                        &[
+                            Value::UInt(burnchain.first_block_height as u128),
+                            Value::UInt(burnchain.pox_constants.prepare_length as u128),
+                            Value::UInt(burnchain.pox_constants.reward_cycle_length as u128),
+                            Value::UInt(burnchain.pox_constants.pox_rejection_fraction as u128),
+                        ],
+                        |_, _| false,
+                    )
+                    .expect("Failed to set burnchain parameters in PoX contract");
                 });
                 boot_block_exec(clarity_tx)
             },

--- a/src/chainstate/coordinator/mod.rs
+++ b/src/chainstate/coordinator/mod.rs
@@ -1,5 +1,7 @@
 use std::collections::VecDeque;
-use std::convert::TryInto;
+use std::convert::{
+    TryInto, TryFrom
+};
 use std::time::Duration;
 
 use burnchains::{
@@ -163,7 +165,26 @@ impl RewardSetProvider for OnChainRewardSetProvider {
     ) -> Result<Vec<StacksAddress>, Error> {
         let res =
             chainstate.get_reward_addresses(burnchain, sortdb, current_burn_height, block_id)?;
-        let addresses = res.iter().map(|a| a.0).collect::<Vec<StacksAddress>>();
+        let liquid_ustx = StacksChainState::get_stacks_block_header_info_by_index_block_hash(
+            chainstate.headers_db(),
+            block_id)?
+            .expect("CORRUPTION: Failed to look up block header info for PoX anchor block")
+            .total_liquid_ustx;
+
+        let threshold = StacksChainState::get_reward_threshold(
+            &burnchain.pox_constants,
+            &res,
+            liquid_ustx);
+        let mut addresses = vec![];
+
+        for (address, stacked_amt) in res.iter() {
+            let slots_taken = u32::try_from(stacked_amt / threshold)
+                .expect("CORRUPTION: Stacker claimed > u32::max() reward slots");
+            for _i in 0..slots_taken {
+                addresses.push(address.clone());
+            }
+        }
+
         Ok(addresses)
     }
 }

--- a/src/chainstate/stacks/boot/mod.rs
+++ b/src/chainstate/stacks/boot/mod.rs
@@ -189,6 +189,34 @@ impl StacksChainState {
         .map(|value| value.expect_bool())
     }
 
+    /// Given a threshold and set of registered addresses, return a reward set where
+    ///   every entry address has stacked more than the threshold, and addresses
+    ///   are repeated floor(stacked_amt / threshold) times.
+    /// If an address appears in `addresses` multiple times, then the address's associated amounts
+    ///   are summed.
+    pub fn make_reward_set(threshold: u128, mut addresses: Vec<(StacksAddress, u128)>) -> Vec<StacksAddress> {
+        let mut reward_set = vec![];
+        // the way that we sum addresses relies on sorting.
+        addresses.sort_by_key(|k| k.0.bytes.0);
+        while let Some((address, mut stacked_amt)) = addresses.pop() {
+            // peak at the next address in the set, and see if we need to sum
+            while addresses.last().map(|x| &x.0) == Some(&address) {
+                let (_, additional_amt) = addresses.pop()
+                    .expect("BUG: first() returned some, but pop() is none.");
+                stacked_amt = stacked_amt.checked_add(additional_amt)
+                    .expect("CORRUPTION: Stacker stacked > u128 max amount");
+            }
+            let slots_taken = u32::try_from(stacked_amt / threshold)
+                .expect("CORRUPTION: Stacker claimed > u32::max() reward slots");
+            info!("Slots taken by {} = {}, on stacked_amt = {}",
+                  &address, slots_taken, stacked_amt);
+            for _i in 0..slots_taken {
+                reward_set.push(address.clone());
+            }
+        }
+        reward_set
+    }
+
     pub fn get_reward_threshold(pox_settings: &PoxConstants, addresses: &[(StacksAddress, u128)], liquid_ustx: u128) -> u128 {
         let participation = addresses
             .iter()
@@ -282,8 +310,6 @@ impl StacksChainState {
             ret.push((StacksAddress::new(version, hash), total_ustx));
         }
 
-        ret.sort_by_key(|k| k.0.bytes.0);
-
         Ok(ret)
     }
 }
@@ -321,6 +347,15 @@ pub mod test {
 
     use util::hash::to_hex;
 
+    #[test]
+    fn make_reward_set_units() {
+        let threshold = 1_000;
+        let addresses = vec![(StacksAddress::from_string("STVK1K405H6SK9NKJAP32GHYHDJ98MMNP8Y6Z9N0").unwrap(), 1500),
+                             (StacksAddress::from_string("ST76D2FMXZ7D2719PNE4N71KPSX84XCCNCMYC940").unwrap(), 500),
+                             (StacksAddress::from_string("STVK1K405H6SK9NKJAP32GHYHDJ98MMNP8Y6Z9N0").unwrap(), 1500),
+                             (StacksAddress::from_string("ST76D2FMXZ7D2719PNE4N71KPSX84XCCNCMYC940").unwrap(), 400)];
+        assert_eq!(StacksChainState::make_reward_set(threshold, addresses).len(), 3);
+    }
 
     #[test]
     fn get_reward_threshold_units() {
@@ -815,6 +850,10 @@ pub mod test {
     ) -> Result<Vec<(StacksAddress, u128)>, Error> {
         let burn_block_height = get_par_burn_block_height(state, block_id);
         state.get_reward_addresses(burnchain, sortdb, burn_block_height, block_id)
+            .and_then(|mut addrs| {
+                addrs.sort_by_key(|k| k.0.bytes.0);
+                Ok(addrs)
+            })
     }
 
     fn get_parent_tip(

--- a/src/chainstate/stacks/boot/mod.rs
+++ b/src/chainstate/stacks/boot/mod.rs
@@ -24,14 +24,10 @@ use chainstate::stacks::StacksBlockHeader;
 
 use address::AddressHashMode;
 use burnchains::bitcoin::address::BitcoinAddress;
-use burnchains::{
-    Address, PoxConstants
-};
+use burnchains::{Address, PoxConstants};
 
-use core::{
-    POX_MAXIMAL_SCALING, POX_THRESHOLD_STEPS_USTX
-};
 use chainstate::burn::db::sortdb::SortitionDB;
+use core::{POX_MAXIMAL_SCALING, POX_THRESHOLD_STEPS_USTX};
 
 use vm::types::{
     PrincipalData, QualifiedContractIdentifier, SequenceData, StandardPrincipalData, TupleData,
@@ -47,9 +43,9 @@ use vm::representations::ContractName;
 use util::hash::Hash160;
 
 use std::boxed::Box;
+use std::cmp;
 use std::convert::TryFrom;
 use std::convert::TryInto;
-use std::cmp;
 
 pub const STACKS_BOOT_CODE_CONTRACT_ADDRESS: &'static str = "ST000000000000000000002AMW42H";
 
@@ -194,22 +190,29 @@ impl StacksChainState {
     ///   are repeated floor(stacked_amt / threshold) times.
     /// If an address appears in `addresses` multiple times, then the address's associated amounts
     ///   are summed.
-    pub fn make_reward_set(threshold: u128, mut addresses: Vec<(StacksAddress, u128)>) -> Vec<StacksAddress> {
+    pub fn make_reward_set(
+        threshold: u128,
+        mut addresses: Vec<(StacksAddress, u128)>,
+    ) -> Vec<StacksAddress> {
         let mut reward_set = vec![];
         // the way that we sum addresses relies on sorting.
         addresses.sort_by_key(|k| k.0.bytes.0);
         while let Some((address, mut stacked_amt)) = addresses.pop() {
             // peak at the next address in the set, and see if we need to sum
             while addresses.last().map(|x| &x.0) == Some(&address) {
-                let (_, additional_amt) = addresses.pop()
+                let (_, additional_amt) = addresses
+                    .pop()
                     .expect("BUG: first() returned some, but pop() is none.");
-                stacked_amt = stacked_amt.checked_add(additional_amt)
+                stacked_amt = stacked_amt
+                    .checked_add(additional_amt)
                     .expect("CORRUPTION: Stacker stacked > u128 max amount");
             }
             let slots_taken = u32::try_from(stacked_amt / threshold)
                 .expect("CORRUPTION: Stacker claimed > u32::max() reward slots");
-            info!("Slots taken by {} = {}, on stacked_amt = {}",
-                  &address, slots_taken, stacked_amt);
+            info!(
+                "Slots taken by {} = {}, on stacked_amt = {}",
+                &address, slots_taken, stacked_amt
+            );
             for _i in 0..slots_taken {
                 reward_set.push(address.clone());
             }
@@ -217,12 +220,19 @@ impl StacksChainState {
         reward_set
     }
 
-    pub fn get_reward_threshold(pox_settings: &PoxConstants, addresses: &[(StacksAddress, u128)], liquid_ustx: u128) -> u128 {
+    pub fn get_reward_threshold(
+        pox_settings: &PoxConstants,
+        addresses: &[(StacksAddress, u128)],
+        liquid_ustx: u128,
+    ) -> u128 {
         let participation = addresses
             .iter()
             .fold(0, |agg, (_, stacked_amt)| agg + stacked_amt);
 
-        assert!(participation <= liquid_ustx, "CORRUPTION: More stacking participation than liquid STX");
+        assert!(
+            participation <= liquid_ustx,
+            "CORRUPTION: More stacking participation than liquid STX"
+        );
 
         let scale_by = cmp::max(participation, liquid_ustx / POX_MAXIMAL_SCALING as u128);
 
@@ -234,7 +244,10 @@ impl StacksChainState {
             remainder => POX_THRESHOLD_STEPS_USTX - remainder,
         };
         let threshold = threshold_precise + ceil_amount;
-        info!("PoX participation threshold is {}, from {}", threshold, threshold_precise);
+        info!(
+            "PoX participation threshold is {}, from {}",
+            threshold, threshold_precise
+        );
         threshold
     }
 
@@ -338,9 +351,9 @@ pub mod test {
 
     use util::*;
 
+    use core::*;
     use vm::contracts::Contract;
     use vm::types::*;
-    use core::*;
 
     use std::convert::From;
     use std::fs;
@@ -350,11 +363,28 @@ pub mod test {
     #[test]
     fn make_reward_set_units() {
         let threshold = 1_000;
-        let addresses = vec![(StacksAddress::from_string("STVK1K405H6SK9NKJAP32GHYHDJ98MMNP8Y6Z9N0").unwrap(), 1500),
-                             (StacksAddress::from_string("ST76D2FMXZ7D2719PNE4N71KPSX84XCCNCMYC940").unwrap(), 500),
-                             (StacksAddress::from_string("STVK1K405H6SK9NKJAP32GHYHDJ98MMNP8Y6Z9N0").unwrap(), 1500),
-                             (StacksAddress::from_string("ST76D2FMXZ7D2719PNE4N71KPSX84XCCNCMYC940").unwrap(), 400)];
-        assert_eq!(StacksChainState::make_reward_set(threshold, addresses).len(), 3);
+        let addresses = vec![
+            (
+                StacksAddress::from_string("STVK1K405H6SK9NKJAP32GHYHDJ98MMNP8Y6Z9N0").unwrap(),
+                1500,
+            ),
+            (
+                StacksAddress::from_string("ST76D2FMXZ7D2719PNE4N71KPSX84XCCNCMYC940").unwrap(),
+                500,
+            ),
+            (
+                StacksAddress::from_string("STVK1K405H6SK9NKJAP32GHYHDJ98MMNP8Y6Z9N0").unwrap(),
+                1500,
+            ),
+            (
+                StacksAddress::from_string("ST76D2FMXZ7D2719PNE4N71KPSX84XCCNCMYC940").unwrap(),
+                400,
+            ),
+        ];
+        assert_eq!(
+            StacksChainState::make_reward_set(threshold, addresses).len(),
+            3
+        );
     }
 
     #[test]
@@ -362,41 +392,69 @@ pub mod test {
         // when the liquid amount = the threshold step,
         //   the threshold should always be the step size.
         let liquid = POX_THRESHOLD_STEPS_USTX;
-        assert_eq!(StacksChainState::get_reward_threshold(&PoxConstants::new(1000, 1, 1, 1), &[], liquid),
-                   POX_THRESHOLD_STEPS_USTX);
-        assert_eq!(StacksChainState::get_reward_threshold(&PoxConstants::new(1000, 1, 1, 1), &[(rand_addr(), liquid)], liquid),
-                   POX_THRESHOLD_STEPS_USTX);
+        assert_eq!(
+            StacksChainState::get_reward_threshold(&PoxConstants::new(1000, 1, 1, 1), &[], liquid),
+            POX_THRESHOLD_STEPS_USTX
+        );
+        assert_eq!(
+            StacksChainState::get_reward_threshold(
+                &PoxConstants::new(1000, 1, 1, 1),
+                &[(rand_addr(), liquid)],
+                liquid
+            ),
+            POX_THRESHOLD_STEPS_USTX
+        );
 
         let liquid = 200_000_000 * MICROSTACKS_PER_STACKS as u128;
         // with zero participation, should scale to 25% of liquid
-        assert_eq!(StacksChainState::get_reward_threshold(&PoxConstants::new(1000, 1, 1, 1), &[], liquid),
-                   50_000 * MICROSTACKS_PER_STACKS as u128);
+        assert_eq!(
+            StacksChainState::get_reward_threshold(&PoxConstants::new(1000, 1, 1, 1), &[], liquid),
+            50_000 * MICROSTACKS_PER_STACKS as u128
+        );
         // should be the same at 25% participation
-        assert_eq!(StacksChainState::get_reward_threshold(&PoxConstants::new(1000, 1, 1, 1), &[(rand_addr(), liquid / 4)], liquid),
-                   50_000 * MICROSTACKS_PER_STACKS as u128);
+        assert_eq!(
+            StacksChainState::get_reward_threshold(
+                &PoxConstants::new(1000, 1, 1, 1),
+                &[(rand_addr(), liquid / 4)],
+                liquid
+            ),
+            50_000 * MICROSTACKS_PER_STACKS as u128
+        );
         // but not at 30% participation
-        assert_eq!(StacksChainState::get_reward_threshold(
-            &PoxConstants::new(1000, 1, 1, 1),
-            &[(rand_addr(), liquid / 4),
-              (rand_addr(), 10_000_000 * (MICROSTACKS_PER_STACKS as u128))],
-            liquid),
-                   60_000 * MICROSTACKS_PER_STACKS as u128);
+        assert_eq!(
+            StacksChainState::get_reward_threshold(
+                &PoxConstants::new(1000, 1, 1, 1),
+                &[
+                    (rand_addr(), liquid / 4),
+                    (rand_addr(), 10_000_000 * (MICROSTACKS_PER_STACKS as u128))
+                ],
+                liquid
+            ),
+            60_000 * MICROSTACKS_PER_STACKS as u128
+        );
 
         // bump by just a little bit, should go to the next threshold step
-        assert_eq!(StacksChainState::get_reward_threshold(
-            &PoxConstants::new(1000, 1, 1, 1),
-            &[(rand_addr(), liquid / 4),
-              (rand_addr(), (MICROSTACKS_PER_STACKS as u128))],
-            liquid),
-                   60_000 * MICROSTACKS_PER_STACKS as u128);
+        assert_eq!(
+            StacksChainState::get_reward_threshold(
+                &PoxConstants::new(1000, 1, 1, 1),
+                &[
+                    (rand_addr(), liquid / 4),
+                    (rand_addr(), (MICROSTACKS_PER_STACKS as u128))
+                ],
+                liquid
+            ),
+            60_000 * MICROSTACKS_PER_STACKS as u128
+        );
 
-                // bump by just a little bit, should go to the next threshold step
-        assert_eq!(StacksChainState::get_reward_threshold(
-            &PoxConstants::new(1000, 1, 1, 1),
-            &[(rand_addr(), liquid)],
-            liquid),
-                   200_000 * MICROSTACKS_PER_STACKS as u128);
-
+        // bump by just a little bit, should go to the next threshold step
+        assert_eq!(
+            StacksChainState::get_reward_threshold(
+                &PoxConstants::new(1000, 1, 1, 1),
+                &[(rand_addr(), liquid)],
+                liquid
+            ),
+            200_000 * MICROSTACKS_PER_STACKS as u128
+        );
     }
 
     fn rand_addr() -> StacksAddress {
@@ -849,7 +907,8 @@ pub mod test {
         block_id: &StacksBlockId,
     ) -> Result<Vec<(StacksAddress, u128)>, Error> {
         let burn_block_height = get_par_burn_block_height(state, block_id);
-        state.get_reward_addresses(burnchain, sortdb, burn_block_height, block_id)
+        state
+            .get_reward_addresses(burnchain, sortdb, burn_block_height, block_id)
             .and_then(|mut addrs| {
                 addrs.sort_by_key(|k| k.0.bytes.0);
                 Ok(addrs)

--- a/src/chainstate/stacks/boot/mod.rs
+++ b/src/chainstate/stacks/boot/mod.rs
@@ -234,6 +234,8 @@ impl StacksChainState {
             "CORRUPTION: More stacking participation than liquid STX"
         );
 
+        // set the lower limit on reward scaling at 25% of liquid_ustx
+        //   (i.e., liquid_ustx / POX_MAXIMAL_SCALING)
         let scale_by = cmp::max(participation, liquid_ustx / POX_MAXIMAL_SCALING as u128);
 
         let reward_slots = pox_settings.reward_slots() as u128;

--- a/src/chainstate/stacks/boot/pox.clar
+++ b/src/chainstate/stacks/boot/pox.clar
@@ -504,9 +504,10 @@
       (ok true)))
 
 ;; Commit partially stacked STX.
-;;   this allows a stacker/delegator to lock fewer STX than the minimal threshold in multiple transactions,
-;;   so long as the pox-addr is the same, and then this "commit" transaction is called _before_ the PoX anchor block
-;;   this ensures that each entry in the reward set returned to the stacks-node is greater than the threshold,
+;;   This allows a stacker/delegator to lock fewer STX than the minimal threshold in multiple transactions,
+;;   so long as: 1. The pox-addr is the same.
+;;               2. This "commit" transaction is called _before_ the PoX anchor block.
+;;   This ensures that each entry in the reward set returned to the stacks-node is greater than the threshold,
 ;;   but does not require it be all locked up within a single transaction
 (define-public (stack-aggregation-commit (pox-addr { version: (buff 1), hashbytes: (buff 20) })
                                          (reward-cycle uint))

--- a/src/chainstate/stacks/boot/pox.clar
+++ b/src/chainstate/stacks/boot/pox.clar
@@ -180,9 +180,7 @@
                           false)))
           ;; is the caller allowance expired?
           (if (< burn-block-height (unwrap! (get until-burn-ht caller-allowed) true))
-              (begin (map-delete allowance-contract-callers
-                                 { sender: tx-sender, contract-caller: contract-caller })
-                     false)
+              false
               true))))
 
 (define-private (get-check-delegation (stacker principal))
@@ -191,9 +189,8 @@
       (if (match (get until-burn-ht delegation-info)
                  until-burn-ht (> burn-block-height until-burn-ht)
                  false)
-          ;; it expired, delete the entry and return none
-          (begin (map-delete delegation-state { stacker: stacker })
-                 none)
+          ;; it expired, return none
+          none
           ;; delegation is active
           (some delegation-info))))
 

--- a/src/chainstate/stacks/boot/pox.clar
+++ b/src/chainstate/stacks/boot/pox.clar
@@ -31,7 +31,7 @@
 ;; This function can only be called once, when it boots up
 (define-public (set-burnchain-parameters (first-burn-height uint) (prepare-cycle-length uint) (reward-cycle-length uint) (rejection-fraction uint))
     (begin
-        (asserts! (and is-in-regtest (not (var-get configured))) (err ERR_NOT_ALLOWED))
+        (asserts! (not (var-get configured)) (err ERR_NOT_ALLOWED))
         (var-set first-burnchain-block-height first-burn-height)
         (var-set pox-prepare-cycle-length prepare-cycle-length)
         (var-set pox-reward-cycle-length reward-cycle-length)

--- a/src/chainstate/stacks/db/headers.rs
+++ b/src/chainstate/stacks/db/headers.rs
@@ -37,6 +37,7 @@ use vm::costs::ExecutionCost;
 use util::db::Error as db_error;
 use util::db::{
     query_count, query_row, query_row_columns, query_rows, DBConn, FromColumn, FromRow,
+    query_row_panic
 };
 
 use core::FIRST_BURNCHAIN_CONSENSUS_HASH;
@@ -278,14 +279,8 @@ impl StacksChainState {
         index_block_hash: &StacksBlockId,
     ) -> Result<Option<StacksHeaderInfo>, Error> {
         let sql = "SELECT * FROM block_headers WHERE index_block_hash = ?1".to_string();
-        let mut rows = query_rows::<StacksHeaderInfo, _>(conn, &sql, &[&index_block_hash])
-            .map_err(Error::DBError)?;
-        let cnt = rows.len();
-        if cnt > 1 {
-            unreachable!("FATAL: multiple rows for the same block hash") // should be unreachable, since index_block_hash is unique
-        }
-
-        Ok(rows.pop())
+        query_row_panic(conn, &sql, &[&index_block_hash], || "FATAL: multiple rows for the same block hash".to_string())
+            .map_err(Error::DBError)
     }
 
     /// Get an ancestor block header

--- a/src/chainstate/stacks/db/headers.rs
+++ b/src/chainstate/stacks/db/headers.rs
@@ -36,8 +36,8 @@ use vm::costs::ExecutionCost;
 
 use util::db::Error as db_error;
 use util::db::{
-    query_count, query_row, query_row_columns, query_rows, DBConn, FromColumn, FromRow,
-    query_row_panic
+    query_count, query_row, query_row_columns, query_row_panic, query_rows, DBConn, FromColumn,
+    FromRow,
 };
 
 use core::FIRST_BURNCHAIN_CONSENSUS_HASH;
@@ -279,8 +279,10 @@ impl StacksChainState {
         index_block_hash: &StacksBlockId,
     ) -> Result<Option<StacksHeaderInfo>, Error> {
         let sql = "SELECT * FROM block_headers WHERE index_block_hash = ?1".to_string();
-        query_row_panic(conn, &sql, &[&index_block_hash], || "FATAL: multiple rows for the same block hash".to_string())
-            .map_err(Error::DBError)
+        query_row_panic(conn, &sql, &[&index_block_hash], || {
+            "FATAL: multiple rows for the same block hash".to_string()
+        })
+        .map_err(Error::DBError)
     }
 
     /// Get an ancestor block header

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -61,10 +61,12 @@ pub const BURNCHAIN_BOOT_CONSENSUS_HASH: ConsensusHash = ConsensusHash([0xff; 20
 
 pub const CHAINSTATE_VERSION: &'static str = "23.0.0.0";
 
+pub const MICROSTACKS_PER_STACKS: u32 = 1_000_000;
+
 pub const POX_PREPARE_WINDOW_LENGTH: u32 = 240;
 pub const POX_REWARD_CYCLE_LENGTH: u32 = 1000;
 pub const POX_MAXIMAL_SCALING: u128 = 4;
-pub const POX_THRESHOLD_STEPS: u128 = 10_000;
+pub const POX_THRESHOLD_STEPS_USTX: u128 = 10_000 * (MICROSTACKS_PER_STACKS as u128);
 
 /// Synchronize burn transactions from the Bitcoin blockchain
 pub fn sync_burnchain_bitcoin(

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -63,6 +63,8 @@ pub const CHAINSTATE_VERSION: &'static str = "23.0.0.0";
 
 pub const POX_PREPARE_WINDOW_LENGTH: u32 = 240;
 pub const POX_REWARD_CYCLE_LENGTH: u32 = 1000;
+pub const POX_MAXIMAL_SCALING: u128 = 4;
+pub const POX_THRESHOLD_STEPS: u128 = 10_000;
 
 /// Synchronize burn transactions from the Bitcoin blockchain
 pub fn sync_burnchain_bitcoin(

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -65,7 +65,13 @@ pub const MICROSTACKS_PER_STACKS: u32 = 1_000_000;
 
 pub const POX_PREPARE_WINDOW_LENGTH: u32 = 240;
 pub const POX_REWARD_CYCLE_LENGTH: u32 = 1000;
+/// The maximum amount that PoX rewards can be scaled by.
+///  That is, if participation is very low, rewards are:
+///      POX_MAXIMAL_SCALING x (rewards with 100% participation)
+///  Set a 4x, this implies the lower bound of participation for scaling
+///   is 25%
 pub const POX_MAXIMAL_SCALING: u128 = 4;
+/// This is the amount that PoX threshold adjustments are stepped by.
 pub const POX_THRESHOLD_STEPS_USTX: u128 = 10_000 * (MICROSTACKS_PER_STACKS as u128);
 
 /// Synchronize burn transactions from the Bitcoin blockchain

--- a/src/net/neighbors.rs
+++ b/src/net/neighbors.rs
@@ -4091,6 +4091,7 @@ mod test {
     }
 
     #[test]
+    #[ignore]
     fn test_step_walk_2_neighbors_rekey() {
         with_timeout(600, || {
             let mut peer_1_config = TestPeerConfig::from_port(32600);

--- a/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
+++ b/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
@@ -53,12 +53,17 @@ pub struct BitcoinRegtestController {
     burnchain_db: Option<BurnchainDB>,
     chain_tip: Option<BurnchainTip>,
     use_coordinator: Option<CoordinatorChannels>,
+    burnchain_config: Option<Burnchain>,
 }
 
 const DUST_UTXO_LIMIT: u64 = 5500;
 
 impl BitcoinRegtestController {
     pub fn new(config: Config, coordinator_channel: Option<CoordinatorChannels>) -> Self {
+        BitcoinRegtestController::with_burnchain(config, coordinator_channel, None)
+    }
+
+    pub fn with_burnchain(config: Config, coordinator_channel: Option<CoordinatorChannels>, burnchain_config: Option<Burnchain>) -> Self {
         std::fs::create_dir_all(&config.node.get_burnchain_path())
             .expect("Unable to create workdir");
 
@@ -93,11 +98,12 @@ impl BitcoinRegtestController {
 
         Self {
             use_coordinator: coordinator_channel,
-            config: config,
+            config,
             indexer_config,
             db: None,
             burnchain_db: None,
             chain_tip: None,
+            burnchain_config
         }
     }
 
@@ -122,22 +128,28 @@ impl BitcoinRegtestController {
 
         Self {
             use_coordinator: None,
-            config: config,
+            config,
             indexer_config,
             db: None,
             burnchain_db: None,
             chain_tip: None,
+            burnchain_config: None
         }
     }
 
     fn setup_burnchain(&self) -> (Burnchain, BitcoinNetworkType) {
         let (network_name, network_type) = self.config.burnchain.get_bitcoin_network();
-        let working_dir = self.config.get_burn_db_path();
-        match Burnchain::new(&working_dir, &self.config.burnchain.chain, &network_name) {
-            Ok(burnchain) => (burnchain, network_type),
-            Err(e) => {
-                error!("Failed to instantiate burnchain: {}", e);
-                panic!()
+        match &self.burnchain_config {
+            Some(burnchain) => (burnchain.clone(), network_type),
+            None => {
+                let working_dir = self.config.get_burn_db_path();
+                match Burnchain::new(&working_dir, &self.config.burnchain.chain, &network_name) {
+                    Ok(burnchain) => (burnchain, network_type),
+                    Err(e) => {
+                        error!("Failed to instantiate burnchain: {}", e);
+                        panic!()
+                    }
+                }
             }
         }
     }
@@ -312,6 +324,90 @@ impl BitcoinRegtestController {
         Ok((burnchain_tip, burnchain_height))
     }
 
+    #[cfg(test)]
+    pub fn get_all_utxos(&self, public_key: &Secp256k1PublicKey) -> Vec<UTXO> {
+        // Configure UTXO filter
+        let pkh = Hash160::from_data(&public_key.to_bytes())
+            .to_bytes()
+            .to_vec();
+        let (_, network_id) = self.config.burnchain.get_bitcoin_network();
+        let address =
+            BitcoinAddress::from_bytes(network_id, BitcoinAddressType::PublicKeyHash, &pkh)
+                .expect("Public key incorrect");
+        let filter_addresses = vec![address.to_b58()];
+        let _result = BitcoinRPCRequest::import_public_key(&self.config, &public_key);
+
+        sleep_ms(1000);
+
+        let min_conf = 0;
+        let max_conf = 9999999;
+        let minimum_amount = ParsedUTXO::sat_to_serialized_btc(1);
+
+        let payload = BitcoinRPCRequest {
+            method: "listunspent".to_string(),
+            params: vec![
+                min_conf.into(),
+                max_conf.into(),
+                filter_addresses.clone().into(),
+                true.into(),
+                json!({ "minimumAmount": minimum_amount }),
+            ],
+            id: "stacks".to_string(),
+            jsonrpc: "2.0".to_string(),
+        };
+
+        let mut res = BitcoinRPCRequest::send(&self.config, payload).unwrap();
+        let mut result_vec = vec![];
+
+        if let Some(ref mut object) = res.as_object_mut() {
+            match object.get_mut("result") {
+                Some(serde_json::Value::Array(entries)) => {
+                    while let Some(entry) = entries.pop() {
+                        let parsed_utxo: ParsedUTXO = match serde_json::from_value(entry) {
+                            Ok(utxo) => utxo,
+                            Err(err) => {
+                                warn!("Failed parsing UTXO: {}", err);
+                                continue;
+                            }
+                        };
+                        let amount = match parsed_utxo.get_sat_amount() {
+                            Some(amount) => amount,
+                            None => continue,
+                        };
+
+                        if amount < 1 {
+                            continue;
+                        }
+
+                        let script_pub_key = match parsed_utxo.get_script_pub_key() {
+                            Some(script_pub_key) => script_pub_key,
+                            None => {
+                                continue;
+                            }
+                        };
+
+                        let txid = match parsed_utxo.get_txid() {
+                            Some(amount) => amount,
+                            None => continue,
+                        };
+
+                        result_vec.push(UTXO {
+                            txid,
+                            vout: parsed_utxo.vout,
+                            script_pub_key,
+                            amount,
+                        });
+                    }
+                }
+                _ => {
+                    warn!("Failed to get UTXOs");
+                }
+            }
+        }
+
+        result_vec
+    }
+
     pub fn get_utxos(
         &self,
         public_key: &Secp256k1PublicKey,
@@ -382,7 +478,7 @@ impl BitcoinRegtestController {
 
         let total_unspent: u64 = utxos.iter().map(|o| o.amount).sum();
         if total_unspent < amount_required {
-            debug!(
+            warn!(
                 "Total unspent {} < {} for {:?}",
                 total_unspent,
                 amount_required,

--- a/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
+++ b/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
@@ -63,7 +63,11 @@ impl BitcoinRegtestController {
         BitcoinRegtestController::with_burnchain(config, coordinator_channel, None)
     }
 
-    pub fn with_burnchain(config: Config, coordinator_channel: Option<CoordinatorChannels>, burnchain_config: Option<Burnchain>) -> Self {
+    pub fn with_burnchain(
+        config: Config,
+        coordinator_channel: Option<CoordinatorChannels>,
+        burnchain_config: Option<Burnchain>,
+    ) -> Self {
         std::fs::create_dir_all(&config.node.get_burnchain_path())
             .expect("Unable to create workdir");
 
@@ -103,7 +107,7 @@ impl BitcoinRegtestController {
             db: None,
             burnchain_db: None,
             chain_tip: None,
-            burnchain_config
+            burnchain_config,
         }
     }
 
@@ -133,7 +137,7 @@ impl BitcoinRegtestController {
             db: None,
             burnchain_db: None,
             chain_tip: None,
-            burnchain_config: None
+            burnchain_config: None,
         }
     }
 

--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -355,6 +355,9 @@ impl Config {
                         .wait_time_for_microblocks
                         .unwrap_or(default_node_config.wait_time_for_microblocks),
                     prometheus_bind: node.prometheus_bind,
+                    pox_sync_sample_secs: node
+                        .pox_sync_sample_secs
+                        .unwrap_or(default_node_config.pox_sync_sample_secs),
                 };
                 node_config.set_bootstrap_node(node.bootstrap_node);
                 node_config
@@ -412,6 +415,9 @@ impl Config {
                         .burnchain_op_tx_fee
                         .unwrap_or(default_burnchain_config.burnchain_op_tx_fee),
                     process_exit_at_block_height: burnchain.process_exit_at_block_height,
+                    poll_time_secs: burnchain
+                        .poll_time_secs
+                        .unwrap_or(default_burnchain_config.poll_time_secs),
                 }
             }
             None => default_burnchain_config,
@@ -719,6 +725,7 @@ pub struct BurnchainConfig {
     pub local_mining_public_key: Option<String>,
     pub burnchain_op_tx_fee: u64,
     pub process_exit_at_block_height: Option<u64>,
+    pub poll_time_secs: u64,
 }
 
 impl BurnchainConfig {
@@ -741,6 +748,7 @@ impl BurnchainConfig {
             local_mining_public_key: None,
             burnchain_op_tx_fee: MINIMUM_DUST_FEE,
             process_exit_at_block_height: None,
+            poll_time_secs: 30, // TODO: this is a testnet specific value.
         }
     }
 
@@ -791,6 +799,7 @@ pub struct BurnchainConfigFile {
     pub local_mining_public_key: Option<String>,
     pub burnchain_op_tx_fee: Option<u64>,
     pub process_exit_at_block_height: Option<u64>,
+    pub poll_time_secs: Option<u64>,
 }
 
 #[derive(Clone, Debug, Default)]
@@ -808,6 +817,7 @@ pub struct NodeConfig {
     pub mine_microblocks: bool,
     pub wait_time_for_microblocks: u64,
     pub prometheus_bind: Option<String>,
+    pub pox_sync_sample_secs: u64,
 }
 
 impl NodeConfig {
@@ -841,6 +851,7 @@ impl NodeConfig {
             mine_microblocks: false,
             wait_time_for_microblocks: 15000,
             prometheus_bind: None,
+            pox_sync_sample_secs: 30,
         }
     }
 
@@ -939,6 +950,7 @@ pub struct NodeConfigFile {
     pub mine_microblocks: Option<bool>,
     pub wait_time_for_microblocks: Option<u64>,
     pub prometheus_bind: Option<String>,
+    pub pox_sync_sample_secs: Option<u64>,
 }
 
 #[derive(Clone, Deserialize, Default)]

--- a/testnet/stacks-node/src/main.rs
+++ b/testnet/stacks-node/src/main.rs
@@ -139,7 +139,7 @@ fn main() {
         || conf.burnchain.mode == "xenon"
     {
         let mut run_loop = neon::RunLoop::new(conf);
-        run_loop.start(num_round);
+        run_loop.start(num_round, None);
     } else {
         println!("Burnchain mode '{}' not supported", conf.burnchain.mode);
     }

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -85,7 +85,7 @@ pub struct NeonGenesisNode {
     pub config: Config,
     keychain: Keychain,
     event_dispatcher: EventDispatcher,
-    burnchain: Burnchain
+    burnchain: Burnchain,
 }
 
 #[cfg(test)]
@@ -597,7 +597,7 @@ impl InitializedNeonNode {
         miner: bool,
         blocks_processed: BlocksProcessedCounter,
         coord_comms: CoordinatorChannels,
-        burnchain: Burnchain
+        burnchain: Burnchain,
     ) -> InitializedNeonNode {
         // we can call _open_ here rather than _connect_, since connect is first called in
         //   make_genesis_block
@@ -1113,7 +1113,12 @@ impl InitializedNeonNode {
 
 impl NeonGenesisNode {
     /// Instantiate and initialize a new node, given a config
-    pub fn new<F>(config: Config, mut event_dispatcher: EventDispatcher, burnchain: Burnchain, boot_block_exec: F) -> Self
+    pub fn new<F>(
+        config: Config,
+        mut event_dispatcher: EventDispatcher,
+        burnchain: Burnchain,
+        boot_block_exec: F,
+    ) -> Self
     where
         F: FnOnce(&mut ClarityTx) -> (),
     {
@@ -1147,7 +1152,7 @@ impl NeonGenesisNode {
             keychain,
             config,
             event_dispatcher,
-            burnchain
+            burnchain,
         }
     }
 
@@ -1169,7 +1174,7 @@ impl NeonGenesisNode {
             true,
             blocks_processed,
             coord_comms,
-            self.burnchain
+            self.burnchain,
         )
     }
 
@@ -1191,7 +1196,7 @@ impl NeonGenesisNode {
             false,
             blocks_processed,
             coord_comms,
-            self.burnchain
+            self.burnchain,
         )
     }
 }

--- a/testnet/stacks-node/src/run_loop/neon.rs
+++ b/testnet/stacks-node/src/run_loop/neon.rs
@@ -33,16 +33,6 @@ pub struct RunLoop {
     coordinator_channels: Option<(CoordinatorReceivers, CoordinatorChannels)>,
 }
 
-#[cfg(not(test))]
-const BURNCHAIN_POLL_TIME: u64 = 30; // TODO: this is testnet-specific
-#[cfg(test)]
-const BURNCHAIN_POLL_TIME: u64 = 1; // TODO: this is testnet-specific
-
-#[cfg(not(test))]
-const POX_SYNC_WAIT_MS: u64 = 1000;
-#[cfg(test)]
-const POX_SYNC_WAIT_MS: u64 = 0;
-
 impl RunLoop {
     /// Sets up a runloop and node, given a config.
     #[cfg(not(test))]
@@ -149,7 +139,6 @@ impl RunLoop {
             .iter()
             .map(|e| (e.address.clone(), e.amount))
             .collect();
-        let burnchain_poll_time = BURNCHAIN_POLL_TIME;
 
         // setup dispatcher
         let mut event_dispatcher = EventDispatcher::new();
@@ -220,9 +209,8 @@ impl RunLoop {
             mainnet,
             chainid,
             chainstate_path,
-            burnchain_poll_time,
-            self.config.connection_options.timeout,
-            POX_SYNC_WAIT_MS,
+            self.config.burnchain.poll_time_secs,
+            self.config.node.pox_sync_sample_secs,
         )
         .unwrap();
         let mut burnchain_height = 1;

--- a/testnet/stacks-node/src/run_loop/neon.rs
+++ b/testnet/stacks-node/src/run_loop/neon.rs
@@ -100,8 +100,11 @@ impl RunLoop {
             .expect("Run loop already started, can only start once after initialization.");
 
         // Initialize and start the burnchain.
-        let mut burnchain =
-            BitcoinRegtestController::with_burnchain(self.config.clone(), Some(coordinator_senders.clone()), burnchain_opt);
+        let mut burnchain = BitcoinRegtestController::with_burnchain(
+            self.config.clone(),
+            Some(coordinator_senders.clone()),
+            burnchain_opt,
+        );
         let pox_constants = burnchain.get_pox_constants();
 
         let is_miner = if self.config.node.miner {
@@ -178,7 +181,12 @@ impl RunLoop {
         let mut block_height = burnchain_tip.block_snapshot.block_height;
 
         // setup genesis
-        let node = NeonGenesisNode::new(self.config.clone(), event_dispatcher, burnchain_config.clone(), |_| {});
+        let node = NeonGenesisNode::new(
+            self.config.clone(),
+            event_dispatcher,
+            burnchain_config.clone(),
+            |_| {},
+        );
         let mut node = if is_miner {
             node.into_initialized_leader_node(
                 burnchain_tip.clone(),
@@ -214,7 +222,7 @@ impl RunLoop {
             chainstate_path,
             burnchain_poll_time,
             self.config.connection_options.timeout,
-            POX_SYNC_WAIT_MS
+            POX_SYNC_WAIT_MS,
         )
         .unwrap();
         let mut burnchain_height = 1;

--- a/testnet/stacks-node/src/syncctl.rs
+++ b/testnet/stacks-node/src/syncctl.rs
@@ -42,7 +42,7 @@ pub struct PoxSyncWatchdog {
     /// chainstate handle
     chainstate: StacksChainState,
     /// ms to sleep on waits
-    wait_ms: u64
+    wait_ms: u64,
 }
 
 impl PoxSyncWatchdog {
@@ -78,7 +78,7 @@ impl PoxSyncWatchdog {
             steady_state_burnchain_sync_interval: burnchain_poll_time,
             steady_state_resync_ts: 0,
             chainstate: chainstate,
-            wait_ms
+            wait_ms,
         })
     }
 

--- a/testnet/stacks-node/src/syncctl.rs
+++ b/testnet/stacks-node/src/syncctl.rs
@@ -41,6 +41,8 @@ pub struct PoxSyncWatchdog {
     steady_state_resync_ts: u64,
     /// chainstate handle
     chainstate: StacksChainState,
+    /// ms to sleep on waits
+    wait_ms: u64
 }
 
 impl PoxSyncWatchdog {
@@ -50,6 +52,7 @@ impl PoxSyncWatchdog {
         chainstate_path: String,
         burnchain_poll_time: u64,
         download_timeout: u64,
+        wait_ms: u64,
     ) -> Result<PoxSyncWatchdog, String> {
         let (chainstate, _) = match StacksChainState::open(mainnet, chain_id, &chainstate_path) {
             Ok(cs) => cs,
@@ -75,6 +78,7 @@ impl PoxSyncWatchdog {
             steady_state_burnchain_sync_interval: burnchain_poll_time,
             steady_state_resync_ts: 0,
             chainstate: chainstate,
+            wait_ms
         })
     }
 
@@ -350,7 +354,7 @@ impl PoxSyncWatchdog {
                                 &self.max_samples
                             );
                         }
-                        sleep_ms(1000);
+                        sleep_ms(self.wait_ms);
                         continue;
                     }
 
@@ -359,7 +363,7 @@ impl PoxSyncWatchdog {
                     {
                         // still waiting for that first block in this reward cycle
                         debug!("PoX watchdog: Still warming up: waiting until {}s for first Stacks block download (estimated download time: {}s)...", expected_first_block_deadline, self.estimated_block_download_time);
-                        sleep_ms(1000);
+                        sleep_ms(self.wait_ms);
                         continue;
                     }
 
@@ -406,7 +410,7 @@ impl PoxSyncWatchdog {
                     {
                         debug!("PoX watchdog: Still processing blocks; waiting until at least min({},{})s before burnchain synchronization (estimated block-processing time: {}s)", 
                                get_epoch_time_secs() + 1, expected_last_block_deadline, self.estimated_block_process_time);
-                        sleep_ms(1000);
+                        sleep_ms(self.wait_ms);
                         continue;
                     }
 
@@ -418,7 +422,7 @@ impl PoxSyncWatchdog {
                                flat_attachable, flat_processed, &attachable_deviants, &processed_deviants);
 
                         if !flat_attachable || !flat_processed {
-                            sleep_ms(1000);
+                            sleep_ms(self.wait_ms);
                             continue;
                         }
                     } else {
@@ -429,7 +433,7 @@ impl PoxSyncWatchdog {
                                 debug!("PoX watchdog: In steady-state; waiting until at least {} before burnchain synchronization", self.steady_state_resync_ts);
                                 steady_state = true;
                             }
-                            sleep_ms(1000);
+                            sleep_ms(self.wait_ms);
                             continue;
                         }
                     }

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -2,19 +2,19 @@ use super::{
     make_contract_call, make_contract_publish, make_contract_publish_microblock_only,
     make_microblock, make_stacks_transfer_mblock_only, to_addr, ADDR_4, SK_1,
 };
-use stacks::burnchains::{Address, PublicKey, PoxConstants};
+use stacks::burnchains::{Address, PoxConstants, PublicKey};
 use stacks::chainstate::burn::ConsensusHash;
 use stacks::chainstate::stacks::{
     db::StacksChainState, StacksAddress, StacksBlock, StacksBlockHeader, StacksPrivateKey,
     StacksPublicKey, StacksTransaction,
 };
+use stacks::core;
 use stacks::net::StacksMessageCodec;
 use stacks::util::secp256k1::Secp256k1PublicKey;
 use stacks::vm::costs::ExecutionCost;
 use stacks::vm::execute;
 use stacks::vm::types::PrincipalData;
 use stacks::vm::Value;
-use stacks::core;
 
 use super::bitcoin_regtest::BitcoinCoreController;
 use crate::{
@@ -725,7 +725,6 @@ fn pox_integration_test() {
             .to_vec(),
     );
 
-
     let (mut conf, miner_account) = neon_integration_test_conf();
 
     let total_bal = 10_000_000_000 * (core::MICROSTACKS_PER_STACKS as u64);
@@ -755,7 +754,6 @@ fn pox_integration_test() {
         .start_bitcoind()
         .map_err(|_e| ())
         .expect("Failed starting bitcoind");
-
 
     let mut btc_regtest_controller = BitcoinRegtestController::new(conf.clone(), None);
     let http_origin = format!("http://{}", &conf.node.rpc_bind);
@@ -945,7 +943,6 @@ fn pox_integration_test() {
         panic!("");
     }
 
-
     // now let's mine a couple blocks, and then check the sender's nonce.
     //  at the end of mining three blocks, there should be _one_ transaction from the microblock
     //  only set that got mined (since the block before this one was empty, a microblock can
@@ -984,22 +981,28 @@ fn pox_integration_test() {
     }
 
     // we should have received _three_ Bitcoin commitments, because our commitment was 3 * threshold
-    let utxos = btc_regtest_controller
-        .get_all_utxos(&pox_pubkey);
+    let utxos = btc_regtest_controller.get_all_utxos(&pox_pubkey);
 
     eprintln!("Got UTXOs: {}", utxos.len());
-    assert_eq!(utxos.len(), 3, "Should have received three outputs during PoX reward cycle");
+    assert_eq!(
+        utxos.len(),
+        3,
+        "Should have received three outputs during PoX reward cycle"
+    );
 
     // we should have received _three_ Bitcoin commitments to pox_2_pubkey, because our commitment was 3 * threshold
     //   note: that if the reward set "summing" isn't implemented, this recipient would only have received _2_ slots,
     //         because each `stack-stx` call only received enough to get 1 slot individually.
-    let utxos = btc_regtest_controller
-        .get_all_utxos(&pox_2_pubkey);
+    let utxos = btc_regtest_controller.get_all_utxos(&pox_2_pubkey);
 
     eprintln!("Got UTXOs: {}", utxos.len());
-    assert_eq!(utxos.len(), 3, "Should have received three outputs during PoX reward cycle");
+    assert_eq!(
+        utxos.len(),
+        3,
+        "Should have received three outputs during PoX reward cycle"
+    );
 
-    // okay, the threshold for participation should be 
+    // okay, the threshold for participation should be
 
     channel.stop_chains_coordinator();
 }

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -45,6 +45,9 @@ fn neon_integration_test_conf() -> (Config, StacksAddress) {
         Some(keychain.generate_op_signer().get_public_key().to_hex());
     conf.burnchain.commit_anchor_block_within = 0;
 
+    conf.burnchain.poll_time_secs = 1;
+    conf.node.pox_sync_sample_secs = 1;
+
     let miner_account = keychain.origin_address().unwrap();
 
     (conf, miner_account)
@@ -726,8 +729,6 @@ fn pox_integration_test() {
     );
 
     let (mut conf, miner_account) = neon_integration_test_conf();
-
-    let total_bal = 10_000_000_000 * (core::MICROSTACKS_PER_STACKS as u64);
 
     let first_bal = 6_000_000_000 * (core::MICROSTACKS_PER_STACKS as u64);
     let second_bal = 2_000_000_000 * (core::MICROSTACKS_PER_STACKS as u64);


### PR DESCRIPTION
This PR implements a few different things:

1. It implements the threshold adjustment described in SIP-007 (#1947)
2. When a Stacker reward address uses _more_ than the threshold, the address is repeated in the reward set (#1924)
3. The chains coordinator, when booting the node, executes `set-burnchain-parameters` on the PoX contract.
4. To speed up the integration tests in the `stacks-node`, this parameterizes the wait time in the syncctl module.

The implementations of 1 and 2 are tested via unit tests, as well as some integration paths in the `pox` test in `neon_integrations` (which also tests 3).