### PR TITLE
PoX: Enforce anchor block recency with burn-block-height parameter

### DIFF
--- a/src/burnchains/mod.rs
+++ b/src/burnchains/mod.rs
@@ -295,6 +295,7 @@ impl PoxConstants {
         prepare_length: u32,
         anchor_threshold: u32,
         pox_rejection_fraction: u64,
+        pox_participation_threshold_pct: u64,
     ) -> PoxConstants {
         assert!(anchor_threshold > (prepare_length / 2));
 
@@ -303,13 +304,13 @@ impl PoxConstants {
             prepare_length,
             anchor_threshold,
             pox_rejection_fraction,
-            pox_participation_threshold_pct: 5,
+            pox_participation_threshold_pct,
             _shadow: PhantomData,
         }
     }
     #[cfg(test)]
     pub fn test_default() -> PoxConstants {
-        PoxConstants::new(10, 5, 3, 25)
+        PoxConstants::new(10, 5, 3, 25, 5)
     }
 
     pub fn reward_slots(&self) -> u32 {
@@ -327,11 +328,11 @@ impl PoxConstants {
     }
 
     pub fn mainnet_default() -> PoxConstants {
-        PoxConstants::new(1000, 240, 192, 25)
+        PoxConstants::new(1000, 240, 192, 25, 5)
     }
 
     pub fn testnet_default() -> PoxConstants {
-        PoxConstants::new(120, 30, 20, 3333333333333333) // total liquid supply is 40000000000000000 µSTX
+        PoxConstants::new(120, 30, 20, 3333333333333333, 5) // total liquid supply is 40000000000000000 µSTX
     }
 }
 

--- a/src/burnchains/mod.rs
+++ b/src/burnchains/mod.rs
@@ -283,6 +283,9 @@ pub struct PoxConstants {
     /// fraction of liquid STX that must vote to reject PoX for
     /// it to revert to PoB in the next reward cycle
     pub pox_rejection_fraction: u64,
+    /// percentage of liquid STX that must participate for PoX
+    ///  to occur
+    pub pox_participation_threshold_pct: u64,
     _shadow: PhantomData<()>,
 }
 
@@ -300,6 +303,7 @@ impl PoxConstants {
             prepare_length,
             anchor_threshold,
             pox_rejection_fraction,
+            pox_participation_threshold_pct: 5,
             _shadow: PhantomData,
         }
     }
