### PR TITLE
Add Dockerfile that can run net-test scripts

### DIFF
--- a/.github/actions/bitcoin-int-tests/Dockerfile.net-tests
+++ b/.github/actions/bitcoin-int-tests/Dockerfile.net-tests
@@ -1,0 +1,21 @@
+FROM rust:buster
+
+WORKDIR /src
+
+COPY . .
+
+RUN cd / && wget https://bitcoin.org/bin/bitcoin-core-0.20.0/bitcoin-0.20.0-x86_64-linux-gnu.tar.gz
+RUN cd / && tar -xvzf bitcoin-0.20.0-x86_64-linux-gnu.tar.gz
+
+RUN ln -s /bitcoin-0.20.0/bin/bitcoind /bin/
+RUN ln -s /bitcoin-0.20.0/bin/bitcoin-cli /bin/
+
+RUN apt-get update
+RUN apt-get install -y jq screen net-tools ncat
+
+RUN cargo build --workspace
+
+ENV PATH="/src/target/debug:/src/net-test/bin:${PATH}"
+
+WORKDIR /src/net-test/bin
+RUN bash

--- a/net-test/bin/faucet.sh
+++ b/net-test/bin/faucet.sh
@@ -43,6 +43,7 @@ http_401() {
 http_500() {
    local ERR="$1"
    local ERR_LEN=${#ERR}
+   log "500 error: ${ERR}"
    printf "HTTP/1.0 500 Internal Server error\r\nContent-Length: $ERR_LEN\r\nContent-Type: text/plain\r\n\r\n$ERR"
 }
 

--- a/net-test/bin/start.sh
+++ b/net-test/bin/start.sh
@@ -61,7 +61,7 @@ start_bitcoind() {
    logln "ok"
    
    log "Starting bitcoind..."
-   bitcoind -conf="$BITCOIN_CONF" >"$BITCOIN_LOGFILE" 2>&1 &
+   bitcoind -fallbackfee=0.0002 -conf="$BITCOIN_CONF" >"$BITCOIN_LOGFILE" 2>&1 &
    local BITCOIN_PID=$!
    logln "PID $BITCOIN_PID"
 


### PR DESCRIPTION
This adds a Dockerfile that can run the net-test scripts, as well as adding more 500 logging to the faucet, and a fallbackfee option to bitcoind (this was necessary to run for me: bitcoind was consistently failing to estimate fees otherwise).