### PR TITLE
PoX Sunsetting

### DIFF
--- a/sip/sip-007-stacking-consensus.md
+++ b/sip/sip-007-stacking-consensus.md
@@ -490,7 +490,6 @@ Due to the costs of remaining vigilent, this proposal recomments _R = 0.25_.
 At the time of this writing, this is higher than any single STX allocation, but
 not so high that large-scale cooperation is needed to stop a mining cartel.
 
-
 # Bitcoin Wire Formats
 
 Supporting PoX in the Stacks blockchain requires modifications to the
@@ -521,3 +520,16 @@ the second through nth outputs:
        block commit transaction must burn BTC by including (M-N) burn outputs.
 2. Otherwise, the second through (M+1)th output must be burn addresses, and the amount burned by
    these outputs will be counted as the amount committed to by the block commit.
+
+In addition, during the sunset phase (i.e., between the 100,000th and 500,000th burn block in the chain),
+the miner must include a _sunset burn_ output. This is an M+1 indexed output that includes the burn amount
+required to fulfill the sunset burn ratio, and must be sent to the burn address:
+
+```
+sunset_burn_amount = (total_block_commit_amount) * (reward_cycle_start_height - 100,000) / (400,000)
+```
+
+Where `total_block_commit_amount` is equal to the sum of outputs [1, M+1].
+
+After the sunset phase _ends_ (i.e., blocks >= 500,000th burn block), block commits are _only_ burns, with
+a single burn output at index 1.

--- a/src/burnchains/bitcoin/blocks.rs
+++ b/src/burnchains/bitcoin/blocks.rs
@@ -375,6 +375,8 @@ impl BitcoinBlockParser {
             return None;
         }
 
+        let data_amt = tx.output[0].value;
+
         let (opcode, data) = data_opt.unwrap();
         let inputs_opt = self.parse_inputs(tx);
         let outputs_opt = self.parse_outputs(tx);