@@ -310,6 +314,14 @@ impl PoxConstants {
 
     pub fn reward_slots(&self) -> u32 {
         self.reward_cycle_length
+    }
+
+    /// is participating_ustx enough to engage in PoX in the next reward cycle?
+    pub fn enough_participation(&self, participating_ustx: u128, liquid_ustx: u128) -> bool {
+        participating_ustx.checked_mul(self.pox_participation_threshold_pct as u128)
+            .expect("OVERFLOW: uSTX overflowed u128") > 
+            liquid_ustx.checked_mul(100)
+            .expect("OVERFLOW: uSTX overflowed u128")
     }
 
     pub fn mainnet_default() -> PoxConstants {

--- a/src/burnchains/mod.rs
+++ b/src/burnchains/mod.rs
@@ -318,10 +318,12 @@ impl PoxConstants {
 
     /// is participating_ustx enough to engage in PoX in the next reward cycle?
     pub fn enough_participation(&self, participating_ustx: u128, liquid_ustx: u128) -> bool {
-        participating_ustx.checked_mul(self.pox_participation_threshold_pct as u128)
-            .expect("OVERFLOW: uSTX overflowed u128") > 
-            liquid_ustx.checked_mul(100)
+        participating_ustx
+            .checked_mul(100)
             .expect("OVERFLOW: uSTX overflowed u128")
+            > liquid_ustx
+                .checked_mul(self.pox_participation_threshold_pct as u128)
+                .expect("OVERFLOW: uSTX overflowed u128")
     }
 
     pub fn mainnet_default() -> PoxConstants {

--- a/src/chainstate/coordinator/mod.rs
+++ b/src/chainstate/coordinator/mod.rs
@@ -176,11 +176,17 @@ impl RewardSetProvider for OnChainRewardSetProvider {
         .expect("CORRUPTION: Failed to look up block header info for PoX anchor block")
         .total_liquid_ustx;
 
-        let threshold = StacksChainState::get_reward_threshold(
+        let (threshold, participation) = StacksChainState::get_reward_threshold_and_participation(
             &burnchain.pox_constants,
             &registered_addrs,
             liquid_ustx,
         );
+
+        if !burnchain.pox_constants.enough_participation(participation, liquid_ustx) {
+            info!("PoX reward cycle did not have enough participation. Defaulting to burn. participation={}, liquid_ustx={}, burn_height={}",
+                  participation, liquid_ustx, current_burn_height);
+            return Ok(vec![])
+        }
 
         Ok(StacksChainState::make_reward_set(
             threshold,

--- a/src/chainstate/coordinator/mod.rs
+++ b/src/chainstate/coordinator/mod.rs
@@ -182,10 +182,13 @@ impl RewardSetProvider for OnChainRewardSetProvider {
             liquid_ustx,
         );
 
-        if !burnchain.pox_constants.enough_participation(participation, liquid_ustx) {
+        if !burnchain
+            .pox_constants
+            .enough_participation(participation, liquid_ustx)
+        {
             info!("PoX reward cycle did not have enough participation. Defaulting to burn. participation={}, liquid_ustx={}, burn_height={}",
                   participation, liquid_ustx, current_burn_height);
-            return Ok(vec![])
+            return Ok(vec![]);
         }
 
         Ok(StacksChainState::make_reward_set(

--- a/src/chainstate/coordinator/tests.rs
+++ b/src/chainstate/coordinator/tests.rs
@@ -252,7 +252,7 @@ fn make_reward_set_coordinator<'a>(
 
 pub fn get_burnchain(path: &str) -> Burnchain {
     let mut b = Burnchain::new(&format!("{}/burnchain/db/", path), "bitcoin", "regtest").unwrap();
-    b.pox_constants = PoxConstants::new(5, 3, 3, 25);
+    b.pox_constants = PoxConstants::new(5, 3, 3, 25, 5);
     b
 }
 

--- a/src/chainstate/stacks/boot/contract_tests.rs
+++ b/src/chainstate/stacks/boot/contract_tests.rs
@@ -343,6 +343,7 @@ fn delegation_tests() {
     // let's do some delegated stacking!
     sim.execute_next_block(|env| {
         // try to stack more than [0]'s delegated amount!
+        let burn_height = env.eval_raw("burn-block-height").unwrap().0;
         assert_eq!(
             env.execute_transaction(
                 (&delegator).into(),
@@ -352,6 +353,7 @@ fn delegation_tests() {
                     (&USER_KEYS[0]).into(),
                     Value::UInt(3 * USTX_PER_HOLDER),
                     POX_ADDRS[1].clone(),
+                    burn_height.clone(),
                     Value::UInt(2)
                 ])
             )
@@ -371,6 +373,7 @@ fn delegation_tests() {
                     (&USER_KEYS[0]).into(),
                     Value::UInt(2 * USTX_PER_HOLDER),
                     POX_ADDRS[1].clone(),
+                    burn_height.clone(),
                     Value::UInt(2)
                 ])
             )
@@ -390,6 +393,7 @@ fn delegation_tests() {
                     (&USER_KEYS[0]).into(),
                     Value::UInt(*MIN_THRESHOLD - 1),
                     POX_ADDRS[1].clone(),
+                    burn_height.clone(),
                     Value::UInt(2)
                 ])
             )
@@ -437,6 +441,7 @@ fn delegation_tests() {
                     (&USER_KEYS[1]).into(),
                     Value::UInt(*MIN_THRESHOLD - 1),
                     POX_ADDRS[1].clone(),
+                    burn_height.clone(),
                     Value::UInt(2)
                 ])
             )
@@ -456,6 +461,7 @@ fn delegation_tests() {
                     (&USER_KEYS[0]).into(),
                     Value::UInt(*MIN_THRESHOLD - 1),
                     POX_ADDRS[1].clone(),
+                    burn_height.clone(),
                     Value::UInt(2)
                 ])
             )
@@ -475,6 +481,7 @@ fn delegation_tests() {
                     (&USER_KEYS[2]).into(),
                     Value::UInt(*MIN_THRESHOLD - 1),
                     POX_ADDRS[1].clone(),
+                    burn_height.clone(),
                     Value::UInt(2)
                 ])
             )
@@ -494,6 +501,7 @@ fn delegation_tests() {
                     (&USER_KEYS[2]).into(),
                     Value::UInt(*MIN_THRESHOLD - 1),
                     POX_ADDRS[1].clone(),
+                    burn_height.clone(),
                     Value::UInt(1)
                 ])
             )
@@ -597,6 +605,7 @@ fn delegation_tests() {
                     (&USER_KEYS[3]).into(),
                     Value::UInt(*MIN_THRESHOLD),
                     POX_ADDRS[1].clone(),
+                    burn_height.clone(),
                     Value::UInt(2)
                 ])
             )
