### PR TITLE
#1950 - add burn block info to events

### DIFF
--- a/src/chainstate/burn/db/sortdb.rs
+++ b/src/chainstate/burn/db/sortdb.rs
@@ -2799,7 +2799,6 @@ impl SortitionDB {
     }
 
     /// Get a block snapshot for a winning block hash in a given burn chain fork.
-    #[cfg(test)]
     pub fn get_block_snapshot_for_winning_stacks_block(
         ic: &SortitionDBConn,
         tip: &SortitionId,

--- a/src/chainstate/coordinator/mod.rs
+++ b/src/chainstate/coordinator/mod.rs
@@ -20,7 +20,7 @@ use std::time::Duration;
 
 use burnchains::{
     db::{BurnchainBlockData, BurnchainDB},
-    Burnchain, BurnchainBlockHeader, BurnchainHeaderHash, Error as BurnchainError,
+    Txid, Burnchain, BurnchainBlockHeader, BurnchainHeaderHash, Error as BurnchainError,
 };
 use chainstate::burn::{
     db::sortdb::{PoxId, SortitionDB, SortitionId},
@@ -107,6 +107,7 @@ pub trait BlockEventDispatcher {
         metadata: StacksHeaderInfo,
         receipts: Vec<StacksTransactionReceipt>,
         parent: &StacksBlockId,
+        winner_txid: Txid
     );
 
     fn dispatch_boot_receipts(&mut self, receipts: Vec<StacksTransactionReceipt>);
@@ -572,15 +573,16 @@ impl<'a, T: BlockEventDispatcher, N: CoordinatorNotices, U: RewardSetProvider>
                     &block_receipt.header.anchored_header.block_hash(),
                 )?;
                 if in_sortition_set {
-                    let new_canonical_stacks_block = SortitionDB::get_block_snapshot(
+                    let new_canonical_block_snapshot = SortitionDB::get_block_snapshot(
                         self.sortition_db.conn(),
                         canonical_sortition_tip,
                     )?
                     .expect(&format!(
                         "FAIL: could not find data for the canonical sortition {}",
                         canonical_sortition_tip
-                    ))
-                    .get_canonical_stacks_block_id();
+                    ));
+                    let new_canonical_stacks_block = new_canonical_block_snapshot
+                        .get_canonical_stacks_block_id();
                     self.canonical_chain_tip = Some(new_canonical_stacks_block);
                     debug!("Bump blocks processed");
                     self.notifier.notify_stacks_block_processed();
@@ -588,7 +590,13 @@ impl<'a, T: BlockEventDispatcher, N: CoordinatorNotices, U: RewardSetProvider>
                     let block_hash = block_receipt.header.anchored_header.block_hash();
 
                     if let Some(dispatcher) = self.dispatcher {
-                        let metadata = &block_receipt.header;
+                        let metadata = &block_receipt.header;                        
+                        let winner_txid = SortitionDB::get_block_snapshot_for_winning_stacks_block(
+                            &self.sortition_db.index_conn(), canonical_sortition_tip, &block_hash)
+                            .expect("FAIL: could not find block snapshot for winning block hash")
+                            .expect("FAIL: could not find block snapshot for winning block hash")
+                            .winning_block_txid;
+
                         let block: StacksBlock = {
                             let block_path = StacksChainState::get_block_path(
                                 &self.chain_state_db.blocks_path,
@@ -609,6 +617,7 @@ impl<'a, T: BlockEventDispatcher, N: CoordinatorNotices, U: RewardSetProvider>
                             block_receipt.header,
                             block_receipt.tx_receipts,
                             &parent,
+                            winner_txid
                         );
                     }
 

--- a/src/chainstate/coordinator/mod.rs
+++ b/src/chainstate/coordinator/mod.rs
@@ -20,7 +20,7 @@ use std::time::Duration;
 
 use burnchains::{
     db::{BurnchainBlockData, BurnchainDB},
-    Txid, Burnchain, BurnchainBlockHeader, BurnchainHeaderHash, Error as BurnchainError,
+    Burnchain, BurnchainBlockHeader, BurnchainHeaderHash, Error as BurnchainError, Txid,
 };
 use chainstate::burn::{
     db::sortdb::{PoxId, SortitionDB, SortitionId},
@@ -107,7 +107,7 @@ pub trait BlockEventDispatcher {
         metadata: StacksHeaderInfo,
         receipts: Vec<StacksTransactionReceipt>,
         parent: &StacksBlockId,
-        winner_txid: Txid
+        winner_txid: Txid,
     );
 
     fn dispatch_boot_receipts(&mut self, receipts: Vec<StacksTransactionReceipt>);
@@ -581,8 +581,8 @@ impl<'a, T: BlockEventDispatcher, N: CoordinatorNotices, U: RewardSetProvider>
                         "FAIL: could not find data for the canonical sortition {}",
                         canonical_sortition_tip
                     ));
-                    let new_canonical_stacks_block = new_canonical_block_snapshot
-                        .get_canonical_stacks_block_id();
+                    let new_canonical_stacks_block =
+                        new_canonical_block_snapshot.get_canonical_stacks_block_id();
                     self.canonical_chain_tip = Some(new_canonical_stacks_block);
                     debug!("Bump blocks processed");
                     self.notifier.notify_stacks_block_processed();
@@ -590,12 +590,15 @@ impl<'a, T: BlockEventDispatcher, N: CoordinatorNotices, U: RewardSetProvider>
                     let block_hash = block_receipt.header.anchored_header.block_hash();
 
                     if let Some(dispatcher) = self.dispatcher {
-                        let metadata = &block_receipt.header;                        
+                        let metadata = &block_receipt.header;
                         let winner_txid = SortitionDB::get_block_snapshot_for_winning_stacks_block(
-                            &self.sortition_db.index_conn(), canonical_sortition_tip, &block_hash)
-                            .expect("FAIL: could not find block snapshot for winning block hash")
-                            .expect("FAIL: could not find block snapshot for winning block hash")
-                            .winning_block_txid;
+                            &self.sortition_db.index_conn(),
+                            canonical_sortition_tip,
+                            &block_hash,
+                        )
+                        .expect("FAIL: could not find block snapshot for winning block hash")
+                        .expect("FAIL: could not find block snapshot for winning block hash")
+                        .winning_block_txid;
 
                         let block: StacksBlock = {
                             let block_path = StacksChainState::get_block_path(
@@ -617,7 +620,7 @@ impl<'a, T: BlockEventDispatcher, N: CoordinatorNotices, U: RewardSetProvider>
                             block_receipt.header,
                             block_receipt.tx_receipts,
                             &parent,
-                            winner_txid
+                            winner_txid,
                         );
                     }
 

--- a/src/chainstate/coordinator/tests.rs
+++ b/src/chainstate/coordinator/tests.rs
@@ -228,7 +228,7 @@ impl BlockEventDispatcher for NullEventDispatcher {
         _metadata: StacksHeaderInfo,
         _receipts: Vec<StacksTransactionReceipt>,
         _parent: &StacksBlockId,
-        _winner_txid: Txid
+        _winner_txid: Txid,
     ) {
         assert!(
             false,

--- a/src/chainstate/coordinator/tests.rs
+++ b/src/chainstate/coordinator/tests.rs
@@ -228,6 +228,7 @@ impl BlockEventDispatcher for NullEventDispatcher {
         _metadata: StacksHeaderInfo,
         _receipts: Vec<StacksTransactionReceipt>,
         _parent: &StacksBlockId,
+        _winner_txid: Txid
     ) {
         assert!(
             false,

--- a/testnet/stacks-node/src/event_dispatcher.rs
+++ b/testnet/stacks-node/src/event_dispatcher.rs
@@ -173,6 +173,7 @@ impl EventObserver {
         chain_tip: &ChainTip,
         parent_index_hash: &StacksBlockId,
         boot_receipts: Option<&Vec<StacksTransactionReceipt>>,
+        winner_txid: &Txid,
     ) {
         // Serialize events to JSON
         let serialized_events: Vec<serde_json::Value> = filtered_events
@@ -201,6 +202,9 @@ impl EventObserver {
         let payload = json!({
             "block_hash": format!("0x{}", chain_tip.block.block_hash()),
             "block_height": chain_tip.metadata.block_height,
+            "burn_block_hash": format!("0x{}", chain_tip.metadata.burn_header_hash),
+            "burn_block_height": chain_tip.metadata.burn_header_height,
+            "miner_txid": format!("0x{}", winner_txid),
             "burn_block_time": chain_tip.metadata.burn_header_timestamp,
             "index_block_hash": format!("0x{}", chain_tip.metadata.index_block_hash()),
             "parent_block_hash": format!("0x{}", chain_tip.block.header.parent_block),
@@ -233,13 +237,14 @@ impl BlockEventDispatcher for EventDispatcher {
         metadata: StacksHeaderInfo,
         receipts: Vec<StacksTransactionReceipt>,
         parent: &StacksBlockId,
+        winner_txid: Txid,
     ) {
         let chain_tip = ChainTip {
             metadata,
             block,
             receipts,
         };
-        self.process_chain_tip(&chain_tip, parent)
+        self.process_chain_tip(&chain_tip, parent, winner_txid)
     }
 
     fn dispatch_boot_receipts(&mut self, receipts: Vec<StacksTransactionReceipt>) {
@@ -260,7 +265,7 @@ impl EventDispatcher {
         }
     }
 
-    pub fn process_chain_tip(&self, chain_tip: &ChainTip, parent_index_hash: &StacksBlockId) {
+    pub fn process_chain_tip(&self, chain_tip: &ChainTip, parent_index_hash: &StacksBlockId, winner_txid: Txid) {
         let mut dispatch_matrix: Vec<HashSet<usize>> = self
             .registered_observers
             .iter()
@@ -346,6 +351,7 @@ impl EventDispatcher {
                 chain_tip,
                 parent_index_hash,
                 boot_receipts,
+                &winner_txid
             );
         }
     }

--- a/testnet/stacks-node/src/event_dispatcher.rs
+++ b/testnet/stacks-node/src/event_dispatcher.rs
@@ -265,7 +265,12 @@ impl EventDispatcher {
         }
     }
 
-    pub fn process_chain_tip(&self, chain_tip: &ChainTip, parent_index_hash: &StacksBlockId, winner_txid: Txid) {
+    pub fn process_chain_tip(
+        &self,
+        chain_tip: &ChainTip,
+        parent_index_hash: &StacksBlockId,
+        winner_txid: Txid,
+    ) {
         let mut dispatch_matrix: Vec<HashSet<usize>> = self
             .registered_observers
             .iter()
@@ -351,7 +356,7 @@ impl EventDispatcher {
                 chain_tip,
                 parent_index_hash,
                 boot_receipts,
-                &winner_txid
+                &winner_txid,
             );
         }
     }

--- a/testnet/stacks-node/src/node.rs
+++ b/testnet/stacks-node/src/node.rs
@@ -631,7 +631,7 @@ impl Node {
         };
 
         self.event_dispatcher
-            .process_chain_tip(&chain_tip, &parent_index_hash);
+            .process_chain_tip(&chain_tip, &parent_index_hash, Txid([0; 32]));
 
         self.chain_tip = Some(chain_tip.clone());
 

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -491,6 +491,28 @@ fn microblock_integration_test() {
             assert_eq!(&parent_index_hash, previous_index_hash);
         }
 
+        // make sure we have a burn_block_hash, burn_block_height and miner_txid
+
+        eprintln!("{}", block);
+
+        let _burn_block_hash = block
+            .get("burn_block_hash")
+            .unwrap()
+            .as_str()
+            .unwrap();
+
+        let _burn_block_height = block
+            .get("burn_block_height")
+            .unwrap()
+            .as_u64()
+            .unwrap();
+
+        let _miner_txid = block
+            .get("miner_txid")
+            .unwrap()
+            .as_str()
+            .unwrap();
+
         prior = Some(my_index_hash);
     }
 

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -495,23 +495,11 @@ fn microblock_integration_test() {
 
         eprintln!("{}", block);
 
-        let _burn_block_hash = block
-            .get("burn_block_hash")
-            .unwrap()
-            .as_str()
-            .unwrap();
+        let _burn_block_hash = block.get("burn_block_hash").unwrap().as_str().unwrap();
 
-        let _burn_block_height = block
-            .get("burn_block_height")
-            .unwrap()
-            .as_u64()
-            .unwrap();
+        let _burn_block_height = block.get("burn_block_height").unwrap().as_u64().unwrap();
 
-        let _miner_txid = block
-            .get("miner_txid")
-            .unwrap()
-            .as_str()
-            .unwrap();
+        let _miner_txid = block.get("miner_txid").unwrap().as_str().unwrap();
 
         prior = Some(my_index_hash);
     }


### PR DESCRIPTION
This adds:

`burn_block_hash`
`burn_block_height`
`miner_txid`

To the block events sent out via the event_dispatcher.