@@ -384,10 +386,11 @@ impl BitcoinBlockParser {
                 Some(BitcoinTransaction {
                     txid: Txid::from_vec_be(&tx.txid().as_bytes().to_vec()).unwrap(), // this *should* panic if it fails
                     vtxindex: vtxindex as u32,
-                    opcode: opcode,
-                    data: data,
-                    inputs: inputs,
-                    outputs: outputs,
+                    opcode,
+                    data,
+                    data_amt,
+                    inputs,
+                    outputs,
                 })
             }
             (_, _) => {
@@ -584,6 +587,7 @@ mod tests {
                 // NAME_UPDATE transaction with 3 singlesig inputs
                 txstr: "010000000320a081bcd1a80d9c1945f863d29dc84278411ed74cb6dcba30541bf8d5770542020000008b483045022100be57031bf2c095945ba2876e97b3f86ee051643a29b908f22ed45ccf58620103022061e056e5f48c5a51c66604a1ca28e4bfaabab1478424c9bbb396cc6afe5c222e0141040fadbbcea0ff3b05f03195b41cd991d7a0af8bd38559943aec99cbdaf0b22cc806b9a4f07579934774cc0c155e781d45c989f94336765e88a66d91cfb9f060b0feffffff20a081bcd1a80d9c1945f863d29dc84278411ed74cb6dcba30541bf8d5770542010000008b483045022100fd9c04b330810694cb4bfef793b193f9cbfaa07325700f217b9cb03e5207005302202f07e7c9c6774c5619a043752444f6da6fd81b9d9d008ec965796d87271598de0141040fadbbcea0ff3b05f03195b41cd991d7a0af8bd38559943aec99cbdaf0b22cc806b9a4f07579934774cc0c155e781d45c989f94336765e88a66d91cfb9f060b0feffffff20a081bcd1a80d9c1945f863d29dc84278411ed74cb6dcba30541bf8d5770542040000008a47304402205e24943a40b8ef876cc218a7e8994f4be7afb7aa02403bb73510fac01b33ead3022033e5fb811c396b2fb50a825cd1d86e82eb83483901a1793d0eb15e3e9f1d1c5b814104c77f262dda02580d65c9069a8a34c56bd77325bba4110b693b90216f5a3edc0bebc8ce28d61aa86b414aa91ecb29823b11aeed06098fcd97fee4bc73d54b1e96feffffff030000000000000000296a2769642bfae543ff5672fb607fe15e16b1c3ef38737c631c7c5d911c6617993c21fba731363f1cfe6c6b0000000000001976a914395f3643cea07ec4eec73b4d9a973dcce56b9bf188acc5120100000000001976a9149f2660e75380675206b6f1e2b4f106ae33266be488ac00000000".to_owned(),
                 result: Some(BitcoinTransaction {
+                    data_amt: 0,
                     txid: to_txid(&hex_bytes("185c112401590b11acdfea6bb26d2a8e37cb31f24a0c89dbb8cc14b3d6271fb1").unwrap()),
                     vtxindex: vtxindex,
                     opcode: '+' as u8,
@@ -627,6 +631,7 @@ mod tests {
                 // NAME_REVOKE with 2 2-of-3 multisig inputs
                 txstr: "0100000002b4c2c2fede361654f0f6b65dd8ba385f3a4b05c76cd573f3689b09b7298b142201000000fd5c010047304402203537b5ded3716553b6f3fc7ccc7e55bc42b6caa1c069c9b2ce068d57f9024de7022026eb81e226b0de30448732835424eef52a3b9d67020c62b48df75974c5fe09870147304402201cc22e43302688d975df3bcad70065c8dad497b092a58e97c6c306b65176c70802200b9c3a62b22865e957331578d6e5d684cad87279fd8b852fcc2d34d3911e8643014cc9524104ff897d48c25c48c598aea0d6b1e835008e6679bddbc8d41d7d9f73e6a0dc2b8fe1402487ce2ba1e5365ee28fed024093499c11b8485fb6758a357c75730557674104f9478048ce8ff9cfc188a184c8c8c0a3e3dee68f96f6c3bc6f0f7e043ca8d241d5a03ab50157422ad43e9ee1a0a80b0dd17f0b0023f891dbd85daa3069554e2b41046fd8c7330fbe307a0fad0bf9472ca080f4941f4b6edea7ab090e3e26075e7277a0bd61f42eff54daf3e6141de46a98a5a8265c9e8d58bd1a86cf36d418788ab853aeffffffffb4c2c2fede361654f0f6b65dd8ba385f3a4b05c76cd573f3689b09b7298b142202000000fd5d0100473044022070cfd1e13d9844db995111ed5cc0578ca4d03504fdec1cf1636cd0054dffeeed022046c8d87291367402f4b54c2ef985a0171e400fe079da5234c912103cf2dd683b0148304502210099f092b12000dc78074934135443656091c606b40c7925bae30a6285946e36b9022062b5fa5e28986e0c27aad11f8fdb1409eb87a169972dc1ebbd91aa45810f9d9a014cc95241046097f22211c1f4832e54f0cc76c06b80a4e1fcf237ea487561c80bd5b28b6a483706a04d99038cb434eee82306902193e7b1a368dba33ad14b3f30e004c95e6e41048e264f76559020fdf50d3a7d9f57ccd548f3dfb962837f958e446add48429951d61e99a109cded2ba9812ee152ebba53a2a6c7b6dfb3c61fcba1b0852928374941044c9f30b4546c1f30087001fa6450e52c645bd49e91a18c9c16965b72f5153f0e4b04712218b42b2bc578017b471beaa7d8c0a9eb69174ad50714d7ef4117863d53aeffffffff030000000000000000176a1569647e7061747269636b7374616e6c6579322e6964f82a00000000000017a914eb1881fb0682c2eb37e478bf918525a2c61bc404876dbd13000000000017a914c26afc6cb80ca477c280780902b40cbef8cd804d8700000000".to_owned(),
                 result: Some(BitcoinTransaction {
+                    data_amt: 0,
                     txid: to_txid(&hex_bytes("eb2e84a45cf411e528185a98cd5fb45ed349843a83d39fd4dff2de47adad8c8f").unwrap()),
                     vtxindex: vtxindex,
                     opcode: '~' as u8,
@@ -667,6 +672,7 @@ mod tests {
                 // NAME_REGISTRATION with p2wpkh-p2sh segwit input
                 txstr: "01000000000101a7ef2b09722ad786c569c0812005a731ce19290bb0a2afc16cb91056c2e4c19e0100000017160014393ffec4f09b38895b8502377693f23c6ae00f19ffffffff0300000000000000000d6a0b69643a666f6f2e746573747c1500000000000017a9144b85301ba8e42bf98472b8ed4939d5f76b98fcea87144d9c290100000017a91431f8968eb1730c83fb58409a9a560a0a0835027f8702483045022100fc82815edf1c0ef0c601cf1e26494626d7b01597be5ab83df025ff1ee67730130220016c4c29d77aadb5ff57c0c9272a43950ca29b84d8adfaed95ac69db90b35d5b012102d341f728783eb93e6fb5921a1ebe9d149e941de31e403cd69afa2f0f1e698e8100000000".to_owned(),
                 result: Some(BitcoinTransaction {
+                    data_amt: 0,
                     txid: to_txid(&hex_bytes("b908952b30ccfdfa59985dc1ffdd2a22ef054d20fa253510d2af7797dddee459").unwrap()),
                     vtxindex: vtxindex,
                     opcode: ':' as u8,
@@ -696,6 +702,7 @@ mod tests {
                 // NAME_PREORDER with a 2-of-3 p2wsh-p2sh multisig segwit input 
                 txstr: "01000000000101e411dc967b8503a27450c614a5cd984698762a6b4bf547293ffdf846ed4ebd22010000002322002067091a41e9871c5ae20b0c69a786f02df5d3c7aa632689b608069181b43a28a2ffffffff030000000000000000296a2769643f9fab7f294936ddb6524a48feff691ecbd0ca9e8f107d845c417a5438d1cb441e827c5126b01ba0290100000017a91487a0487869af70b6b1cc79bd374b75ba1be5cff98700a86100000000001976a914000000000000000000000000000000000000000088ac0400473044022064c5b5f61baad8bb8ecad98666b99e09f1777ef805df41a1c7926f8468b6b6df02205eac177c77f274acb670cd24d504f01b27de767e0241c818c91e479cb0ddcf18014730440220053ce777bc7bb842d8eef83769a027797567624ab9eed5722889ed3192f431b30220256e8aaef8de2a571198acde708fcbca02fb18780ac470c0d7f811734af729af0169522102d341f728783eb93e6fb5921a1ebe9d149e941de31e403cd69afa2f0f1e698e812102f21b29694df4c2188bee97103d10d017d1865fb40528f25589af9db6e0786b6521028791dc45c049107fb99e673265a38a096536aacdf78aa90710a32fff7750f9f953ae00000000".to_owned(),
                 result: Some(BitcoinTransaction {
+                    data_amt: 0,
                     txid: to_txid(&hex_bytes("16751ca54407b922e3072830cf4be58c5562a6dc350f6703192b673c4cc86182").unwrap()),
                     vtxindex: vtxindex,
                     opcode: '?' as u8,
@@ -773,6 +780,7 @@ mod tests {
                     block_hash: to_block_hash(&hex_bytes("7483b1104341d596c1d0d2499cb1821b0e078329deabc4e7504c016a5b393e08").unwrap()),
                     txs: vec![
                         BitcoinTransaction {
+                            data_amt: 0,
                             // NAME_REGISTRATION with segwit p2wpkh-p2sh input
                             txid: to_txid(&hex_bytes("b908952b30ccfdfa59985dc1ffdd2a22ef054d20fa253510d2af7797dddee459").unwrap()),
                             vtxindex: 1,
@@ -814,6 +822,7 @@ mod tests {
                     timestamp: 1543272755,
                     txs: vec![
                         BitcoinTransaction {
+                            data_amt: 0,
                             // TOKEN_TRANSFER
                             txid: to_txid(&hex_bytes("13f2c54dbbe3d4d6ed6c9fd1a68fe3c4238ec5de50316d102a106553b57b8728").unwrap()),
                             vtxindex: 2,
@@ -840,6 +849,7 @@ mod tests {
                             ]
                         },
                         BitcoinTransaction {
+                            data_amt: 0,
                             // TOKEN_TRANSFER 
                             txid: to_txid(&hex_bytes("7c7c60ae8617daeb351da01d0f683633e6778eb39b69e6e652b24ca0ce230291").unwrap()),
                             vtxindex: 4,
@@ -866,6 +876,7 @@ mod tests {
                             ]
                         },
                         BitcoinTransaction {
+                            data_amt: 0,
                             // TOKEN_TRANSFER 
                             txid: to_txid(&hex_bytes("ae1cf8b812cf28ea96c7343dc7ee9ff2d8dfb2f441ab11c886dfcd56a0a1a2b4").unwrap()),
                             vtxindex: 7,
@@ -892,6 +903,7 @@ mod tests {
                             ]
                         },
                         BitcoinTransaction {
+                            data_amt: 0,
                             // TOKEN_TRANSFER
                             txid: to_txid(&hex_bytes("12fed1db482a35dba87535a13089692cea35a71bfb159b21d0a04be41219b2bd").unwrap()),
                             vtxindex: 10,
@@ -918,6 +930,7 @@ mod tests {
                             ]
                         },
                         BitcoinTransaction {
+                            data_amt: 0,
                             // TOKEN_TRANSFER 
                             txid: to_txid(&hex_bytes("78035609a8733f214555cfec29e3eee1d24014863dc9f9d98092f6fbc5df63e8").unwrap()),
                             vtxindex: 13,

--- a/src/burnchains/bitcoin/mod.rs
+++ b/src/burnchains/bitcoin/mod.rs
@@ -182,6 +182,8 @@ pub struct BitcoinTransaction {
     pub vtxindex: u32,
     pub opcode: u8,
     pub data: Vec<u8>,
+    /// how much BTC was sent to the data output
+    pub data_amt: u64,
     pub inputs: Vec<BitcoinTxInput>,
     pub outputs: Vec<BitcoinTxOutput>,
 }

--- a/src/burnchains/burnchain.rs
+++ b/src/burnchains/burnchain.rs
@@ -774,7 +774,7 @@ impl Burnchain {
         );
 
         let header = block.header();
-        let blockstack_txs = burnchain_db.store_new_burnchain_block(&block, 0)?;
+        let blockstack_txs = burnchain_db.store_new_burnchain_block(&block, u64::max_value())?;
 
         let sortition_tip = SortitionDB::get_canonical_sortition_tip(db.conn())?;
 

--- a/src/burnchains/burnchain.rs
+++ b/src/burnchains/burnchain.rs
@@ -1608,6 +1608,7 @@ pub mod tests {
         };
 
         let block_commit_1 = LeaderBlockCommitOp {
+            sunset_burn: 0,
             commit_outs: vec![],
             block_header_hash: BlockHeaderHash::from_bytes(
                 &hex_bytes("2222222222222222222222222222222222222222222222222222222222222222")
@@ -1646,6 +1647,7 @@ pub mod tests {
         };
 
         let block_commit_2 = LeaderBlockCommitOp {
+            sunset_burn: 0,
             commit_outs: vec![],
             block_header_hash: BlockHeaderHash::from_bytes(
                 &hex_bytes("2222222222222222222222222222222222222222222222222222222222222223")
@@ -1684,6 +1686,7 @@ pub mod tests {
         };
 
         let block_commit_3 = LeaderBlockCommitOp {
+            sunset_burn: 0,
             commit_outs: vec![],
             block_header_hash: BlockHeaderHash::from_bytes(
                 &hex_bytes("2222222222222222222222222222222222222222222222222222222222222224")
@@ -2137,6 +2140,7 @@ pub mod tests {
 
         for i in 0..10 {
             let op = BlockstackOperationType::LeaderBlockCommit(LeaderBlockCommitOp {
+                sunset_burn: 0,
                 commit_outs: vec![],
                 block_header_hash: BlockHeaderHash::from_bytes(&vec![
                     i, i, i, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -2177,6 +2181,7 @@ pub mod tests {
         }
 
         let noncolliding_op = BlockstackOperationType::LeaderBlockCommit(LeaderBlockCommitOp {
+            sunset_burn: 0,
             commit_outs: vec![],
             block_header_hash: BlockHeaderHash([0xbb; 32]),
             new_seed: VRFSeed([0xcc; 32]),
@@ -2386,6 +2391,7 @@ pub mod tests {
             // insert block commit paired to previous round's leader key, as well as a user burn
             if i > 0 {
                 let next_block_commit = LeaderBlockCommitOp {
+                    sunset_burn: 0,
                     commit_outs: vec![],
                     block_header_hash: BlockHeaderHash::from_bytes(&vec![
                         i, i, i, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,

--- a/src/burnchains/db.rs
+++ b/src/burnchains/db.rs
@@ -296,7 +296,8 @@ impl BurnchainDB {
         sunset_end_ht: u64,
     ) -> Result<Vec<BlockstackOperationType>, BurnchainError> {
         let header = block.header();
-        let mut blockstack_ops = BurnchainDB::get_blockstack_transactions(block, &header, sunset_end_ht);
+        let mut blockstack_ops =
+            BurnchainDB::get_blockstack_transactions(block, &header, sunset_end_ht);
         apply_blockstack_txs_safety_checks(header.block_height, &mut blockstack_ops);
 
         let db_tx = self.tx_begin()?;

--- a/src/burnchains/mod.rs
+++ b/src/burnchains/mod.rs
@@ -298,6 +298,8 @@ impl PoxConstants {
         anchor_threshold: u32,
         pox_rejection_fraction: u64,
         pox_participation_threshold_pct: u64,
+        sunset_start: u64,
+        sunset_end: u64,
     ) -> PoxConstants {
         assert!(anchor_threshold > (prepare_length / 2));
 
@@ -307,13 +309,14 @@ impl PoxConstants {
             anchor_threshold,
             pox_rejection_fraction,
             pox_participation_threshold_pct,
-            sunset_end: 5000,
+            sunset_start,
+            sunset_end,
             _shadow: PhantomData,
         }
     }
     #[cfg(test)]
     pub fn test_default() -> PoxConstants {
-        PoxConstants::new(10, 5, 3, 25, 5)
+        PoxConstants::new(10, 5, 3, 25, 5, 5000, 10000)
     }
 
     pub fn reward_slots(&self) -> u32 {
@@ -331,7 +334,7 @@ impl PoxConstants {
         let expected_u128 = (burn_fee as u128) * ((burn_height - self.sunset_start) as u128) / self.sunset_end as u128;
         u64::try_from(expected_u128)
             // should never be possible, because sunset_burn is <= burn_fee, which is a u64
-            .expect("Overflowed u64 in calculating expected sunset_burn");
+            .expect("Overflowed u64 in calculating expected sunset_burn")
     }
 
     /// is participating_ustx enough to engage in PoX in the next reward cycle?
@@ -345,11 +348,11 @@ impl PoxConstants {
     }
 
     pub fn mainnet_default() -> PoxConstants {
-        PoxConstants::new(1000, 240, 192, 25, 5)
+        PoxConstants::new(POX_REWARD_CYCLE_LENGTH, POX_PREPARE_WINDOW_LENGTH, 192, 25, 5, POX_SUNSET_START, POX_SUNSET_END)
     }
 
     pub fn testnet_default() -> PoxConstants {
-        PoxConstants::new(120, 30, 20, 3333333333333333, 5) // total liquid supply is 40000000000000000 µSTX
+        PoxConstants::new(120, 30, 20, 3333333333333333, 5, POX_SUNSET_START, POX_SUNSET_END) // total liquid supply is 40000000000000000 µSTX
     }
 }
 

--- a/src/burnchains/mod.rs
+++ b/src/burnchains/mod.rs
@@ -238,6 +238,12 @@ impl BurnchainTransaction {
                 .collect(),
         }
     }
+
+    pub fn get_burn_amount(&self) -> u64 {
+        match *self {
+            BurnchainTransaction::Bitcoin(ref btc) => btc.data_amt,
+        }
+    }
 }
 
 #[derive(Debug, PartialEq, Clone)]

--- a/src/chainstate/burn/db/processing.rs
+++ b/src/chainstate/burn/db/processing.rs
@@ -24,7 +24,7 @@ use chainstate::burn::db::sortdb::{PoxId, SortitionHandleTx, SortitionId};
 use chainstate::coordinator::RewardCycleInfo;
 
 use chainstate::burn::operations::{
-    leader_block_commit::RewardSetInfo, BlockstackOperation, BlockstackOperationType,
+    leader_block_commit::RewardSetInfo, BlockstackOperationType,
 };
 
 use burnchains::{

--- a/src/chainstate/burn/db/processing.rs
+++ b/src/chainstate/burn/db/processing.rs
@@ -23,9 +23,7 @@ use chainstate::burn::db::sortdb::{PoxId, SortitionHandleTx, SortitionId};
 
 use chainstate::coordinator::RewardCycleInfo;
 
-use chainstate::burn::operations::{
-    leader_block_commit::RewardSetInfo, BlockstackOperationType,
-};
+use chainstate::burn::operations::{leader_block_commit::RewardSetInfo, BlockstackOperationType};
 
 use burnchains::{
     Burnchain, BurnchainBlockHeader, BurnchainHeaderHash, BurnchainStateTransition,

--- a/src/chainstate/burn/db/sortdb.rs
+++ b/src/chainstate/burn/db/sortdb.rs
@@ -49,8 +49,7 @@ use core::CHAINSTATE_VERSION;
 
 use chainstate::burn::operations::{
     leader_block_commit::{RewardSetInfo, OUTPUTS_PER_COMMIT},
-    BlockstackOperationType, LeaderBlockCommitOp, LeaderKeyRegisterOp,
-    UserBurnSupportOp,
+    BlockstackOperationType, LeaderBlockCommitOp, LeaderKeyRegisterOp, UserBurnSupportOp,
 };
 
 use burnchains::{Address, BurnchainHeaderHash, PublicKey, Txid};
@@ -2352,12 +2351,11 @@ impl SortitionDB {
             .sortition_hash
             .mix_burn_header(&parent_snapshot.burn_header_hash);
 
-        let reward_set_info =
-            if burn_header.block_height >= burnchain.pox_constants.sunset_end {
-                None
-            } else {
-                sortition_db_handle.pick_recipients(&reward_set_vrf_hash, next_pox_info.as_ref())?
-            };
+        let reward_set_info = if burn_header.block_height >= burnchain.pox_constants.sunset_end {
+            None
+        } else {
+            sortition_db_handle.pick_recipients(&reward_set_vrf_hash, next_pox_info.as_ref())?
+        };
 
         let new_snapshot = sortition_db_handle.process_block_txs(
             &parent_snapshot,
@@ -2380,7 +2378,7 @@ impl SortitionDB {
     pub fn test_get_next_block_recipients(
         &mut self,
         next_pox_info: Option<&RewardCycleInfo>,
-        sunset_ht: u64
+        sunset_ht: u64,
     ) -> Result<Option<RewardSetInfo>, BurnchainError> {
         let parent_snapshot = SortitionDB::get_canonical_burn_chain_tip(self.conn())?;
         self.get_next_block_recipients(&parent_snapshot, next_pox_info, sunset_ht)
@@ -2390,7 +2388,7 @@ impl SortitionDB {
         &mut self,
         parent_snapshot: &BlockSnapshot,
         next_pox_info: Option<&RewardCycleInfo>,
-        sunset_end_ht: u64
+        sunset_end_ht: u64,
     ) -> Result<Option<RewardSetInfo>, BurnchainError> {
         let reward_set_vrf_hash = parent_snapshot
             .sortition_hash
@@ -3473,8 +3471,7 @@ mod tests {
     use util::get_epoch_time_secs;
 
     use chainstate::burn::operations::{
-        BlockstackOperationType, LeaderBlockCommitOp, LeaderKeyRegisterOp,
-        UserBurnSupportOp,
+        BlockstackOperationType, LeaderBlockCommitOp, LeaderKeyRegisterOp, UserBurnSupportOp,
     };
 
     use burnchains::bitcoin::address::BitcoinAddress;

--- a/src/chainstate/burn/distribution.rs
+++ b/src/chainstate/burn/distribution.rs
@@ -638,6 +638,7 @@ mod tests {
         };
 
         let block_commit_1 = LeaderBlockCommitOp {
+            sunset_burn: 0,
             block_header_hash: BlockHeaderHash::from_bytes(
                 &hex_bytes("2222222222222222222222222222222222222222222222222222222222222222")
                     .unwrap(),
@@ -679,6 +680,7 @@ mod tests {
         };
 
         let block_commit_2 = LeaderBlockCommitOp {
+            sunset_burn: 0,
             block_header_hash: BlockHeaderHash::from_bytes(
                 &hex_bytes("2222222222222222222222222222222222222222222222222222222222222223")
                     .unwrap(),
@@ -720,6 +722,7 @@ mod tests {
         };
 
         let block_commit_3 = LeaderBlockCommitOp {
+            sunset_burn: 0,
             block_header_hash: BlockHeaderHash::from_bytes(
                 &hex_bytes("2222222222222222222222222222222222222222222222222222222222222224")
                     .unwrap(),

--- a/src/chainstate/burn/distribution.rs
+++ b/src/chainstate/burn/distribution.rs
@@ -17,8 +17,7 @@
 use std::collections::BTreeMap;
 
 use chainstate::burn::operations::{
-    BlockstackOperationType, LeaderBlockCommitOp, LeaderKeyRegisterOp,
-    UserBurnSupportOp,
+    BlockstackOperationType, LeaderBlockCommitOp, LeaderKeyRegisterOp, UserBurnSupportOp,
 };
 
 use burnchains::Address;
@@ -311,8 +310,7 @@ mod tests {
     use burnchains::PublicKey;
 
     use chainstate::burn::operations::{
-        BlockstackOperationType, LeaderBlockCommitOp, LeaderKeyRegisterOp,
-        UserBurnSupportOp,
+        BlockstackOperationType, LeaderBlockCommitOp, LeaderKeyRegisterOp, UserBurnSupportOp,
     };
 
     use burnchains::bitcoin::address::BitcoinAddress;

--- a/src/chainstate/burn/distribution.rs
+++ b/src/chainstate/burn/distribution.rs
@@ -17,7 +17,7 @@
 use std::collections::BTreeMap;
 
 use chainstate::burn::operations::{
-    BlockstackOperation, BlockstackOperationType, LeaderBlockCommitOp, LeaderKeyRegisterOp,
+    BlockstackOperationType, LeaderBlockCommitOp, LeaderKeyRegisterOp,
     UserBurnSupportOp,
 };
 
@@ -311,7 +311,7 @@ mod tests {
     use burnchains::PublicKey;
 
     use chainstate::burn::operations::{
-        BlockstackOperation, BlockstackOperationType, LeaderBlockCommitOp, LeaderKeyRegisterOp,
+        BlockstackOperationType, LeaderBlockCommitOp, LeaderKeyRegisterOp,
         UserBurnSupportOp,
     };
 

--- a/src/chainstate/burn/operations/leader_block_commit.rs
+++ b/src/chainstate/burn/operations/leader_block_commit.rs
@@ -745,7 +745,7 @@ mod tests {
                     address: BitcoinAddress {
                         addrtype: BitcoinAddressType::PublicKeyHash,
                         network_id: BitcoinNetworkType::Mainnet,
-                        bytes: Hash160([1; 20]),
+                        bytes: Hash160([0; 20]),
                     },
                 },
                 BitcoinTxOutput {

--- a/src/chainstate/burn/operations/leader_block_commit.rs
+++ b/src/chainstate/burn/operations/leader_block_commit.rs
@@ -261,15 +261,7 @@ impl LeaderBlockCommitOp {
             (vec![address], 0, amount)
         } else {
             // check if this transaction provided a sunset burn
-            let sunset_burn = if let Some(sunset_burn_output) = outputs.get(OUTPUTS_PER_COMMIT) {
-                if sunset_burn_output.address.is_burn() {
-                    sunset_burn_output.amount
-                } else {
-                    0
-                }
-            } else {
-                0
-            };
+            let sunset_burn = tx.get_burn_amount();
 
             let mut commit_outs = vec![];
             let mut pox_fee = None;
@@ -698,6 +690,7 @@ mod tests {
     #[test]
     fn test_parse_sunset_end() {
         let tx = BurnchainTransaction::Bitcoin(BitcoinTransaction {
+            data_amt: 0,
             txid: Txid([0; 32]),
             vtxindex: 0,
             opcode: Opcodes::LeaderBlockCommit as u8,
@@ -750,6 +743,7 @@ mod tests {
         });
 
         let tx = BurnchainTransaction::Bitcoin(BitcoinTransaction {
+            data_amt: 0,
             txid: Txid([0; 32]),
             vtxindex: 0,
             opcode: Opcodes::LeaderBlockCommit as u8,
@@ -803,6 +797,7 @@ mod tests {
     #[test]
     fn test_parse_pox_commits() {
         let tx = BurnchainTransaction::Bitcoin(BitcoinTransaction {
+            data_amt: 30,
             txid: Txid([0; 32]),
             vtxindex: 0,
             opcode: Opcodes::LeaderBlockCommit as u8,
@@ -855,6 +850,7 @@ mod tests {
         assert_eq!(op.sunset_burn, 30);
 
         let tx = BurnchainTransaction::Bitcoin(BitcoinTransaction {
+            data_amt: 0,
             txid: Txid([0; 32]),
             vtxindex: 0,
             opcode: Opcodes::LeaderBlockCommit as u8,
@@ -898,6 +894,7 @@ mod tests {
         };
 
         let tx = BurnchainTransaction::Bitcoin(BitcoinTransaction {
+            data_amt: 0,
             txid: Txid([0; 32]),
             vtxindex: 0,
             opcode: Opcodes::LeaderBlockCommit as u8,
@@ -966,6 +963,7 @@ mod tests {
         assert_eq!(op.sunset_burn, 0);
 
         let tx = BurnchainTransaction::Bitcoin(BitcoinTransaction {
+            data_amt: 0,
             txid: Txid([0; 32]),
             vtxindex: 0,
             opcode: Opcodes::LeaderBlockCommit as u8,
@@ -999,6 +997,7 @@ mod tests {
         };
 
         let tx = BurnchainTransaction::Bitcoin(BitcoinTransaction {
+            data_amt: 0,
             txid: Txid([0; 32]),
             vtxindex: 0,
             opcode: Opcodes::LeaderBlockCommit as u8,
@@ -1042,6 +1041,7 @@ mod tests {
         };
 
         let tx = BurnchainTransaction::Bitcoin(BitcoinTransaction {
+            data_amt: 0,
             txid: Txid([0; 32]),
             vtxindex: 0,
             opcode: Opcodes::LeaderBlockCommit as u8,

--- a/src/chainstate/burn/operations/leader_key_register.rs
+++ b/src/chainstate/burn/operations/leader_key_register.rs
@@ -21,8 +21,7 @@ use chainstate::burn::ConsensusHash;
 use chainstate::burn::Opcodes;
 
 use chainstate::burn::operations::{
-    BlockstackOperationType, LeaderBlockCommitOp, LeaderKeyRegisterOp,
-    UserBurnSupportOp,
+    BlockstackOperationType, LeaderBlockCommitOp, LeaderKeyRegisterOp, UserBurnSupportOp,
 };
 
 use util::db::DBConn;
@@ -292,8 +291,7 @@ pub mod tests {
     use util::log;
 
     use chainstate::burn::operations::{
-        BlockstackOperationType, LeaderBlockCommitOp, LeaderKeyRegisterOp,
-        UserBurnSupportOp,
+        BlockstackOperationType, LeaderBlockCommitOp, LeaderKeyRegisterOp, UserBurnSupportOp,
     };
 
     pub struct OpFixture {

--- a/src/chainstate/burn/operations/leader_key_register.rs
+++ b/src/chainstate/burn/operations/leader_key_register.rs
@@ -21,7 +21,7 @@ use chainstate::burn::ConsensusHash;
 use chainstate::burn::Opcodes;
 
 use chainstate::burn::operations::{
-    BlockstackOperation, BlockstackOperationType, LeaderBlockCommitOp, LeaderKeyRegisterOp,
+    BlockstackOperationType, LeaderBlockCommitOp, LeaderKeyRegisterOp,
     UserBurnSupportOp,
 };
 
@@ -227,16 +227,14 @@ impl StacksMessageCodec for LeaderKeyRegisterOp {
     }
 }
 
-impl BlockstackOperation for LeaderKeyRegisterOp {
-    fn from_tx(
+impl LeaderKeyRegisterOp {
+    pub fn from_tx(
         block_header: &BurnchainBlockHeader,
         tx: &BurnchainTransaction,
     ) -> Result<LeaderKeyRegisterOp, op_error> {
         LeaderKeyRegisterOp::parse_from_tx(block_header.block_height, &block_header.block_hash, tx)
     }
-}
 
-impl LeaderKeyRegisterOp {
     pub fn check(&self, burnchain: &Burnchain, tx: &mut SortitionHandleTx) -> Result<(), op_error> {
         /////////////////////////////////////////////////////////////////
         // Keys must be unique -- no one can register the same key twice
@@ -294,7 +292,7 @@ pub mod tests {
     use util::log;
 
     use chainstate::burn::operations::{
-        BlockstackOperation, BlockstackOperationType, LeaderBlockCommitOp, LeaderKeyRegisterOp,
+        BlockstackOperationType, LeaderBlockCommitOp, LeaderKeyRegisterOp,
         UserBurnSupportOp,
     };
 

--- a/src/chainstate/burn/operations/mod.rs
+++ b/src/chainstate/burn/operations/mod.rs
@@ -152,6 +152,8 @@ pub struct LeaderBlockCommitOp {
 
     /// PoX/Burn outputs
     pub commit_outs: Vec<StacksAddress>,
+    /// how much sunset burn this block performed
+    pub sunset_burn: u64,
 
     // common to all transactions
     pub txid: Txid,                            // transaction ID

--- a/src/chainstate/burn/operations/mod.rs
+++ b/src/chainstate/burn/operations/mod.rs
@@ -193,15 +193,6 @@ pub struct UserBurnSupportOp {
     pub burn_header_hash: BurnchainHeaderHash, // hash of burnchain block with this tx
 }
 
-pub trait BlockstackOperation {
-    fn from_tx(
-        block_header: &BurnchainBlockHeader,
-        tx: &BurnchainTransaction,
-    ) -> Result<Self, Error>
-    where
-        Self: Sized;
-}
-
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum BlockstackOperationType {
     LeaderKeyRegister(LeaderKeyRegisterOp),

--- a/src/chainstate/burn/operations/user_burn_support.rs
+++ b/src/chainstate/burn/operations/user_burn_support.rs
@@ -25,7 +25,7 @@ use chainstate::burn::Opcodes;
 use chainstate::stacks::index::TrieHash;
 
 use chainstate::burn::operations::{
-    parse_u16_from_be, parse_u32_from_be, BlockstackOperation, BlockstackOperationType,
+    parse_u16_from_be, parse_u32_from_be, BlockstackOperationType,
     LeaderBlockCommitOp, LeaderKeyRegisterOp, UserBurnSupportOp,
 };
 
@@ -213,16 +213,14 @@ impl StacksMessageCodec for UserBurnSupportOp {
     }
 }
 
-impl BlockstackOperation for UserBurnSupportOp {
-    fn from_tx(
+impl UserBurnSupportOp {
+    pub fn from_tx(
         block_header: &BurnchainBlockHeader,
         tx: &BurnchainTransaction,
     ) -> Result<UserBurnSupportOp, op_error> {
         UserBurnSupportOp::parse_from_tx(block_header.block_height, &block_header.block_hash, tx)
     }
-}
 
-impl UserBurnSupportOp {
     pub fn check(&self, burnchain: &Burnchain, tx: &mut SortitionHandleTx) -> Result<(), op_error> {
         let leader_key_block_height = self.key_block_ptr as u64;
 
@@ -298,7 +296,7 @@ mod tests {
     use burnchains::bitcoin::keys::BitcoinPublicKey;
 
     use chainstate::burn::operations::{
-        BlockstackOperation, BlockstackOperationType, LeaderBlockCommitOp, LeaderKeyRegisterOp,
+        BlockstackOperationType, LeaderBlockCommitOp, LeaderKeyRegisterOp,
         UserBurnSupportOp,
     };
 

--- a/src/chainstate/burn/operations/user_burn_support.rs
+++ b/src/chainstate/burn/operations/user_burn_support.rs
@@ -25,8 +25,8 @@ use chainstate::burn::Opcodes;
 use chainstate::stacks::index::TrieHash;
 
 use chainstate::burn::operations::{
-    parse_u16_from_be, parse_u32_from_be, BlockstackOperationType,
-    LeaderBlockCommitOp, LeaderKeyRegisterOp, UserBurnSupportOp,
+    parse_u16_from_be, parse_u32_from_be, BlockstackOperationType, LeaderBlockCommitOp,
+    LeaderKeyRegisterOp, UserBurnSupportOp,
 };
 
 use burnchains::Address;
@@ -296,8 +296,7 @@ mod tests {
     use burnchains::bitcoin::keys::BitcoinPublicKey;
 
     use chainstate::burn::operations::{
-        BlockstackOperationType, LeaderBlockCommitOp, LeaderKeyRegisterOp,
-        UserBurnSupportOp,
+        BlockstackOperationType, LeaderBlockCommitOp, LeaderKeyRegisterOp, UserBurnSupportOp,
     };
 
     use chainstate::burn::db::sortdb::*;

--- a/src/chainstate/burn/sortition.rs
+++ b/src/chainstate/burn/sortition.rs
@@ -27,7 +27,7 @@ use core::*;
 use chainstate::burn::db::sortdb::{PoxId, SortitionHandleTx, SortitionId};
 use chainstate::burn::distribution::BurnSamplePoint;
 use chainstate::burn::operations::{
-    BlockstackOperation, BlockstackOperationType, LeaderBlockCommitOp, LeaderKeyRegisterOp,
+    BlockstackOperationType, LeaderBlockCommitOp, LeaderKeyRegisterOp,
     UserBurnSupportOp,
 };
 use chainstate::burn::{BlockHeaderHash, BlockSnapshot};

--- a/src/chainstate/burn/sortition.rs
+++ b/src/chainstate/burn/sortition.rs
@@ -27,8 +27,7 @@ use core::*;
 use chainstate::burn::db::sortdb::{PoxId, SortitionHandleTx, SortitionId};
 use chainstate::burn::distribution::BurnSamplePoint;
 use chainstate::burn::operations::{
-    BlockstackOperationType, LeaderBlockCommitOp, LeaderKeyRegisterOp,
-    UserBurnSupportOp,
+    BlockstackOperationType, LeaderBlockCommitOp, LeaderKeyRegisterOp, UserBurnSupportOp,
 };
 use chainstate::burn::{BlockHeaderHash, BlockSnapshot};
 

--- a/src/chainstate/coordinator/mod.rs
+++ b/src/chainstate/coordinator/mod.rs
@@ -369,7 +369,11 @@ pub fn get_next_recipients<U: RewardSetProvider>(
         provider,
     )?;
     sort_db
-        .get_next_block_recipients(sortition_tip, reward_cycle_info.as_ref(), burnchain.pox_constants.sunset_end)
+        .get_next_block_recipients(
+            sortition_tip,
+            reward_cycle_info.as_ref(),
+            burnchain.pox_constants.sunset_end,
+        )
         .map_err(|e| Error::from(e))
 }
 
@@ -391,7 +395,7 @@ pub fn get_reward_cycle_info<U: RewardSetProvider>(
         if burn_height >= burnchain.pox_constants.sunset_end {
             return Ok(Some(RewardCycleInfo {
                 anchor_status: PoxAnchorBlockStatus::NotSelected,
-            }))
+            }));
         }
 
         info!("Beginning reward cycle. block_height={}", burn_height);

--- a/src/chainstate/coordinator/mod.rs
+++ b/src/chainstate/coordinator/mod.rs
@@ -369,7 +369,7 @@ pub fn get_next_recipients<U: RewardSetProvider>(
         provider,
     )?;
     sort_db
-        .get_next_block_recipients(sortition_tip, reward_cycle_info.as_ref())
+        .get_next_block_recipients(sortition_tip, reward_cycle_info.as_ref(), burnchain.pox_constants.sunset_end)
         .map_err(|e| Error::from(e))
 }
 
@@ -388,6 +388,12 @@ pub fn get_reward_cycle_info<U: RewardSetProvider>(
     provider: &U,
 ) -> Result<Option<RewardCycleInfo>, Error> {
     if burnchain.is_reward_cycle_start(burn_height) {
+        if burn_height >= burnchain.pox_constants.sunset_end {
+            return Ok(Some(RewardCycleInfo {
+                anchor_status: PoxAnchorBlockStatus::NotSelected,
+            }))
+        }
+
         info!("Beginning reward cycle. block_height={}", burn_height);
         let reward_cycle_info = {
             let ic = sort_db.index_handle(sortition_tip);

--- a/src/chainstate/coordinator/tests.rs
+++ b/src/chainstate/coordinator/tests.rs
@@ -268,7 +268,7 @@ fn make_reward_set_coordinator<'a>(
 
 pub fn get_burnchain(path: &str) -> Burnchain {
     let mut b = Burnchain::new(&format!("{}/burnchain/db/", path), "bitcoin", "regtest").unwrap();
-    b.pox_constants = PoxConstants::new(5, 3, 3, 25, 5);
+    b.pox_constants = PoxConstants::new(5, 3, 3, 25, 5, u64::max_value(), u64::max_value());
     b
 }
 

--- a/src/chainstate/coordinator/tests.rs
+++ b/src/chainstate/coordinator/tests.rs
@@ -818,7 +818,7 @@ fn test_sortition_with_reward_set() {
             reward_recipients.clear();
         }
         let next_block_recipients = get_rw_sortdb(path)
-            .test_get_next_block_recipients(reward_cycle_info.as_ref())
+            .test_get_next_block_recipients(reward_cycle_info.as_ref(), 5000)
             .unwrap();
         if let Some(ref next_block_recipients) = next_block_recipients {
             for (addr, _) in next_block_recipients.recipients.iter() {
@@ -1063,7 +1063,7 @@ fn test_sortition_with_burner_reward_set() {
             reward_recipients.clear();
         }
         let next_block_recipients = get_rw_sortdb(path)
-            .test_get_next_block_recipients(reward_cycle_info.as_ref())
+            .test_get_next_block_recipients(reward_cycle_info.as_ref(), 5000)
             .unwrap();
         if let Some(ref next_block_recipients) = next_block_recipients {
             for (addr, _) in next_block_recipients.recipients.iter() {

--- a/src/chainstate/coordinator/tests.rs
+++ b/src/chainstate/coordinator/tests.rs
@@ -376,6 +376,7 @@ fn make_genesis_block_with_recipients(
     };
 
     let commit_op = LeaderBlockCommitOp {
+        sunset_burn: 0,
         block_header_hash: block.block_hash(),
         burn_fee: my_burn,
         input: BurnchainSigner {
@@ -503,6 +504,7 @@ fn make_stacks_block_with_recipients(
     };
 
     let commit_op = LeaderBlockCommitOp {
+        sunset_burn: 0,
         block_header_hash: block.block_hash(),
         burn_fee: my_burn,
         input: BurnchainSigner {

--- a/src/chainstate/coordinator/tests.rs
+++ b/src/chainstate/coordinator/tests.rs
@@ -127,12 +127,12 @@ fn p2pkh_from(sk: &StacksPrivateKey) -> StacksAddress {
     .unwrap()
 }
 
-pub fn setup_states(paths: &[&str], vrf_keys: &[VRFPrivateKey], committers: &[StacksPrivateKey]) {
+pub fn setup_states(paths: &[&str], vrf_keys: &[VRFPrivateKey], committers: &[StacksPrivateKey], pox_consts: Option<PoxConstants>) {
     let mut burn_block = None;
     let mut others = vec![];
 
     for path in paths.iter() {
-        let burnchain = get_burnchain(path);
+        let burnchain = get_burnchain(path, pox_consts.clone());
 
         let sortition_db = SortitionDB::connect(
             &burnchain.get_db_path(),
@@ -241,7 +241,7 @@ impl BlockEventDispatcher for NullEventDispatcher {
 pub fn make_coordinator<'a>(
     path: &str,
 ) -> ChainsCoordinator<'a, NullEventDispatcher, (), OnChainRewardSetProvider> {
-    ChainsCoordinator::test_new(&get_burnchain(path), path, OnChainRewardSetProvider())
+    ChainsCoordinator::test_new(&get_burnchain(path, None), path, OnChainRewardSetProvider())
 }
 
 struct StubbedRewardSetProvider(Vec<StacksAddress>);
@@ -262,28 +262,29 @@ impl RewardSetProvider for StubbedRewardSetProvider {
 fn make_reward_set_coordinator<'a>(
     path: &str,
     addrs: Vec<StacksAddress>,
+    pox_consts: Option<PoxConstants>,
 ) -> ChainsCoordinator<'a, NullEventDispatcher, (), StubbedRewardSetProvider> {
-    ChainsCoordinator::test_new(&get_burnchain(path), path, StubbedRewardSetProvider(addrs))
+    ChainsCoordinator::test_new(&get_burnchain(path, pox_consts), path, StubbedRewardSetProvider(addrs))
 }
 
-pub fn get_burnchain(path: &str) -> Burnchain {
+pub fn get_burnchain(path: &str, pox_consts: Option<PoxConstants>) -> Burnchain {
     let mut b = Burnchain::new(&format!("{}/burnchain/db/", path), "bitcoin", "regtest").unwrap();
-    b.pox_constants = PoxConstants::new(5, 3, 3, 25, 5, u64::max_value(), u64::max_value());
+    b.pox_constants = pox_consts.unwrap_or(PoxConstants::new(5, 3, 3, 25, 5, u64::max_value(), u64::max_value()));
     b
 }
 
-pub fn get_sortition_db(path: &str) -> SortitionDB {
-    let burnchain = get_burnchain(path);
+pub fn get_sortition_db(path: &str, pox_consts: Option<PoxConstants>) -> SortitionDB {
+    let burnchain = get_burnchain(path, pox_consts);
     SortitionDB::open(&burnchain.get_db_path(), false).unwrap()
 }
 
-pub fn get_rw_sortdb(path: &str) -> SortitionDB {
-    let burnchain = get_burnchain(path);
+pub fn get_rw_sortdb(path: &str, pox_consts: Option<PoxConstants>) -> SortitionDB {
+    let burnchain = get_burnchain(path, pox_consts);
     SortitionDB::open(&burnchain.get_db_path(), true).unwrap()
 }
 
-pub fn get_burnchain_db(path: &str) -> BurnchainDB {
-    let burnchain = get_burnchain(path);
+pub fn get_burnchain_db(path: &str, pox_consts: Option<PoxConstants>) -> BurnchainDB {
+    let burnchain = get_burnchain(path, pox_consts);
     BurnchainDB::open(&burnchain.get_burnchaindb_path(), true).unwrap()
 }
 
@@ -422,6 +423,7 @@ fn make_stacks_block(
         None,
     )
 }
+
 /// build a stacks block with just the coinbase off of
 ///  parent_block, in the canonical sortition fork of SortitionDB.
 /// parent_block _must_ be included in the StacksChainState
@@ -434,6 +436,35 @@ fn make_stacks_block_with_recipients(
     vrf_key: &VRFPrivateKey,
     key_index: u32,
     recipients: Option<&RewardSetInfo>,
+) -> (BlockstackOperationType, StacksBlock) {
+    make_stacks_block_with_recipients_and_sunset_burn(
+        sort_db,
+        state,
+        parent_block,
+        miner,
+        my_burn,
+        vrf_key,
+        key_index,
+        recipients,
+        0,
+        false
+    )
+}
+
+/// build a stacks block with just the coinbase off of
+///  parent_block, in the canonical sortition fork of SortitionDB.
+/// parent_block _must_ be included in the StacksChainState
+fn make_stacks_block_with_recipients_and_sunset_burn(
+    sort_db: &SortitionDB,
+    state: &mut StacksChainState,
+    parent_block: &BlockHeaderHash,
+    miner: &StacksPrivateKey,
+    my_burn: u64,
+    vrf_key: &VRFPrivateKey,
+    key_index: u32,
+    recipients: Option<&RewardSetInfo>,
+    sunset_burn: u64,
+    post_sunset_burn: bool
 ) -> (BlockstackOperationType, StacksBlock) {
     let tx_auth = TransactionAuth::from_p2pkh(miner).unwrap();
 
@@ -499,12 +530,14 @@ fn make_stacks_block_with_recipients(
             .iter()
             .map(|(a, _)| a.clone())
             .collect()
+    } else if post_sunset_burn {
+        vec![StacksAddress::burn_address(false)]
     } else {
         vec![]
     };
 
     let commit_op = LeaderBlockCommitOp {
-        sunset_burn: 0,
+        sunset_burn,
         block_header_hash: block.block_hash(),
         burn_fee: my_burn,
         input: BurnchainSigner {
@@ -541,7 +574,7 @@ fn test_simple_setup() {
     let vrf_keys: Vec<_> = (0..50).map(|_| VRFPrivateKey::new()).collect();
     let committers: Vec<_> = (0..50).map(|_| StacksPrivateKey::new()).collect();
 
-    setup_states(&[path, path_blinded], &vrf_keys, &committers);
+    setup_states(&[path, path_blinded], &vrf_keys, &committers, None);
 
     let mut coord = make_coordinator(path);
     let mut coord_blind = make_coordinator(path_blinded);
@@ -549,7 +582,7 @@ fn test_simple_setup() {
     coord.handle_new_burnchain_block().unwrap();
     coord_blind.handle_new_burnchain_block().unwrap();
 
-    let sort_db = get_sortition_db(path);
+    let sort_db = get_sortition_db(path, None);
 
     let tip = SortitionDB::get_canonical_burn_chain_tip(sort_db.conn()).unwrap();
     assert_eq!(tip.block_height, 1);
@@ -559,7 +592,7 @@ fn test_simple_setup() {
         .unwrap()
         .unwrap();
 
-    let sort_db_blind = get_sortition_db(path_blinded);
+    let sort_db_blind = get_sortition_db(path_blinded, None);
 
     let tip = SortitionDB::get_canonical_burn_chain_tip(sort_db_blind.conn()).unwrap();
     assert_eq!(tip.block_height, 1);
@@ -581,7 +614,7 @@ fn test_simple_setup() {
     let mut stacks_blocks = vec![];
     let mut anchor_blocks = vec![];
     for (ix, (vrf_key, miner)) in vrf_keys.iter().zip(committers.iter()).enumerate() {
-        let mut burnchain = get_burnchain_db(path);
+        let mut burnchain = get_burnchain_db(path, None);
         let mut chainstate = get_chainstate(path);
         let (op, block) = if ix == 0 {
             make_genesis_block(
@@ -605,7 +638,7 @@ fn test_simple_setup() {
             )
         };
         let burnchain_tip = burnchain.get_canonical_chain_tip().unwrap();
-        let burnchain_blinded = get_burnchain_db(path_blinded);
+        let burnchain_blinded = get_burnchain_db(path_blinded, None);
         produce_burn_block(
             &mut burnchain,
             &burnchain_tip.block_hash,
@@ -616,7 +649,7 @@ fn test_simple_setup() {
         coord.handle_new_burnchain_block().unwrap();
         coord_blind.handle_new_burnchain_block().unwrap();
 
-        let b = get_burnchain(path);
+        let b = get_burnchain(path, None);
         let new_burnchain_tip = burnchain.get_canonical_chain_tip().unwrap();
         if b.is_reward_cycle_start(new_burnchain_tip.block_height) {
             // the "blinded" sortition db and the one that's processed all the blocks
@@ -737,13 +770,13 @@ fn test_sortition_with_reward_set() {
         .map(|_| p2pkh_from(&StacksPrivateKey::new()))
         .collect();
 
-    setup_states(&[path], &vrf_keys, &committers);
+    setup_states(&[path], &vrf_keys, &committers, None);
 
-    let mut coord = make_reward_set_coordinator(path, reward_set);
+    let mut coord = make_reward_set_coordinator(path, reward_set, None);
 
     coord.handle_new_burnchain_block().unwrap();
 
-    let sort_db = get_sortition_db(path);
+    let sort_db = get_sortition_db(path, None);
 
     let tip = SortitionDB::get_canonical_burn_chain_tip(sort_db.conn()).unwrap();
     assert_eq!(tip.block_height, 1);
@@ -785,7 +818,7 @@ fn test_sortition_with_reward_set() {
         let vrf_wrong_out = &vrf_key_wrong_outs[ix];
         let miner_wrong_out = &miner_wrong_outs[ix];
 
-        let mut burnchain = get_burnchain_db(path);
+        let mut burnchain = get_burnchain_db(path, None);
         let mut chainstate = get_chainstate(path);
 
         let parent = if ix == 0 {
@@ -817,7 +850,7 @@ fn test_sortition_with_reward_set() {
             //  recipients are now eligible again in the new reward cycle
             reward_recipients.clear();
         }
-        let next_block_recipients = get_rw_sortdb(path)
+        let next_block_recipients = get_rw_sortdb(path, None)
             .test_get_next_block_recipients(reward_cycle_info.as_ref(), 5000)
             .unwrap();
         if let Some(ref next_block_recipients) = next_block_recipients {
@@ -919,7 +952,7 @@ fn test_sortition_with_reward_set() {
         // handle the sortition
         coord.handle_new_burnchain_block().unwrap();
 
-        let b = get_burnchain(path);
+        let b = get_burnchain(path, None);
         let new_burnchain_tip = burnchain.get_canonical_chain_tip().unwrap();
         if b.is_reward_cycle_start(new_burnchain_tip.block_height) {
             started_first_reward_cycle = true;
@@ -985,13 +1018,13 @@ fn test_sortition_with_burner_reward_set() {
         .collect();
     reward_set.push(p2pkh_from(&StacksPrivateKey::new()));
 
-    setup_states(&[path], &vrf_keys, &committers);
+    setup_states(&[path], &vrf_keys, &committers, None);
 
-    let mut coord = make_reward_set_coordinator(path, reward_set);
+    let mut coord = make_reward_set_coordinator(path, reward_set, None);
 
     coord.handle_new_burnchain_block().unwrap();
 
-    let sort_db = get_sortition_db(path);
+    let sort_db = get_sortition_db(path, None);
 
     let tip = SortitionDB::get_canonical_burn_chain_tip(sort_db.conn()).unwrap();
     assert_eq!(tip.block_height, 1);
@@ -1033,7 +1066,7 @@ fn test_sortition_with_burner_reward_set() {
         let vrf_wrong_out = &vrf_key_wrong_outs[ix];
         let miner_wrong_out = &miner_wrong_outs[ix];
 
-        let mut burnchain = get_burnchain_db(path);
+        let mut burnchain = get_burnchain_db(path, None);
         let mut chainstate = get_chainstate(path);
 
         let parent = if ix == 0 {
@@ -1062,7 +1095,7 @@ fn test_sortition_with_burner_reward_set() {
             //  recipients are now eligible again in the new reward cycle
             reward_recipients.clear();
         }
-        let next_block_recipients = get_rw_sortdb(path)
+        let next_block_recipients = get_rw_sortdb(path, None)
             .test_get_next_block_recipients(reward_cycle_info.as_ref(), 5000)
             .unwrap();
         if let Some(ref next_block_recipients) = next_block_recipients {
@@ -1143,7 +1176,7 @@ fn test_sortition_with_burner_reward_set() {
         // handle the sortition
         coord.handle_new_burnchain_block().unwrap();
 
-        let b = get_burnchain(path);
+        let b = get_burnchain(path, None);
         let new_burnchain_tip = burnchain.get_canonical_chain_tip().unwrap();
         if b.is_reward_cycle_start(new_burnchain_tip.block_height) {
             started_first_reward_cycle = true;
@@ -1195,6 +1228,237 @@ fn test_sortition_with_burner_reward_set() {
 }
 
 #[test]
+fn test_sortition_with_sunset() {
+    let path = "/tmp/stacks-blockchain-sortition-with-sunset";
+    let _r = std::fs::remove_dir_all(path);
+
+    let sunset_ht = 80;
+    let pox_consts_inner = PoxConstants::new(5, 3, 3, 25, 5, 10, sunset_ht);
+    let pox_consts = Some(pox_consts_inner.clone());
+
+    let mut vrf_keys: Vec<_> = (0..200).map(|_| VRFPrivateKey::new()).collect();
+    let mut committers: Vec<_> = (0..200).map(|_| StacksPrivateKey::new()).collect();
+
+    let reward_set_size = 10;
+    let reward_set: Vec<_> = (0..reward_set_size)
+        .map(|_| p2pkh_from(&StacksPrivateKey::new()))
+        .collect();
+
+    setup_states(&[path], &vrf_keys, &committers, pox_consts.clone());
+
+    let mut coord = make_reward_set_coordinator(path, reward_set, pox_consts.clone());
+
+    coord.handle_new_burnchain_block().unwrap();
+
+    let sort_db = get_sortition_db(path, pox_consts.clone());
+
+    let tip = SortitionDB::get_canonical_burn_chain_tip(sort_db.conn()).unwrap();
+    assert_eq!(tip.block_height, 1);
+    assert_eq!(tip.sortition, false);
+    let (_, ops) = sort_db
+        .get_sortition_result(&tip.sortition_id)
+        .unwrap()
+        .unwrap();
+
+    // we should have all the VRF registrations accepted
+    assert_eq!(ops.accepted_ops.len(), vrf_keys.len());
+    assert_eq!(ops.consumed_leader_keys.len(), 0);
+
+    let mut started_first_reward_cycle = false;
+    // process sequential blocks, and their sortitions...
+    let mut stacks_blocks: Vec<(SortitionId, StacksBlock)> = vec![];
+    let mut anchor_blocks = vec![];
+
+    // split up the vrf keys and committers so that we have some that will be mining "correctly"
+    //   and some that will be producing bad outputs
+
+    let WRONG_OUTS_OFFSET = 100;
+    let vrf_key_wrong_outs = vrf_keys.split_off(WRONG_OUTS_OFFSET);
+    let miner_wrong_outs = committers.split_off(WRONG_OUTS_OFFSET);
+
+    // track the reward set consumption
+    let mut reward_recipients = HashSet::new();
+    for ix in 0..vrf_keys.len() {
+        let vrf_key = &vrf_keys[ix];
+        let miner = &committers[ix];
+
+        let vrf_wrong_out = &vrf_key_wrong_outs[ix];
+        let miner_wrong_out = &miner_wrong_outs[ix];
+
+        let mut burnchain = get_burnchain_db(path, pox_consts.clone());
+        let mut chainstate = get_chainstate(path);
+
+        let parent = if ix == 0 {
+            BlockHeaderHash([0; 32])
+        } else {
+            stacks_blocks[ix - 1].1.header.block_hash()
+        };
+
+        let burnchain_tip = burnchain.get_canonical_chain_tip().unwrap();
+        let next_mock_header = BurnchainBlockHeader {
+            block_height: burnchain_tip.block_height + 1,
+            block_hash: BurnchainHeaderHash([0; 32]),
+            parent_block_hash: burnchain_tip.block_hash,
+            num_txs: 0,
+            timestamp: 1,
+        };
+
+        let reward_cycle_info = coord.get_reward_cycle_info(&next_mock_header).unwrap();
+        if reward_cycle_info.is_some() {
+            // did we process a reward set last cycle? check if the
+            //  recipient set size matches our expectation
+            if started_first_reward_cycle {
+                if burnchain_tip.block_height == sunset_ht {
+                    // sunset finished in the last reward cycle,
+                    //   the last two slots were left unfilled.
+                    assert_eq!(reward_recipients.len(), reward_set_size - 2);                    
+                } else if burnchain_tip.block_height > sunset_ht {
+                    assert_eq!(reward_recipients.len(), 0);                    
+                } else {
+                    assert_eq!(reward_recipients.len(), reward_set_size);
+                }
+            }
+            // clear the reward recipients tracker, since those
+            //  recipients are now eligible again in the new reward cycle
+            reward_recipients.clear();
+        }
+        let next_block_recipients = get_rw_sortdb(path, pox_consts.clone())
+            .test_get_next_block_recipients(reward_cycle_info.as_ref(), sunset_ht)
+            .unwrap();
+        if next_mock_header.block_height >= sunset_ht {
+            assert!(next_block_recipients.is_none());
+        }
+
+        if let Some(ref next_block_recipients) = next_block_recipients {
+            for (addr, _) in next_block_recipients.recipients.iter() {
+                if !addr.is_burn() {
+                    assert!(
+                        !reward_recipients.contains(addr),
+                        "Reward set should not already contain address {}",
+                        addr
+                    );
+                }
+                eprintln!("At iteration: {}, inserting address ... {}", ix, addr);
+                reward_recipients.insert(addr.clone());
+            }
+        }
+
+        let sunset_burn = pox_consts_inner.expected_sunset_burn(
+            next_mock_header.block_height, 10000);
+
+        let (good_op, block) = if ix == 0 {
+            make_genesis_block_with_recipients(
+                &sort_db,
+                &mut chainstate,
+                &parent,
+                miner,
+                10000,
+                vrf_key,
+                ix as u32,
+                next_block_recipients.as_ref(),
+            )
+        } else {
+            make_stacks_block_with_recipients_and_sunset_burn(
+                &sort_db,
+                &mut chainstate,
+                &parent,
+                miner,
+                10000,
+                vrf_key,
+                ix as u32,
+                next_block_recipients.as_ref(),
+                sunset_burn + (rand::random::<u8>() as u64),
+                next_mock_header.block_height >= sunset_ht
+            )
+        };
+
+        let expected_winner = good_op.txid();
+        let mut ops = vec![good_op];
+
+        if sunset_burn > 0 {
+            let (bad_outs_op, _) = make_stacks_block_with_recipients_and_sunset_burn(
+                &sort_db,
+                &mut chainstate,
+                &parent,
+                miner,
+                10000,
+                vrf_wrong_out,
+                (ix + WRONG_OUTS_OFFSET) as u32,
+                next_block_recipients.as_ref(),
+                sunset_burn - 1,
+                false
+            );
+            ops.push(bad_outs_op);
+        }
+
+        let burnchain_tip = burnchain.get_canonical_chain_tip().unwrap();
+        produce_burn_block(
+            &mut burnchain,
+            &burnchain_tip.block_hash,
+            ops,
+            vec![].iter_mut(),
+        );
+        // handle the sortition
+        coord.handle_new_burnchain_block().unwrap();
+
+        let b = get_burnchain(path, pox_consts.clone());
+        let new_burnchain_tip = burnchain.get_canonical_chain_tip().unwrap();
+        if b.is_reward_cycle_start(new_burnchain_tip.block_height) {
+            if new_burnchain_tip.block_height < sunset_ht {
+                started_first_reward_cycle = true;
+                // store the anchor block for this sortition for later checking
+                let ic = sort_db.index_handle_at_tip();
+                let bhh = ic.get_last_anchor_block_hash().unwrap().unwrap();
+                anchor_blocks.push(bhh);
+            } else {
+                // store the anchor block for this sortition for later checking
+                let ic = sort_db.index_handle_at_tip();
+                assert!(ic.get_last_anchor_block_hash().unwrap().is_none(), "No PoX anchor block should be chosen after PoX sunset");
+            }
+        } 
+
+        let tip = SortitionDB::get_canonical_burn_chain_tip(sort_db.conn()).unwrap();
+        assert_eq!(&tip.winning_block_txid, &expected_winner);
+
+        // load the block into staging
+        let block_hash = block.header.block_hash();
+
+        assert_eq!(&tip.winning_stacks_block_hash, &block_hash);
+        stacks_blocks.push((tip.sortition_id.clone(), block.clone()));
+
+        preprocess_block(&mut chainstate, &sort_db, &tip, block);
+
+        // handle the stacks block
+        coord.handle_new_stacks_block().unwrap();
+    }
+
+    let stacks_tip = SortitionDB::get_canonical_stacks_chain_tip_hash(sort_db.conn()).unwrap();
+    let mut chainstate = get_chainstate(path);
+    assert_eq!(
+        chainstate.with_read_only_clarity_tx(
+            &sort_db.index_conn(),
+            &StacksBlockId::new(&stacks_tip.0, &stacks_tip.1),
+            |conn| conn
+                .with_readonly_clarity_env(
+                    PrincipalData::parse("SP3Q4A5WWZ80REGBN0ZXNE540ECJ9JZ4A765Q5K2Q").unwrap(),
+                    LimitedCostTracker::new_max_limit(),
+                    |env| env.eval_raw("block-height")
+                )
+                .unwrap()
+        ),
+        Value::UInt(100)
+    );
+
+    {
+        let ic = sort_db.index_handle_at_tip();
+        let pox_id = ic.get_pox_id().unwrap();
+        assert_eq!(&pox_id.to_string(),
+                   "111111111111111111111",
+                   "PoX ID should reflect the 10 reward cycles _with_ a known anchor block, plus the 'initial' known reward cycle at genesis");
+    }
+}
+
+#[test]
 // This test should panic until the MARF stability issue
 // https://github.com/blockstack/stacks-blockchain/issues/1805
 // is resolved:
@@ -1214,7 +1478,7 @@ fn test_pox_processable_block_in_different_pox_forks() {
     let vrf_keys: Vec<_> = (0..12).map(|_| VRFPrivateKey::new()).collect();
     let committers: Vec<_> = (0..12).map(|_| StacksPrivateKey::new()).collect();
 
-    setup_states(&[path, path_blinded], &vrf_keys, &committers);
+    setup_states(&[path, path_blinded], &vrf_keys, &committers, None);
 
     let mut coord = make_coordinator(path);
     let mut coord_blind = make_coordinator(path_blinded);
@@ -1222,7 +1486,7 @@ fn test_pox_processable_block_in_different_pox_forks() {
     coord.handle_new_burnchain_block().unwrap();
     coord_blind.handle_new_burnchain_block().unwrap();
 
-    let sort_db = get_sortition_db(path);
+    let sort_db = get_sortition_db(path, None);
 
     let tip = SortitionDB::get_canonical_burn_chain_tip(sort_db.conn()).unwrap();
     assert_eq!(tip.block_height, 1);
@@ -1232,7 +1496,7 @@ fn test_pox_processable_block_in_different_pox_forks() {
         .unwrap()
         .unwrap();
 
-    let sort_db_blind = get_sortition_db(path_blinded);
+    let sort_db_blind = get_sortition_db(path_blinded, None);
 
     let tip = SortitionDB::get_canonical_burn_chain_tip(sort_db_blind.conn()).unwrap();
     assert_eq!(tip.block_height, 1);
@@ -1259,7 +1523,7 @@ fn test_pox_processable_block_in_different_pox_forks() {
     //  blocks `10` and `11` can be processed either
     //    in PoX fork 111 or in 110
     for (ix, (vrf_key, miner)) in vrf_keys.iter().zip(committers.iter()).enumerate() {
-        let mut burnchain = get_burnchain_db(path);
+        let mut burnchain = get_burnchain_db(path, None);
         let mut chainstate = get_chainstate(path);
         eprintln!("Making block {}", ix);
         let (op, block) = if ix == 0 {
@@ -1289,7 +1553,7 @@ fn test_pox_processable_block_in_different_pox_forks() {
             )
         };
         let burnchain_tip = burnchain.get_canonical_chain_tip().unwrap();
-        let burnchain_blinded = get_burnchain_db(path_blinded);
+        let burnchain_blinded = get_burnchain_db(path_blinded, None);
         produce_burn_block(
             &mut burnchain,
             &burnchain_tip.block_hash,
@@ -1300,7 +1564,7 @@ fn test_pox_processable_block_in_different_pox_forks() {
         coord.handle_new_burnchain_block().unwrap();
         coord_blind.handle_new_burnchain_block().unwrap();
 
-        let b = get_burnchain(path);
+        let b = get_burnchain(path, None);
         let new_burnchain_tip = burnchain.get_canonical_chain_tip().unwrap();
         if b.is_reward_cycle_start(new_burnchain_tip.block_height) {
             eprintln!(
@@ -1455,7 +1719,7 @@ fn test_pox_no_anchor_selected() {
     let vrf_keys: Vec<_> = (0..10).map(|_| VRFPrivateKey::new()).collect();
     let committers: Vec<_> = (0..10).map(|_| StacksPrivateKey::new()).collect();
 
-    setup_states(&[path, path_blinded], &vrf_keys, &committers);
+    setup_states(&[path, path_blinded], &vrf_keys, &committers, None);
 
     let mut coord = make_coordinator(path);
     let mut coord_blind = make_coordinator(path_blinded);
@@ -1463,7 +1727,7 @@ fn test_pox_no_anchor_selected() {
     coord.handle_new_burnchain_block().unwrap();
     coord_blind.handle_new_burnchain_block().unwrap();
 
-    let sort_db = get_sortition_db(path);
+    let sort_db = get_sortition_db(path, None);
 
     let tip = SortitionDB::get_canonical_burn_chain_tip(sort_db.conn()).unwrap();
     assert_eq!(tip.block_height, 1);
@@ -1473,7 +1737,7 @@ fn test_pox_no_anchor_selected() {
         .unwrap()
         .unwrap();
 
-    let sort_db_blind = get_sortition_db(path_blinded);
+    let sort_db_blind = get_sortition_db(path_blinded, None);
 
     let tip = SortitionDB::get_canonical_burn_chain_tip(sort_db_blind.conn()).unwrap();
     assert_eq!(tip.block_height, 1);
@@ -1498,7 +1762,7 @@ fn test_pox_no_anchor_selected() {
     //   0 - 1 - 2 - 3 - 4 - 5 - 6
     //    \_ 7   \_ 8 _ 9
     for (ix, (vrf_key, miner)) in vrf_keys.iter().zip(committers.iter()).enumerate() {
-        let mut burnchain = get_burnchain_db(path);
+        let mut burnchain = get_burnchain_db(path, None);
         let mut chainstate = get_chainstate(path);
         eprintln!("Making block {}", ix);
         let (op, block) = if ix == 0 {
@@ -1530,7 +1794,7 @@ fn test_pox_no_anchor_selected() {
             )
         };
         let burnchain_tip = burnchain.get_canonical_chain_tip().unwrap();
-        let burnchain_blinded = get_burnchain_db(path_blinded);
+        let burnchain_blinded = get_burnchain_db(path_blinded, None);
         produce_burn_block(
             &mut burnchain,
             &burnchain_tip.block_hash,
@@ -1541,7 +1805,7 @@ fn test_pox_no_anchor_selected() {
         coord.handle_new_burnchain_block().unwrap();
         coord_blind.handle_new_burnchain_block().unwrap();
 
-        let b = get_burnchain(path);
+        let b = get_burnchain(path, None);
         let new_burnchain_tip = burnchain.get_canonical_chain_tip().unwrap();
         if b.is_reward_cycle_start(new_burnchain_tip.block_height) {
             eprintln!(
@@ -1656,7 +1920,7 @@ fn test_pox_fork_out_of_order() {
     let vrf_keys: Vec<_> = (0..15).map(|_| VRFPrivateKey::new()).collect();
     let committers: Vec<_> = (0..15).map(|_| StacksPrivateKey::new()).collect();
 
-    setup_states(&[path, path_blinded], &vrf_keys, &committers);
+    setup_states(&[path, path_blinded], &vrf_keys, &committers, None);
 
     let mut coord = make_coordinator(path);
     let mut coord_blind = make_coordinator(path_blinded);
@@ -1664,7 +1928,7 @@ fn test_pox_fork_out_of_order() {
     coord.handle_new_burnchain_block().unwrap();
     coord_blind.handle_new_burnchain_block().unwrap();
 
-    let sort_db = get_sortition_db(path);
+    let sort_db = get_sortition_db(path, None);
 
     let tip = SortitionDB::get_canonical_burn_chain_tip(sort_db.conn()).unwrap();
     assert_eq!(tip.block_height, 1);
@@ -1674,7 +1938,7 @@ fn test_pox_fork_out_of_order() {
         .unwrap()
         .unwrap();
 
-    let sort_db_blind = get_sortition_db(path_blinded);
+    let sort_db_blind = get_sortition_db(path_blinded, None);
 
     let tip = SortitionDB::get_canonical_burn_chain_tip(sort_db_blind.conn()).unwrap();
     assert_eq!(tip.block_height, 1);
@@ -1699,7 +1963,7 @@ fn test_pox_fork_out_of_order() {
     //  2 forks: 0 - 1 - 2 - 3 - 4 - 5 - 11 - 12 - 13 - 14 - 15
     //            \_ 6 _ 7 _ 8 _ 9 _ 10
     for (ix, (vrf_key, miner)) in vrf_keys.iter().zip(committers.iter()).enumerate() {
-        let mut burnchain = get_burnchain_db(path);
+        let mut burnchain = get_burnchain_db(path, None);
         let mut chainstate = get_chainstate(path);
         eprintln!("Making block {}", ix);
         let (op, block) = if ix == 0 {
@@ -1733,7 +1997,7 @@ fn test_pox_fork_out_of_order() {
             )
         };
         let burnchain_tip = burnchain.get_canonical_chain_tip().unwrap();
-        let burnchain_blinded = get_burnchain_db(path_blinded);
+        let burnchain_blinded = get_burnchain_db(path_blinded, None);
         produce_burn_block(
             &mut burnchain,
             &burnchain_tip.block_hash,
@@ -1744,7 +2008,7 @@ fn test_pox_fork_out_of_order() {
         coord.handle_new_burnchain_block().unwrap();
         coord_blind.handle_new_burnchain_block().unwrap();
 
-        let b = get_burnchain(path);
+        let b = get_burnchain(path, None);
         let new_burnchain_tip = burnchain.get_canonical_chain_tip().unwrap();
         if b.is_reward_cycle_start(new_burnchain_tip.block_height) {
             eprintln!(

--- a/src/chainstate/stacks/block.rs
+++ b/src/chainstate/stacks/block.rs
@@ -1366,6 +1366,7 @@ mod test {
         };
 
         let mut block_commit = LeaderBlockCommitOp {
+            sunset_burn: 0,
             block_header_hash: header.block_hash(),
             new_seed: VRFSeed::from_proof(&header.proof),
             parent_block_ptr: 0,

--- a/src/chainstate/stacks/boot/mod.rs
+++ b/src/chainstate/stacks/boot/mod.rs
@@ -388,7 +388,7 @@ pub mod test {
 
     #[test]
     fn get_reward_threshold_units() {
-        let test_pox_constants = PoxConstants::new(500, 1, 1, 1, 5);
+        let test_pox_constants = PoxConstants::new(500, 1, 1, 1, 5, 5000, 10000);
         // when the liquid amount = the threshold step,
         //   the threshold should always be the step size.
         let liquid = POX_THRESHOLD_STEPS_USTX;

--- a/src/chainstate/stacks/miner.rs
+++ b/src/chainstate/stacks/miner.rs
@@ -1070,8 +1070,7 @@ pub mod test {
     use address::*;
     use chainstate::burn::db::sortdb::*;
     use chainstate::burn::operations::{
-        BlockstackOperationType, LeaderBlockCommitOp, LeaderKeyRegisterOp,
-        UserBurnSupportOp,
+        BlockstackOperationType, LeaderBlockCommitOp, LeaderKeyRegisterOp, UserBurnSupportOp,
     };
     use chainstate::burn::*;
     use chainstate::stacks::db::test::*;

--- a/src/chainstate/stacks/miner.rs
+++ b/src/chainstate/stacks/miner.rs
@@ -1067,7 +1067,7 @@ pub mod test {
     use address::*;
     use chainstate::burn::db::sortdb::*;
     use chainstate::burn::operations::{
-        BlockstackOperation, BlockstackOperationType, LeaderBlockCommitOp, LeaderKeyRegisterOp,
+        BlockstackOperationType, LeaderBlockCommitOp, LeaderKeyRegisterOp,
         UserBurnSupportOp,
     };
     use chainstate::burn::*;

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -60,6 +60,9 @@ pub const CHAINSTATE_VERSION: &'static str = "23.0.0.0";
 
 pub const MICROSTACKS_PER_STACKS: u32 = 1_000_000;
 
+pub const POX_SUNSET_START: u64 = (FIRST_BURNCHAIN_BLOCK_HEIGHT as u64) + 100_000;
+pub const POX_SUNSET_END: u64 = POX_SUNSET_START + 400_000;
+
 pub const POX_PREPARE_WINDOW_LENGTH: u32 = 240;
 pub const POX_REWARD_CYCLE_LENGTH: u32 = 1000;
 /// The maximum amount that PoX rewards can be scaled by.

--- a/src/net/inv.rs
+++ b/src/net/inv.rs
@@ -2564,7 +2564,7 @@ mod test {
     #[test]
     fn test_inv_merge_pox_inv() {
         let mut burnchain = Burnchain::new("unused", "bitcoin", "regtest").unwrap();
-        burnchain.pox_constants = PoxConstants::new(5, 3, 3, 25, 5);
+        burnchain.pox_constants = PoxConstants::new(5, 3, 3, 25, 5, u64::max_value(), u64::max_value());
 
         let mut peer_inv = PeerBlocksInv::new(vec![0x01], vec![0x01], vec![0x01], 1, 1, 0);
         for i in 0..32 {
@@ -2582,7 +2582,7 @@ mod test {
     #[test]
     fn test_inv_truncate_pox_inv() {
         let mut burnchain = Burnchain::new("unused", "bitcoin", "regtest").unwrap();
-        burnchain.pox_constants = PoxConstants::new(5, 3, 3, 25, 5);
+        burnchain.pox_constants = PoxConstants::new(5, 3, 3, 25, 5, u64::max_value(), u64::max_value());
 
         let mut peer_inv = PeerBlocksInv::new(vec![0x01], vec![0x01], vec![0x01], 1, 1, 0);
         for i in 0..5 {

--- a/src/net/inv.rs
+++ b/src/net/inv.rs
@@ -2564,7 +2564,8 @@ mod test {
     #[test]
     fn test_inv_merge_pox_inv() {
         let mut burnchain = Burnchain::new("unused", "bitcoin", "regtest").unwrap();
-        burnchain.pox_constants = PoxConstants::new(5, 3, 3, 25, 5, u64::max_value(), u64::max_value());
+        burnchain.pox_constants =
+            PoxConstants::new(5, 3, 3, 25, 5, u64::max_value(), u64::max_value());
 
         let mut peer_inv = PeerBlocksInv::new(vec![0x01], vec![0x01], vec![0x01], 1, 1, 0);
         for i in 0..32 {
@@ -2582,7 +2583,8 @@ mod test {
     #[test]
     fn test_inv_truncate_pox_inv() {
         let mut burnchain = Burnchain::new("unused", "bitcoin", "regtest").unwrap();
-        burnchain.pox_constants = PoxConstants::new(5, 3, 3, 25, 5, u64::max_value(), u64::max_value());
+        burnchain.pox_constants =
+            PoxConstants::new(5, 3, 3, 25, 5, u64::max_value(), u64::max_value());
 
         let mut peer_inv = PeerBlocksInv::new(vec![0x01], vec![0x01], vec![0x01], 1, 1, 0);
         for i in 0..5 {

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -2016,7 +2016,8 @@ pub mod test {
                 )
                 .unwrap(),
             );
-            burnchain.pox_constants = PoxConstants::new(5, 3, 3, 25, 5, u64::max_value(), u64::max_value());
+            burnchain.pox_constants =
+                PoxConstants::new(5, 3, 3, 25, 5, u64::max_value(), u64::max_value());
 
             let spending_account = TestMinerFactory::new().next_miner(
                 &burnchain,

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -2154,7 +2154,7 @@ pub mod test {
             let mut miner =
                 miner_factory.next_miner(&config.burnchain, 1, 1, AddressHashMode::SerializeP2PKH);
 
-            let mut burnchain = get_burnchain(&test_path);
+            let mut burnchain = get_burnchain(&test_path, None);
             burnchain.first_block_height = config.burnchain.first_block_height;
             burnchain.first_block_hash = config.burnchain.first_block_hash;
 

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -2012,7 +2012,7 @@ pub mod test {
                 )
                 .unwrap(),
             );
-            burnchain.pox_constants = PoxConstants::new(5, 3, 3, 25, 5);
+            burnchain.pox_constants = PoxConstants::new(5, 3, 3, 25, 5, u64::max_value(), u64::max_value());
 
             let spending_account = TestMinerFactory::new().next_miner(
                 &burnchain,

--- a/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
+++ b/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
@@ -574,8 +574,14 @@ impl BitcoinRegtestController {
             buffer
         };
 
+        let sunset_burn = if payload.sunset_burn > 0 {
+            cmp::max(payload.sunset_burn, DUST_UTXO_LIMIT)
+        } else {
+            0
+        };
+
         let consensus_output = TxOut {
-            value: 0,
+            value: sunset_burn,
             script_pubkey: Builder::new()
                 .push_opcode(opcodes::All::OP_RETURN)
                 .push_slice(&op_bytes)
@@ -593,15 +599,6 @@ impl BitcoinRegtestController {
             tx.output
                 .push(commit_to.to_bitcoin_tx_out(value_per_transfer));
         }
-
-        let sunset_burn = if payload.sunset_burn > 0 {
-            let burn_amt = cmp::max(payload.sunset_burn, DUST_UTXO_LIMIT);
-            tx.output
-                .push(StacksAddress::burn_address(false).to_bitcoin_tx_out(burn_amt));
-            burn_amt
-        } else {
-            0
-        };
 
         self.finalize_tx(
             &mut tx,

--- a/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
+++ b/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
@@ -10,6 +10,8 @@ use http_types::{Method, Request, Url};
 use serde::Serialize;
 use serde_json::value::RawValue;
 
+use std::cmp;
+
 use super::super::operations::BurnchainOpSigner;
 use super::super::Config;
 use super::{BurnchainController, BurnchainTip, Error as BurnchainControllerError};
@@ -29,9 +31,10 @@ use stacks::burnchains::PoxConstants;
 use stacks::burnchains::PublicKey;
 use stacks::chainstate::burn::db::sortdb::SortitionDB;
 use stacks::chainstate::burn::operations::{
-    leader_block_commit::OUTPUTS_PER_COMMIT, BlockstackOperationType, LeaderBlockCommitOp,
+    BlockstackOperationType, LeaderBlockCommitOp,
     LeaderKeyRegisterOp, UserBurnSupportOp,
 };
+use stacks::chainstate::stacks::StacksAddress;
 use stacks::chainstate::coordinator::comm::CoordinatorChannels;
 use stacks::deps::bitcoin::blockdata::opcodes;
 use stacks::deps::bitcoin::blockdata::script::{Builder, Script};
@@ -582,17 +585,8 @@ impl BitcoinRegtestController {
 
         tx.output = vec![consensus_output];
 
-        if OUTPUTS_PER_COMMIT < payload.commit_outs.len() {
-            error!("Generated block commit with more commit outputs than OUTPUTS_PER_COMMIT");
-            return None;
-        }
-
-        if OUTPUTS_PER_COMMIT != payload.commit_outs.len() {
-            error!("Generated block commit with wrong OUTPUTS_PER_COMMIT");
-            return None;
-        }
-        let value_per_transfer = payload.burn_fee / (OUTPUTS_PER_COMMIT as u64);
-        if value_per_transfer < 5500 {
+        let value_per_transfer = payload.burn_fee / (payload.commit_outs.len() as u64);
+        if value_per_transfer < DUST_UTXO_LIMIT {
             error!("Total burn fee not enough for number of outputs");
             return None;
         }
@@ -601,7 +595,16 @@ impl BitcoinRegtestController {
                 .push(commit_to.to_bitcoin_tx_out(value_per_transfer));
         }
 
-        self.finalize_tx(&mut tx, payload.burn_fee, utxos, signer, attempt)?;
+        let sunset_burn = if payload.sunset_burn > 0 {
+            let burn_amt = cmp::max(payload.sunset_burn, DUST_UTXO_LIMIT);
+            tx.output
+                .push(StacksAddress::burn_address(false).to_bitcoin_tx_out(burn_amt));
+            burn_amt
+        } else {
+            0
+        };
+
+        self.finalize_tx(&mut tx, payload.burn_fee + sunset_burn, utxos, signer, attempt)?;
 
         increment_btc_ops_sent_counter();
 

--- a/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
+++ b/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
@@ -31,11 +31,10 @@ use stacks::burnchains::PoxConstants;
 use stacks::burnchains::PublicKey;
 use stacks::chainstate::burn::db::sortdb::SortitionDB;
 use stacks::chainstate::burn::operations::{
-    BlockstackOperationType, LeaderBlockCommitOp,
-    LeaderKeyRegisterOp, UserBurnSupportOp,
+    BlockstackOperationType, LeaderBlockCommitOp, LeaderKeyRegisterOp, UserBurnSupportOp,
 };
-use stacks::chainstate::stacks::StacksAddress;
 use stacks::chainstate::coordinator::comm::CoordinatorChannels;
+use stacks::chainstate::stacks::StacksAddress;
 use stacks::deps::bitcoin::blockdata::opcodes;
 use stacks::deps::bitcoin::blockdata::script::{Builder, Script};
 use stacks::deps::bitcoin::blockdata::transaction::{OutPoint, Transaction, TxIn, TxOut};
@@ -604,7 +603,13 @@ impl BitcoinRegtestController {
             0
         };
 
-        self.finalize_tx(&mut tx, payload.burn_fee + sunset_burn, utxos, signer, attempt)?;
+        self.finalize_tx(
+            &mut tx,
+            payload.burn_fee + sunset_burn,
+            utxos,
+            signer,
+            attempt,
+        )?;
 
         increment_btc_ops_sent_counter();
 

--- a/testnet/stacks-node/src/burnchains/mocknet_controller.rs
+++ b/testnet/stacks-node/src/burnchains/mocknet_controller.rs
@@ -159,6 +159,7 @@ impl BurnchainController for MocknetController {
                 }
                 BlockstackOperationType::LeaderBlockCommit(payload) => {
                     BlockstackOperationType::LeaderBlockCommit(LeaderBlockCommitOp {
+                        sunset_burn: 0,
                         block_header_hash: payload.block_header_hash,
                         new_seed: payload.new_seed,
                         parent_block_ptr: payload.parent_block_ptr,

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -212,6 +212,7 @@ fn inner_generate_block_commit_op(
     let commit_outs = RewardSetInfo::into_commit_outs(recipients, false);
 
     BlockstackOperationType::LeaderBlockCommit(LeaderBlockCommitOp {
+        sunset_burn: 0,
         block_header_hash,
         burn_fee,
         input,

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -1048,8 +1048,8 @@ impl InitializedNeonNode {
             }
         };
 
-        let sunset_burn = burnchain.pox_constants.expected_sunset_burn(
-            burn_block.block_height + 1, burn_fee_cap);
+        let sunset_burn = burnchain.expected_sunset_burn(burn_block.block_height + 1, burn_fee_cap);
+        let rest_commit = burn_fee_cap - sunset_burn;
 
         let commit_outs = if burn_block.block_height + 1 < burnchain.pox_constants.sunset_end {
             RewardSetInfo::into_commit_outs(recipients, false)
@@ -1061,7 +1061,7 @@ impl InitializedNeonNode {
         let op = inner_generate_block_commit_op(
             keychain.get_burnchain_signer(),
             anchored_block.block_hash(),
-            burn_fee_cap,
+            rest_commit,
             &registered_key,
             parent_block_burn_height
                 .try_into()
@@ -1069,7 +1069,7 @@ impl InitializedNeonNode {
             parent_winning_vtxindex,
             VRFSeed::from_proof(&vrf_proof),
             commit_outs,
-            sunset_burn
+            sunset_burn,
         );
         let mut op_signer = keychain.generate_op_signer();
         bitcoin_controller.submit_operation(op, &mut op_signer, attempt);

--- a/testnet/stacks-node/src/node.rs
+++ b/testnet/stacks-node/src/node.rs
@@ -696,6 +696,7 @@ impl Node {
         let commit_outs = RewardSetInfo::into_commit_outs(None, false);
 
         BlockstackOperationType::LeaderBlockCommit(LeaderBlockCommitOp {
+            sunset_burn: 0,
             block_header_hash,
             burn_fee,
             input: self.keychain.get_burnchain_signer(),

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -761,7 +761,7 @@ fn pox_integration_test() {
     let http_origin = format!("http://{}", &conf.node.rpc_bind);
 
     let mut burnchain_config = btc_regtest_controller.get_burnchain();
-    let pox_constants = PoxConstants::new(10, 5, 4, 5, 15);
+    let pox_constants = PoxConstants::new(10, 5, 4, 5, 15, u64::max_value(), u64::max_value());
     burnchain_config.pox_constants = pox_constants;
 
     btc_regtest_controller.bootstrap_chain(201);

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -761,7 +761,7 @@ fn pox_integration_test() {
     let http_origin = format!("http://{}", &conf.node.rpc_bind);
 
     let mut burnchain_config = btc_regtest_controller.get_burnchain();
-    let pox_constants = PoxConstants::new(10, 5, 4, 5, 15, u64::max_value(), u64::max_value());
+    let pox_constants = PoxConstants::new(10, 5, 4, 5, 15, 239, 250);
     burnchain_config.pox_constants = pox_constants;
 
     btc_regtest_controller.bootstrap_chain(201);
@@ -835,7 +835,7 @@ fn pox_integration_test() {
             .unwrap()
             .unwrap(),
             Value::UInt(sort_height as u128),
-            Value::UInt(3),
+            Value::UInt(6),
         ],
     );
 
@@ -893,7 +893,7 @@ fn pox_integration_test() {
             .unwrap()
             .unwrap(),
             Value::UInt(sort_height as u128),
-            Value::UInt(3),
+            Value::UInt(6),
         ],
     );
 
@@ -936,7 +936,7 @@ fn pox_integration_test() {
             .unwrap()
             .unwrap(),
             Value::UInt(sort_height as u128),
-            Value::UInt(3),
+            Value::UInt(6),
         ],
     );
 
@@ -981,6 +981,7 @@ fn pox_integration_test() {
         "Should have received no outputs during PoX reward cycle"
     );
 
+    // before sunset
     // mine until the end of the next reward cycle,
     //   the participation threshold now should be met.
     while sort_height < 239 {
@@ -1011,7 +1012,73 @@ fn pox_integration_test() {
         "Should have received three outputs during PoX reward cycle"
     );
 
-    // okay, the threshold for participation should be
+    // get the canonical chain tip
+    let path = format!("{}/v2/info", &http_origin);
+    let tip_info = client
+        .get(&path)
+        .send()
+        .unwrap()
+        .json::<RPCPeerInfoData>()
+        .unwrap();
+
+    assert_eq!(tip_info.stacks_tip_height, 36);
+
+    // now let's mine into the sunset
+    while sort_height < 249 {
+        next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+        sort_height = channel.get_sortitions_processed();
+        eprintln!("Sort height: {}", sort_height);
+    }
+
+    // get the canonical chain tip
+    let path = format!("{}/v2/info", &http_origin);
+    let tip_info = client
+        .get(&path)
+        .send()
+        .unwrap()
+        .json::<RPCPeerInfoData>()
+        .unwrap();
+
+    assert_eq!(tip_info.stacks_tip_height, 46);
+
+    let utxos = btc_regtest_controller.get_all_utxos(&pox_2_pubkey);
+
+    // should receive more rewards during this cycle...
+    eprintln!("Got UTXOs: {}", utxos.len());
+    assert_eq!(
+        utxos.len(),
+        14,
+        "Should have received more outputs during the sunsetting PoX reward cycle"
+    );
+
+    // and after sunset
+    while sort_height < 259 {
+        next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+        sort_height = channel.get_sortitions_processed();
+        eprintln!("Sort height: {}", sort_height);
+    }
+
+    let utxos = btc_regtest_controller.get_all_utxos(&pox_2_pubkey);
+
+    // should *not* receive more rewards during the after sunset cycle...
+    eprintln!("Got UTXOs: {}", utxos.len());
+    assert_eq!(
+        utxos.len(),
+        14,
+        "Should have received no more outputs after sunset PoX reward cycle"
+    );
+
+    // should have progressed the chain, though!
+    // get the canonical chain tip
+    let path = format!("{}/v2/info", &http_origin);
+    let tip_info = client
+        .get(&path)
+        .send()
+        .unwrap()
+        .json::<RPCPeerInfoData>()
+        .unwrap();
+
+    assert_eq!(tip_info.stacks_tip_height, 56);
 
     channel.stop_chains_coordinator();
 }


### PR DESCRIPTION
This PR implements the sunset phase of PoX, per the description in SIP-007.

In particular:

* [Before Sunset](https://en.wikipedia.org/wiki/Before_Sunset) - everything here behaves the same as before -- there are 2 commit outputs required for every block commit, selected using the PoX anchor block logic.
* After sunset begin, Before sunset end - an additional output is required in each block commit. This output is the "sunset burn", and it must be greater than the required sunset ratio (described in SIP-007: for each reward cycle during the sunset phase, the sunset burn ratio must be > the progress percentage through the sunset phase).
* After sunset end - the first output of the block commit must be a burn output, and it is the only output counted in the block commit

This is tested with parsing tests in leader_block_commit, some integration tests in coordinator::tests (that test a sunset end occurring before the end of a reward cycle), and an extension of the pox test in neon_integrations.