@@ -707,6 +716,7 @@ fn delegation_tests() {
                     (&USER_KEYS[1]).into(),
                     Value::UInt(*MIN_THRESHOLD),
                     POX_ADDRS[0].clone(),
+                    burn_height.clone(),
                     Value::UInt(2)
                 ])
             )
@@ -756,6 +766,7 @@ fn delegation_tests() {
                     (&USER_KEYS[4]).into(),
                     Value::UInt(*MIN_THRESHOLD - 1),
                     POX_ADDRS[0].clone(),
+                    burn_height.clone(),
                     Value::UInt(2)
                 ])
             )

--- a/src/chainstate/stacks/boot/mod.rs
+++ b/src/chainstate/stacks/boot/mod.rs
@@ -395,7 +395,12 @@ pub mod test {
         //   the threshold should always be the step size.
         let liquid = POX_THRESHOLD_STEPS_USTX;
         assert_eq!(
-            StacksChainState::get_reward_threshold_and_participation(&PoxConstants::new(1000, 1, 1, 1), &[], liquid).0,
+            StacksChainState::get_reward_threshold_and_participation(
+                &PoxConstants::new(1000, 1, 1, 1),
+                &[],
+                liquid
+            )
+            .0,
             POX_THRESHOLD_STEPS_USTX
         );
         assert_eq!(
@@ -403,14 +408,20 @@ pub mod test {
                 &PoxConstants::new(1000, 1, 1, 1),
                 &[(rand_addr(), liquid)],
                 liquid
-            ).0,
+            )
+            .0,
             POX_THRESHOLD_STEPS_USTX
         );
 
         let liquid = 200_000_000 * MICROSTACKS_PER_STACKS as u128;
         // with zero participation, should scale to 25% of liquid
         assert_eq!(
-            StacksChainState::get_reward_threshold_and_participation(&PoxConstants::new(1000, 1, 1, 1), &[], liquid).0,
+            StacksChainState::get_reward_threshold_and_participation(
+                &PoxConstants::new(1000, 1, 1, 1),
+                &[],
+                liquid
+            )
+            .0,
             50_000 * MICROSTACKS_PER_STACKS as u128
         );
         // should be the same at 25% participation
@@ -419,7 +430,8 @@ pub mod test {
                 &PoxConstants::new(1000, 1, 1, 1),
                 &[(rand_addr(), liquid / 4)],
                 liquid
-            ).0,
+            )
+            .0,
             50_000 * MICROSTACKS_PER_STACKS as u128
         );
         // but not at 30% participation
@@ -431,7 +443,8 @@ pub mod test {
                     (rand_addr(), 10_000_000 * (MICROSTACKS_PER_STACKS as u128))
                 ],
                 liquid
-            ).0,
+            )
+            .0,
             60_000 * MICROSTACKS_PER_STACKS as u128
         );
 
@@ -444,7 +457,8 @@ pub mod test {
                     (rand_addr(), (MICROSTACKS_PER_STACKS as u128))
                 ],
                 liquid
-            ).0,
+            )
+            .0,
             60_000 * MICROSTACKS_PER_STACKS as u128
         );
 
@@ -454,7 +468,8 @@ pub mod test {
                 &PoxConstants::new(1000, 1, 1, 1),
                 &[(rand_addr(), liquid)],
                 liquid
-            ).0,
+            )
+            .0,
             200_000 * MICROSTACKS_PER_STACKS as u128
         );
     }
@@ -1260,7 +1275,7 @@ pub mod test {
                             AddressHashMode::SerializeP2PKH,
                             key_to_stacks_addr(&alice).bytes,
                             12,
-                            tip.block_height
+                            tip.block_height,
                         );
                         block_txs.push(alice_lockup);
                     }
@@ -1711,7 +1726,7 @@ pub mod test {
                             AddressHashMode::SerializeP2PKH,
                             key_to_stacks_addr(&alice).bytes,
                             12,
-                            tip.block_height
+                            tip.block_height,
                         );
                         block_txs.push(alice_lockup);
 
