### PR TITLE
Fix: set default burn cap for multiple commits

### DIFF
--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -733,7 +733,7 @@ impl BurnchainConfig {
         BurnchainConfig {
             chain: "bitcoin".to_string(),
             mode: "mocknet".to_string(),
-            burn_fee_cap: 10000,
+            burn_fee_cap: 20000,
             commit_anchor_block_within: 5000,
             peer_host: "0.0.0.0".to_string(),
             peer_port: 8333,


### PR DESCRIPTION
With the number of PoX outputs increasing, the default burn cap has to increase to clear the dust UTXO limit.