### PR TITLE
Feat/network test framework

### DIFF
--- a/net-test/README.md
+++ b/net-test/README.md
@@ -1,0 +1,15 @@
+# Stacks Network Testing
+
+A rudimentary set of tools for testing multiple Stacks nodes at once, locally.
+Relevant files:
+
+* `bin/start.sh` -- start up a master node, a miner node, or a follower node, as
+  well as ancilliary processes.
+* `bin/faucet.sh` -- a rudimentary Bitcoin faucet.
+* `bin/txload.sh` -- a rudimentary Stacks transaction generator and load-tester.
+* `etc/*.in` -- templates that `bin/start.sh` uses to create configuration
+  files.
+
+To use, you will need to install `stacks-node`, `blockstack-cli`,
+`bitcoin-neon-controller`, and `bin/faucet.sh` to somewhere in your `$PATH`.
+You will also need a recent `bitcoind` and `bitcoin-cli`.

--- a/net-test/bin/config.sh
+++ b/net-test/bin/config.sh
@@ -1,0 +1,26 @@
+# local config
+__ROOT="$(realpath "$(pwd)"/..)"
+__ETC="$_ROOT/etc"
+__MNT="$_ROOT/mnt"
+
+BITCOIN_CONF="$__ETC/bitcoin.conf"
+BITCOIN_CONTROLLER_CONF="$__ETC/bitcoin-neon-controller.toml"
+STACKS_MASTER_CONF="$__ETC/stacks-master.toml"
+STACKS_MINER_CONF="$__ETC/stacks-miner.toml"
+STACKS_FOLLOWER_CONF="$__ETC/stacks-follower.toml"
+
+BITCOIN_LOGFILE="$__MNT/bitcoin.log"
+BITCOIN_NEON_CONTROLLER_LOGFILE="$__MNT/bitcoin-neon-controller.log"
+
+STACKS_MASTER_LOGFILE="$__MNT/stacks-node-master.log"
+STACKS_MINER_LOGFILE="$__MNT/stacks-node-miner.log"
+STACKS_FOLLOWER_LOGFILE="$__MNT/stacks-node-follower.log"
+FAUCET_LOGFILE="$__MNT/faucet.log"
+
+STACKS_MASTER_PUBLIC_IP="127.0.0.1"
+
+__NOW="$(date +%s)"
+STACKS_CHAINSTATE_DIR="$__MNT/stacks-chainstate-$__NOW"
+BITCOIN_DATA_DIR="$__MNT/bitcoin-$__NOW"
+
+echo >&2 "Loaded external config"

--- a/net-test/bin/config.sh
+++ b/net-test/bin/config.sh
@@ -1,7 +1,7 @@
 # local config
 __ROOT="$(realpath "$(pwd)"/..)"
-__ETC="$_ROOT/etc"
-__MNT="$_ROOT/mnt"
+__ETC="$__ROOT/etc"
+__MNT="$__ROOT/mnt"
 
 BITCOIN_CONF="$__ETC/bitcoin.conf"
 BITCOIN_CONTROLLER_CONF="$__ETC/bitcoin-neon-controller.toml"
@@ -18,6 +18,8 @@ STACKS_FOLLOWER_LOGFILE="$__MNT/stacks-node-follower.log"
 FAUCET_LOGFILE="$__MNT/faucet.log"
 
 STACKS_MASTER_PUBLIC_IP="127.0.0.1"
+
+FAUCET_PORT=8080
 
 __NOW="$(date +%s)"
 STACKS_CHAINSTATE_DIR="$__MNT/stacks-chainstate-$__NOW"

--- a/net-test/bin/faucet.sh
+++ b/net-test/bin/faucet.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Yup, it's a faucet HTTP server written in bash.  This is what my life has come to.
 