@@ -1723,7 +1738,7 @@ pub mod test {
                             AddressHashMode::SerializeP2PKH,
                             key_to_stacks_addr(&bob).bytes,
                             12,
-                            tip.block_height
+                            tip.block_height,
                         );
                         block_txs.push(bob_lockup);
                     }
@@ -2129,7 +2144,8 @@ pub mod test {
                             AddressHashMode::SerializeP2PKH,
                             key_to_stacks_addr(&alice).bytes,
                             1,
-                            tip.block_height);
+                            tip.block_height,
+                        );
                         block_txs.push(alice_lockup);
                     }
 
@@ -2363,7 +2379,8 @@ pub mod test {
                             AddressHashMode::SerializeP2PKH,
                             key_to_stacks_addr(&alice).bytes,
                             1,
-                            tip.block_height);
+                            tip.block_height,
+                        );
                         block_txs.push(alice_lockup);
 
                         // Bob creates a locking contract
@@ -2390,7 +2407,8 @@ pub mod test {
                             AddressHashMode::SerializeP2PKH,
                             key_to_stacks_addr(&alice).bytes,
                             1,
-                            tip.block_height);
+                            tip.block_height,
+                        );
                         block_txs.push(alice_lockup);
 
                         // Charlie locks up half of his tokens
@@ -2832,7 +2850,8 @@ pub mod test {
                             AddressHashMode::SerializeP2PKH,
                             key_to_stacks_addr(&alice).bytes,
                             1,
-                            tip.block_height);
+                            tip.block_height,
+                        );
                         block_txs.push(alice_lockup);
 
                         let bob_lockup = make_pox_lockup(
@@ -2842,7 +2861,8 @@ pub mod test {
                             AddressHashMode::SerializeP2PKH,
                             key_to_stacks_addr(&bob).bytes,
                             1,
-                            tip.block_height);
+                            tip.block_height,
+                        );
                         block_txs.push(bob_lockup);
 
                         let charlie_lockup = make_pox_lockup(
@@ -2852,7 +2872,8 @@ pub mod test {
                             AddressHashMode::SerializeP2PKH,
                             key_to_stacks_addr(&charlie).bytes,
                             1,
-                            tip.block_height);
+                            tip.block_height,
+                        );
                         block_txs.push(charlie_lockup);
 
                         let danielle_lockup = make_pox_lockup(
@@ -2862,7 +2883,8 @@ pub mod test {
                             AddressHashMode::SerializeP2PKH,
                             key_to_stacks_addr(&danielle).bytes,
                             1,
-                            tip.block_height);
+                            tip.block_height,
+                        );
                         block_txs.push(danielle_lockup);
 
                         let bob_contract = make_pox_lockup_contract(&bob, 1, "do-lockup");

