### PR TITLE
Implement #1641 rpc call public functions as read-only

### DIFF
--- a/src/net/inv.rs
+++ b/src/net/inv.rs
@@ -1358,7 +1358,7 @@ impl PeerNetwork {
         };
 
         debug!(
-            "{:?}: Send GetPoxInv to {:?} for {} rewad cycles starting at {} ({})",
+            "{:?}: Send GetPoxInv to {:?} for {} reward cycles starting at {} ({})",
             &self.local_peer,
             nk,
             num_reward_cycles,

--- a/src/net/rpc.rs
+++ b/src/net/rpc.rs
@@ -879,20 +879,22 @@ impl ConversationHttp {
                 result: Some(format!("0x{}", data.serialize())),
                 cause: None,
             },
-            Err(e) => {
-                match e {
-                    Unchecked(CheckErrors::CostBalanceExceeded(actual_cost, _)) if actual_cost.write_count > 0 => CallReadOnlyResponse {
+            Err(e) => match e {
+                Unchecked(CheckErrors::CostBalanceExceeded(actual_cost, _))
+                    if actual_cost.write_count > 0 =>
+                {
+                    CallReadOnlyResponse {
                         okay: false,
                         result: None,
                         cause: Some("NotReadOnly".to_string()),
-                    },
-                    _ => CallReadOnlyResponse {
-                        okay: false,
-                        result: None,
-                        cause: Some(e.to_string()),
                     }
                 }
-            }
+                _ => CallReadOnlyResponse {
+                    okay: false,
+                    result: None,
+                    cause: Some(e.to_string()),
+                },
+            },
         };
 
         let response = HttpResponseType::CallReadOnlyFunction(response_metadata, response);

--- a/testnet/stacks-node/src/tests/integrations.rs
+++ b/testnet/stacks-node/src/tests/integrations.rs
@@ -17,10 +17,9 @@ use stacks::vm::{
         mem_type_check,
     },
     database::ClaritySerializable,
-    types::{QualifiedContractIdentifier, TupleData},
+    types::{QualifiedContractIdentifier, ResponseData, TupleData},
     Value,
 };
-use stacks::vm::types::ResponseData;
 use std::fmt::Write;
 
 use crate::config::InitialBalance;
@@ -169,14 +168,12 @@ fn integration_test_get_info() {
                     .mem_pool
                     .submit_raw(&consensus_hash, &header_hash, publish_tx)
                     .unwrap();
-                let publish_tx =
-                    make_contract_publish(&contract_sk, 1, 0, "other", OTHER_CONTRACT);
+                let publish_tx = make_contract_publish(&contract_sk, 1, 0, "other", OTHER_CONTRACT);
                 tenure
                     .mem_pool
                     .submit_raw(&consensus_hash, &header_hash, publish_tx)
                     .unwrap();
-                let publish_tx =
-                    make_contract_publish(&contract_sk, 2, 0, "main", MAIN_CONTRACT);
+                let publish_tx = make_contract_publish(&contract_sk, 2, 0, "main", MAIN_CONTRACT);
                 tenure
                     .mem_pool
                     .submit_raw(&consensus_hash, &header_hash, publish_tx)


### PR DESCRIPTION
In starting to look into implementing #1981, I stumbled upon the implementation of `call-read` and thought maybe there was a way to call the same function in a read only fashion if it was made `public` instead of `read-only`.

And turns out, that the implementation was quite simple by changing a parameter and checking whether the code made any writes, and fail if it did.

#1981 still forthcoming.

Not consensus altering, so can be merged to master directly.