### PR TITLE
fix: enable debug logs in release build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ percent-encoding = "2.1.0"
 sha2 = "0.8.0"
 prometheus = { version = "0.9", optional = true }
 integer-sqrt = "0.1.3"
-slog = "2.5.2"
+slog = { version = "2.5.2", features = [ "max_level_trace" ] }
 slog-term = "2.6.0"
 slog-json = { version = "2.3.0", optional = true }
 

--- a/src/util/log.rs
+++ b/src/util/log.rs
@@ -125,7 +125,7 @@ fn make_logger() -> Logger {
     if env::var("BLOCKSTACK_LOG_JSON") == Ok("1".into()) {
         make_json_logger()
     } else {
-        let plain = slog_term::PlainSyncDecorator::new(std::io::stdout());
+        let plain = slog_term::PlainSyncDecorator::new(std::io::stderr());
         let drain = TermFormat::new(plain);
 
         let logger = Logger::root(drain.fuse(), o!());

--- a/testnet/stacks-node/Cargo.toml
+++ b/testnet/stacks-node/Cargo.toml
@@ -19,7 +19,7 @@ http-types = "1.0"
 base64 = "0.12.0"
 backtrace = "0.3.50"
 libc = "0.2"
-slog = "2.5.2"
+slog = { version = "2.5.2", features = [ "max_level_trace" ] }
 
 [dev-dependencies]
 warp = "0.2"


### PR DESCRIPTION
This re-enables debug logs in release builds (slog uses rust's debug-assertions by default to turn off debug logs during release builds).