--- a/src/chainstate/stacks/boot/mod.rs
+++ b/src/chainstate/stacks/boot/mod.rs
@@ -391,12 +391,13 @@ pub mod test {
 
     #[test]
     fn get_reward_threshold_units() {
+        let test_pox_constants = PoxConstants::new(1000, 1, 1, 1, 5);
         // when the liquid amount = the threshold step,
         //   the threshold should always be the step size.
         let liquid = POX_THRESHOLD_STEPS_USTX;
         assert_eq!(
             StacksChainState::get_reward_threshold_and_participation(
-                &PoxConstants::new(1000, 1, 1, 1),
+                &test_pox_constants,
                 &[],
                 liquid
             )
@@ -405,7 +406,7 @@ pub mod test {
         );
         assert_eq!(
             StacksChainState::get_reward_threshold_and_participation(
-                &PoxConstants::new(1000, 1, 1, 1),
+                &test_pox_constants,
                 &[(rand_addr(), liquid)],
                 liquid
             )
@@ -417,7 +418,7 @@ pub mod test {
         // with zero participation, should scale to 25% of liquid
         assert_eq!(
             StacksChainState::get_reward_threshold_and_participation(
-                &PoxConstants::new(1000, 1, 1, 1),
+                &test_pox_constants,
                 &[],
                 liquid
             )
@@ -427,7 +428,7 @@ pub mod test {
         // should be the same at 25% participation
         assert_eq!(
             StacksChainState::get_reward_threshold_and_participation(
-                &PoxConstants::new(1000, 1, 1, 1),
+                &test_pox_constants,
                 &[(rand_addr(), liquid / 4)],
                 liquid
             )
@@ -437,7 +438,7 @@ pub mod test {
         // but not at 30% participation
         assert_eq!(
             StacksChainState::get_reward_threshold_and_participation(
-                &PoxConstants::new(1000, 1, 1, 1),
+                &test_pox_constants,
                 &[
                     (rand_addr(), liquid / 4),
                     (rand_addr(), 10_000_000 * (MICROSTACKS_PER_STACKS as u128))
@@ -451,7 +452,7 @@ pub mod test {
         // bump by just a little bit, should go to the next threshold step
         assert_eq!(
             StacksChainState::get_reward_threshold_and_participation(
-                &PoxConstants::new(1000, 1, 1, 1),
+                &test_pox_constants,
                 &[
                     (rand_addr(), liquid / 4),
                     (rand_addr(), (MICROSTACKS_PER_STACKS as u128))
@@ -465,7 +466,7 @@ pub mod test {
         // bump by just a little bit, should go to the next threshold step
         assert_eq!(
             StacksChainState::get_reward_threshold_and_participation(
-                &PoxConstants::new(1000, 1, 1, 1),
+                &test_pox_constants,
                 &[(rand_addr(), liquid)],
                 liquid
             )

--- a/src/chainstate/stacks/boot/pox.clar
+++ b/src/chainstate/stacks/boot/pox.clar
@@ -18,6 +18,7 @@
 (define-constant ERR_DELEGATION_EXPIRES_DURING_LOCK 21)
 (define-constant ERR_DELEGATION_TOO_MUCH_LOCKED 22)
 (define-constant ERR_DELEGATION_POX_ADDR_REQUIRED 23)
+(define-constant ERR_INVALID_START_BURN_HEIGHT 24)
 
 ;; PoX disabling threshold (a percent)
 (define-constant POX_REJECTION_FRACTION u25)
@@ -425,13 +426,22 @@
 ;; at the time this method is called.
 ;; * You may need to increase the amount of uSTX locked up later, since the minimum uSTX threshold
 ;; may increase between reward cycles.
+;; * The Stacker will receive rewards in the reward cycle following `start-burn-ht`.
+;; Importantly, `start-burn-ht` may not be further into the future than the next reward cycle,
+;; and in most cases should be set to the current burn block height.
 ;;
 ;; The tokens will unlock and be returned to the Stacker (tx-sender) automatically.
 (define-public (stack-stx (amount-ustx uint)
                           (pox-addr (tuple (version (buff 1)) (hashbytes (buff 20))))
+                          (start-burn-ht uint)
                           (lock-period uint))
     ;; this stacker's first reward cycle is the _next_ reward cycle
-    (let ((first-reward-cycle (+ u1 (current-pox-reward-cycle))))
+    (let ((first-reward-cycle (+ u1 (current-pox-reward-cycle)))
+          (specified-reward-cycle (+ u1 (burn-height-to-reward-cycle start-burn-ht))))
+      ;; the start-burn-ht must result in the next reward cycle, do not allow stackers
+      ;;  to "post-date" their `stack-stx` transaction
+      (asserts! (is-eq first-reward-cycle specified-reward-cycle)
+                (err ERR_INVALID_START_BURN_HEIGHT))
 
       ;; must be called directly by the tx-sender or by an allowed contract-caller
       (asserts! (check-caller-allowed)
@@ -547,10 +557,16 @@
 (define-public (delegate-stack-stx (stacker principal)
                                    (amount-ustx uint)
                                    (pox-addr { version: (buff 1), hashbytes: (buff 20) })
+                                   (start-burn-ht uint)
                                    (lock-period uint))
     ;; this stacker's first reward cycle is the _next_ reward cycle
     (let ((first-reward-cycle (+ u1 (current-pox-reward-cycle)))
+          (specified-reward-cycle (+ u1 (burn-height-to-reward-cycle start-burn-ht)))
           (unlock-burn-height (reward-cycle-to-burn-height (+ (current-pox-reward-cycle) u1 lock-period))))
+      ;; the start-burn-ht must result in the next reward cycle, do not allow stackers
+      ;;  to "post-date" their `stack-stx` transaction
+      (asserts! (is-eq first-reward-cycle specified-reward-cycle)
+                (err ERR_INVALID_START_BURN_HEIGHT))
 
       ;; must be called directly by the tx-sender or by an allowed contract-caller
       (asserts! (check-caller-allowed)

--- a/src/net/inv.rs
+++ b/src/net/inv.rs
@@ -2559,7 +2559,7 @@ mod test {
     #[test]
     fn test_inv_merge_pox_inv() {
         let mut burnchain = Burnchain::new("unused", "bitcoin", "regtest").unwrap();
-        burnchain.pox_constants = PoxConstants::new(5, 3, 3, 25);
+        burnchain.pox_constants = PoxConstants::new(5, 3, 3, 25, 5);
 
         let mut peer_inv = PeerBlocksInv::new(vec![0x01], vec![0x01], vec![0x01], 1, 1, 0);
         for i in 0..32 {
@@ -2577,7 +2577,7 @@ mod test {
     #[test]
     fn test_inv_truncate_pox_inv() {
         let mut burnchain = Burnchain::new("unused", "bitcoin", "regtest").unwrap();
-        burnchain.pox_constants = PoxConstants::new(5, 3, 3, 25);
+        burnchain.pox_constants = PoxConstants::new(5, 3, 3, 25, 5);
 
         let mut peer_inv = PeerBlocksInv::new(vec![0x01], vec![0x01], vec![0x01], 1, 1, 0);
         for i in 0..5 {

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -2015,7 +2015,7 @@ pub mod test {
                 )
                 .unwrap(),
             );
-            burnchain.pox_constants = PoxConstants::new(5, 3, 3, 25);
+            burnchain.pox_constants = PoxConstants::new(5, 3, 3, 25, 5);
 
             let spending_account = TestMinerFactory::new().next_miner(
                 &burnchain,

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -784,6 +784,8 @@ fn pox_integration_test() {
     // second block will be the first mined Stacks block
     next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
 
+    let sort_height = channel.get_sortitions_processed();
+
     // let's query the miner's account nonce:
 
     eprintln!("Miner account: {}", miner_account);
@@ -817,7 +819,7 @@ fn pox_integration_test() {
     let tx = make_contract_call(
         &spender_sk,
         0,
-        243,
+        260,
         &StacksAddress::from_string("ST000000000000000000002AMW42H").unwrap(),
         "pox",
         "stack-stx",
@@ -829,6 +831,7 @@ fn pox_integration_test() {
             ))
             .unwrap()
             .unwrap(),
+            Value::UInt(sort_height as u128),
             Value::UInt(3),
         ],
     );
@@ -862,7 +865,7 @@ fn pox_integration_test() {
     let tx = make_contract_call(
         &spender_2_sk,
         0,
-        243,
+        260,
         &StacksAddress::from_string("ST000000000000000000002AMW42H").unwrap(),
         "pox",
         "stack-stx",
@@ -874,6 +877,7 @@ fn pox_integration_test() {
             ))
             .unwrap()
             .unwrap(),
+            Value::UInt(sort_height as u128),
             Value::UInt(3),
         ],
     );
@@ -904,7 +908,7 @@ fn pox_integration_test() {
     let tx = make_contract_call(
         &spender_3_sk,
         0,
-        243,
+        260,
         &StacksAddress::from_string("ST000000000000000000002AMW42H").unwrap(),
         "pox",
         "stack-stx",
@@ -916,6 +920,7 @@ fn pox_integration_test() {
             ))
             .unwrap()
             .unwrap(),
+            Value::UInt(sort_height as u128),
             Value::UInt(3),
         ],
     );

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -759,8 +759,7 @@ fn pox_integration_test() {
     let http_origin = format!("http://{}", &conf.node.rpc_bind);
 
     let mut burnchain_config = btc_regtest_controller.get_burnchain();
-    let mut pox_constants = PoxConstants::new(10, 5, 4, 5);
-    pox_constants.pox_participation_threshold_pct = 15;
+    let mut pox_constants = PoxConstants::new(10, 5, 4, 5, 15);
     burnchain_config.pox_constants = pox_constants;
 
     btc_regtest_controller.bootstrap_chain(201);


### PR DESCRIPTION
This PR implements #1897, by adding `burn-block-ht` parameters to `stack-stx` and `delegate-stack-stx`, which must correspond to the next reward cycle (this parameter ensures that the transaction could not be replayed in a Stacks fork occurring at a much later burn block). Further, this PR requires that PoX participation cross a threshold before activation.

Closing #1897 