--- a/net-test/bin/faucet.sh
+++ b/net-test/bin/faucet.sh
@@ -1,0 +1,294 @@
+#!/bin/bash
+
+# Yup, it's a faucet HTTP server written in bash.  This is what my life has come to.
+
+MAX_BODY_LENGTH=65536
+FAUCET_AMOUNT="1.0"
+
+MODE="$1"
+BITCOIN_CONF="$2"
+
+set -uo pipefail
+
+exit_error() {
+   printf >&2 "$1"
+   exit 1
+}
+
+log() {
+   printf >&2 "%s\n" "$1"
+}
+
+http_ok() {
+   local CONTENT_LENGTH
+   local CONTENT_TYPE
+
+   CONTENT_LENGTH=$1
+   CONTENT_TYPE=$2
+   printf "HTTP/1.0 200 OK\r\nContent-Length: $CONTENT_LENGTH\r\nContent-Type: $CONTENT_TYPE\r\n\r\n"
+}
+
+http_401() {
+   printf "HTTP/1.0 401 Unsupported Method\r\n\r\n"
+}
+
+http_500() {
+   local ERR="$1"
+   local ERR_LEN=${#ERR}
+   printf "HTTP/1.0 500 Internal Server error\r\nContent-Length: $ERR_LEN\r\nContent-Type: text/plain\r\n\r\n$ERR"
+}
+
+http_404() {
+   printf "HTTP/1.0 404 Not Found\r\n\r\n"
+}
+
+get_ping() {
+   http_ok 5 "text/plain"
+   printf "alive"
+   return 0
+}
+
+get_bitcoin_ping() {
+   bitcoin-cli -conf="$BITCOIN_CONF" ping >/dev/null 2>&1
+   if [ $? -eq 0 ]; then 
+      local MSG="Bitcoind appears to be running"
+      http_ok ${#MSG} "text/plain"
+      echo "$MSG"
+      return 0
+   else
+      http_500 "Bitcoind appears to be stopped"
+      return 1
+   fi
+}
+
+get_balance() {
+   BALANCE="$(bitcoin-cli -conf="$BITCOIN_CONF" getbalance 2>&1)"
+   if [ $? -eq 0 ]; then
+      http_ok "${#BALANCE}" "text/plain"
+      echo "$BALANCE"
+      return 0
+   else
+      http_500 "$BALANCE"
+      return 1
+   fi
+}
+
+get_utxos() {
+   local ADDR="$1"
+   UTXOS="$(bitcoin-cli -conf="$BITCOIN_CONF" listunspent 1 1000000 "[\"$ADDR\"]" 2>&1)"
+   if [ $? -eq 0 ]; then 
+      http_ok ${#UTXOS} "application/json"
+      echo "$UTXOS"
+      return 0
+   else
+      http_500 "$UTXOS"
+      return 1
+   fi
+}
+
+get_confirmations() {
+   local TXID="$1"
+   CONFIRMATIONS="$(bitcoin-cli -conf="$BITCOIN_CONF" gettransaction "$TXID" | jq -r '.confirmations')"
+   RC=$?
+   if [ $RC -eq 0 ]; then 
+      http_ok ${#CONFIRMATIONS} "text/plain"
+      echo "$CONFIRMATIONS"
+      return 0
+   elif [ $RC -eq 1 ]; then 
+      http_500 "$CONFIRMATIONS"
+      return 1
+   else
+      http_404
+      return 2
+   fi
+}
+
+post_sendbtc() {
+   local ADDR
+
+   # format: address\n
+   read ADDR
+   TXID="$(bitcoin-cli -conf="$BITCOIN_CONF" sendtoaddress "$ADDR" "$FAUCET_AMOUNT" 2>&1)"
+   if [ $? -ne 0 ]; then
+      http_500 "$TXID"
+      return 1
+   fi
+
+   ERR="$(bitcoin-cli -conf="$BITCOIN_CONF" importaddress "$ADDR" 2>&1)"
+   if [ $? -ne 0 ]; then
+      http_500 "$ERR"
+      return 1
+   fi
+
+   http_ok ${#TXID} "text/plain"
+   echo "$TXID"
+   return 0
+}
+
+parse_request() {
+   local REQLINE
+   local VERB=""
+   local REQPATH=""
+   local CONTENT_TYPE=""
+   local CONTENT_LENGTH=0
+
+   while read REQLINE; do
+      # trim trailing whitespace
+      REQLINE="${REQLINE%"${REQLINE##*[![:space:]]}"}"
+      if [ -z "$REQLINE" ]; then
+         break
+      fi
+
+      # log "   reqline = '$REQLINE'"
+
+      TOK="$(echo "$REQLINE" | egrep "GET|POST" | sed -r 's/^(GET|POST)[ ]+([^ ]+)[ ]+HTTP\/1.(0|1)$/\1 \2/g')"
+      if [ -n "$TOK" ] && [ -z "$VERB" ] && [ -z "$REQPATH" ]; then 
+         set -- $TOK
+         VERB="$1"
+         REQPATH="$2"
+         continue
+      fi
+
+      TOK="$(echo "$REQLINE" | grep -i "content-type" | cut -d ' ' -f 2)"
+      if [ -n "$TOK" ] && [ -z "$CONTENT_TYPE" ]; then
+         CONTENT_TYPE="${TOK,,}"
+         continue
+      fi
+
+      TOK="$(echo "$REQLINE" | grep -i "content-length" | cut -d ' ' -f 2)"
+      if [ -n "$TOK" ] && [ $CONTENT_LENGTH -eq 0 ]; then
+         if [[ "$TOK" =~ ^[0-9]+$ ]]; then
+            CONTENT_LENGTH="$TOK"
+            continue
+         fi
+      fi
+   done
+
+   if [ $CONTENT_LENGTH -gt $MAX_BODY_LENGTH ]; then 
+      exit 1
+   fi
+
+   if [ -z "$VERB" ] || [ -z "$REQPATH" ]; then
+      exit 1
+   fi
+   
+   # log "   verb = '$VERB', reqpath = '$REQPATH', content-type = '$CONTENT_TYPE', content-length = '$CONTENT_LENGTH'"
+
+   printf "$VERB\n$REQPATH\n$CONTENT_TYPE\n$CONTENT_LENGTH\n"
+   dd bs=$CONTENT_LENGTH 2>/dev/null
+   return 0
+}
+
+handle_request() {
+   local VERB
+   local REQPATH
+   local CONTENT_TYPE
+   local CONTENT_LENGTH
+   local STATUS=200
+
+   read VERB
+   read REQPATH
+   read CONTENT_TYPE
+   read CONTENT_LENGTH
+
+   case "$VERB" in
+      GET)
+         case "$REQPATH" in
+            /ping)
+               get_ping
+               if [ $? -ne 0 ]; then
+                  STATUS=500
+               fi
+               ;;
+
+            /bitcoin)
+               get_bitcoin_ping
+               if [ $? -ne 0 ]; then
+                  STATUS=500
+               fi
+               ;;
+
+            /balance)
+               get_balance
+               if [ $? -ne 0 ]; then
+                  STATUS=500
+               fi
+               ;;
+
+            /confirmations/*)
+               TXID="${REQPATH#/confirmations/}"
+               get_confirmations "$TXID"
+               if [ $? -eq 1 ]; then
+                  STATUS=500
+               elif [ $? -eq 2 ]; then
+                  STATUS=404
+               fi
+               ;;
+
+            /utxos/*)
+               ADDR="${REQPATH#/utxos/}"
+               get_utxos "$ADDR"
+               if [ $? -ne 0 ]; then
+                  STATUS=500
+               fi
+               ;;
+            *)
+               http_404
+               STATUS=404
+               ;;
+         esac
+         ;;
+      POST)
+         case "$REQPATH" in
+            /fund)
+               if [ "$CONTENT_TYPE" != "text/plain" ]; then
+                  http_401
+                  STATUS=401
+               else
+                  post_sendbtc
+                  if [ $? -ne 0 ]; then
+                     STATUS=500
+                  fi
+               fi
+               ;;
+            *)
+               http_404
+               STATUS=404
+               ;;
+         esac
+         ;;
+      *)
+         http_401
+         STATUS=404
+         ;;
+   esac
+
+   log "[$(date +%s)] $VERB $REQPATH ($CONTENT_LENGTH bytes) - $STATUS"
+}
+
+usage() {
+   exit_error "Usage:\n   $0 serve </path/to/bitcoin.conf>\n   $0 <port> </path/to/bitcoin.conf>\n"
+}
+
+if [ -z "$MODE" ] || [ -z "$BITCOIN_CONF" ]; then
+   usage
+fi
+
+if [ "$MODE" = "serve" ]; then
+   parse_request | handle_request
+   exit 0
+elif [ "$MODE" = "parse" ]; then 
+   # undocumented test mode
+   parse_request
+   exit 0
+fi
+
+if ! [[ $MODE =~ ^[0-9]+$ ]]; then
+   usage
+fi
+
+for cmd in ncat bitcoin-cli egrep grep tr dd sed cut date; do
+   which $cmd >/dev/null 2>&1 || exit_error "Missing command: $cmd"
+done
+
+exec ncat -k -l -p $MODE -c "bash $0 serve \"$BITCOIN_CONF\""

--- a/net-test/bin/start.sh
+++ b/net-test/bin/start.sh
@@ -1,0 +1,363 @@
+#!/bin/bash
+
+MODE="$1"
+set -uo pipefail
+
+BITCOIN_LOGFILE="/mnt/bitcoin.log"
+BITCOIN_NEON_CONTROLLER_LOGFILE="/mnt/bitcoin-neon-controller.log"
+STACKS_MASTER_LOGFILE="/mnt/stacks-node-master.log"
+STACKS_MINER_LOGFILE="/mnt/stacks-node-miner.log"
+STACKS_FOLLOWER_LOGFILE="/mnt/stacks-node-follower.log"
+FAUCET_LOGFILE="/mnt/faucet.log"
+
+BITCOIN_CONF="/etc/bitcoin.conf"
+BITCOIN_CONTROLLER_CONF="/etc/bitcoin-neon-controller.toml"
+STACKS_MASTER_CONF="/etc/stacks-master.toml"
+STACKS_MINER_CONF="/etc/stacks-miner.toml"
+STACKS_FOLLOWER_CONF="/etc/stacks-follower.toml"
+
+STACKS_CHAINSTATE_DIR="/mnt/stacks-chainstate"
+BITCOIN_DATA_DIR="/mnt/bitcoin"
+
+STACKS_MASTER_PUBLIC_IP="127.0.0.1"
+
+FAUCET_PORT=8080
+
+if [ -f "./config.sh" ]; then
+   source ./config.sh
+fi
+
+function exit_error() {
+   printf "$1" >&2
+   exit 1
+}
+
+function log() {
+   printf "%s" "$1" >&2
+}
+
+function logln() {
+   printf "%s\n" "$1" >&2
+}
+
+start_bitcoind() {
+   logln "Setting up Bitcoind..."
+   test -f "$BITCOIN_CONF".in || exit_error "No such file or directory: $BITCOIN_CONF"
+   mkdir -p "$BITCOIN_DATA_DIR" || exit_error "Failed to create Bitcoin data directory $BITCOIN_DATA_DIR"
+
+   log "  Generating Bitcoind config file..."
+   sed -r \
+     -e "s!@@BITCOIN_DATA_DIR@@!$BITCOIN_DATA_DIR!g" \
+     "$BITCOIN_CONF".in \
+     > "$BITCOIN_CONF"
+   logln "ok"
+   
+   log "Starting bitcoind..."
+   bitcoind -conf="$BITCOIN_CONF" >"$BITCOIN_LOGFILE" 2>&1 &
+   local BITCOIN_PID=$!
+   logln "PID $BITCOIN_PID"
+
+   while true; do 
+      bitcoin-cli -regtest -conf="$BITCOIN_CONF" ping >/dev/null 2>&1
+      if [ $? -eq 0 ]; then
+         break
+      fi
+      sleep 1
+   done
+
+   echo "$BITCOIN_PID"
+   return 0
+}
+
+start_bitcoind_controller() {
+   logln "Setting up Bitcoind controller..."
+   test -f "$BITCOIN_CONTROLLER_CONF".in || exit_error "No such file or directory: $BITCOIN_CONTROLLER_CONF.in"
+
+   log "  Generating Bitcoind controller config file..."
+   local NOW="$(date +%s)"
+   sed -r \
+    -e "s/@@BITCOIN_NEON_CONTROLLER_GENESIS_TIMESTAMP@@/$NOW/g" \
+    "$BITCOIN_CONTROLLER_CONF".in \
+    > "$BITCOIN_CONTROLLER_CONF"
+   logln "ok"
+
+   log "Starting bitcoind controller..."
+   bitcoin-neon-controller "$BITCOIN_CONTROLLER_CONF" >"$BITCOIN_NEON_CONTROLLER_LOGFILE" 2>&1 &
+   local RC=$?
+   local BITCOIN_NEON_CONTROLLER_PID=$!
+
+   if [ $RC -ne 0 ]; then 
+      logln "FAILED"
+      return 1
+   fi
+
+   logln "PID $BITCOIN_NEON_CONTROLLER_PID"
+
+   echo "$BITCOIN_NEON_CONTROLLER_PID"
+   return 0
+}
+
+start_faucet() {
+   logln "Setting up Bitcoin faucet..."
+   test -f "$BITCOIN_CONTROLLER_CONF" || exit_error "No such file or directory: $BITCOIN_CONTROLLER_CONF"
+   test -f "$BITCOIN_CONF" || exit_error "No such file or directory: $BITCOIN_CONF"
+
+   local PRIVKEY="$(cat "$BITCOIN_CONTROLLER_CONF" | grep "# WIF" | cut -d ' ' -f 3)"
+
+   log "  Importing faucet private key..."
+   bitcoin-cli -conf="$BITCOIN_CONF" importprivkey "$PRIVKEY" >"$FAUCET_LOGFILE" 2>&1
+   local RC=$?
+   if [ $RC -ne 0 ]; then
+      logln "FAILED!"
+      return 1
+   fi
+   logln "ok"
+
+   local MINER_ADDR="$(cat "$BITCOIN_CONTROLLER_CONF" | grep "miner_address =" | cut -d ' ' -f 3 | sed -r 's/"//g')"
+
+   log "  Importing miner address $MINER_ADDR..."
+   
+   echo "Try importing miner address $MINER_ADDR" >>"$FAUCET_LOGFILE"
+   bitcoin-cli -conf="$BITCOIN_CONF" importaddress "$MINER_ADDR" >>"$FAUCET_LOGFILE" 2>&1
+   RC=$?
+   if [ $RC -ne 0 ]; then 
+      logln "FAILED!"
+      return 1
+   fi
+
+   logln "ok"
+
+   log "Starting Bitcoin faucet..."
+   faucet.sh "$FAUCET_PORT" "$BITCOIN_CONF" >"$FAUCET_LOGFILE" 2>&1 &
+   local FAUCET_PID=$!
+   logln "PID $FAUCET_PID"
+
+   echo "$FAUCET_PID"
+   return 0
+}
+
+start_stacks_master_node() {
+   logln "Setting up Stacks master node..."
+   test -f "$STACKS_MASTER_CONF".in || exit_error "No such file or directory: $STACKS_MASTER_CONF.in"
+
+   log "  Generating Stacks master config file..."
+   sed -r \
+      -e "s!@@STACKS_CHAINSTATE_DIR@@!$STACKS_CHAINSTATE_DIR!g" \
+      -e "s!@@STACKS_PUBLIC_IP@@!$STACKS_MASTER_PUBLIC_IP!g" \
+      "$STACKS_MASTER_CONF".in \
+      > "$STACKS_MASTER_CONF"
+   logln "ok"
+
+   log "Starting Stacks master node..."
+   BLOCKSTACK_DEBUG=1 RUST_BACKTRACE=full stacks-node start --config="$STACKS_MASTER_CONF" >"$STACKS_MASTER_LOGFILE" 2>&1 &
+   local STACKS_PID=$!
+   logln "PID $STACKS_PID"
+
+   echo "$STACKS_PID"
+   return 0
+}
+
+start_stacks_miner_node() {
+   logln "Setting up Stacks miner node..."
+   test -f "$STACKS_MINER_CONF".in || exit_error "No such file or directory: $STACKS_MINER_CONF.in"
+
+   log "  Generating Stacks miner config file..."
+   local STACKS_MASTER_IP="$1"
+   local BITCOIN_IP="$2"
+   local FAUCET_URL="$3"
+   local STACKS_MINER_SEED="$(blockstack-cli generate-sk | jq -r '.secretKey')"
+
+   sed -r \
+      -e "s/@@STACKS_MASTER_IP@@/$STACKS_MASTER_IP/g" \
+      -e "s/@@BITCOIN_IP@@/$BITCOIN_IP/g" \
+      -e "s/@@STACKS_MINER_SEED@@/$STACKS_MINER_SEED/g" \
+      -e "s!@@STACKS_CHAINSTATE_DIR@@!$STACKS_CHAINSTATE_DIR!g" \
+      "$STACKS_MINER_CONF".in \
+      > "$STACKS_MINER_CONF"
+   logln "ok"
+
+   local BTCADDR="$(blockstack-cli --testnet addresses "$STACKS_MINER_SEED" | jq -r '.BTC')"
+   local TIMEOUT=2
+   local TXID=""
+   local CONFIRMATIONS=0
+
+   log "  Fetching BTC from the faucet for this miner ($BTCADDR)..."
+   for i in $(seq 1 10); do
+       TXID="$(curl -sf -X POST -d $BTCADDR$'\n' -H "content-type: text/plain" "$FAUCET_URL"/fund)"
+       local RC=$?
+       if [ $RC -ne 0 ]; then 
+          # curl failed, or we didn't get 200.  Try again
+          logln "FAILED!  Try again in $TIMEOUT seconds..."
+          sleep $TIMEOUT
+
+          TIMEOUT=$((TIMEOUT + $RANDOM % TIMEOUT))
+          continue
+       fi
+       break
+   done
+   logln "txid $TXID"
+
+   log "  Waiting for BTC to get confirmed..."
+   for i in $(seq 1 5); do
+       sleep 60
+       local CONFIRMATIONS="$(curl -sf "$FAUCET_URL"/confirmations/"$TXID")"
+       local RC=$?
+       if [ $RC -ne 0 ]; then 
+          logln "FAILED!  Try again (attempt $i)..."
+          continue
+       fi
+       if [ $CONFIRMATIONS -gt 0 ]; then 
+          break
+       fi
+   done
+
+   if [ $CONFIRMATIONS -eq 0 ]; then 
+      logln "FAILED"
+      return 1
+   fi
+   logln "ok"
+   
+   log "Starting Stacks miner node..."
+   BLOCKSTACK_DEBUG=1 RUST_BACKTRACE=full stacks-node start --config="$STACKS_MINER_CONF" >"$STACKS_MINER_LOGFILE" 2>&1 &
+   local STACKS_PID=$!
+   logln "PID $STACKS_PID"
+
+   echo "$STACKS_PID"
+   return 0
+}
+
+start_stacks_follower_node() {
+   logln "Setting up Stacks follower node..."
+   test -f "$STACKS_FOLLOWER_CONF".in || exit_error "No such file or directory: $STACKS_FOLLOWER_CONF.in"
+
+   log "  Generating Stacks follower config file..."
+   local STACKS_MASTER_IP="$1"
+   local BITCOIN_IP="$2"
+   sed -r \
+      -e "s/@@STACKS_MASTER_IP@@/$STACKS_MASTER_IP/g" \
+      -e "s/@@BITCOIN_IP@@/$BITCOIN_IP/g" \
+      -e "s!@@STACKS_CHAINSTATE_DIR@@!$STACKS_CHAINSTATE_DIR!g" \
+      "$STACKS_FOLLOWER_CONF".in \
+      > "$STACKS_FOLLOWER_CONF"
+   logln "ok"
+   
+   log "Starting Stacks follower node..."
+   BLOCKSTACK_DEBUG=1 RUST_BACKTRACE=full stacks-node start --config="$STACKS_FOLLOWER_CONF" >"$STACKS_FOLLOWER_LOGFILE" 2>&1 &
+   local STACKS_PID=$!
+   logln "PID $STACKS_PID"
+
+   echo "$STACKS_PID"
+   return 0
+}
+
+check_if_running() {
+   local PID=$1
+   if [ $PID -gt 0 ]; then 
+       kill -s 0 "$PID" 2>/dev/null
+       return $?
+   else
+       return 0
+   fi
+}
+
+kill_if_running() {
+   local SIG="$1"
+   local PID=$2
+
+   if [ $PID -gt 0 ]; then
+      check_if_running $PID
+      if [ $? -eq 0 ]; then
+         logln "Send $SIG to PID $PID"
+         kill -s "$SIG" "$PID" 2>/dev/null || true
+      fi
+   fi
+}
+
+usage() {
+   exit_error "Usage:\n   $0 master\n   $0 miner STACKS_MASTER_IP BITCOIN_IP FAUCET_URL\n   $0 follower STACKS_MASTER_IP BITCOIN_IP\n\n"
+}
+
+if [ -z "$MODE" ]; then
+   usage
+fi
+
+for cmd in bitcoind bitcoin-cli bitcoin-neon-controller stacks-node blockstack-cli date jq grep sed kill cat curl faucet.sh seq; do
+   which $cmd 2>&1 >/dev/null || exit_error "Missing \"$cmd\""
+done
+
+BITCOIN_PID=0
+BITCOIN_NEON_CONTROLLER_PID=0
+STACKS_NODE_PID=0
+FAUCET_PID=0
+
+shutdown() {
+   echo "Sending SIGTERM to all processes"
+   for PID in $BITCOIN_PID $BITCOIN_NEON_CONTROLLER_PID $STACKS_NODE_PID $FAUCET_PID; do
+       kill_if_running SIGTERM $PID
+   done
+
+   sleep 5
+   echo "Sending SIGKILL to all processes"
+   for PID in $BITCOIN_PID $BITCOIN_NEON_CONTROLLER_PID $STACKS_NODE_PID $FAUCET_PID; do
+       kill_if_running SIGKILL $PID
+   done
+
+   exit 0
+}
+
+trap 'shutdown' INT
+
+case "$MODE" in
+   master)
+      BITCOIN_PID="$(start_bitcoind)"
+
+      sleep 5
+      BITCOIN_NEON_CONTROLLER_PID="$(start_bitcoind_controller)"
+
+      sleep 5
+      FAUCET_PID="$(start_faucet)"
+
+      sleep 5
+      STACKS_NODE_PID="$(start_stacks_master_node)"
+      ;;
+
+   miner)
+      test -n "$2" || usage
+      test -n "$3" || usage
+      test -n "$4" || usage
+      STACKS_NODE_PID="$(start_stacks_miner_node "$2" "$3" "$4")"
+      ;;
+
+   follower)
+      test -n "$2" || usage
+      test -n "$3" || usage
+      STACKS_NODE_PID="$(start_stacks_follower_node "$2" "$3")"
+      ;;
+   *)
+      usage
+      ;;
+esac
+
+echo "Running!"
+
+# reap children
+while true; do
+   wait
+   sleep 5
+
+   ALL_GOOD=0
+   for PID in $BITCOIN_PID $BITCOIN_NEON_CONTROLLER_PID $STACKS_NODE_PID $FAUCET_PID; do
+      check_if_running $PID
+      if [ $? -ne 0 ]; then
+         ALL_GOOD=1
+         break
+      fi
+   done
+
+   if [ $ALL_GOOD -ne 0 ]; then
+      break
+   fi
+done
+
+echo "Some process exited unexpectedly"
+shutdown

--- a/net-test/bin/start.sh
+++ b/net-test/bin/start.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 BITCOIN_LOGFILE="/mnt/bitcoin.log"
 BITCOIN_NEON_CONTROLLER_LOGFILE="/mnt/bitcoin-neon-controller.log"

--- a/net-test/bin/txload.sh
+++ b/net-test/bin/txload.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 FEE_RATE=300
 MAX_CHAINING=5

--- a/net-test/bin/txload.sh
+++ b/net-test/bin/txload.sh
@@ -1,0 +1,320 @@
+#!/bin/bash
+
+FEE_RATE=300
+MAX_CHAINING=5
+CONFIRMATIONS=1
+
+# grab fd 3 for curl
+exec 3>&1
+
+exit_error() {
+   printf "$1"
+   exit 1
+}
+
+usage() {
+   exit_error "$0 <private-key-hex> <stacks-url> <num-txs>\n"
+}
+
+MAIN_PRIVATE_KEY="$1"
+STACKS_NODE_URL="$2"
+NUM_TXS="$3"
+
+if [ -z "$MAIN_PRIVATE_KEY" ] || [ -z "$STACKS_NODE_URL" ] || [ -z "$NUM_TXS" ]; then 
+   usage
+fi
+
+set -uo pipefail
+
+function log() {
+   printf "%s" "$1" >&2
+}
+
+function logln() {
+   printf "%s\n" "$1" >&2
+}
+
+make_token_transfer() {
+   local PRIVKEY="$1"
+   local NONCE="$2"
+   local DEST="$3"
+   local AMOUNT="$4"
+   local MEMO="load test $NONCE"
+   local TX="$(blockstack-cli --testnet token-transfer "$PRIVKEY" "$FEE_RATE" "$NONCE" "$DEST" "$AMOUNT" "$MEMO" 2>&1)"
+   local RC=$?
+   if [ $RC -ne 0 ]; then 
+      logln "Failed to generate tx: blockstack-cli --testnet token-transfer $PRIVKEY $FEE_RATE $NONCE $DEST $AMOUNT \"$MEMO\""
+      return 1
+   fi
+
+   printf "$TX"
+   return 0
+}
+
+send_tx() {
+   local STACKS_NODE_URL="$1"
+
+   read TX
+   TXID="$(printf "$TX" | \
+      xxd -r -p | \
+      curl -s -X POST --data-binary @- -w "%{http_code}" -o >(cat >&3) -H "content-type: application/octet-stream" "$STACKS_NODE_URL"/v2/transactions 2>&1 | ( \
+        read HTTP_CODE
+        read BODY
+        if [ $HTTP_CODE -ne 200 ]; then 
+           logln "Failed to send to node $STACKS_NODE_URL: server replied $HTTP_CODE. Tx was $TX"
+           logln "Error text: $BODY"
+           return 1
+        fi
+        echo "$BODY"
+   ))"
+
+   local RC=$?
+   if [ $RC -ne 0 ]; then 
+      return 1
+   fi
+
+   echo "$TXID"
+   return 0
+}
+
+get_chain_tip() {
+   local STACKS_NODE_URL="$1"
+   local TIP="$(curl -sf "$STACKS_NODE_URL"/v2/info | jq -r '.stacks_tip' 2>&1)"
+   local RC=$?
+
+   if [ $RC -ne 0 ]; then 
+      logln "Failed to query chain tip on node $STACKS_NODE_URL: curl exited with code $RC"
+      return 1
+   fi
+
+   echo "$TIP"
+   return 0
+}
+
+get_account_nonce() {
+   local STACKS_NODE_URL="$1"
+   local ADDR="$2"
+   local NONCE="$(curl -sf "$STACKS_NODE_URL"/v2/accounts/"$ADDR""?proof=0" | jq -r '.nonce')"
+   local RC=$?
+
+   if [ $RC -ne 0 ]; then 
+      logln "Failed to query account $ADDR on node $STACKS_NODE_URL: curl exited with code $RC"
+      return 1
+   fi
+
+   echo "$NONCE"
+   return 0
+}
+
+wait_for_new_stacks_block() {
+   local TIP="$1"
+   local STACKS_NODE_URL="$2"
+   while true; do 
+       local CUR_TIP="$(get_chain_tip "$STACKS_NODE_URL")"
+       local RC=$?
+       if [ $RC -ne 0 ]; then 
+          return 1
+       fi
+
+       if [[ "$CUR_TIP" != "$TIP" ]]; then
+          echo "$CUR_TIP"
+          return 0
+       fi
+       
+       sleep 5
+    done
+}
+
+wait_for_confirmations() {
+   local CONFS=$1
+   local STACKS_NODE_URL="$2"
+   local TIP="$(get_chain_tip "$STACKS_NODE_URL")"
+
+   local CONF=0
+   for CONF in $(seq 0 $CONFS); do
+      TIP="$(wait_for_new_stacks_block "$TIP" "$STACKS_NODE_URL")"
+      RC=$?
+
+      if [ $RC -ne 0 ]; then 
+         return 1
+      fi
+   done
+
+   echo "$TIP"
+   return 0
+}
+
+fund_keys() {
+   local MAIN_PRIVKEY="$1"
+   local AMOUNT="$2"
+   local STACKS_NODE_URL="$3"
+
+   local MAIN_ADDR="$(blockstack-cli --testnet addresses "$MAIN_PRIVKEY" | jq -r '.STX')"
+   local RC=$?
+   if [ $RC -ne 0 ]; then 
+      logln "Failed to generate address for \"$MAIN_PRIVKEY\""
+      return 1
+   fi
+
+   local MAIN_NONCE="$(get_account_nonce "$STACKS_NODE_URL" "$MAIN_ADDR")"
+   RC=$?
+   if [ $RC -ne 0 ]; then 
+      return 1
+   fi
+
+   local NEXT_PRIVKEY=""
+   local CHAIN_TIP="$(get_chain_tip "$STACKS_NODE_URL")"
+   local TX_COUNT=0
+
+   while read NEXT_PRIVKEY; do
+      local ADDR="$(blockstack-cli --testnet addresses "$NEXT_PRIVKEY" | jq -r '.STX')"
+      RC=$?
+
+      if [ $RC -ne 0 ]; then 
+         logln "Failed to generate address for \"$NEXT_PRIVKEY\""
+         return 1
+      fi
+
+      log "Funding $NEXT_PRIVKEY ($ADDR) with $AMOUNT uSTX as tx #$MAIN_NONCE..."
+      TXID="$(make_token_transfer "$MAIN_PRIVKEY" "$MAIN_NONCE" "$ADDR" "$AMOUNT" | send_tx "$STACKS_NODE_URL")"
+      RC=$?
+
+      if [ $RC -ne 0 ]; then 
+         logln "FAILED!"
+         logln "Failed to send fund-load token-transfer to $NEXT_PRIVKEY ($ADDR)"
+         return 1
+      fi
+      logln " ok"
+      echo "$NEXT_PRIVKEY"
+
+      MAIN_NONCE=$((MAIN_NONCE + 1))
+      TX_COUNT=$((TX_COUNT + 1))
+      if (( $TX_COUNT >= $MAX_CHAINING )); then 
+         while true; do
+            log "Wait for at least $CONFIRMATIONS new Stacks blocks after $CHAIN_TIP..."
+            CHAIN_TIP="$(wait_for_confirmations $CONFIRMATIONS "$STACKS_NODE_URL")"
+            RC=$?
+
+            if [ $RC -ne 0 ]; then 
+               logln "FAILED"
+               return 1
+            fi
+            logln "ok"
+
+            TX_COUNT=0
+
+            # wait for blockchain to catch up with us
+            local CUR_NONCE="$(get_account_nonce "$STACKS_NODE_URL" "$MAIN_ADDR")"
+            if [ $RC -ne 0 ]; then 
+               return 1
+            fi
+            if (( $CUR_NONCE >= $MAIN_NONCE )); then
+               MAIN_NONCE=$CUR_NONCE
+               break
+            else
+               logln "Current nonce of fund key is $CUR_NONCE; need to wait until it is $MAIN_NONCE"
+            fi
+         done
+      fi
+   done
+
+   return 0
+}
+
+get_addrs_and_nonces() {
+   local NEXT_PRIVKEY=""
+   local STACKS_NODE_URL="$1" 
+   while read NEXT_PRIVKEY; do
+      local ADDR="$(blockstack-cli --testnet addresses "$NEXT_PRIVKEY" | jq -r '.STX')"
+      RC=$?
+
+      if [ $RC -ne 0 ]; then 
+         logln "Failed to generate address for \"$NEXT_PRIVKEY\""
+         return 1
+      fi
+
+      NONCE="$(get_account_nonce "$STACKS_NODE_URL" "$ADDR")"
+      if [ $RC -ne 0 ]; then 
+         return 1
+      fi
+
+      echo "$NEXT_PRIVKEY $ADDR $NONCE"
+   done
+
+   return 0
+}
+
+tx_load() {
+   local DEST="$1"
+   local AMOUNT="$2"
+   local STACKS_NODE_URL="$3"
+
+   local NEXT_PRIVKEY=""
+   local RC=0
+   local NONCE=0
+
+   while read NEXT_PRIVKEY_ADDR_NONCE; do
+      set -- $NEXT_PRIVKEY_ADDR_NONCE
+      NEXT_PRIVKEY="$1"
+      ADDR="$2"
+      NONCE="$3"
+
+      log "Send $AMOUNT uSTX from $NEXT_PRIVKEY ($ADDR) to $DEST as tx #$NONCE..."
+      TXID="$(make_token_transfer "$NEXT_PRIVKEY" "$NONCE" "$DEST" "$AMOUNT" | send_tx "$STACKS_NODE_URL")"
+      RC=$?
+
+      if [ $RC -ne 0 ]; then 
+         logln "FAILED!"
+         logln "Failed to send tx-load token-transfer from $NEXT_PRIVKEY ($ADDR) to $DEST"
+         return 1
+      fi
+      logln " ok"
+   done
+
+   return 0
+}
+
+generate_keys() {
+   local NUM_KEYS="$1"
+   local CNT=0
+   for CNT in $(seq 1 $NUM_KEYS); do
+      local PRIVKEY="$(blockstack-cli --testnet generate-sk | jq -r '.secretKey')"
+      RC=$?
+
+      if [ $RC -ne 0 ]; then 
+         logln "Failed to generate private key"
+         return 1
+      fi
+
+      echo "$PRIVKEY"
+   done
+   return 0
+}
+
+DEST_ADDR="$(blockstack-cli --testnet generate-sk | jq -r '.secretKey,.stacksAddress' | ( \
+   read DEST_PRIVKEY
+   read DEST_ADDR
+   logln "Destination private key: $DEST_PRIVKEY ($DEST_ADDR)"
+   echo "$DEST_ADDR"
+))"
+
+AMOUNT=1
+
+generate_keys "$NUM_TXS" | \
+   fund_keys "$MAIN_PRIVATE_KEY" "$((AMOUNT + FEE_RATE))" "$STACKS_NODE_URL" \
+   > /tmp/tx-load.keys
+
+logln "Waiting for $CONFIRMATIONS confirmations before beginning"
+TIP="$(wait_for_confirmations $CONFIRMATIONS "$STACKS_NODE_URL")"
+RC=$?
+
+if [ $RC -ne 0 ]; then 
+    logln "FAILED"
+    exit 1
+fi
+
+cat /tmp/tx-load.keys | \
+   get_addrs_and_nonces "$STACKS_NODE_URL" | \
+   tx_load "$DEST_ADDR" "$AMOUNT" "$STACKS_NODE_URL"
+
+exit $?

--- a/net-test/bin/txload.sh
+++ b/net-test/bin/txload.sh
@@ -4,13 +4,21 @@ FEE_RATE=300
 MAX_CHAINING=5
 CONFIRMATIONS=1
 
-# grab fd 3 for curl
-exec 3>&1
-
 exit_error() {
    printf "$1"
    exit 1
 }
+
+for CMD in cut grep egrep sed blockstack-cli curl; do
+   which "$CMD" >/dev/null 2>&1 || exit_error "Missing command $CMD"
+done
+
+if [ $(echo ${BASH_VERSION} | cut -d '.' -f 1) -lt 4 ]; then
+   exit_error "This script requires Bash 4.x or higher"
+fi
+
+# grab fd 3 for curl
+exec 3>&1
 
 usage() {
    exit_error "$0 <private-key-hex> <stacks-url> <num-txs>\n"

--- a/net-test/etc/bitcoin-neon-controller.toml.in
+++ b/net-test/etc/bitcoin-neon-controller.toml.in
@@ -1,0 +1,30 @@
+[neon]
+rpc_bind = "0.0.0.0:28443"
+block_time = 30000
+miner_address = "mmNe3BjtYa8ZWtpQxfpsE8aWKgHh77LYTT"
+faucet_address = "n3k15aVS4rEWhVYn4YfAFjD8Em5mmsducg"
+bitcoind_rpc_host = "127.0.0.1:18443"
+bitcoind_rpc_user = "blockstack"
+bitcoind_rpc_pass = "blockstacksystem"
+genesis_timestamp = @@BITCOIN_NEON_CONTROLLER_GENESIS_TIMESTAMP@@
+whitelisted_rpc_calls = [
+    "listunspent",
+    "importaddress",
+    "sendrawtransaction",
+    "getrawtransaction",
+    "scantxoutset",
+    "getrawmempool",
+]
+
+# Faucet:
+# Private Key          b20fea233f7718d956d2c5ed71889836ec872fec7d1de2068f19f40faf297f3001
+# Public Key           02327e09dc18fee1d51fe2b19b487e01eba4e6adcb325bf102213fce7bbdcde6bd
+# Address              n3k15aVS4rEWhVYn4YfAFjD8Em5mmsducg
+# Format               p2pkh
+# Network              testnet
+# Compressed           true
+
+# NOTE: the miner_address is the address of the Stacks master node's mining private key ("seed")
+
+# NOTE: the following lines are meant to be grep'ed by the node runner:
+# WIF cTYqAVPS7uJTAcxyzkXWjmRGoCjkPcb38wZVRjyXov1RiRDWPQj3

--- a/net-test/etc/bitcoin.conf.in
+++ b/net-test/etc/bitcoin.conf.in
@@ -1,0 +1,15 @@
+server=1
+regtest=1
+rpcallowip=0.0.0.0/0
+rpcallowip=::/0
+rpcuser=blockstack
+rpcpassword=blockstacksystem
+txindex=1
+listen=1
+debug=1
+rpcserialversion=0
+datadir=@@BITCOIN_DATA_DIR@@
+
+[regtest]
+bind=0.0.0.0:18444
+rpcbind=0.0.0.0:18443

--- a/net-test/etc/stacks-follower.toml.in
+++ b/net-test/etc/stacks-follower.toml.in
@@ -1,0 +1,30 @@
+[node]
+rpc_bind = "0.0.0.0:20443"
+p2p_bind = "0.0.0.0:20444"
+bootstrap_node = "04ee0b1602eb18fef7986887a7e8769a30c9df981d33c8380d255edef003abdcd243a0eb74afdf6740e6c423e62aec631519a24cf5b1d62bf8a3e06ddc695dcb77@@@STACKS_MASTER_IP:20444@@"
+working_dir = "@@STACKS_CHAINSTATE_DIR@@"
+
+[burnchain]
+chain = "bitcoin"
+mode = "krypton"
+peer_host = "@@BITCOIN_IP@@"
+rpc_port = 28443
+peer_port = 18444
+
+[[mstx_balance]]
+# Private key: b8d99fd45da58038d630d9855d3ca2466e8e0f89d3894c4724f0efc9ff4b51f001
+address = "ST2ZRX0K27GW0SP3GJCEMHD95TQGJMKB7G9Y0X1MH"
+amount = 10000000000000000
+[[mstx_balance]]
+# Private key: 3a4e84abb8abe0c1ba37cef4b604e73c82b1fe8d99015cb36b029a65099d373601
+address = "ST26FVX16539KKXZKJN098Q08HRX3XBAP541MFS0P"
+amount = 10000000000000000
+[[mstx_balance]]
+# Private key: 052cc5b8f25b1e44a65329244066f76c8057accd5316c889f476d0ea0329632c01
+address = "ST3CECAKJ4BH08JYY7W53MC81BYDT4YDA5M7S5F53"
+amount = 10000000000000000
+[[mstx_balance]]
+# Private key: 9aef533e754663a453984b69d36f109be817e9940519cc84979419e2be00864801
+address = "ST31HHVBKYCYQQJ5AQ25ZHA6W2A548ZADDQ6S16GP"
+amount = 10000000000000000
+

--- a/net-test/etc/stacks-master.toml.in
+++ b/net-test/etc/stacks-master.toml.in
@@ -1,0 +1,35 @@
+[node]
+rpc_bind = "0.0.0.0:20443"
+p2p_bind = "0.0.0.0:20444"
+seed = "bbd40688849e9d0f3bc3132a576835df11bb84b307a5a0588d8fecc4d6ba32d201"
+miner = true
+working_dir = "@@STACKS_CHAINSTATE_DIR@@"
+pox_sync_sample_secs = 10
+wait_time_for_microblocks = 0
+p2p_address = "@@STACKS_PUBLIC_IP@@:20444"
+
+[burnchain]
+chain = "bitcoin"
+mode = "krypton"
+peer_host = "0.0.0.0"
+rpc_port = 28443
+peer_port = 18444
+poll_time_secs = 5
+
+[[mstx_balance]]
+# Private key: b8d99fd45da58038d630d9855d3ca2466e8e0f89d3894c4724f0efc9ff4b51f001
+address = "ST2ZRX0K27GW0SP3GJCEMHD95TQGJMKB7G9Y0X1MH"
+amount = 10000000000000000
+[[mstx_balance]]
+# Private key: 3a4e84abb8abe0c1ba37cef4b604e73c82b1fe8d99015cb36b029a65099d373601
+address = "ST26FVX16539KKXZKJN098Q08HRX3XBAP541MFS0P"
+amount = 10000000000000000
+[[mstx_balance]]
+# Private key: 052cc5b8f25b1e44a65329244066f76c8057accd5316c889f476d0ea0329632c01
+address = "ST3CECAKJ4BH08JYY7W53MC81BYDT4YDA5M7S5F53"
+amount = 10000000000000000
+[[mstx_balance]]
+# Private key: 9aef533e754663a453984b69d36f109be817e9940519cc84979419e2be00864801
+address = "ST31HHVBKYCYQQJ5AQ25ZHA6W2A548ZADDQ6S16GP"
+amount = 10000000000000000
+

--- a/net-test/etc/stacks-miner.toml.in
+++ b/net-test/etc/stacks-miner.toml.in
@@ -2,7 +2,6 @@
 rpc_bind = "0.0.0.0:21443"
 p2p_bind = "0.0.0.0:21444"
 bootstrap_node = "04ee0b1602eb18fef7986887a7e8769a30c9df981d33c8380d255edef003abdcd243a0eb74afdf6740e6c423e62aec631519a24cf5b1d62bf8a3e06ddc695dcb77@@@STACKS_MASTER_IP@@:20444"
-# bootstrap_node = "03ee0b1602eb18fef7986887a7e8769a30c9df981d33c8380d255edef003abdcd2@@@STACKS_MASTER_IP@@:20444"
 seed = "@@STACKS_MINER_SEED@@"
 miner = true
 working_dir = "@@STACKS_CHAINSTATE_DIR@@"

--- a/net-test/etc/stacks-miner.toml.in
+++ b/net-test/etc/stacks-miner.toml.in
@@ -1,0 +1,36 @@
+[node]
+rpc_bind = "0.0.0.0:21443"
+p2p_bind = "0.0.0.0:21444"
+bootstrap_node = "04ee0b1602eb18fef7986887a7e8769a30c9df981d33c8380d255edef003abdcd243a0eb74afdf6740e6c423e62aec631519a24cf5b1d62bf8a3e06ddc695dcb77@@@STACKS_MASTER_IP@@:20444"
+# bootstrap_node = "03ee0b1602eb18fef7986887a7e8769a30c9df981d33c8380d255edef003abdcd2@@@STACKS_MASTER_IP@@:20444"
+seed = "@@STACKS_MINER_SEED@@"
+miner = true
+working_dir = "@@STACKS_CHAINSTATE_DIR@@"
+pox_sync_sample_secs = 10
+wait_time_for_microblocks = 0
+
+[burnchain]
+chain = "bitcoin"
+mode = "krypton"
+peer_host = "@@BITCOIN_IP@@"
+rpc_port = 28443
+peer_port = 18444
+poll_time_secs = 5
+
+[[mstx_balance]]
+# Private key: b8d99fd45da58038d630d9855d3ca2466e8e0f89d3894c4724f0efc9ff4b51f001
+address = "ST2ZRX0K27GW0SP3GJCEMHD95TQGJMKB7G9Y0X1MH"
+amount = 10000000000000000
+[[mstx_balance]]
+# Private key: 3a4e84abb8abe0c1ba37cef4b604e73c82b1fe8d99015cb36b029a65099d373601
+address = "ST26FVX16539KKXZKJN098Q08HRX3XBAP541MFS0P"
+amount = 10000000000000000
+[[mstx_balance]]
+# Private key: 052cc5b8f25b1e44a65329244066f76c8057accd5316c889f476d0ea0329632c01
+address = "ST3CECAKJ4BH08JYY7W53MC81BYDT4YDA5M7S5F53"
+amount = 10000000000000000
+[[mstx_balance]]
+# Private key: 9aef533e754663a453984b69d36f109be817e9940519cc84979419e2be00864801
+address = "ST31HHVBKYCYQQJ5AQ25ZHA6W2A548ZADDQ6S16GP"
+amount = 10000000000000000
+

--- a/net-test/mnt/cleanup.sh
+++ b/net-test/mnt/cleanup.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+mkdir -p archive
+mv bitcoin-1* stacks-chainstate-* archive

--- a/src/blockstack_cli.rs
+++ b/src/blockstack_cli.rs
@@ -43,7 +43,9 @@ use std::io::Read;
 use std::{env, fs, io};
 
 use blockstack_lib::address::b58;
-use blockstack_lib::burnchains::bitcoin::address::{ADDRESS_VERSION_MAINNET_SINGLESIG, ADDRESS_VERSION_TESTNET_SINGLESIG};
+use blockstack_lib::burnchains::bitcoin::address::{
+    ADDRESS_VERSION_MAINNET_SINGLESIG, ADDRESS_VERSION_TESTNET_SINGLESIG,
+};
 
 const TESTNET_CHAIN_ID: u32 = 0x80000000;
 const MAINNET_CHAIN_ID: u32 = 0x00000001;
@@ -482,20 +484,19 @@ fn get_addresses(args: &[String], version: TransactionVersion) -> Result<String,
         return Err(CliError::Message(format!("USAGE:\n {}", ADDRESSES_USAGE)));
     }
 
-    let sk = StacksPrivateKey::from_hex(&args[0])
-        .expect("Failed to load private key");
+    let sk = StacksPrivateKey::from_hex(&args[0]).expect("Failed to load private key");
 
     let pk = StacksPublicKey::from_private(&sk);
     let c32_version = match version {
         TransactionVersion::Mainnet => C32_ADDRESS_VERSION_MAINNET_SINGLESIG,
         TransactionVersion::Testnet => C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
     };
-    
+
     let b58_version = match version {
         TransactionVersion::Mainnet => ADDRESS_VERSION_MAINNET_SINGLESIG,
-        TransactionVersion::Testnet => ADDRESS_VERSION_TESTNET_SINGLESIG
+        TransactionVersion::Testnet => ADDRESS_VERSION_TESTNET_SINGLESIG,
     };
-    
+
     let stx_address = StacksAddress::from_public_keys(
         c32_version,
         &AddressHashMode::SerializeP2PKH,
@@ -503,7 +504,7 @@ fn get_addresses(args: &[String], version: TransactionVersion) -> Result<String,
         &vec![pk.clone()],
     )
     .expect("Failed to generate address from public key");
-    
+
     let mut b58_addr_slice = [0u8; 21];
     b58_addr_slice[0] = b58_version;
     b58_addr_slice[1..].copy_from_slice(&stx_address.bytes.0);
@@ -513,8 +514,7 @@ fn get_addresses(args: &[String], version: TransactionVersion) -> Result<String,
     \"STX\": \"{}\",
     \"BTC\": \"{}\"
 }}",
-    &stx_address,
-    &b58_address_string
+        &stx_address, &b58_address_string
     ))
 }
 
@@ -813,7 +813,7 @@ mod test {
     fn simple_addresses() {
         let addr_args = [
             "addresses",
-            "2945c6be8758994652a498f0445d534d0fadb0b2025b37c72297b059ebf887ed01"
+            "2945c6be8758994652a498f0445d534d0fadb0b2025b37c72297b059ebf887ed01",
         ];
 
         let result = main_handler(to_string_vec(&addr_args)).unwrap();
@@ -823,7 +823,7 @@ mod test {
         let addr_args = [
             "--testnet",
             "addresses",
-            "2945c6be8758994652a498f0445d534d0fadb0b2025b37c72297b059ebf887ed01"
+            "2945c6be8758994652a498f0445d534d0fadb0b2025b37c72297b059ebf887ed01",
         ];
 
         let result = main_handler(to_string_vec(&addr_args)).unwrap();

--- a/src/blockstack_cli.rs
+++ b/src/blockstack_cli.rs
@@ -24,13 +24,13 @@ extern crate blockstack_lib;
 use blockstack_lib::address::AddressHashMode;
 use blockstack_lib::burnchains::Address;
 use blockstack_lib::chainstate::stacks::{
-    StacksAddress, StacksPrivateKey, StacksPublicKey, StacksTransaction, StacksTransactionSigner,
+    StacksAddress, StacksBlock, StacksPrivateKey, StacksPublicKey, StacksTransaction, StacksTransactionSigner,
     TokenTransferMemo, TransactionAuth, TransactionContractCall, TransactionPayload,
     TransactionSmartContract, TransactionSpendingCondition, TransactionVersion,
     C32_ADDRESS_VERSION_MAINNET_SINGLESIG, C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
 };
 use blockstack_lib::net::{Error as NetError, StacksMessageCodec};
-use blockstack_lib::util::{hash::hex_bytes, hash::to_hex, log, strings::StacksString};
+use blockstack_lib::util::{hash::hex_bytes, hash::to_hex, log, strings::StacksString, retry::LogReader};
 use blockstack_lib::vm;
 use blockstack_lib::vm::{
     errors::{Error as ClarityError, RuntimeErrorType},
@@ -115,6 +115,18 @@ const ADDRESSES_USAGE: &str = "blockstack-cli (options) addresses [secret-key-he
 The addresses command calculates both the Bitcoin and Stacks addresses from a secret key.
 If successful, this command outputs both the Bitcoin and Stacks addresses to stdout, formatted
 as JSON, and exits with code 0";
+
+const DECODE_TRANSACTION_USAGE: &str = "blockstack-cli (options) decode-tx [transaction-hex-or-stdin]
+
+The decode-tx command decodes a serialized Stacks transaction and prints it to stdout as JSON.
+The transaction, if given, must be a hex string.  Alternatively, you may pass - instead, and the
+raw binary transaction will be read from stdin";
+
+const DECODE_BLOCK_USAGE: &str = "blockstack-cli (options) decode-block [block-path-or-stdin]
+
+The decode-tx command decodes a serialized Stacks block and prints it to stdout as JSON.
+The block, if given, must be a hex string.  Alternatively, you may pass - instead, and the
+raw binary block will be read from stdin";
 
 #[derive(Debug)]
 enum CliError {
@@ -518,6 +530,81 @@ fn get_addresses(args: &[String], version: TransactionVersion) -> Result<String,
     ))
 }
 
+fn decode_transaction(args: &[String], _version: TransactionVersion) -> Result<String, CliError> {
+    if (args.len() >= 1 && args[0] == "-h") || args.len() != 1 {
+        return Err(CliError::Message(format!("Usage: {}\n", DECODE_TRANSACTION_USAGE)));
+    }
+
+    let tx_str =
+        if args[0] == "-" {
+            // read from stdin
+            let mut tx_str = Vec::new();
+            io::stdin().read_to_end(&mut tx_str).expect("Failed to read transaction from stdin");
+            tx_str
+        }
+        else {
+            // given as a command-line arg
+            hex_bytes(&args[0].clone())
+                .expect("Failed to decode transaction: must be a hex string")
+        };
+
+    let mut cursor = io::Cursor::new(&tx_str);
+    let mut debug_cursor = LogReader::from_reader(&mut cursor);
+
+    match StacksTransaction::consensus_deserialize(&mut debug_cursor) {
+        Ok(tx) => {
+            Ok(serde_json::to_string(&tx).expect("Failed to serialize transaction to JSON"))
+        },
+        Err(e) => {
+            let mut ret = String::new();
+            ret.push_str(&format!("Failed to decode transaction: {:?}\n", &e));
+            ret.push_str("Bytes consumed:\n");
+            for buf in debug_cursor.log().iter() {
+                ret.push_str(&format!("   {}", to_hex(buf)));
+            }
+            ret.push_str("\n");
+            Ok(ret)
+        }
+    }
+}
+
+fn decode_block(args: &[String], _version: TransactionVersion) -> Result<String, CliError> {
+    if (args.len() >= 1 && args[0] == "-h") || args.len() != 1 {
+        return Err(CliError::Message(format!("Usage: {}\n", DECODE_BLOCK_USAGE)));
+    }
+    let block_data =
+        if args[0] == "-" {
+            // read from stdin
+            let mut block_str = Vec::new();
+            io::stdin().read_to_end(&mut block_str).expect("Failed to read block from stdin");
+            block_str
+        }
+        else {
+            // given as a command-line arg
+            hex_bytes(&args[0].clone())
+                .expect("Failed to decode block: must be a hex string")
+        };
+
+    let mut cursor = io::Cursor::new(&block_data);
+    let mut debug_cursor = LogReader::from_reader(&mut cursor);
+
+    match StacksBlock::consensus_deserialize(&mut debug_cursor) {
+        Ok(block) => {
+            Ok(serde_json::to_string(&block).expect("Failed to serialize block to JSON"))
+        },
+        Err(e) => {
+            let mut ret = String::new();
+            ret.push_str(&format!("Failed to decode block: {:?}\n", &e));
+            ret.push_str("Bytes consumed:\n");
+            for buf in debug_cursor.log().iter() {
+                ret.push_str(&format!("   {}", to_hex(buf)));
+            }
+            ret.push_str("\n");
+            Ok(ret)
+        }
+    }
+}
+
 fn main() {
     log::set_loglevel(log::LOG_DEBUG).unwrap();
     let mut argv: Vec<String> = env::args().collect();
@@ -556,6 +643,8 @@ fn main_handler(mut argv: Vec<String>) -> Result<String, CliError> {
             "token-transfer" => handle_token_transfer(args, tx_version, chain_id),
             "generate-sk" => generate_secret_key(args, tx_version),
             "addresses" => get_addresses(args, tx_version),
+            "decode-tx" => decode_transaction(args, tx_version),
+            "decode-block" => decode_block(args, tx_version),
             _ => Err(CliError::Usage),
         }
     } else {
@@ -829,5 +918,27 @@ mod test {
         let result = main_handler(to_string_vec(&addr_args)).unwrap();
         assert!(result.contains("mzGHS7KN25DEtXipGxjo1tFebb7Fw5aAkp"));
         assert!(result.contains("ST36T883PDD2EK4PHVTA5GFHC8NQW6558XJQX6Q3K"));
+    }
+
+    #[test]
+    fn simple_decode_tx() {
+        let tx_args = [
+            "decode-tx",
+            "8080000000040021a3c334fc0ee50359353799e8b2605ac6be1fe4000000000000000100000000000000000100c90ae0235365f3a73c595f8c6ab3c529807feb3cb269247329c9a24218d50d3f34c7eef5d28ba26831affa652a73ec32f098fec4bf1decd1ceb3fde4b8ce216b030200000000021a21a3c334fc0ee50359353799e8b2605ac6be1fe40573746f7265096765742d76616c7565000000010d00000003666f6f"
+        ];
+
+        let result = main_handler(to_string_vec(&tx_args)).unwrap();
+        eprintln!("result:\n{}", result);
+    }
+
+    #[test]
+    fn simple_decode_block() {
+        let block_args = [
+            "decode-block",
+            "000000000000395f800000000000000179cb51f6bbd6d90cb257616e77a495919667c3772dd08ea7c4f5c372739490bc91da6609c5c95c96f612dbc8cab2f7a0d8bfb83abdb630167579ccc36b66c03c1d0d250cd3b3615c03afcdaef313dbd30d3d5b0fd10ed5acbc35d042abfba66cdfc32881c5a665ad9685a2eb6e0c131fb400000000000000000000000000000000000000000000000000000000000000000000e87f28593f66d77ae3c57abd4e5ae0e632b837b2596be14c2b2572cd4d0015229976eb5c4a5b08816b31f485513d2e6501f6cd29ee240a2c4056b1f7cc32c2e118ef6499e0fcc575da75fca8cc409e5c884eb3450000000180800000000400403e2ff80a8a8ecacfb827dcf6adddd21fdd4c3c000000000000017800000000000000000000f3f497268f8a12e318f96ba4f1ad3ed2485e87cefe75b88bf735bb1bbb7db754746e6a244ba869183a2ab73002c6465936b7d9b059ffc5a94488bee7b5afb33c010200000000040000000000000000000000000000000000000000000000000000000000000000",
+        ];
+
+        let result = main_handler(to_string_vec(&block_args)).unwrap();
+        eprintln!("result:\n{}", result);
     }
 }

--- a/src/blockstack_cli.rs
+++ b/src/blockstack_cli.rs
@@ -24,13 +24,15 @@ extern crate blockstack_lib;
 use blockstack_lib::address::AddressHashMode;
 use blockstack_lib::burnchains::Address;
 use blockstack_lib::chainstate::stacks::{
-    StacksAddress, StacksBlock, StacksPrivateKey, StacksPublicKey, StacksTransaction, StacksTransactionSigner,
-    TokenTransferMemo, TransactionAuth, TransactionContractCall, TransactionPayload,
-    TransactionSmartContract, TransactionSpendingCondition, TransactionVersion,
+    StacksAddress, StacksBlock, StacksPrivateKey, StacksPublicKey, StacksTransaction,
+    StacksTransactionSigner, TokenTransferMemo, TransactionAuth, TransactionContractCall,
+    TransactionPayload, TransactionSmartContract, TransactionSpendingCondition, TransactionVersion,
     C32_ADDRESS_VERSION_MAINNET_SINGLESIG, C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
 };
 use blockstack_lib::net::{Error as NetError, StacksMessageCodec};
-use blockstack_lib::util::{hash::hex_bytes, hash::to_hex, log, strings::StacksString, retry::LogReader};
+use blockstack_lib::util::{
+    hash::hex_bytes, hash::to_hex, log, retry::LogReader, strings::StacksString,
+};
 use blockstack_lib::vm;
 use blockstack_lib::vm::{
     errors::{Error as ClarityError, RuntimeErrorType},
@@ -116,7 +118,8 @@ The addresses command calculates both the Bitcoin and Stacks addresses from a se
 If successful, this command outputs both the Bitcoin and Stacks addresses to stdout, formatted
 as JSON, and exits with code 0";
 
-const DECODE_TRANSACTION_USAGE: &str = "blockstack-cli (options) decode-tx [transaction-hex-or-stdin]
+const DECODE_TRANSACTION_USAGE: &str =
+    "blockstack-cli (options) decode-tx [transaction-hex-or-stdin]
 
 The decode-tx command decodes a serialized Stacks transaction and prints it to stdout as JSON.
 The transaction, if given, must be a hex string.  Alternatively, you may pass - instead, and the
@@ -532,29 +535,29 @@ fn get_addresses(args: &[String], version: TransactionVersion) -> Result<String,
 
 fn decode_transaction(args: &[String], _version: TransactionVersion) -> Result<String, CliError> {
     if (args.len() >= 1 && args[0] == "-h") || args.len() != 1 {
-        return Err(CliError::Message(format!("Usage: {}\n", DECODE_TRANSACTION_USAGE)));
+        return Err(CliError::Message(format!(
+            "Usage: {}\n",
+            DECODE_TRANSACTION_USAGE
+        )));
     }
 
-    let tx_str =
-        if args[0] == "-" {
-            // read from stdin
-            let mut tx_str = Vec::new();
-            io::stdin().read_to_end(&mut tx_str).expect("Failed to read transaction from stdin");
-            tx_str
-        }
-        else {
-            // given as a command-line arg
-            hex_bytes(&args[0].clone())
-                .expect("Failed to decode transaction: must be a hex string")
-        };
+    let tx_str = if args[0] == "-" {
+        // read from stdin
+        let mut tx_str = Vec::new();
+        io::stdin()
+            .read_to_end(&mut tx_str)
+            .expect("Failed to read transaction from stdin");
+        tx_str
+    } else {
+        // given as a command-line arg
+        hex_bytes(&args[0].clone()).expect("Failed to decode transaction: must be a hex string")
+    };
 
     let mut cursor = io::Cursor::new(&tx_str);
     let mut debug_cursor = LogReader::from_reader(&mut cursor);
 
     match StacksTransaction::consensus_deserialize(&mut debug_cursor) {
-        Ok(tx) => {
-            Ok(serde_json::to_string(&tx).expect("Failed to serialize transaction to JSON"))
-        },
+        Ok(tx) => Ok(serde_json::to_string(&tx).expect("Failed to serialize transaction to JSON")),
         Err(e) => {
             let mut ret = String::new();
             ret.push_str(&format!("Failed to decode transaction: {:?}\n", &e));
@@ -570,28 +573,28 @@ fn decode_transaction(args: &[String], _version: TransactionVersion) -> Result<S
 
 fn decode_block(args: &[String], _version: TransactionVersion) -> Result<String, CliError> {
     if (args.len() >= 1 && args[0] == "-h") || args.len() != 1 {
-        return Err(CliError::Message(format!("Usage: {}\n", DECODE_BLOCK_USAGE)));
+        return Err(CliError::Message(format!(
+            "Usage: {}\n",
+            DECODE_BLOCK_USAGE
+        )));
     }
-    let block_data =
-        if args[0] == "-" {
-            // read from stdin
-            let mut block_str = Vec::new();
-            io::stdin().read_to_end(&mut block_str).expect("Failed to read block from stdin");
-            block_str
-        }
-        else {
-            // given as a command-line arg
-            hex_bytes(&args[0].clone())
-                .expect("Failed to decode block: must be a hex string")
-        };
+    let block_data = if args[0] == "-" {
+        // read from stdin
+        let mut block_str = Vec::new();
+        io::stdin()
+            .read_to_end(&mut block_str)
+            .expect("Failed to read block from stdin");
+        block_str
+    } else {
+        // given as a command-line arg
+        hex_bytes(&args[0].clone()).expect("Failed to decode block: must be a hex string")
+    };
 
     let mut cursor = io::Cursor::new(&block_data);
     let mut debug_cursor = LogReader::from_reader(&mut cursor);
 
     match StacksBlock::consensus_deserialize(&mut debug_cursor) {
-        Ok(block) => {
-            Ok(serde_json::to_string(&block).expect("Failed to serialize block to JSON"))
-        },
+        Ok(block) => Ok(serde_json::to_string(&block).expect("Failed to serialize block to JSON")),
         Err(e) => {
             let mut ret = String::new();
             ret.push_str(&format!("Failed to decode block: {:?}\n", &e));

--- a/src/chainstate/stacks/block.rs
+++ b/src/chainstate/stacks/block.rs
@@ -1287,7 +1287,7 @@ mod test {
         };
 
         let pubk = StacksPublicKey::from_private(&privk);
-        let pubkh = Hash160::from_node_public_key(&pubk.to_bytes());
+        let pubkh = Hash160::from_node_public_key(&pubk);
 
         mblock_header.sign(&privk).unwrap();
         mblock_header.verify(&pubkh).unwrap();

--- a/src/chainstate/stacks/block.rs
+++ b/src/chainstate/stacks/block.rs
@@ -722,8 +722,6 @@ impl StacksMicroblockHeader {
                 )
             })?;
 
-        debug!("Recovered {:?} from {:?}", &pubk.to_hex(), &self.signature);
-
         pubk.set_compressed(true);
         Ok(StacksBlockHeader::pubkey_hash(&pubk))
     }
@@ -737,7 +735,7 @@ impl StacksMicroblockHeader {
                 &pubkh.to_hex()
             );
             return Err(net_error::VerifyingError(format!(
-                "Failed to verify signature: public key not recover to expected hash {}",
+                "Failed to verify signature: public key did not recover to expected hash {}",
                 pubkh.to_hex()
             )));
         }

--- a/src/chainstate/stacks/block.rs
+++ b/src/chainstate/stacks/block.rs
@@ -142,12 +142,7 @@ impl StacksMessageCodec for StacksBlockHeader {
 
 impl StacksBlockHeader {
     pub fn pubkey_hash(pubk: &StacksPublicKey) -> Hash160 {
-        let pubkey_buf = StacksPublicKeyBuffer::from_public_key(pubk);
-        let mut bytes = vec![];
-        pubkey_buf
-            .consensus_serialize(&mut bytes)
-            .expect("BUG: failed to serialize public key to a vec");
-        Hash160::from_data(&bytes[..])
+        Hash160::from_node_public_key(pubk)
     }
 
     pub fn genesis_block_header() -> StacksBlockHeader {
@@ -717,10 +712,13 @@ impl StacksMicroblockHeader {
 
         let mut pubk =
             StacksPublicKey::recover_to_pubkey(&digest_bits, &self.signature).map_err(|_ve| {
+                test_debug!("Failed to verify signature: failed to recover public key from {:?}: {:?}", &self.signature, &_ve);
                 net_error::VerifyingError(
                     "Failed to verify signature: failed to recover public key".to_string(),
                 )
             })?;
+
+        debug!("Recovered {:?} from {:?}", &pubk.to_hex(), &self.signature);
 
         pubk.set_compressed(true);
         Ok(StacksBlockHeader::pubkey_hash(&pubk))
@@ -730,8 +728,9 @@ impl StacksMicroblockHeader {
         let pubkh = self.check_recover_pubkey()?;
 
         if pubkh != *pubk_hash {
+            test_debug!("Failed to verify signature: public key did not recover to hash {}", &pubkh.to_hex());
             return Err(net_error::VerifyingError(format!(
-                "Failed to verify signature: public key {} did not recover to expected hash",
+                "Failed to verify signature: public key not recover to expected hash {}",
                 pubkh.to_hex()
             )));
         }
@@ -1281,7 +1280,7 @@ mod test {
         };
 
         let pubk = StacksPublicKey::from_private(&privk);
-        let pubkh = Hash160::from_data(&pubk.to_bytes());
+        let pubkh = Hash160::from_node_public_key(&pubk.to_bytes());
 
         mblock_header.sign(&privk).unwrap();
         mblock_header.verify(&pubkh).unwrap();

--- a/src/chainstate/stacks/block.rs
+++ b/src/chainstate/stacks/block.rs
@@ -712,7 +712,11 @@ impl StacksMicroblockHeader {
 
         let mut pubk =
             StacksPublicKey::recover_to_pubkey(&digest_bits, &self.signature).map_err(|_ve| {
-                test_debug!("Failed to verify signature: failed to recover public key from {:?}: {:?}", &self.signature, &_ve);
+                test_debug!(
+                    "Failed to verify signature: failed to recover public key from {:?}: {:?}",
+                    &self.signature,
+                    &_ve
+                );
                 net_error::VerifyingError(
                     "Failed to verify signature: failed to recover public key".to_string(),
                 )
@@ -728,7 +732,10 @@ impl StacksMicroblockHeader {
         let pubkh = self.check_recover_pubkey()?;
 
         if pubkh != *pubk_hash {
-            test_debug!("Failed to verify signature: public key did not recover to hash {}", &pubkh.to_hex());
+            test_debug!(
+                "Failed to verify signature: public key did not recover to hash {}",
+                &pubkh.to_hex()
+            );
             return Err(net_error::VerifyingError(format!(
                 "Failed to verify signature: public key not recover to expected hash {}",
                 pubkh.to_hex()

--- a/src/chainstate/stacks/boot/mod.rs
+++ b/src/chainstate/stacks/boot/mod.rs
@@ -974,9 +974,8 @@ pub mod test {
 
         for tenure_id in 0..num_blocks {
             let microblock_privkey = StacksPrivateKey::new();
-            let microblock_pubkeyhash = Hash160::from_node_public_key(
-                &StacksPublicKey::from_private(&microblock_privkey)
-            );
+            let microblock_pubkeyhash =
+                Hash160::from_node_public_key(&StacksPublicKey::from_private(&microblock_privkey));
             let tip =
                 SortitionDB::get_canonical_burn_chain_tip(&peer.sortdb.as_ref().unwrap().conn())
                     .unwrap();
@@ -1040,9 +1039,8 @@ pub mod test {
 
         for tenure_id in 0..num_blocks {
             let microblock_privkey = StacksPrivateKey::new();
-            let microblock_pubkeyhash = Hash160::from_node_public_key(
-                &StacksPublicKey::from_private(&microblock_privkey)
-            );
+            let microblock_pubkeyhash =
+                Hash160::from_node_public_key(&StacksPublicKey::from_private(&microblock_privkey));
             let tip =
                 SortitionDB::get_canonical_burn_chain_tip(&peer.sortdb.as_ref().unwrap().conn())
                     .unwrap();
@@ -1153,9 +1151,8 @@ pub mod test {
 
         for tenure_id in 0..num_blocks {
             let microblock_privkey = StacksPrivateKey::new();
-            let microblock_pubkeyhash = Hash160::from_node_public_key(
-                &StacksPublicKey::from_private(&microblock_privkey)
-            );
+            let microblock_pubkeyhash =
+                Hash160::from_node_public_key(&StacksPublicKey::from_private(&microblock_privkey));
             let tip =
                 SortitionDB::get_canonical_burn_chain_tip(&peer.sortdb.as_ref().unwrap().conn())
                     .unwrap();
@@ -1249,9 +1246,8 @@ pub mod test {
 
         for tenure_id in 0..num_blocks {
             let microblock_privkey = StacksPrivateKey::new();
-            let microblock_pubkeyhash = Hash160::from_node_public_key(
-                &StacksPublicKey::from_private(&microblock_privkey)
-            );
+            let microblock_pubkeyhash =
+                Hash160::from_node_public_key(&StacksPublicKey::from_private(&microblock_privkey));
             let tip =
                 SortitionDB::get_canonical_burn_chain_tip(&peer.sortdb.as_ref().unwrap().conn())
                     .unwrap();
@@ -1448,9 +1444,8 @@ pub mod test {
 
         for tenure_id in 0..num_blocks {
             let microblock_privkey = StacksPrivateKey::new();
-            let microblock_pubkeyhash = Hash160::from_node_public_key(
-                &StacksPublicKey::from_private(&microblock_privkey)
-            );
+            let microblock_pubkeyhash =
+                Hash160::from_node_public_key(&StacksPublicKey::from_private(&microblock_privkey));
             let tip =
                 SortitionDB::get_canonical_burn_chain_tip(&peer.sortdb.as_ref().unwrap().conn())
                     .unwrap();
@@ -1702,9 +1697,8 @@ pub mod test {
 
         for tenure_id in 0..num_blocks {
             let microblock_privkey = StacksPrivateKey::new();
-            let microblock_pubkeyhash = Hash160::from_node_public_key(
-                &StacksPublicKey::from_private(&microblock_privkey)
-            );
+            let microblock_pubkeyhash =
+                Hash160::from_node_public_key(&StacksPublicKey::from_private(&microblock_privkey));
             let tip =
                 SortitionDB::get_canonical_burn_chain_tip(&peer.sortdb.as_ref().unwrap().conn())
                     .unwrap();
@@ -1909,9 +1903,8 @@ pub mod test {
 
         for tenure_id in 0..num_blocks {
             let microblock_privkey = StacksPrivateKey::new();
-            let microblock_pubkeyhash = Hash160::from_node_public_key(
-                &StacksPublicKey::from_private(&microblock_privkey)
-            );
+            let microblock_pubkeyhash =
+                Hash160::from_node_public_key(&StacksPublicKey::from_private(&microblock_privkey));
             let tip =
                 SortitionDB::get_canonical_burn_chain_tip(&peer.sortdb.as_ref().unwrap().conn())
                     .unwrap();
@@ -2122,9 +2115,8 @@ pub mod test {
 
         for tenure_id in 0..num_blocks {
             let microblock_privkey = StacksPrivateKey::new();
-            let microblock_pubkeyhash = Hash160::from_node_public_key(
-                &StacksPublicKey::from_private(&microblock_privkey)
-            );
+            let microblock_pubkeyhash =
+                Hash160::from_node_public_key(&StacksPublicKey::from_private(&microblock_privkey));
             let tip =
                 SortitionDB::get_canonical_burn_chain_tip(&peer.sortdb.as_ref().unwrap().conn())
                     .unwrap();
@@ -2358,9 +2350,8 @@ pub mod test {
 
         for tenure_id in 0..num_blocks {
             let microblock_privkey = StacksPrivateKey::new();
-            let microblock_pubkeyhash = Hash160::from_node_public_key(
-                &StacksPublicKey::from_private(&microblock_privkey)
-            );
+            let microblock_pubkeyhash =
+                Hash160::from_node_public_key(&StacksPublicKey::from_private(&microblock_privkey));
             let tip =
                 SortitionDB::get_canonical_burn_chain_tip(&peer.sortdb.as_ref().unwrap().conn())
                     .unwrap();
@@ -2830,9 +2821,8 @@ pub mod test {
 
         for tenure_id in 0..num_blocks {
             let microblock_privkey = StacksPrivateKey::new();
-            let microblock_pubkeyhash = Hash160::from_node_public_key(
-                &StacksPublicKey::from_private(&microblock_privkey)
-            );
+            let microblock_pubkeyhash =
+                Hash160::from_node_public_key(&StacksPublicKey::from_private(&microblock_privkey));
             let tip =
                 SortitionDB::get_canonical_burn_chain_tip(&peer.sortdb.as_ref().unwrap().conn())
                     .unwrap();
@@ -3272,9 +3262,8 @@ pub mod test {
 
         for tenure_id in 0..num_blocks {
             let microblock_privkey = StacksPrivateKey::new();
-            let microblock_pubkeyhash = Hash160::from_node_public_key(
-                &StacksPublicKey::from_private(&microblock_privkey)
-            );
+            let microblock_pubkeyhash =
+                Hash160::from_node_public_key(&StacksPublicKey::from_private(&microblock_privkey));
             let tip =
                 SortitionDB::get_canonical_burn_chain_tip(&peer.sortdb.as_ref().unwrap().conn())
                     .unwrap();

--- a/src/chainstate/stacks/boot/mod.rs
+++ b/src/chainstate/stacks/boot/mod.rs
@@ -974,8 +974,9 @@ pub mod test {
 
         for tenure_id in 0..num_blocks {
             let microblock_privkey = StacksPrivateKey::new();
-            let microblock_pubkeyhash =
-                Hash160::from_node_public_key(&StacksPublicKey::from_private(&microblock_privkey).to_bytes());
+            let microblock_pubkeyhash = Hash160::from_node_public_key(
+                &StacksPublicKey::from_private(&microblock_privkey).to_bytes(),
+            );
             let tip =
                 SortitionDB::get_canonical_burn_chain_tip(&peer.sortdb.as_ref().unwrap().conn())
                     .unwrap();
@@ -1039,8 +1040,9 @@ pub mod test {
 
         for tenure_id in 0..num_blocks {
             let microblock_privkey = StacksPrivateKey::new();
-            let microblock_pubkeyhash =
-                Hash160::from_node_public_key(&StacksPublicKey::from_private(&microblock_privkey).to_bytes());
+            let microblock_pubkeyhash = Hash160::from_node_public_key(
+                &StacksPublicKey::from_private(&microblock_privkey).to_bytes(),
+            );
             let tip =
                 SortitionDB::get_canonical_burn_chain_tip(&peer.sortdb.as_ref().unwrap().conn())
                     .unwrap();
@@ -1151,8 +1153,9 @@ pub mod test {
 
         for tenure_id in 0..num_blocks {
             let microblock_privkey = StacksPrivateKey::new();
-            let microblock_pubkeyhash =
-                Hash160::from_node_public_key(&StacksPublicKey::from_private(&microblock_privkey).to_bytes());
+            let microblock_pubkeyhash = Hash160::from_node_public_key(
+                &StacksPublicKey::from_private(&microblock_privkey).to_bytes(),
+            );
             let tip =
                 SortitionDB::get_canonical_burn_chain_tip(&peer.sortdb.as_ref().unwrap().conn())
                     .unwrap();
@@ -1246,8 +1249,9 @@ pub mod test {
 
         for tenure_id in 0..num_blocks {
             let microblock_privkey = StacksPrivateKey::new();
-            let microblock_pubkeyhash =
-                Hash160::from_node_public_key(&StacksPublicKey::from_private(&microblock_privkey).to_bytes());
+            let microblock_pubkeyhash = Hash160::from_node_public_key(
+                &StacksPublicKey::from_private(&microblock_privkey).to_bytes(),
+            );
             let tip =
                 SortitionDB::get_canonical_burn_chain_tip(&peer.sortdb.as_ref().unwrap().conn())
                     .unwrap();
@@ -1444,8 +1448,9 @@ pub mod test {
 
         for tenure_id in 0..num_blocks {
             let microblock_privkey = StacksPrivateKey::new();
-            let microblock_pubkeyhash =
-                Hash160::from_node_public_key(&StacksPublicKey::from_private(&microblock_privkey).to_bytes());
+            let microblock_pubkeyhash = Hash160::from_node_public_key(
+                &StacksPublicKey::from_private(&microblock_privkey).to_bytes(),
+            );
             let tip =
                 SortitionDB::get_canonical_burn_chain_tip(&peer.sortdb.as_ref().unwrap().conn())
                     .unwrap();
@@ -1697,8 +1702,9 @@ pub mod test {
 
         for tenure_id in 0..num_blocks {
             let microblock_privkey = StacksPrivateKey::new();
-            let microblock_pubkeyhash =
-                Hash160::from_node_public_key(&StacksPublicKey::from_private(&microblock_privkey).to_bytes());
+            let microblock_pubkeyhash = Hash160::from_node_public_key(
+                &StacksPublicKey::from_private(&microblock_privkey).to_bytes(),
+            );
             let tip =
                 SortitionDB::get_canonical_burn_chain_tip(&peer.sortdb.as_ref().unwrap().conn())
                     .unwrap();
@@ -1903,8 +1909,9 @@ pub mod test {
 
         for tenure_id in 0..num_blocks {
             let microblock_privkey = StacksPrivateKey::new();
-            let microblock_pubkeyhash =
-                Hash160::from_node_public_key(&StacksPublicKey::from_private(&microblock_privkey).to_bytes());
+            let microblock_pubkeyhash = Hash160::from_node_public_key(
+                &StacksPublicKey::from_private(&microblock_privkey).to_bytes(),
+            );
             let tip =
                 SortitionDB::get_canonical_burn_chain_tip(&peer.sortdb.as_ref().unwrap().conn())
                     .unwrap();
@@ -2115,8 +2122,9 @@ pub mod test {
 
         for tenure_id in 0..num_blocks {
             let microblock_privkey = StacksPrivateKey::new();
-            let microblock_pubkeyhash =
-                Hash160::from_node_public_key(&StacksPublicKey::from_private(&microblock_privkey).to_bytes());
+            let microblock_pubkeyhash = Hash160::from_node_public_key(
+                &StacksPublicKey::from_private(&microblock_privkey).to_bytes(),
+            );
             let tip =
                 SortitionDB::get_canonical_burn_chain_tip(&peer.sortdb.as_ref().unwrap().conn())
                     .unwrap();
@@ -2350,8 +2358,9 @@ pub mod test {
 
         for tenure_id in 0..num_blocks {
             let microblock_privkey = StacksPrivateKey::new();
-            let microblock_pubkeyhash =
-                Hash160::from_node_public_key(&StacksPublicKey::from_private(&microblock_privkey).to_bytes());
+            let microblock_pubkeyhash = Hash160::from_node_public_key(
+                &StacksPublicKey::from_private(&microblock_privkey).to_bytes(),
+            );
             let tip =
                 SortitionDB::get_canonical_burn_chain_tip(&peer.sortdb.as_ref().unwrap().conn())
                     .unwrap();
@@ -2821,8 +2830,9 @@ pub mod test {
 
         for tenure_id in 0..num_blocks {
             let microblock_privkey = StacksPrivateKey::new();
-            let microblock_pubkeyhash =
-                Hash160::from_node_public_key(&StacksPublicKey::from_private(&microblock_privkey).to_bytes());
+            let microblock_pubkeyhash = Hash160::from_node_public_key(
+                &StacksPublicKey::from_private(&microblock_privkey).to_bytes(),
+            );
             let tip =
                 SortitionDB::get_canonical_burn_chain_tip(&peer.sortdb.as_ref().unwrap().conn())
                     .unwrap();
@@ -3262,8 +3272,9 @@ pub mod test {
 
         for tenure_id in 0..num_blocks {
             let microblock_privkey = StacksPrivateKey::new();
-            let microblock_pubkeyhash =
-                Hash160::from_node_public_key(&StacksPublicKey::from_private(&microblock_privkey).to_bytes());
+            let microblock_pubkeyhash = Hash160::from_node_public_key(
+                &StacksPublicKey::from_private(&microblock_privkey).to_bytes(),
+            );
             let tip =
                 SortitionDB::get_canonical_burn_chain_tip(&peer.sortdb.as_ref().unwrap().conn())
                     .unwrap();

--- a/src/chainstate/stacks/boot/mod.rs
+++ b/src/chainstate/stacks/boot/mod.rs
@@ -975,7 +975,7 @@ pub mod test {
         for tenure_id in 0..num_blocks {
             let microblock_privkey = StacksPrivateKey::new();
             let microblock_pubkeyhash = Hash160::from_node_public_key(
-                &StacksPublicKey::from_private(&microblock_privkey).to_bytes(),
+                &StacksPublicKey::from_private(&microblock_privkey)
             );
             let tip =
                 SortitionDB::get_canonical_burn_chain_tip(&peer.sortdb.as_ref().unwrap().conn())
@@ -1041,7 +1041,7 @@ pub mod test {
         for tenure_id in 0..num_blocks {
             let microblock_privkey = StacksPrivateKey::new();
             let microblock_pubkeyhash = Hash160::from_node_public_key(
-                &StacksPublicKey::from_private(&microblock_privkey).to_bytes(),
+                &StacksPublicKey::from_private(&microblock_privkey)
             );
             let tip =
                 SortitionDB::get_canonical_burn_chain_tip(&peer.sortdb.as_ref().unwrap().conn())
@@ -1154,7 +1154,7 @@ pub mod test {
         for tenure_id in 0..num_blocks {
             let microblock_privkey = StacksPrivateKey::new();
             let microblock_pubkeyhash = Hash160::from_node_public_key(
-                &StacksPublicKey::from_private(&microblock_privkey).to_bytes(),
+                &StacksPublicKey::from_private(&microblock_privkey)
             );
             let tip =
                 SortitionDB::get_canonical_burn_chain_tip(&peer.sortdb.as_ref().unwrap().conn())
@@ -1250,7 +1250,7 @@ pub mod test {
         for tenure_id in 0..num_blocks {
             let microblock_privkey = StacksPrivateKey::new();
             let microblock_pubkeyhash = Hash160::from_node_public_key(
-                &StacksPublicKey::from_private(&microblock_privkey).to_bytes(),
+                &StacksPublicKey::from_private(&microblock_privkey)
             );
             let tip =
                 SortitionDB::get_canonical_burn_chain_tip(&peer.sortdb.as_ref().unwrap().conn())
@@ -1449,7 +1449,7 @@ pub mod test {
         for tenure_id in 0..num_blocks {
             let microblock_privkey = StacksPrivateKey::new();
             let microblock_pubkeyhash = Hash160::from_node_public_key(
-                &StacksPublicKey::from_private(&microblock_privkey).to_bytes(),
+                &StacksPublicKey::from_private(&microblock_privkey)
             );
             let tip =
                 SortitionDB::get_canonical_burn_chain_tip(&peer.sortdb.as_ref().unwrap().conn())
@@ -1703,7 +1703,7 @@ pub mod test {
         for tenure_id in 0..num_blocks {
             let microblock_privkey = StacksPrivateKey::new();
             let microblock_pubkeyhash = Hash160::from_node_public_key(
-                &StacksPublicKey::from_private(&microblock_privkey).to_bytes(),
+                &StacksPublicKey::from_private(&microblock_privkey)
             );
             let tip =
                 SortitionDB::get_canonical_burn_chain_tip(&peer.sortdb.as_ref().unwrap().conn())
@@ -1910,7 +1910,7 @@ pub mod test {
         for tenure_id in 0..num_blocks {
             let microblock_privkey = StacksPrivateKey::new();
             let microblock_pubkeyhash = Hash160::from_node_public_key(
-                &StacksPublicKey::from_private(&microblock_privkey).to_bytes(),
+                &StacksPublicKey::from_private(&microblock_privkey)
             );
             let tip =
                 SortitionDB::get_canonical_burn_chain_tip(&peer.sortdb.as_ref().unwrap().conn())
@@ -2123,7 +2123,7 @@ pub mod test {
         for tenure_id in 0..num_blocks {
             let microblock_privkey = StacksPrivateKey::new();
             let microblock_pubkeyhash = Hash160::from_node_public_key(
-                &StacksPublicKey::from_private(&microblock_privkey).to_bytes(),
+                &StacksPublicKey::from_private(&microblock_privkey)
             );
             let tip =
                 SortitionDB::get_canonical_burn_chain_tip(&peer.sortdb.as_ref().unwrap().conn())
@@ -2359,7 +2359,7 @@ pub mod test {
         for tenure_id in 0..num_blocks {
             let microblock_privkey = StacksPrivateKey::new();
             let microblock_pubkeyhash = Hash160::from_node_public_key(
-                &StacksPublicKey::from_private(&microblock_privkey).to_bytes(),
+                &StacksPublicKey::from_private(&microblock_privkey)
             );
             let tip =
                 SortitionDB::get_canonical_burn_chain_tip(&peer.sortdb.as_ref().unwrap().conn())
@@ -2831,7 +2831,7 @@ pub mod test {
         for tenure_id in 0..num_blocks {
             let microblock_privkey = StacksPrivateKey::new();
             let microblock_pubkeyhash = Hash160::from_node_public_key(
-                &StacksPublicKey::from_private(&microblock_privkey).to_bytes(),
+                &StacksPublicKey::from_private(&microblock_privkey)
             );
             let tip =
                 SortitionDB::get_canonical_burn_chain_tip(&peer.sortdb.as_ref().unwrap().conn())
@@ -3273,7 +3273,7 @@ pub mod test {
         for tenure_id in 0..num_blocks {
             let microblock_privkey = StacksPrivateKey::new();
             let microblock_pubkeyhash = Hash160::from_node_public_key(
-                &StacksPublicKey::from_private(&microblock_privkey).to_bytes(),
+                &StacksPublicKey::from_private(&microblock_privkey)
             );
             let tip =
                 SortitionDB::get_canonical_burn_chain_tip(&peer.sortdb.as_ref().unwrap().conn())

--- a/src/chainstate/stacks/boot/mod.rs
+++ b/src/chainstate/stacks/boot/mod.rs
@@ -975,7 +975,7 @@ pub mod test {
         for tenure_id in 0..num_blocks {
             let microblock_privkey = StacksPrivateKey::new();
             let microblock_pubkeyhash =
-                Hash160::from_data(&StacksPublicKey::from_private(&microblock_privkey).to_bytes());
+                Hash160::from_node_public_key(&StacksPublicKey::from_private(&microblock_privkey).to_bytes());
             let tip =
                 SortitionDB::get_canonical_burn_chain_tip(&peer.sortdb.as_ref().unwrap().conn())
                     .unwrap();
@@ -1040,7 +1040,7 @@ pub mod test {
         for tenure_id in 0..num_blocks {
             let microblock_privkey = StacksPrivateKey::new();
             let microblock_pubkeyhash =
-                Hash160::from_data(&StacksPublicKey::from_private(&microblock_privkey).to_bytes());
+                Hash160::from_node_public_key(&StacksPublicKey::from_private(&microblock_privkey).to_bytes());
             let tip =
                 SortitionDB::get_canonical_burn_chain_tip(&peer.sortdb.as_ref().unwrap().conn())
                     .unwrap();
@@ -1152,7 +1152,7 @@ pub mod test {
         for tenure_id in 0..num_blocks {
             let microblock_privkey = StacksPrivateKey::new();
             let microblock_pubkeyhash =
-                Hash160::from_data(&StacksPublicKey::from_private(&microblock_privkey).to_bytes());
+                Hash160::from_node_public_key(&StacksPublicKey::from_private(&microblock_privkey).to_bytes());
             let tip =
                 SortitionDB::get_canonical_burn_chain_tip(&peer.sortdb.as_ref().unwrap().conn())
                     .unwrap();
@@ -1247,7 +1247,7 @@ pub mod test {
         for tenure_id in 0..num_blocks {
             let microblock_privkey = StacksPrivateKey::new();
             let microblock_pubkeyhash =
-                Hash160::from_data(&StacksPublicKey::from_private(&microblock_privkey).to_bytes());
+                Hash160::from_node_public_key(&StacksPublicKey::from_private(&microblock_privkey).to_bytes());
             let tip =
                 SortitionDB::get_canonical_burn_chain_tip(&peer.sortdb.as_ref().unwrap().conn())
                     .unwrap();
@@ -1445,7 +1445,7 @@ pub mod test {
         for tenure_id in 0..num_blocks {
             let microblock_privkey = StacksPrivateKey::new();
             let microblock_pubkeyhash =
-                Hash160::from_data(&StacksPublicKey::from_private(&microblock_privkey).to_bytes());
+                Hash160::from_node_public_key(&StacksPublicKey::from_private(&microblock_privkey).to_bytes());
             let tip =
                 SortitionDB::get_canonical_burn_chain_tip(&peer.sortdb.as_ref().unwrap().conn())
                     .unwrap();
@@ -1698,7 +1698,7 @@ pub mod test {
         for tenure_id in 0..num_blocks {
             let microblock_privkey = StacksPrivateKey::new();
             let microblock_pubkeyhash =
-                Hash160::from_data(&StacksPublicKey::from_private(&microblock_privkey).to_bytes());
+                Hash160::from_node_public_key(&StacksPublicKey::from_private(&microblock_privkey).to_bytes());
             let tip =
                 SortitionDB::get_canonical_burn_chain_tip(&peer.sortdb.as_ref().unwrap().conn())
                     .unwrap();
@@ -1904,7 +1904,7 @@ pub mod test {
         for tenure_id in 0..num_blocks {
             let microblock_privkey = StacksPrivateKey::new();
             let microblock_pubkeyhash =
-                Hash160::from_data(&StacksPublicKey::from_private(&microblock_privkey).to_bytes());
+                Hash160::from_node_public_key(&StacksPublicKey::from_private(&microblock_privkey).to_bytes());
             let tip =
                 SortitionDB::get_canonical_burn_chain_tip(&peer.sortdb.as_ref().unwrap().conn())
                     .unwrap();
@@ -2116,7 +2116,7 @@ pub mod test {
         for tenure_id in 0..num_blocks {
             let microblock_privkey = StacksPrivateKey::new();
             let microblock_pubkeyhash =
-                Hash160::from_data(&StacksPublicKey::from_private(&microblock_privkey).to_bytes());
+                Hash160::from_node_public_key(&StacksPublicKey::from_private(&microblock_privkey).to_bytes());
             let tip =
                 SortitionDB::get_canonical_burn_chain_tip(&peer.sortdb.as_ref().unwrap().conn())
                     .unwrap();
@@ -2351,7 +2351,7 @@ pub mod test {
         for tenure_id in 0..num_blocks {
             let microblock_privkey = StacksPrivateKey::new();
             let microblock_pubkeyhash =
-                Hash160::from_data(&StacksPublicKey::from_private(&microblock_privkey).to_bytes());
+                Hash160::from_node_public_key(&StacksPublicKey::from_private(&microblock_privkey).to_bytes());
             let tip =
                 SortitionDB::get_canonical_burn_chain_tip(&peer.sortdb.as_ref().unwrap().conn())
                     .unwrap();
@@ -2822,7 +2822,7 @@ pub mod test {
         for tenure_id in 0..num_blocks {
             let microblock_privkey = StacksPrivateKey::new();
             let microblock_pubkeyhash =
-                Hash160::from_data(&StacksPublicKey::from_private(&microblock_privkey).to_bytes());
+                Hash160::from_node_public_key(&StacksPublicKey::from_private(&microblock_privkey).to_bytes());
             let tip =
                 SortitionDB::get_canonical_burn_chain_tip(&peer.sortdb.as_ref().unwrap().conn())
                     .unwrap();
@@ -3263,7 +3263,7 @@ pub mod test {
         for tenure_id in 0..num_blocks {
             let microblock_privkey = StacksPrivateKey::new();
             let microblock_pubkeyhash =
-                Hash160::from_data(&StacksPublicKey::from_private(&microblock_privkey).to_bytes());
+                Hash160::from_node_public_key(&StacksPublicKey::from_private(&microblock_privkey).to_bytes());
             let tip =
                 SortitionDB::get_canonical_burn_chain_tip(&peer.sortdb.as_ref().unwrap().conn())
                     .unwrap();

--- a/src/chainstate/stacks/db/blocks.rs
+++ b/src/chainstate/stacks/db/blocks.rs
@@ -3174,11 +3174,12 @@ impl StacksChainState {
         };
 
         let mut dup = microblock.clone();
-        if dup.verify(&pubkey_hash).is_err() {
+        if let Err(e) = dup.verify(&pubkey_hash) {
             let msg = format!(
-                "Invalid microblock {}: failed to verify signature with {}",
+                "Invalid microblock {}: failed to verify signature with {}: {:?}",
                 microblock.block_hash(),
-                pubkey_hash
+                pubkey_hash,
+                &e
             );
             warn!("{}", &msg);
             return Err(Error::InvalidStacksMicroblock(msg, microblock.block_hash()));
@@ -4868,7 +4869,7 @@ pub mod test {
         };
 
         let mblock_pubkey_hash =
-            Hash160::from_data(&StacksPublicKey::from_private(mblock_key).to_bytes());
+            Hash160::from_node_public_key(&StacksPublicKey::from_private(mblock_key).to_bytes());
         let mut block = StacksBlock::from_parent(
             &parent_header,
             &parent_microblock_header,

--- a/src/chainstate/stacks/db/blocks.rs
+++ b/src/chainstate/stacks/db/blocks.rs
@@ -4869,7 +4869,7 @@ pub mod test {
         };
 
         let mblock_pubkey_hash =
-            Hash160::from_node_public_key(&StacksPublicKey::from_private(mblock_key).to_bytes());
+            Hash160::from_node_public_key(&StacksPublicKey::from_private(mblock_key));
         let mut block = StacksBlock::from_parent(
             &parent_header,
             &parent_microblock_header,

--- a/src/chainstate/stacks/db/unconfirmed.rs
+++ b/src/chainstate/stacks/db/unconfirmed.rs
@@ -398,8 +398,9 @@ mod test {
         let mut last_block: Option<StacksBlock> = None;
         for tenure_id in 0..num_blocks {
             let microblock_privkey = StacksPrivateKey::new();
-            let microblock_pubkeyhash =
-                Hash160::from_node_public_key(&StacksPublicKey::from_private(&microblock_privkey).to_bytes());
+            let microblock_pubkeyhash = Hash160::from_node_public_key(
+                &StacksPublicKey::from_private(&microblock_privkey).to_bytes(),
+            );
 
             // send transactions to the mempool
             let tip =
@@ -626,8 +627,9 @@ mod test {
         let mut last_block: Option<StacksBlock> = None;
         for tenure_id in 0..num_blocks {
             let microblock_privkey = StacksPrivateKey::new();
-            let microblock_pubkeyhash =
-                Hash160::from_node_public_key(&StacksPublicKey::from_private(&microblock_privkey).to_bytes());
+            let microblock_pubkeyhash = Hash160::from_node_public_key(
+                &StacksPublicKey::from_private(&microblock_privkey).to_bytes(),
+            );
 
             // send transactions to the mempool
             let tip =

--- a/src/chainstate/stacks/db/unconfirmed.rs
+++ b/src/chainstate/stacks/db/unconfirmed.rs
@@ -399,7 +399,7 @@ mod test {
         for tenure_id in 0..num_blocks {
             let microblock_privkey = StacksPrivateKey::new();
             let microblock_pubkeyhash = Hash160::from_node_public_key(
-                &StacksPublicKey::from_private(&microblock_privkey).to_bytes(),
+                &StacksPublicKey::from_private(&microblock_privkey)
             );
 
             // send transactions to the mempool
@@ -628,7 +628,7 @@ mod test {
         for tenure_id in 0..num_blocks {
             let microblock_privkey = StacksPrivateKey::new();
             let microblock_pubkeyhash = Hash160::from_node_public_key(
-                &StacksPublicKey::from_private(&microblock_privkey).to_bytes(),
+                &StacksPublicKey::from_private(&microblock_privkey)
             );
 
             // send transactions to the mempool

--- a/src/chainstate/stacks/db/unconfirmed.rs
+++ b/src/chainstate/stacks/db/unconfirmed.rs
@@ -399,7 +399,7 @@ mod test {
         for tenure_id in 0..num_blocks {
             let microblock_privkey = StacksPrivateKey::new();
             let microblock_pubkeyhash =
-                Hash160::from_data(&StacksPublicKey::from_private(&microblock_privkey).to_bytes());
+                Hash160::from_node_public_key(&StacksPublicKey::from_private(&microblock_privkey).to_bytes());
 
             // send transactions to the mempool
             let tip =
@@ -627,7 +627,7 @@ mod test {
         for tenure_id in 0..num_blocks {
             let microblock_privkey = StacksPrivateKey::new();
             let microblock_pubkeyhash =
-                Hash160::from_data(&StacksPublicKey::from_private(&microblock_privkey).to_bytes());
+                Hash160::from_node_public_key(&StacksPublicKey::from_private(&microblock_privkey).to_bytes());
 
             // send transactions to the mempool
             let tip =

--- a/src/chainstate/stacks/db/unconfirmed.rs
+++ b/src/chainstate/stacks/db/unconfirmed.rs
@@ -398,9 +398,8 @@ mod test {
         let mut last_block: Option<StacksBlock> = None;
         for tenure_id in 0..num_blocks {
             let microblock_privkey = StacksPrivateKey::new();
-            let microblock_pubkeyhash = Hash160::from_node_public_key(
-                &StacksPublicKey::from_private(&microblock_privkey)
-            );
+            let microblock_pubkeyhash =
+                Hash160::from_node_public_key(&StacksPublicKey::from_private(&microblock_privkey));
 
             // send transactions to the mempool
             let tip =
@@ -627,9 +626,8 @@ mod test {
         let mut last_block: Option<StacksBlock> = None;
         for tenure_id in 0..num_blocks {
             let microblock_privkey = StacksPrivateKey::new();
-            let microblock_pubkeyhash = Hash160::from_node_public_key(
-                &StacksPublicKey::from_private(&microblock_privkey)
-            );
+            let microblock_pubkeyhash =
+                Hash160::from_node_public_key(&StacksPublicKey::from_private(&microblock_privkey));
 
             // send transactions to the mempool
             let tip =

--- a/src/chainstate/stacks/index/mod.rs
+++ b/src/chainstate/stacks/index/mod.rs
@@ -46,6 +46,7 @@ pub struct TrieHash(pub [u8; 32]);
 impl_array_newtype!(TrieHash, u8, 32);
 impl_array_hexstring_fmt!(TrieHash);
 impl_byte_array_newtype!(TrieHash, u8, 32);
+impl_byte_array_serde!(TrieHash);
 pub const TRIEHASH_ENCODED_SIZE: usize = 32;
 
 /// Structure that holds the actual data in a MARF leaf node.

--- a/src/chainstate/stacks/miner.rs
+++ b/src/chainstate/stacks/miner.rs
@@ -118,7 +118,7 @@ impl<'a> StacksMicroblockBuilder<'a> {
         miner_key: &Secp256k1PrivateKey,
     ) -> Result<StacksMicroblock, Error> {
         let miner_pubkey_hash =
-            Hash160::from_data(&StacksPublicKey::from_private(miner_key).to_bytes());
+            Hash160::from_node_public_key(&StacksPublicKey::from_private(miner_key));
         if txs_to_broadcast.len() == 0 {
             return Err(Error::NoTransactionsToMine);
         }
@@ -386,7 +386,7 @@ impl StacksBlockBuilder {
     ) -> StacksBlockBuilder {
         let mut pubk = StacksPublicKey::from_private(microblock_privkey);
         pubk.set_compressed(true);
-        let pubkh = Hash160::from_data(&pubk.to_bytes());
+        let pubkh = Hash160::from_node_public_key(&pubk);
 
         let mut builder = StacksBlockBuilder::from_parent_pubkey_hash(
             miner_id,
@@ -442,7 +442,7 @@ impl StacksBlockBuilder {
     ) -> StacksBlockBuilder {
         let mut pubk = StacksPublicKey::from_private(microblock_privkey);
         pubk.set_compressed(true);
-        let pubkh = Hash160::from_data(&pubk.to_bytes());
+        let pubkh = Hash160::from_node_public_key(&pubk);
 
         let mut builder = StacksBlockBuilder::first_pubkey_hash(
             miner_id,

--- a/src/chainstate/stacks/miner.rs
+++ b/src/chainstate/stacks/miner.rs
@@ -528,6 +528,8 @@ impl StacksBlockBuilder {
                     _ => e,
                 })?;
 
+            debug!("Include tx {}", tx.txid());
+
             // save
             self.txs.push(tx.clone());
             self.total_anchored_fees += fee;
@@ -668,8 +670,9 @@ impl StacksBlockBuilder {
         );
 
         info!(
-            "Miner: mined anchored block {}, parent block {}, state root = {}",
+            "Miner: mined anchored block {} with {} txs, parent block {}, state root = {}",
             block.block_hash(),
+            block.txs.len(),
             &self.header.parent_block,
             state_root_hash
         );
@@ -861,7 +864,7 @@ impl StacksBlockBuilder {
         for tx in txs.drain(..) {
             match builder.try_mine_tx(&mut epoch_tx, &tx) {
                 Ok(_) => {
-                    test_debug!("Included {}", &tx.txid());
+                    debug!("Included {}", &tx.txid());
                 }
                 Err(Error::BlockTooBigError) => {
                     // done mining -- our execution budget is exceeded.

--- a/src/chainstate/stacks/mod.rs
+++ b/src/chainstate/stacks/mod.rs
@@ -322,7 +322,7 @@ pub const STACKS_ADDRESS_ENCODED_SIZE: u32 = 1 + HASH160_ENCODED_SIZE;
 
 /// How a transaction may be appended to the Stacks blockchain
 #[repr(u8)]
-#[derive(Debug, Clone, PartialEq, Copy)]
+#[derive(Debug, Clone, PartialEq, Copy, Serialize, Deserialize)]
 pub enum TransactionAnchorMode {
     OnChainOnly = 1,  // must be included in a StacksBlock
     OffChainOnly = 2, // must be included in a StacksMicroBlock
@@ -330,7 +330,7 @@ pub enum TransactionAnchorMode {
 }
 
 #[repr(u8)]
-#[derive(Debug, Clone, PartialEq, Copy)]
+#[derive(Debug, Clone, PartialEq, Copy, Serialize, Deserialize)]
 pub enum TransactionAuthFlags {
     // types of auth
     AuthStandard = 0x04,
@@ -344,7 +344,7 @@ pub enum TransactionAuthFlags {
 /// An auth field can be a public key or a signature.  In both cases, the public key (either given
 /// in-the-raw or embedded in a signature) may be encoded as compressed or uncompressed.
 #[repr(u8)]
-#[derive(Debug, Clone, PartialEq, Copy)]
+#[derive(Debug, Clone, PartialEq, Copy, Serialize, Deserialize)]
 pub enum TransactionAuthFieldID {
     // types of auth fields
     PublicKeyCompressed = 0x00,
@@ -354,7 +354,7 @@ pub enum TransactionAuthFieldID {
 }
 
 #[repr(u8)]
-#[derive(Debug, Clone, PartialEq, Copy)]
+#[derive(Debug, Clone, PartialEq, Copy, Serialize, Deserialize)]
 pub enum TransactionPublicKeyEncoding {
     // ways we can encode a public key
     Compressed = 0x00,
@@ -375,7 +375,7 @@ impl TransactionPublicKeyEncoding {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum TransactionAuthField {
     PublicKey(StacksPublicKey),
     Signature(TransactionPublicKeyEncoding, MessageSignature),
@@ -433,14 +433,14 @@ impl TransactionAuthField {
 // tag address hash modes as "singlesig" or "multisig" so we can't accidentally construct an
 // invalid spending condition
 #[repr(u8)]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum SinglesigHashMode {
     P2PKH = 0x00,
     P2WPKH = 0x02,
 }
 
 #[repr(u8)]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum MultisigHashMode {
     P2SH = 0x01,
     P2WSH = 0x03,
@@ -500,7 +500,7 @@ impl MultisigHashMode {
 /// a transaction's execution against a Stacks address.
 /// public_keys + signatures_required determines the Principal.
 /// nonce is the "check number" for the Principal.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct MultisigSpendingCondition {
     pub hash_mode: MultisigHashMode,
     pub signer: Hash160,
@@ -510,7 +510,7 @@ pub struct MultisigSpendingCondition {
     pub signatures_required: u16,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SinglesigSpendingCondition {
     pub hash_mode: SinglesigHashMode,
     pub signer: Hash160,
@@ -520,21 +520,21 @@ pub struct SinglesigSpendingCondition {
     pub signature: MessageSignature,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum TransactionSpendingCondition {
     Singlesig(SinglesigSpendingCondition),
     Multisig(MultisigSpendingCondition),
 }
 
 /// Types of transaction authorizations
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum TransactionAuth {
     Standard(TransactionSpendingCondition),
     Sponsored(TransactionSpendingCondition, TransactionSpendingCondition), // the second account pays on behalf of the first account
 }
 
 /// A transaction that calls into a smart contract
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct TransactionContractCall {
     pub address: StacksAddress,
     pub contract_name: ContractName,
@@ -543,7 +543,7 @@ pub struct TransactionContractCall {
 }
 
 /// A transaction that instantiates a smart contract
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct TransactionSmartContract {
     pub name: ContractName,
     pub code_body: StacksString,
@@ -555,6 +555,7 @@ impl_byte_array_message_codec!(CoinbasePayload, 32);
 impl_array_newtype!(CoinbasePayload, u8, 32);
 impl_array_hexstring_fmt!(CoinbasePayload);
 impl_byte_array_newtype!(CoinbasePayload, u8, 32);
+impl_byte_array_serde!(CoinbasePayload);
 pub const CONIBASE_PAYLOAD_ENCODED_SIZE: u32 = 32;
 
 pub struct TokenTransferMemo(pub [u8; 34]); // same length as it is in stacks v1
@@ -562,9 +563,10 @@ impl_byte_array_message_codec!(TokenTransferMemo, 34);
 impl_array_newtype!(TokenTransferMemo, u8, 34);
 impl_array_hexstring_fmt!(TokenTransferMemo);
 impl_byte_array_newtype!(TokenTransferMemo, u8, 34);
+impl_byte_array_serde!(TokenTransferMemo);
 pub const TOKEN_TRANSFER_MEMO_LENGTH: usize = 34; // same as it is in Stacks v1
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum TransactionPayload {
     TokenTransfer(PrincipalData, u64, TokenTransferMemo),
     ContractCall(TransactionContractCall),
@@ -586,7 +588,7 @@ impl TransactionPayload {
 }
 
 #[repr(u8)]
-#[derive(Debug, Clone, PartialEq, Copy)]
+#[derive(Debug, Clone, PartialEq, Copy, Serialize, Deserialize)]
 pub enum TransactionPayloadID {
     TokenTransfer = 0,
     SmartContract = 1,
@@ -596,7 +598,7 @@ pub enum TransactionPayloadID {
 }
 
 /// Encoding of an asset type identifier
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct AssetInfo {
     pub contract_address: StacksAddress,
     pub contract_name: ContractName,
@@ -605,7 +607,7 @@ pub struct AssetInfo {
 
 /// numeric wire-format ID of an asset info type variant
 #[repr(u8)]
-#[derive(Debug, Clone, PartialEq, Copy)]
+#[derive(Debug, Clone, PartialEq, Copy, Serialize, Deserialize)]
 pub enum AssetInfoID {
     STX = 0,
     FungibleAsset = 1,
@@ -624,7 +626,7 @@ impl AssetInfoID {
 }
 
 #[repr(u8)]
-#[derive(Debug, Clone, PartialEq, Copy)]
+#[derive(Debug, Clone, PartialEq, Copy, Serialize, Deserialize)]
 pub enum FungibleConditionCode {
     SentEq = 0x01,
     SentGt = 0x02,
@@ -657,7 +659,7 @@ impl FungibleConditionCode {
 }
 
 #[repr(u8)]
-#[derive(Debug, Clone, PartialEq, Copy)]
+#[derive(Debug, Clone, PartialEq, Copy, Serialize, Deserialize)]
 pub enum NonfungibleConditionCode {
     Sent = 0x10,
     NotSent = 0x11,
@@ -695,7 +697,7 @@ impl NonfungibleConditionCode {
 }
 
 /// Post-condition principal.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum PostConditionPrincipal {
     Origin,
     Standard(StacksAddress),
@@ -720,7 +722,7 @@ impl PostConditionPrincipal {
 }
 
 #[repr(u8)]
-#[derive(Debug, Clone, PartialEq, Copy)]
+#[derive(Debug, Clone, PartialEq, Copy, Serialize, Deserialize)]
 pub enum PostConditionPrincipalID {
     Origin = 0x01,
     Standard = 0x02,
@@ -728,7 +730,7 @@ pub enum PostConditionPrincipalID {
 }
 
 /// Post-condition on a transaction
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum TransactionPostCondition {
     STX(PostConditionPrincipal, FungibleConditionCode, u64),
     Fungible(
@@ -747,7 +749,7 @@ pub enum TransactionPostCondition {
 
 /// Post-condition modes for unspecified assets
 #[repr(u8)]
-#[derive(Debug, Clone, PartialEq, Copy)]
+#[derive(Debug, Clone, PartialEq, Copy, Serialize, Deserialize)]
 pub enum TransactionPostConditionMode {
     Allow = 0x01, // allow any other changes not specified
     Deny = 0x02,  // deny any other changes not specified
@@ -755,13 +757,13 @@ pub enum TransactionPostConditionMode {
 
 /// Stacks transaction versions
 #[repr(u8)]
-#[derive(Debug, Clone, PartialEq, Copy)]
+#[derive(Debug, Clone, PartialEq, Copy, Serialize, Deserialize)]
 pub enum TransactionVersion {
     Mainnet = 0x00,
     Testnet = 0x80,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct StacksTransaction {
     pub version: TransactionVersion,
     pub chain_id: u32,
@@ -782,14 +784,14 @@ pub struct StacksTransactionSigner {
 }
 
 /// How much work has gone into this chain so far?
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct StacksWorkScore {
     pub burn: u64, // number of burn tokens destroyed
     pub work: u64, // in Stacks, "work" == the length of the fork
 }
 
 /// The header for an on-chain-anchored Stacks block
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct StacksBlockHeader {
     pub version: u8,
     pub total_work: StacksWorkScore, // NOTE: this is the work done on the chain tip this block builds on (i.e. take this from the parent)
@@ -804,14 +806,14 @@ pub struct StacksBlockHeader {
 
 /// A block that contains blockchain-anchored data
 /// (corresponding to a LeaderBlockCommitOp)
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct StacksBlock {
     pub header: StacksBlockHeader,
     pub txs: Vec<StacksTransaction>,
 }
 
 /// Header structure for a microblock
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct StacksMicroblockHeader {
     pub version: u8,
     pub sequence: u16,
@@ -822,7 +824,7 @@ pub struct StacksMicroblockHeader {
 
 /// A microblock that contains non-blockchain-anchored data,
 /// but is tied to an on-chain block
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct StacksMicroblock {
     pub header: StacksMicroblockHeader,
     pub txs: Vec<StacksTransaction>,

--- a/src/net/chat.rs
+++ b/src/net/chat.rs
@@ -4116,9 +4116,9 @@ mod test {
             peer: NeighborAddress {
                 addrbytes: local_peer.addrbytes.clone(),
                 port: local_peer.port,
-                public_key_hash: Hash160::from_node_public_key(
-                    &StacksPublicKey::from_private(&local_peer.private_key)
-                ),
+                public_key_hash: Hash160::from_node_public_key(&StacksPublicKey::from_private(
+                    &local_peer.private_key,
+                )),
             },
             seq: 789,
         }];

--- a/src/net/chat.rs
+++ b/src/net/chat.rs
@@ -560,7 +560,7 @@ impl ConversationP2P {
 
     pub fn to_neighbor_address(&self) -> NeighborAddress {
         let pubkh = if let Some(ref pubk) = self.ref_public_key() {
-            Hash160::from_data(&pubk.to_bytes())
+            Hash160::from_node_public_key(pubk)
         } else {
             Hash160([0u8; 20])
         };
@@ -574,7 +574,7 @@ impl ConversationP2P {
 
     pub fn to_handshake_neighbor_address(&self) -> NeighborAddress {
         let pubkh = if let Some(ref pubk) = self.ref_public_key() {
-            Hash160::from_data(&pubk.to_bytes())
+            Hash160::from_node_public_key(pubk)
         } else {
             Hash160([0u8; 20])
         };
@@ -600,7 +600,7 @@ impl ConversationP2P {
 
     pub fn get_public_key_hash(&self) -> Option<Hash160> {
         self.ref_public_key()
-            .map(|pubk| Hash160::from_data(&pubk.to_bytes()))
+            .map(|pubk| Hash160::from_node_public_key(pubk))
     }
 
     pub fn ref_public_key(&self) -> Option<&StacksPublicKey> {
@@ -980,7 +980,7 @@ impl ConversationP2P {
         let cur_pubk_opt = self.connection.get_public_key();
         if let Some(cur_pubk) = cur_pubk_opt {
             if pubk != cur_pubk {
-                test_debug!(
+                debug!(
                     "{:?}: Upgrade key {:?} to {:?} expires {:?}",
                     &self,
                     &to_hex(&cur_pubk.to_bytes_compressed()),
@@ -4116,8 +4116,8 @@ mod test {
             peer: NeighborAddress {
                 addrbytes: local_peer.addrbytes.clone(),
                 port: local_peer.port,
-                public_key_hash: Hash160::from_data(
-                    &StacksPublicKey::from_private(&local_peer.private_key).to_bytes(),
+                public_key_hash: Hash160::from_node_public_key(
+                    &StacksPublicKey::from_private(&local_peer.private_key)
                 ),
             },
             seq: 789,

--- a/src/net/codec.rs
+++ b/src/net/codec.rs
@@ -657,7 +657,7 @@ impl NeighborAddress {
         NeighborAddress {
             addrbytes: n.addr.addrbytes.clone(),
             port: n.addr.port,
-            public_key_hash: Hash160::from_data(&n.public_key.to_bytes_compressed()[..]),
+            public_key_hash: Hash160::from_node_public_key(&n.public_key)
         }
     }
 }

--- a/src/net/codec.rs
+++ b/src/net/codec.rs
@@ -657,7 +657,7 @@ impl NeighborAddress {
         NeighborAddress {
             addrbytes: n.addr.addrbytes.clone(),
             port: n.addr.port,
-            public_key_hash: Hash160::from_node_public_key(&n.public_key)
+            public_key_hash: Hash160::from_node_public_key(&n.public_key),
         }
     }
 }

--- a/src/net/db.rs
+++ b/src/net/db.rs
@@ -185,9 +185,9 @@ impl LocalPeer {
         NeighborAddress {
             addrbytes: self.addrbytes.clone(),
             port: self.port,
-            public_key_hash: Hash160::from_node_public_key(
-                &StacksPublicKey::from_private(&self.private_key),
-            ),
+            public_key_hash: Hash160::from_node_public_key(&StacksPublicKey::from_private(
+                &self.private_key,
+            )),
         }
     }
 }
@@ -256,7 +256,8 @@ impl FromRow<Neighbor> for Neighbor {
         let network_id: u32 = row.get("network_id");
         let addrbytes: PeerAddress = PeerAddress::from_column(row, "addrbytes")?;
         let port: u16 = row.get("port");
-        let mut public_key: Secp256k1PublicKey = Secp256k1PublicKey::from_column(row, "public_key")?;
+        let mut public_key: Secp256k1PublicKey =
+            Secp256k1PublicKey::from_column(row, "public_key")?;
         let expire_block_height = u64::from_column(row, "expire_block_height")?;
         let last_contact_time = u64::from_column(row, "last_contact_time")?;
         let asn: u32 = row.get("asn");

--- a/src/net/db.rs
+++ b/src/net/db.rs
@@ -150,7 +150,9 @@ impl LocalPeer {
         key_expire: u64,
         data_url: UrlString,
     ) -> LocalPeer {
-        let pkey = privkey.unwrap_or(Secp256k1PrivateKey::new());
+        let mut pkey = privkey.unwrap_or(Secp256k1PrivateKey::new());
+        pkey.set_compress_public(true);
+
         let mut rng = thread_rng();
         let mut my_nonce = [0u8; 32];
 
@@ -183,8 +185,8 @@ impl LocalPeer {
         NeighborAddress {
             addrbytes: self.addrbytes.clone(),
             port: self.port,
-            public_key_hash: Hash160::from_data(
-                &StacksPublicKey::from_private(&self.private_key).to_bytes(),
+            public_key_hash: Hash160::from_node_public_key(
+                &StacksPublicKey::from_private(&self.private_key),
             ),
         }
     }
@@ -254,7 +256,7 @@ impl FromRow<Neighbor> for Neighbor {
         let network_id: u32 = row.get("network_id");
         let addrbytes: PeerAddress = PeerAddress::from_column(row, "addrbytes")?;
         let port: u16 = row.get("port");
-        let public_key: Secp256k1PublicKey = Secp256k1PublicKey::from_column(row, "public_key")?;
+        let mut public_key: Secp256k1PublicKey = Secp256k1PublicKey::from_column(row, "public_key")?;
         let expire_block_height = u64::from_column(row, "expire_block_height")?;
         let last_contact_time = u64::from_column(row, "last_contact_time")?;
         let asn: u32 = row.get("asn");
@@ -263,6 +265,8 @@ impl FromRow<Neighbor> for Neighbor {
         let denied: i64 = row.get("denied");
         let in_degree: u32 = row.get("in_degree");
         let out_degree: u32 = row.get("out_degree");
+
+        public_key.set_compressed(true);
 
         Ok(Neighbor {
             addr: NeighborKey {

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -212,7 +212,7 @@ pub enum Error {
     /// view of state is stale (e.g. from the sortition db)
     StaleView,
     /// Tried to connect to myself
-    ConnectionCycle
+    ConnectionCycle,
 }
 
 /// Enum for passing data for ClientErrors
@@ -350,7 +350,7 @@ impl error::Error for Error {
             Error::MARFError(ref e) => Some(e),
             Error::CoordinatorClosed => None,
             Error::StaleView => None,
-            Error::ConnectionCycle => None
+            Error::ConnectionCycle => None,
         }
     }
 }

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -211,6 +211,8 @@ pub enum Error {
     CoordinatorClosed,
     /// view of state is stale (e.g. from the sortition db)
     StaleView,
+    /// Tried to connect to myself
+    ConnectionCycle
 }
 
 /// Enum for passing data for ClientErrors
@@ -291,6 +293,7 @@ impl fmt::Display for Error {
             Error::ClientError(ref e) => write!(f, "ClientError: {}", e),
             Error::CoordinatorClosed => write!(f, "Coordinator hung up"),
             Error::StaleView => write!(f, "State view is stale"),
+            Error::ConnectionCycle => write!(f, "Tried to connect to myself"),
         }
     }
 }
@@ -347,6 +350,7 @@ impl error::Error for Error {
             Error::MARFError(ref e) => Some(e),
             Error::CoordinatorClosed => None,
             Error::StaleView => None,
+            Error::ConnectionCycle => None
         }
     }
 }

--- a/src/net/neighbors.rs
+++ b/src/net/neighbors.rs
@@ -2232,10 +2232,6 @@ impl PeerNetwork {
                     for na in neighbor_addrs {
                         // don't talk to myself if we're listed as a neighbor of this
                         // remote peer.
-                        debug!(
-                            "{:?}: {} =?= {} the world wonders",
-                            &network.local_peer, &my_pubkey_hash, &na.public_key_hash
-                        );
                         if na.public_key_hash == my_pubkey_hash {
                             test_debug!("{:?}: skip handshaking with myself", &network.local_peer);
                             continue;

--- a/src/net/neighbors.rs
+++ b/src/net/neighbors.rs
@@ -158,7 +158,7 @@ impl Neighbor {
                 if peer.expire_block < block_height {
                     Ok(None)
                 } else {
-                    let pubkey_160 = Hash160::from_data(&peer.public_key.to_bytes_compressed()[..]);
+                    let pubkey_160 = Hash160::from_node_public_key(&peer.public_key);
                     if pubkey_160 == neighbor_address.public_key_hash {
                         // we know this neighbor's key
                         Ok(Some(peer))
@@ -727,6 +727,19 @@ impl NeighborWalk {
         Ok((resolved, to_resolve))
     }
 
+    /// Select neighbors that are routable, and ignore ones that are not.
+    /// TODO: expand if we ever want to filter by unroutable network class or something
+    fn filter_sensible_neighbors(neighbors: Vec<NeighborAddress>) -> Vec<NeighborAddress> {
+        let mut ret = vec![];
+        for neighbor in neighbors.into_iter() {
+            if neighbor.addrbytes.is_anynet() {
+                continue;
+            }
+            ret.push(neighbor);
+        }
+        ret
+    }
+
     /// Try to finish the getneighbors request to cur_neighbor
     /// Returns the list of neighbors we need to resolve
     /// Return None if we're not done yet, or haven't started yet.
@@ -763,17 +776,18 @@ impl NeighborWalk {
                 }
                 match message.payload {
                     StacksMessageType::Neighbors(ref data) => {
-                        test_debug!(
-                            "{:?}: Neighbors of {:?} are {:?}",
+                        debug!(
+                            "{:?}: Got Neighbors from {:?}: {:?}",
                             &self.local_peer,
                             &self.cur_neighbor.addr,
                             data.neighbors
                         );
+                        let neighbors = NeighborWalk::filter_sensible_neighbors(data.neighbors.clone());
                         let (mut found, to_resolve) = NeighborWalk::lookup_stale_neighbors(
                             network.peerdb.conn(),
                             message.preamble.network_id,
                             block_height,
-                            &data.neighbors,
+                            &neighbors,
                         )?;
 
                         for (_naddr, neighbor) in found.drain() {
@@ -1161,8 +1175,9 @@ impl NeighborWalk {
                                     "{:?}: Got Neighbors from {:?}: {:?}",
                                     &self.local_peer, &nkey, &data.neighbors
                                 );
+                                let neighbors = NeighborWalk::filter_sensible_neighbors(data.neighbors.clone());
                                 self.resolved_getneighbors_neighbors
-                                    .insert(nkey, data.neighbors.clone());
+                                    .insert(nkey, neighbors);
                             }
                             StacksMessageType::Nack(ref data) => {
                                 // not broken; likely because it hasn't gotten to processing our
@@ -1459,7 +1474,7 @@ impl NeighborWalk {
 
                                 // must have the same key; otherwise don't add
                                 let neighbor_pubkey_hash =
-                                    Hash160::from_data(data.handshake.node_public_key.as_bytes());
+                                    Hash160::from_node_public_key_buffer(&data.handshake.node_public_key);
                                 if neighbor_pubkey_hash != naddr.public_key_hash {
                                     debug!("{:?}: Neighbor {:?} had an unexpected pubkey hash: expected {:?} != {:?}",
                                            &self.local_peer, &message.to_neighbor_key(&data.handshake.addrbytes, data.handshake.port), &naddr.public_key_hash, &neighbor_pubkey_hash);
@@ -1995,8 +2010,8 @@ impl PeerNetwork {
                 }
                 None => {
                     // if cur_neighbor is _us_, then grab a different neighbor and try again
-                    if walk.cur_neighbor.public_key
-                        == Secp256k1PublicKey::from_private(&network.local_peer.private_key)
+                    if Hash160::from_node_public_key(&walk.cur_neighbor.public_key)
+                        == Hash160::from_node_public_key(&Secp256k1PublicKey::from_private(&network.local_peer.private_key))
                     {
                         debug!(
                             "{:?}: Walk stepped to ourselves.  Will reset instead.",
@@ -2005,6 +2020,8 @@ impl PeerNetwork {
                         return Err(net_error::NoSuchNeighbor);
                     }
 
+                    // if cur_neighbor is our bind address, then grab a different neighbor and try
+                    // again
                     if network.is_bound(&walk.cur_neighbor.addr) {
                         debug!(
                             "{:?}: Walk stepped to our bind address ({:?}).  Will reset instead.",
@@ -2013,32 +2030,53 @@ impl PeerNetwork {
                         return Err(net_error::NoSuchNeighbor);
                     }
 
-                    let my_addr = walk.cur_neighbor.addr.clone();
+                    // if cur_neighbor is an anynet address, then grab a different neighbor and try
+                    // again
+                    if walk.cur_neighbor.addr.addrbytes.is_anynet() {
+                        debug!(
+                            "{:?}: Walk stepped to an any-network address ({:?}).  Will reset instead.",
+                            &walk.local_peer, &walk.cur_neighbor.addr
+                        );
+                        return Err(net_error::NoSuchNeighbor);
+                    }
+
+                    let cur_addr = walk.cur_neighbor.addr.clone();
                     walk.clear_state();
 
-                    let my_pubkh = Hash160::from_data(&walk.cur_neighbor.public_key.to_bytes());
-                    let res = match network.can_register_peer_with_pubkey(&my_addr, true, &my_pubkh)
+                    let cur_pubkh = Hash160::from_node_public_key(&walk.cur_neighbor.public_key);
+                    let res = match network.can_register_peer_with_pubkey(&cur_addr, true, &cur_pubkh)
                     {
-                        Ok(_) => network.walk_connect_and_handshake(walk, &my_addr)?,
+                        Ok(_) => network.walk_connect_and_handshake(walk, &cur_addr)?,
                         Err(net_error::AlreadyConnected(event_id, handshake_nk)) => {
                             // already connected, but on a possibly-different address.
-                            // use peer-announced neighbor address if available.
-                            debug!(
-                                "{:?}: Already connected to {:?} on event {} (address: {:?})",
-                                &network.local_peer, &my_addr, &event_id, &handshake_nk
-                            );
-                            network
-                                .walk_handshake(walk, &handshake_nk)
-                                .and_then(|handle| Ok(Some(handle)))?
+                            // If the already-connected handle is inbound, and we're _not_ doing an
+                            // inbound neighbor walk, try to connect to this address anyway in
+                            // order to maximize our outbound connections we have.
+                            if let Some(convo) = network.peers.get(&event_id) {
+                                if !convo.is_outbound() {
+                                    debug!("{:?}: Already connected to {:?} on inbound event {} (address {:?}). Try to establish outbound connection to {:?} {:?}.",
+                                           &network.local_peer, &cur_addr, &event_id, &handshake_nk, &cur_pubkh, &cur_addr);
+                                    network.walk_connect_and_handshake(walk, &cur_addr)?
+                                }
+                                else {
+                                    debug!(
+                                        "{:?}: Already connected to {:?} on event {} (address: {:?})",
+                                        &network.local_peer, &cur_addr, &event_id, &handshake_nk
+                                    );
+                                    network
+                                        .walk_handshake(walk, &handshake_nk)
+                                        .and_then(|handle| Ok(Some(handle)))?
+                                }
+                            }
+                            else {
+                                // should never be reachable
+                                unreachable!("AlreadyConnected error on event {} has no conversation", event_id);
+                            }
                         }
                         Err(e) => {
                             debug!(
-                                "{:?}: Failed to check connection to {:?}: {:?}",
-                                &network.local_peer, &my_addr, &e
-                            );
-                            debug!(
-                                "{:?}: No Handshake sent (dest was {:?})",
-                                &walk.local_peer, &my_addr
+                                "{:?}: Failed to check connection to {:?}: {:?}. No handshake sent.",
+                                &network.local_peer, &cur_addr, &e
                             );
                             return Ok(false);
                         }
@@ -2046,14 +2084,14 @@ impl PeerNetwork {
 
                     match res {
                         Some(handle) => {
-                            debug!("{:?}: Handshake sent to {:?}", &walk.local_peer, &my_addr);
+                            debug!("{:?}: Handshake sent to {:?}", &walk.local_peer, &cur_addr);
                             walk.handshake_begin(handle);
                             Ok(true)
                         }
                         None => {
                             debug!(
                                 "{:?}: No Handshake sent (dest was {:?})",
-                                &walk.local_peer, &my_addr
+                                &walk.local_peer, &cur_addr
                             );
                             Ok(false)
                         }
@@ -2081,7 +2119,7 @@ impl PeerNetwork {
             match walk.getneighbors_request {
                 Some(_) => Ok(()),
                 None => {
-                    test_debug!(
+                    debug!(
                         "{:?}: send GetNeighbors to {:?}",
                         &walk.local_peer,
                         &walk.cur_neighbor.addr
@@ -2134,7 +2172,7 @@ impl PeerNetwork {
                     if let Some(ref mut naddrs) = walk.pending_neighbor_addrs {
                         test_debug!("{:?}: will try to handshake with inbound neighbor {:?}'s advertized address {:?} as well", &walk.local_peer, &walk.cur_neighbor.addr, &walk.neighbor_from_handshake);
                         let cur_neighbor_pubkey_hash =
-                            Hash160::from_data(&walk.cur_neighbor.public_key.to_bytes());
+                            Hash160::from_node_public_key(&walk.cur_neighbor.public_key);
                         naddrs.push(NeighborAddress::from_neighbor_key(
                             walk.neighbor_from_handshake.clone(),
                             cur_neighbor_pubkey_hash,
@@ -2164,9 +2202,10 @@ impl PeerNetwork {
     /// Start handshaking with our neighbors' neighbors.
     pub fn walk_neighbor_handshakes_begin(&mut self) -> Result<bool, net_error> {
         PeerNetwork::with_walk_state(self, |ref mut network, ref mut walk| {
-            let my_pubkey_hash = Hash160::from_data(
-                &Secp256k1PublicKey::from_private(&walk.local_peer.private_key).to_bytes()[..],
+            let my_pubkey_hash = Hash160::from_node_public_key(
+                &Secp256k1PublicKey::from_private(&walk.local_peer.private_key)
             );
+            debug!("{:?}: my public key hash is {}", &walk.local_peer, &my_pubkey_hash);
             let pending_neighbor_addrs = walk.pending_neighbor_addrs.take();
 
             let res = match pending_neighbor_addrs {
@@ -2187,6 +2226,7 @@ impl PeerNetwork {
                     for na in neighbor_addrs {
                         // don't talk to myself if we're listed as a neighbor of this
                         // remote peer.
+                        debug!("{:?}: {} =?= {} the world wonders", &network.local_peer, &my_pubkey_hash, &na.public_key_hash);
                         if na.public_key_hash == my_pubkey_hash {
                             test_debug!("{:?}: skip handshaking with myself", &network.local_peer);
                             continue;
@@ -2220,6 +2260,17 @@ impl PeerNetwork {
                             network.local_peer.network_id,
                             &na,
                         );
+
+                        // don't talk to a neighbor if it's unroutable anyway
+                        if network.is_bound(&nk) || nk.addrbytes.is_anynet() {
+                            test_debug!(
+                                "{:?}: will not connect to bind / anynet address {:?}",
+                                &network.local_peer,
+                                &nk
+                            );
+                            continue;
+                        }
+
                         match network.can_register_peer_with_pubkey(&nk, true, &na.public_key_hash)
                         {
                             Ok(_) => {
@@ -2234,8 +2285,8 @@ impl PeerNetwork {
                                 match network.walk_connect_and_handshake(walk, &nk) {
                                     Ok(Some(handle)) => {
                                         debug!(
-                                            "{:?}: will Handshake with neighbor-of-neighbor {:?}",
-                                            &network.local_peer, &nk
+                                            "{:?}: will Handshake with neighbor-of-neighbor {:?} ({})",
+                                            &network.local_peer, &nk, &na.public_key_hash
                                         );
                                         walk.unresolved_handshake_neighbors
                                             .insert(na.clone(), handle);
@@ -2264,7 +2315,7 @@ impl PeerNetwork {
                                 // connected already -- just proceed to send handshake
                                 match network.walk_handshake(walk, &handshake_nk) {
                                     Ok(handle) => {
-                                        debug!("{:?}: will Handshake with neighbor-of-neighbor {:?} ({:?})", &network.local_peer, &handshake_nk, &nk);
+                                        debug!("{:?}: will Handshake with neighbor-of-neighbor {:?} {:?} (connected as {:?})", &network.local_peer, &na.public_key_hash, &nk, &handshake_nk);
                                         walk.unresolved_handshake_neighbors
                                             .insert(na.clone(), handle);
                                     }
@@ -2275,8 +2326,8 @@ impl PeerNetwork {
                                 }
                             }
                             Err(_e) => {
-                                info!(
-                                    "{:?}: cannot register peer {:?}: {:?}",
+                                debug!(
+                                    "{:?}: cannot handshake with neighbor peer {:?}: {:?}",
                                     &network.local_peer, &nk, &_e
                                 );
                                 continue;
@@ -2335,11 +2386,11 @@ impl PeerNetwork {
             for nk in walk.handshake_neighbor_keys.drain(..) {
                 if !network.is_registered(&nk) {
                     // not connected to this neighbor -- can't ask for neighbors
-                    warn!("Not connected to {:?}", &nk);
+                    debug!("{:?}: Not connected to {:?}", &network.local_peer, &nk);
                     continue;
                 }
 
-                test_debug!("{:?}: send GetNeighbors to {:?}", &walk.local_peer, &nk);
+                debug!("{:?}: send GetNeighbors to {:?}", &walk.local_peer, &nk);
 
                 let msg = network.sign_for_peer(&nk, StacksMessageType::GetNeighbors)?;
                 let rh_res = network.send_message(&nk, msg, network.connection_opts.timeout);
@@ -2350,7 +2401,7 @@ impl PeerNetwork {
                     Err(e) => {
                         // failed to begin getneighbors
                         debug!(
-                            "{:?}: Not connected to {:?}: {:?}",
+                            "{:?}: Could not send to {:?}: {:?}",
                             &walk.local_peer, &nk, &e
                         );
                         continue;
@@ -2462,7 +2513,7 @@ impl PeerNetwork {
                     }
                     Err(e) => {
                         debug!(
-                            "{:?}: Failed to connect to {:?}: {:?}",
+                            "{:?}: Failed to connect to pingback {:?}: {:?}",
                             &network.local_peer, &nk, &e
                         );
                         continue;

--- a/src/net/p2p.rs
+++ b/src/net/p2p.rs
@@ -582,7 +582,7 @@ impl PeerNetwork {
                     // safety check -- don't send to someone who has already been a relayer
                     let mut do_relay = true;
                     if let Some(pubkey) = convo.ref_public_key() {
-                        let pubkey_hash = Hash160::from_data(&pubkey.to_bytes());
+                        let pubkey_hash = Hash160::from_node_public_key(pubkey);
                         for rhint in relay_hints.iter() {
                             if rhint.peer.public_key_hash == pubkey_hash {
                                 do_relay = false;
@@ -819,7 +819,7 @@ impl PeerNetwork {
         // don't send a message to anyone who sent this message to us
         for (_, convo) in self.peers.iter() {
             if let Some(pubkey) = convo.ref_public_key() {
-                let pubkey_hash = Hash160::from_data(&pubkey.to_bytes());
+                let pubkey_hash = Hash160::from_node_public_key(pubkey);
                 if relay_pubkhs.contains(&pubkey_hash) {
                     let nk = convo.to_neighbor_key();
                     debug!(
@@ -1105,16 +1105,19 @@ impl PeerNetwork {
     }
 
     /// Is a node with the given public key hash registered?
-    /// Return the event ID if so
-    pub fn get_pubkey_event(&self, pubkh: &Hash160) -> Option<usize> {
-        for (_, convo) in self.peers.iter() {
-            if let Some(convo_pubkh) = convo.get_public_key_hash() {
-                if convo_pubkh == *pubkh {
-                    return Some(convo.conn_id);
+    /// Return the event IDs if so
+    pub fn get_pubkey_events(&self, pubkh: &Hash160) -> Vec<usize> {
+        let mut ret = vec![];
+        for (event_id, convo) in self.peers.iter() {
+            if convo.is_authenticated() {
+                if let Some(convo_pubkh) = convo.get_public_key_hash() {
+                    if convo_pubkh == *pubkh {
+                        ret.push(*event_id);
+                    }
                 }
             }
         }
-        None
+        ret
     }
 
     /// Find the neighbor key bound to an event ID
@@ -1193,22 +1196,39 @@ impl PeerNetwork {
         Ok(())
     }
 
-    /// Check to see if we can register a peer with a given public key
+    /// Check to see if we can register a peer with a given public key in a given direction
     pub fn can_register_peer_with_pubkey(
         &mut self,
         nk: &NeighborKey,
         outbound: bool,
         pubkh: &Hash160,
     ) -> Result<(), net_error> {
+        // can't talk to myself
+        let my_pubkey_hash = Hash160::from_node_public_key(
+            &Secp256k1PublicKey::from_private(&self.local_peer.private_key)
+        );
+        debug!("{:?}: my public key hash is {}", &self.local_peer, &my_pubkey_hash);
+        if pubkh == &my_pubkey_hash {
+            return Err(net_error::ConnectionCycle);
+        }
+
         self.can_register_peer(nk, outbound).and_then(|_| {
-            if let Some(event_id) = self.get_pubkey_event(pubkh) {
-                let nk = self
-                    .get_event_neighbor_key(event_id)
-                    .ok_or(net_error::PeerNotConnected)?;
-                Err(net_error::AlreadyConnected(event_id, nk))
-            } else {
-                Ok(())
+            let other_events = self.get_pubkey_events(pubkh);
+            if other_events.len() > 0 {
+                debug!("{:?}: events with public key {} for {:?}: {:?}", &self.local_peer, pubkh, nk, &other_events);
+                for event_id in other_events.into_iter() {
+                    if let Some(convo) = self.peers.get(&event_id) {
+                        // only care if we're trying to connect in the same direction
+                        if outbound == convo.is_outbound() {
+                            let nk = self
+                                .get_event_neighbor_key(event_id)
+                                .ok_or(net_error::PeerNotConnected)?;
+                            return Err(net_error::AlreadyConnected(event_id, nk));
+                        }
+                    }
+                }
             }
+            return Ok(());
         })
     }
 
@@ -1417,7 +1437,7 @@ impl PeerNetwork {
         match self.events.get(&peer_key) {
             None => {
                 // not connected
-                info!("Could not sign for peer {:?}: not connected", peer_key);
+                debug!("Could not sign for peer {:?}: not connected", peer_key);
                 Err(net_error::PeerNotConnected)
             }
             Some(event_id) => match self.peers.get_mut(&event_id) {
@@ -2918,8 +2938,8 @@ impl PeerNetwork {
             self.walk_pingbacks.remove(&naddr);
         }
 
-        let my_pubkey_hash = Hash160::from_data(
-            &Secp256k1PublicKey::from_private(&self.local_peer.private_key).to_bytes()[..],
+        let my_pubkey_hash = Hash160::from_node_public_key(
+            &Secp256k1PublicKey::from_private(&self.local_peer.private_key)
         );
 
         // add new pingbacks

--- a/src/net/p2p.rs
+++ b/src/net/p2p.rs
@@ -1204,10 +1204,13 @@ impl PeerNetwork {
         pubkh: &Hash160,
     ) -> Result<(), net_error> {
         // can't talk to myself
-        let my_pubkey_hash = Hash160::from_node_public_key(
-            &Secp256k1PublicKey::from_private(&self.local_peer.private_key)
+        let my_pubkey_hash = Hash160::from_node_public_key(&Secp256k1PublicKey::from_private(
+            &self.local_peer.private_key,
+        ));
+        debug!(
+            "{:?}: my public key hash is {}",
+            &self.local_peer, &my_pubkey_hash
         );
-        debug!("{:?}: my public key hash is {}", &self.local_peer, &my_pubkey_hash);
         if pubkh == &my_pubkey_hash {
             return Err(net_error::ConnectionCycle);
         }
@@ -1215,7 +1218,10 @@ impl PeerNetwork {
         self.can_register_peer(nk, outbound).and_then(|_| {
             let other_events = self.get_pubkey_events(pubkh);
             if other_events.len() > 0 {
-                debug!("{:?}: events with public key {} for {:?}: {:?}", &self.local_peer, pubkh, nk, &other_events);
+                debug!(
+                    "{:?}: events with public key {} for {:?}: {:?}",
+                    &self.local_peer, pubkh, nk, &other_events
+                );
                 for event_id in other_events.into_iter() {
                     if let Some(convo) = self.peers.get(&event_id) {
                         // only care if we're trying to connect in the same direction
@@ -2938,9 +2944,9 @@ impl PeerNetwork {
             self.walk_pingbacks.remove(&naddr);
         }
 
-        let my_pubkey_hash = Hash160::from_node_public_key(
-            &Secp256k1PublicKey::from_private(&self.local_peer.private_key)
-        );
+        let my_pubkey_hash = Hash160::from_node_public_key(&Secp256k1PublicKey::from_private(
+            &self.local_peer.private_key,
+        ));
 
         // add new pingbacks
         for event_id in event_ids.into_iter() {

--- a/src/net/p2p.rs
+++ b/src/net/p2p.rs
@@ -1207,10 +1207,6 @@ impl PeerNetwork {
         let my_pubkey_hash = Hash160::from_node_public_key(&Secp256k1PublicKey::from_private(
             &self.local_peer.private_key,
         ));
-        debug!(
-            "{:?}: my public key hash is {}",
-            &self.local_peer, &my_pubkey_hash
-        );
         if pubkh == &my_pubkey_hash {
             return Err(net_error::ConnectionCycle);
         }
@@ -1218,10 +1214,6 @@ impl PeerNetwork {
         self.can_register_peer(nk, outbound).and_then(|_| {
             let other_events = self.get_pubkey_events(pubkh);
             if other_events.len() > 0 {
-                debug!(
-                    "{:?}: events with public key {} for {:?}: {:?}",
-                    &self.local_peer, pubkh, nk, &other_events
-                );
                 for event_id in other_events.into_iter() {
                     if let Some(convo) = self.peers.get(&event_id) {
                         // only care if we're trying to connect in the same direction

--- a/src/net/rpc.rs
+++ b/src/net/rpc.rs
@@ -316,7 +316,7 @@ impl RPCNeighborsInfo {
             .map(|n| {
                 RPCNeighbor::from_neighbor_key_and_pubkh(
                     n.addr.clone(),
-                    Hash160::from_data(&n.public_key.to_bytes()),
+                    Hash160::from_node_public_key(&n.public_key),
                     true,
                 )
             })
@@ -2187,7 +2187,7 @@ mod test {
         .unwrap();
         let microblock_privkey = StacksPrivateKey::new();
         let microblock_pubkeyhash =
-            Hash160::from_data(&StacksPublicKey::from_private(&microblock_privkey).to_bytes());
+            Hash160::from_node_public_key(&StacksPublicKey::from_private(&microblock_privkey));
 
         let addr1 = StacksAddress::from_public_keys(
             C32_ADDRESS_VERSION_TESTNET_SINGLESIG,

--- a/src/util/hash.rs
+++ b/src/util/hash.rs
@@ -21,6 +21,7 @@ use std::mem;
 
 use util::log;
 use util::pair::*;
+use util::secp256k1::Secp256k1PublicKey;
 use util::HexError;
 
 use ripemd160::Ripemd160;
@@ -28,6 +29,8 @@ use sha2::{Digest, Sha256, Sha512, Sha512Trunc256};
 use sha3::Keccak256;
 
 use util::uint::Uint256;
+
+use net::StacksPublicKeyBuffer;
 
 use serde::de::Deserialize;
 use serde::de::Error as de_Error;
@@ -182,6 +185,14 @@ impl Hash160 {
         let sha2_result = Sha256::digest(data);
         let ripe_160_result = Ripemd160::digest(sha2_result.as_slice());
         Hash160::from(ripe_160_result.as_slice())
+    }
+
+    pub fn from_node_public_key(pubkey: &Secp256k1PublicKey) -> Hash160 {
+        Hash160::from_data(&pubkey.to_bytes_compressed())
+    }
+
+    pub fn from_node_public_key_buffer(pubkey_buf: &StacksPublicKeyBuffer) -> Hash160 {
+        Hash160::from_data(pubkey_buf.as_bytes())
     }
 }
 

--- a/src/util/secp256k1.rs
+++ b/src/util/secp256k1.rs
@@ -73,6 +73,7 @@ pub struct MessageSignature(pub [u8; 65]);
 impl_array_newtype!(MessageSignature, u8, 65);
 impl_array_hexstring_fmt!(MessageSignature);
 impl_byte_array_newtype!(MessageSignature, u8, 65);
+impl_byte_array_serde!(MessageSignature);
 pub const MESSAGE_SIGNATURE_ENCODED_SIZE: u32 = 65;
 
 impl MessageSignature {

--- a/src/util/strings.rs
+++ b/src/util/strings.rs
@@ -46,7 +46,7 @@ use util::retry::BoundReader;
 
 /// printable-ASCII-only string, but encodable.
 /// Note that it cannot be longer than ARRAY_MAX_LEN (4.1 billion bytes)
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Serialize, Deserialize)]
 pub struct StacksString(Vec<u8>);
 
 impl fmt::Display for StacksString {

--- a/src/util/vrf.rs
+++ b/src/util/vrf.rs
@@ -396,6 +396,20 @@ impl VRFProof {
     }
 }
 
+impl serde::Serialize for VRFProof {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        let inst = self.to_hex();
+        s.serialize_str(&inst)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for VRFProof {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<VRFProof, D::Error> {
+        let inst_str = String::deserialize(d)?;
+        VRFProof::from_hex(&inst_str).ok_or(serde::de::Error::custom(Error::InvalidDataError))
+    }
+}
+
 pub struct VRF {}
 
 impl VRF {

--- a/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
+++ b/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
@@ -56,7 +56,7 @@ pub struct BitcoinRegtestController {
     burnchain_config: Option<Burnchain>,
     last_utxos: Vec<UTXO>,
     last_tx_len: u64,
-    min_relay_fee: u64,     // satoshis/byte
+    min_relay_fee: u64, // satoshis/byte
 }
 
 const DUST_UTXO_LIMIT: u64 = 5500;
@@ -113,7 +113,7 @@ impl BitcoinRegtestController {
             burnchain_config,
             last_utxos: vec![],
             last_tx_len: 0,
-            min_relay_fee: 1024     // TODO: learn from bitcoind
+            min_relay_fee: 1024, // TODO: learn from bitcoind
         }
     }
 
@@ -146,7 +146,7 @@ impl BitcoinRegtestController {
             burnchain_config: None,
             last_utxos: vec![],
             last_tx_len: 0,
-            min_relay_fee: 1024     // TODO: learn from bitcoind
+            min_relay_fee: 1024, // TODO: learn from bitcoind
         }
     }
 
@@ -671,9 +671,10 @@ impl BitcoinRegtestController {
         utxos.sort_by(|u1, u2| u1.amount.cmp(&u2.amount));
         utxos.reverse();
 
-        // RBF 
-        let tx_fee = self.config.burnchain.burnchain_op_tx_fee + (attempt * self.last_tx_len * self.min_relay_fee);
-        
+        // RBF
+        let tx_fee = self.config.burnchain.burnchain_op_tx_fee
+            + (attempt * self.last_tx_len * self.min_relay_fee);
+
         let public_key = signer.get_public_key();
         let mut total_consumed = 0;
 
@@ -687,7 +688,7 @@ impl BitcoinRegtestController {
                 break;
             }
         }
-        
+
         // Append the change output
         let change_address_hash = Hash160::from_data(&public_key.to_bytes());
         if total_consumed < total_spent + tx_fee {
@@ -710,7 +711,7 @@ impl BitcoinRegtestController {
             let input = TxIn {
                 previous_output: OutPoint {
                     txid: utxo.txid,
-                    vout: utxo.vout
+                    vout: utxo.vout,
                 },
                 script_sig: Script::new(),
                 sequence: 0xFFFFFFFD, // allow RBF
@@ -738,7 +739,7 @@ impl BitcoinRegtestController {
                 .push_slice(&public_key.to_bytes())
                 .into_script();
         }
-        
+
         signer.dispose();
 
         // remember how long the transaction is, in case we need to RBF
@@ -1296,7 +1297,7 @@ impl BitcoinRPCRequest {
                 }
             }
         })?;
-       
+
         let status = response.status();
 
         let (res, buffer) = async_std::task::block_on(async move {
@@ -1305,14 +1306,15 @@ impl BitcoinRPCRequest {
             let res = body.read_to_end(&mut buffer).await;
             (res, buffer)
         });
-        
+
         if !status.is_success() {
             return Err(RPCError::Network(format!(
                 "Bitcoin RPC: status({}) != success, body is '{:?}'",
                 status,
                 match serde_json::from_slice::<serde_json::Value>(&buffer[..]) {
                     Ok(v) => v,
-                    Err(_e) => serde_json::from_str("\"(unparseable)\"").expect("Failed to parse JSON literal")
+                    Err(_e) => serde_json::from_str("\"(unparseable)\"")
+                        .expect("Failed to parse JSON literal"),
                 }
             )));
         }

--- a/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
+++ b/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
@@ -54,7 +54,7 @@ pub struct BitcoinRegtestController {
     chain_tip: Option<BurnchainTip>,
     use_coordinator: Option<CoordinatorChannels>,
     burnchain_config: Option<Burnchain>,
-    last_utxos: Vec<UTXO>
+    last_utxos: Vec<UTXO>,
 }
 
 const DUST_UTXO_LIMIT: u64 = 5500;
@@ -109,7 +109,7 @@ impl BitcoinRegtestController {
             burnchain_db: None,
             chain_tip: None,
             burnchain_config,
-            last_utxos: vec![]
+            last_utxos: vec![],
         }
     }
 
@@ -140,7 +140,7 @@ impl BitcoinRegtestController {
             burnchain_db: None,
             chain_tip: None,
             burnchain_config: None,
-            last_utxos: vec![]
+            last_utxos: vec![],
         }
     }
 
@@ -501,7 +501,7 @@ impl BitcoinRegtestController {
         &mut self,
         payload: LeaderKeyRegisterOp,
         signer: &mut BurnchainOpSigner,
-        attempt: u64
+        attempt: u64,
     ) -> Option<Transaction> {
         let public_key = signer.get_public_key();
 
@@ -549,7 +549,7 @@ impl BitcoinRegtestController {
         &mut self,
         payload: LeaderBlockCommitOp,
         signer: &mut BurnchainOpSigner,
-        attempt: u64
+        attempt: u64,
     ) -> Option<Transaction> {
         let public_key = signer.get_public_key();
 
@@ -620,28 +620,26 @@ impl BitcoinRegtestController {
         &mut self,
         public_key: &Secp256k1PublicKey,
         ops_fee: u64,
-        attempt: u64
+        attempt: u64,
     ) -> Option<(Transaction, Vec<UTXO>)> {
         let tx_fee = self.config.burnchain.burnchain_op_tx_fee;
         let amount_required = tx_fee + ops_fee;
 
-        let utxos =
-            if attempt > 1 && self.last_utxos.len() > 0 {
-                // in RBF, you have to consume the same UTXOs
-                self.last_utxos.clone()
-            }
-            else {
-                // Fetch some UTXOs
-                let new_utxos = match self.get_utxos(&public_key, amount_required) {
-                    Some(utxos) => utxos,
-                    None => {
-                        debug!("No UTXOs for {}", &public_key.to_hex());
-                        return None;
-                    }
-                };
-                self.last_utxos = new_utxos.clone();
-                new_utxos
+        let utxos = if attempt > 1 && self.last_utxos.len() > 0 {
+            // in RBF, you have to consume the same UTXOs
+            self.last_utxos.clone()
+        } else {
+            // Fetch some UTXOs
+            let new_utxos = match self.get_utxos(&public_key, amount_required) {
+                Some(utxos) => utxos,
+                None => {
+                    debug!("No UTXOs for {}", &public_key.to_hex());
+                    return None;
+                }
             };
+            self.last_utxos = new_utxos.clone();
+            new_utxos
+        };
 
         let mut inputs = vec![];
 
@@ -654,7 +652,7 @@ impl BitcoinRegtestController {
             let input = TxIn {
                 previous_output,
                 script_sig: Script::new(),
-                sequence: 0xFFFFFFFD,       // allow RBF
+                sequence: 0xFFFFFFFD, // allow RBF
                 witness: vec![],
             };
 
@@ -678,7 +676,7 @@ impl BitcoinRegtestController {
         total_spent: u64,
         utxos: Vec<UTXO>,
         signer: &mut BurnchainOpSigner,
-        attempt: u64
+        attempt: u64,
     ) -> Option<()> {
         // TODO: crude RBF -- total tx fee and tx fee per vbyte must both be greater than they were
         // before.
@@ -735,7 +733,7 @@ impl BitcoinRegtestController {
         &mut self,
         _payload: UserBurnSupportOp,
         _signer: &mut BurnchainOpSigner,
-        _attempt: u64
+        _attempt: u64,
     ) -> Option<Transaction> {
         unimplemented!()
     }
@@ -906,7 +904,7 @@ impl BurnchainController for BitcoinRegtestController {
         &mut self,
         operation: BlockstackOperationType,
         op_signer: &mut BurnchainOpSigner,
-        attempt: u64
+        attempt: u64,
     ) -> bool {
         let transaction = match operation {
             BlockstackOperationType::LeaderBlockCommit(payload) => {

--- a/testnet/stacks-node/src/burnchains/mocknet_controller.rs
+++ b/testnet/stacks-node/src/burnchains/mocknet_controller.rs
@@ -121,7 +121,7 @@ impl BurnchainController for MocknetController {
         &mut self,
         operation: BlockstackOperationType,
         _op_signer: &mut BurnchainOpSigner,
-        _attempt: u64
+        _attempt: u64,
     ) -> bool {
         self.queued_operations.push_back(operation);
         true

--- a/testnet/stacks-node/src/burnchains/mocknet_controller.rs
+++ b/testnet/stacks-node/src/burnchains/mocknet_controller.rs
@@ -121,6 +121,7 @@ impl BurnchainController for MocknetController {
         &mut self,
         operation: BlockstackOperationType,
         _op_signer: &mut BurnchainOpSigner,
+        _attempt: u64
     ) -> bool {
         self.queued_operations.push_back(operation);
         true

--- a/testnet/stacks-node/src/burnchains/mod.rs
+++ b/testnet/stacks-node/src/burnchains/mod.rs
@@ -37,6 +37,7 @@ pub trait BurnchainController {
         &mut self,
         operation: BlockstackOperationType,
         op_signer: &mut BurnchainOpSigner,
+        attempt: u64
     ) -> bool;
     fn sync(&mut self, target_block_height_opt: Option<u64>) -> Result<(BurnchainTip, u64), Error>;
     fn sortdb_ref(&self) -> &SortitionDB;

--- a/testnet/stacks-node/src/burnchains/mod.rs
+++ b/testnet/stacks-node/src/burnchains/mod.rs
@@ -37,7 +37,7 @@ pub trait BurnchainController {
         &mut self,
         operation: BlockstackOperationType,
         op_signer: &mut BurnchainOpSigner,
-        attempt: u64
+        attempt: u64,
     ) -> bool;
     fn sync(&mut self, target_block_height_opt: Option<u64>) -> Result<(BurnchainTip, u64), Error>;
     fn sortdb_ref(&self) -> &SortitionDB;

--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -53,7 +53,7 @@ impl ConfigFile {
         };
 
         let node = NodeConfigFile {
-            bootstrap_node: Some("048dd4f26101715853533dee005f0915375854fd5be73405f679c1917a5d4d16aaaf3c4c0d7a9c132a36b8c5fe1287f07dad8c910174d789eb24bdfb5ae26f5f27@neon.blockstack.org:20444".to_string()),
+            bootstrap_node: Some("038dd4f26101715853533dee005f0915375854fd5be73405f679c1917a5d4d16aa@neon.blockstack.org:20444".to_string()),
             miner: Some(false),
             ..NodeConfigFile::default()
         };
@@ -489,7 +489,7 @@ impl Config {
                 let ip_addr = match opts.public_ip_address {
                     Some(public_ip_address) => {
                         let addr = public_ip_address.parse::<SocketAddr>().unwrap();
-                        println!("addr.parse {:?}", addr);
+                        debug!("addr.parse {:?}", addr);
                         Some((PeerAddress::from_socketaddr(&addr), addr.port()))
                     }
                     None => None,
@@ -748,7 +748,7 @@ impl BurnchainConfig {
             local_mining_public_key: None,
             burnchain_op_tx_fee: MINIMUM_DUST_FEE,
             process_exit_at_block_height: None,
-            poll_time_secs: 30, // TODO: this is a testnet specific value.
+            poll_time_secs: 10, // TODO: this is a testnet specific value.
         }
     }
 
@@ -849,7 +849,7 @@ impl NodeConfig {
             local_peer_seed: local_peer_seed.to_vec(),
             miner: false,
             mine_microblocks: false,
-            wait_time_for_microblocks: 15000,
+            wait_time_for_microblocks: 5000,
             prometheus_bind: None,
             pox_sync_sample_secs: 30,
         }
@@ -868,6 +868,9 @@ impl NodeConfig {
             let comps: Vec<&str> = bootstrap_node.split("@").collect();
             match comps[..] {
                 [public_key, peer_addr] => {
+                    let mut pubk = Secp256k1PublicKey::from_hex(public_key).unwrap();
+                    pubk.set_compressed(true);
+
                     let mut addrs_iter = peer_addr.to_socket_addrs().unwrap();
                     let sock_addr = addrs_iter.next().unwrap();
                     let neighbor = Neighbor {
@@ -877,7 +880,7 @@ impl NodeConfig {
                             addrbytes: PeerAddress::from_socketaddr(&sock_addr),
                             port: sock_addr.port(),
                         },
-                        public_key: Secp256k1PublicKey::from_hex(public_key).unwrap(),
+                        public_key: pubk,
                         expire_block: 99999,
                         last_contact_time: 0,
                         allowed: 0,

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -990,7 +990,8 @@ impl InitializedNeonNode {
         // Generates a new secret key for signing the trail of microblocks
         // of the upcoming tenure.
         let microblock_secret_key = keychain.rotate_microblock_keypair();
-        let mblock_pubkey_hash = Hash160::from_node_public_key(&StacksPublicKey::from_private(&microblock_secret_key));
+        let mblock_pubkey_hash =
+            Hash160::from_node_public_key(&StacksPublicKey::from_private(&microblock_secret_key));
 
         let coinbase_tx = inner_generate_coinbase_tx(keychain, coinbase_nonce);
 

--- a/testnet/stacks-node/src/node.rs
+++ b/testnet/stacks-node/src/node.rs
@@ -358,7 +358,7 @@ impl Node {
         let consensus_hash = burnchain_tip.block_snapshot.consensus_hash;
         let key_reg_op = self.generate_leader_key_register_op(vrf_pk, &consensus_hash);
         let mut op_signer = self.keychain.generate_op_signer();
-        burnchain_controller.submit_operation(key_reg_op, &mut op_signer);
+        burnchain_controller.submit_operation(key_reg_op, &mut op_signer, 1);
     }
 
     /// Process an state coming from the burnchain, by extracting the validated KeyRegisterOp
@@ -520,7 +520,7 @@ impl Node {
             );
 
             let mut op_signer = self.keychain.generate_op_signer();
-            burnchain_controller.submit_operation(op, &mut op_signer);
+            burnchain_controller.submit_operation(op, &mut op_signer, 1);
         }
     }
 

--- a/testnet/stacks-node/src/run_loop/neon.rs
+++ b/testnet/stacks-node/src/run_loop/neon.rs
@@ -211,7 +211,7 @@ impl RunLoop {
             chainstate_path,
             self.config.burnchain.poll_time_secs,
             self.config.connection_options.timeout,
-            self.config.node.pox_sync_sample_secs
+            self.config.node.pox_sync_sample_secs,
         )
         .unwrap();
         let mut burnchain_height = 1;
@@ -274,7 +274,10 @@ impl RunLoop {
 
             if block_height >= burnchain_height {
                 // at tip. proceed to mine.
-                debug!("Synchronized full burnchain up to height {}. Proceeding to mine blocks", block_height);
+                debug!(
+                    "Synchronized full burnchain up to height {}. Proceeding to mine blocks",
+                    block_height
+                );
                 if !node.relayer_issue_tenure() {
                     // relayer hung up, exit.
                     error!("Block relayer and miner hung up, exiting.");

--- a/testnet/stacks-node/src/run_loop/neon.rs
+++ b/testnet/stacks-node/src/run_loop/neon.rs
@@ -1,5 +1,3 @@
-use std::thread;
-
 use crate::{
     neon_node, BitcoinRegtestController, BurnchainController, Config, EventDispatcher, Keychain,
     NeonGenesisNode,
@@ -10,6 +8,8 @@ use stacks::burnchains::{Address, Burnchain};
 use stacks::chainstate::burn::db::sortdb::SortitionDB;
 use stacks::chainstate::coordinator::comm::{CoordinatorChannels, CoordinatorReceivers};
 use stacks::chainstate::coordinator::{ChainsCoordinator, CoordinatorCommunication};
+use std::cmp;
+use std::thread;
 
 use super::RunLoopCallbacks;
 
@@ -233,7 +233,15 @@ impl RunLoop {
                     }
                 };
 
-            target_burnchain_block_height += pox_constants.reward_cycle_length as u64;
+            target_burnchain_block_height = cmp::min(
+                target_burnchain_block_height + pox_constants.reward_cycle_length as u64,
+                burnchain_height + 1,
+            );
+            debug!(
+                "Downloaded burnchain blocks up to height {}; new target height is {}",
+                next_burnchain_height, target_burnchain_block_height
+            );
+
             burnchain_tip = next_burnchain_tip;
             burnchain_height = next_burnchain_height;
 
@@ -267,7 +275,7 @@ impl RunLoop {
 
                 block_height = next_height;
                 debug!(
-                    "Synchronized up to block height {} (chain tip height is {})",
+                    "Synchronized burnchain up to block height {} (chain tip height is {})",
                     block_height, burnchain_height
                 );
             }

--- a/testnet/stacks-node/src/run_loop/neon.rs
+++ b/testnet/stacks-node/src/run_loop/neon.rs
@@ -210,7 +210,8 @@ impl RunLoop {
             chainid,
             chainstate_path,
             self.config.burnchain.poll_time_secs,
-            self.config.node.pox_sync_sample_secs,
+            self.config.connection_options.timeout,
+            self.config.node.pox_sync_sample_secs
         )
         .unwrap();
         let mut burnchain_height = 1;
@@ -238,44 +239,42 @@ impl RunLoop {
 
             let sortition_tip = &burnchain_tip.block_snapshot.sortition_id;
             let next_height = burnchain_tip.block_snapshot.block_height;
-            if next_height <= block_height {
-                warn!("burnchain.sync() did not progress block height");
-                continue;
-            }
 
-            // first, let's process all blocks in (block_height, next_height]
-            for block_to_process in (block_height + 1)..(next_height + 1) {
-                let block = {
-                    let ic = burnchain.sortdb_ref().index_conn();
-                    SortitionDB::get_ancestor_snapshot(&ic, block_to_process, sortition_tip)
-                        .unwrap()
-                        .expect("Failed to find block in fork processed by bitcoin indexer")
-                };
-                let sortition_id = &block.sortition_id;
+            if next_height > block_height {
+                // first, let's process all blocks in (block_height, next_height]
+                for block_to_process in (block_height + 1)..(next_height + 1) {
+                    let block = {
+                        let ic = burnchain.sortdb_ref().index_conn();
+                        SortitionDB::get_ancestor_snapshot(&ic, block_to_process, sortition_tip)
+                            .unwrap()
+                            .expect("Failed to find block in fork processed by bitcoin indexer")
+                    };
+                    let sortition_id = &block.sortition_id;
 
-                // Have the node process the new block, that can include, or not, a sortition.
-                node.process_burnchain_state(burnchain.sortdb_mut(), sortition_id, ibd);
+                    // Have the node process the new block, that can include, or not, a sortition.
+                    node.process_burnchain_state(burnchain.sortdb_mut(), sortition_id, ibd);
 
-                // Now, tell the relayer to check if it won a sortition during this block,
-                //   and, if so, to process and advertize the block
-                //
-                // _this will block if the relayer's buffer is full_
-                if !node.relayer_sortition_notify() {
-                    // relayer hung up, exit.
-                    error!("Block relayer and miner hung up, exiting.");
-                    return;
+                    // Now, tell the relayer to check if it won a sortition during this block,
+                    //   and, if so, to process and advertize the block
+                    //
+                    // _this will block if the relayer's buffer is full_
+                    if !node.relayer_sortition_notify() {
+                        // relayer hung up, exit.
+                        error!("Block relayer and miner hung up, exiting.");
+                        return;
+                    }
                 }
-            }
 
-            block_height = next_height;
-            debug!(
-                "Synchronized up to block height {} (chain tip height is {})",
-                block_height, burnchain_height
-            );
+                block_height = next_height;
+                debug!(
+                    "Synchronized up to block height {} (chain tip height is {})",
+                    block_height, burnchain_height
+                );
+            }
 
             if block_height >= burnchain_height {
                 // at tip. proceed to mine.
-                debug!("Synchronized full burnchain. Proceeding to mine blocks");
+                debug!("Synchronized full burnchain up to height {}. Proceeding to mine blocks", block_height);
                 if !node.relayer_issue_tenure() {
                     // relayer hung up, exit.
                     error!("Block relayer and miner hung up, exiting.");

--- a/testnet/stacks-node/src/run_loop/neon.rs
+++ b/testnet/stacks-node/src/run_loop/neon.rs
@@ -272,8 +272,8 @@ impl RunLoop {
                 );
             }
 
-            if block_height >= burnchain_height {
-                // at tip. proceed to mine.
+            if block_height >= burnchain_height && !ibd {
+                // at tip, and not downloading. proceed to mine.
                 debug!(
                     "Synchronized full burnchain up to height {}. Proceeding to mine blocks",
                     block_height

--- a/testnet/stacks-node/src/syncctl.rs
+++ b/testnet/stacks-node/src/syncctl.rs
@@ -52,6 +52,7 @@ impl PoxSyncWatchdog {
         chainstate_path: String,
         burnchain_poll_time: u64,
         download_timeout: u64,
+        max_samples: u64,
     ) -> Result<PoxSyncWatchdog, String> {
         let (chainstate, _) = match StacksChainState::open(mainnet, chain_id, &chainstate_path) {
             Ok(cs) => cs,
@@ -68,7 +69,7 @@ impl PoxSyncWatchdog {
             new_processed_blocks: VecDeque::new(),
             last_attachable_query: 0,
             last_processed_query: 0,
-            max_samples: download_timeout, // sample once per second for however long we expect a timeout to be
+            max_samples: max_samples,
             max_staging: 10,
             watch_start_ts: 0,
             last_block_processed_ts: 0,

--- a/testnet/stacks-node/src/syncctl.rs
+++ b/testnet/stacks-node/src/syncctl.rs
@@ -434,6 +434,12 @@ impl PoxSyncWatchdog {
                             }
                             sleep_ms(PER_SAMPLE_WAIT_MS);
                             continue;
+                        } else {
+                            // steady state
+                            if !steady_state {
+                                debug!("PoX watchdog: In steady-state, but ready burnchain synchronization as of {}", self.steady_state_resync_ts);
+                                steady_state = true;
+                            }
                         }
                     }
                 }

--- a/testnet/stacks-node/src/tenure.rs
+++ b/testnet/stacks-node/src/tenure.rs
@@ -4,7 +4,6 @@ use super::{BurnchainTip, Config};
 use std::thread;
 use std::time::{Duration, Instant};
 
-use stacks::burnchains::PublicKey;
 use stacks::chainstate::burn::VRFSeed;
 use stacks::chainstate::stacks::db::StacksChainState;
 use stacks::chainstate::stacks::{
@@ -50,7 +49,7 @@ impl<'a> Tenure {
     ) -> Tenure {
         let mut microblock_pubkey = StacksPublicKey::from_private(&microblock_secret_key);
         microblock_pubkey.set_compressed(true);
-        let microblock_pubkeyhash = Hash160::from_data(&microblock_pubkey.to_bytes());
+        let microblock_pubkeyhash = Hash160::from_node_public_key(&microblock_pubkey);
 
         let parent_block_total_burn = burnchain_tip.block_snapshot.total_burn;
 

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -2,7 +2,7 @@ use super::{
     make_contract_call, make_contract_publish, make_contract_publish_microblock_only,
     make_microblock, make_stacks_transfer_mblock_only, to_addr, ADDR_4, SK_1,
 };
-use stacks::burnchains::{Address, PoxConstants, PublicKey};
+use stacks::burnchains::{Address, PoxConstants};
 use stacks::chainstate::burn::ConsensusHash;
 use stacks::chainstate::stacks::{
     db::StacksChainState, StacksAddress, StacksBlock, StacksBlockHeader, StacksPrivateKey,
@@ -180,7 +180,7 @@ fn find_microblock_privkey(
     let mut keychain = Keychain::default(conf.node.seed.clone());
     for _ in 0..max_tries {
         let privk = keychain.rotate_microblock_keypair();
-        let pubkh = Hash160::from_data(&StacksPublicKey::from_private(&privk).to_bytes());
+        let pubkh = Hash160::from_node_public_key(&StacksPublicKey::from_private(&privk));
         if pubkh == *pubkey_hash {
             return Some(privk);
         }
@@ -716,14 +716,14 @@ fn pox_integration_test() {
     )
     .unwrap();
     let pox_pubkey_hash = bytes_to_hex(
-        &Hash160::from_data(&pox_pubkey.to_bytes())
+        &Hash160::from_node_public_key(&pox_pubkey)
             .to_bytes()
             .to_vec(),
     );
 
     let pox_2_pubkey = Secp256k1PublicKey::from_private(&StacksPrivateKey::new());
     let pox_2_pubkey_hash = bytes_to_hex(
-        &Hash160::from_data(&pox_2_pubkey.to_bytes())
+        &Hash160::from_node_public_key(&pox_2_pubkey)
             .to_bytes()
             .to_vec(),
     );


### PR DESCRIPTION
This PR adds a rudimentary set of tools for testing multiple Stacks nodes.  No container tech is used (or needed) yet -- so far, I've been using the tools without it successfully.  They have all been added to the new `./net-test` directory, and a simple `README.md` has been added.  Soon (but not in this PR), we can create some end-to-end integration tests with them that run as Github actions.

This PR also fixes #1979, #1978, #1966, #1943, #1941, as well as our long-time foes #1745 and #1760.  The resulting high-level behaviors have changed:

* When mining, the node will now attempt to assemble a block multiple times during the tenure.  It will do so whenever it notices that the canonical chain tip has changed since it last assembled a block in the same tenure.  Each time it does so, it uses Bitcoin's replace-by-fee to broadcast the newer block-commit and override the older one.  If _one of_ its block-commits wins sortition, it broadcasts the associated Stacks block that won.  By generating multiple Stacks blocks per tenure, the miner will have a much, much better chance of building off of the true chain tip.

* The networking code had neglected to enforce a canonical public key representation for node session keys.  This omission was responsible for the node accidentally relaying transactions back to the original sender -- due to this oversight, the node calculated the wrong `Hash160` for its neighbors' public keys by using a different representation than the remote neighbor had been using.  This PR fixes this, and as a result, it correctly identifies relay cycles and avoids re-sending messages back to a relayer that had already seen them.

* The neighbor-walk logic had not been aggressive enough in establishing outbound connections.  Namely, if node A had established an outbound connection to node B, then node B would _not_ try and establish an outbound connection to node A since node B was already connected inbound.  This, in turn, prevents B from downloading A's block inventories and blocks.  If A and B are miners, this causes B to miss some blocks -- if A doesn't select B as a target for block propagation, then B can't recover by downloading the block from A later.  This PR fixes this so B will always try and establish an outbound connection to A, even if A is already connected inbound.

In testing this code with the (rudimentary) network testing tools, I have successfully observed two Stacks miners collaboratively produce a 500-block chain _with no forks_, and I have been able to broadcast hundreds of transactions to one of the miners and have the other both receive them into its own mempool and never attempt to re-relay them back to the sender.