### PR TITLE
Fix/1955

### DIFF
--- a/src/net/p2p.rs
+++ b/src/net/p2p.rs
@@ -2692,19 +2692,24 @@ impl PeerNetwork {
         new_blocks: &BlocksData,
     ) -> () {
         let (remote_neighbor_key, remote_is_authenticated) = match self.peers.get(&event_id) {
-            Some(convo) => (
-                convo.to_neighbor_key(),
-                convo.is_authenticated()
-            ),
+            Some(convo) => (convo.to_neighbor_key(), convo.is_authenticated()),
             None => {
-                test_debug!("{:?}: No such neighbor event={}", &self.local_peer, event_id);
+                test_debug!(
+                    "{:?}: No such neighbor event={}",
+                    &self.local_peer,
+                    event_id
+                );
                 return;
             }
         };
 
         if !remote_is_authenticated {
             // drop -- a correct peer will have authenticated before sending this message
-            test_debug!("{:?}: Drop unauthenticated BlocksData from {:?}", &self.local_peer, &remote_neighbor_key);
+            test_debug!(
+                "{:?}: Drop unauthenticated BlocksData from {:?}",
+                &self.local_peer,
+                &remote_neighbor_key
+            );
             return;
         }
 
@@ -2713,7 +2718,9 @@ impl PeerNetwork {
         debug!(
             "{:?}: Process BlocksData from {:?} with {} entries",
             &self.local_peer,
-            outbound_neighbor_key_opt.as_ref().unwrap_or(&remote_neighbor_key),
+            outbound_neighbor_key_opt
+                .as_ref()
+                .unwrap_or(&remote_neighbor_key),
             new_blocks.blocks.len()
         );
 

--- a/src/net/relay.rs
+++ b/src/net/relay.rs
@@ -2458,14 +2458,14 @@ mod test {
             );
         })
     }
-    
+
     #[test]
     #[ignore]
     fn test_get_blocks_and_microblocks_2_peers_push_blocks_and_microblocks_outbound() {
         // simulates node 0 pushing blocks to node 1, but node 0 is publicly routable
         test_get_blocks_and_microblocks_2_peers_push_blocks_and_microblocks(true)
     }
-    
+
     #[test]
     #[ignore]
     fn test_get_blocks_and_microblocks_2_peers_push_blocks_and_microblocks_inbound() {

--- a/src/net/relay.rs
+++ b/src/net/relay.rs
@@ -2231,10 +2231,8 @@ mod test {
         push_message(peer, dest, relay_hints, msg)
     }
 
-    #[test]
-    #[ignore]
-    fn test_get_blocks_and_microblocks_2_peers_push_blocks_and_microblocks() {
-        with_timeout(600, || {
+    fn test_get_blocks_and_microblocks_2_peers_push_blocks_and_microblocks(outbound_test: bool) {
+        with_timeout(600, move || {
             let original_blocks_and_microblocks = RefCell::new(vec![]);
             let blocks_and_microblocks = RefCell::new(vec![]);
             let idx = RefCell::new(0);
@@ -2267,7 +2265,12 @@ mod test {
                     let peer_1 = peer_configs[1].to_neighbor();
 
                     peer_configs[0].add_neighbor(&peer_1);
-                    peer_configs[1].add_neighbor(&peer_0);
+
+                    if outbound_test {
+                        // neighbor relationship is symmetric -- peer 1 has an outbound connection
+                        // to peer 0.
+                        peer_configs[1].add_neighbor(&peer_0);
+                    }
                 },
                 |num_blocks, ref mut peers| {
                     let tip = SortitionDB::get_canonical_burn_chain_tip(
@@ -2454,6 +2457,20 @@ mod test {
                 |_| true,
             );
         })
+    }
+    
+    #[test]
+    #[ignore]
+    fn test_get_blocks_and_microblocks_2_peers_push_blocks_and_microblocks_outbound() {
+        // simulates node 0 pushing blocks to node 1, but node 0 is publicly routable
+        test_get_blocks_and_microblocks_2_peers_push_blocks_and_microblocks(true)
+    }
+    
+    #[test]
+    #[ignore]
+    fn test_get_blocks_and_microblocks_2_peers_push_blocks_and_microblocks_inbound() {
+        // simulates node 0 pushing blocks to node 1, where node 0 is behind a NAT
+        test_get_blocks_and_microblocks_2_peers_push_blocks_and_microblocks(false)
     }
 
     fn make_test_smart_contract_transaction(


### PR DESCRIPTION
This fixes #1955, and hopefully the strange miner behavior we're seeing on the Krypton testnet.  It makes it so a node can accept `BlocksData` messages from inbound authenticated neighbors, as well as outbound.