### PR TITLE
fix: correct tuple signature

### DIFF
--- a/src/vm/docs/mod.rs
+++ b/src/vm/docs/mod.rs
@@ -621,13 +621,8 @@ const TUPLE_CONS_API: SpecialAPI = SpecialAPI {
     description: "The `tuple` special form constructs a typed tuple from the supplied key and expression pairs.
 A `get` function can use typed tuples as input to select specific values from a given tuple.
 Key names may not appear multiple times in the same tuple definition. Supplied expressions are evaluated and
-associated with the expressions' paired key name.
-
-As a shorthand the name `tuple` can be removed, or curly brackets can be used as shown in the examples.",
-    example: "(tuple (name \"blockstack\") (id 1337)) ;; using tuple
-((name \"blockstack\") (id 1337)) ;; using shorthand
-{name: \"blockstack\", id: 1337};; using curly brackets
-",
+associated with the expressions' paired key name.",
+    example: "(tuple (name \"blockstack\") (id 1337))",
 };
 
 const TUPLE_GET_API: SpecialAPI = SpecialAPI {

--- a/src/vm/docs/mod.rs
+++ b/src/vm/docs/mod.rs
@@ -618,16 +618,16 @@ const TUPLE_CONS_API: SpecialAPI = SpecialAPI {
     input_type: "(key-name A), (key-name-2 B), ...",
     output_type: "(tuple (key-name A) (key-name-2 B) ...)",
     signature: "(tuple (key0 expr0) (key1 expr1) ...)",
-    description: "The `tuple` function constructs a typed tuple from the supplied key and expression pairs.
+    description: "The `tuple` special form constructs a typed tuple from the supplied key and expression pairs.
 A `get` function can use typed tuples as input to select specific values from a given tuple.
 Key names may not appear multiple times in the same tuple definition. Supplied expressions are evaluated and
 associated with the expressions' paired key name.
 
-As a shorthand the function name `tuple` can be removed, or curly brackets can be used as shown in the examples.",
-
-    example: "(tuple (name \"blockstack\") (id 1337))",
-    example: "((name \"blockstack\") (id 1337))",
-    example: "{name: \"blockstack\", id: 1337}"
+As a shorthand the name `tuple` can be removed, or curly brackets can be used as shown in the examples.",
+    example: "(tuple (name \"blockstack\") (id 1337)) ;; using tuple
+((name \"blockstack\") (id 1337)) ;; using shorthand
+{name: \"blockstack\", id: 1337};; using curly brackets
+",
 };
 
 const TUPLE_GET_API: SpecialAPI = SpecialAPI {

--- a/src/vm/docs/mod.rs
+++ b/src/vm/docs/mod.rs
@@ -617,12 +617,17 @@ If a value did not exist for this key in the data map, the function returns `fal
 const TUPLE_CONS_API: SpecialAPI = SpecialAPI {
     input_type: "(key-name A), (key-name-2 B), ...",
     output_type: "(tuple (key-name A) (key-name-2 B) ...)",
-    signature: "(tuple ((key0 expr0) (key1 expr1) ...))",
+    signature: "(tuple (key0 expr0) (key1 expr1) ...)",
     description: "The `tuple` function constructs a typed tuple from the supplied key and expression pairs.
 A `get` function can use typed tuples as input to select specific values from a given tuple.
 Key names may not appear multiple times in the same tuple definition. Supplied expressions are evaluated and
-associated with the expressions' paired key name.",
-    example: "(tuple (name \"blockstack\") (id 1337))"
+associated with the expressions' paired key name.
+
+As a shorthand the function name `tuple` can be removed, or curly brackets can be used as shown in the examples.",
+
+    example: "(tuple (name \"blockstack\") (id 1337))",
+    example: "((name \"blockstack\") (id 1337))",
+    example: "{name: \"blockstack\", id: 1337}"
 };
 
 const TUPLE_GET_API: SpecialAPI = SpecialAPI {

--- a/src/vm/docs/mod.rs
+++ b/src/vm/docs/mod.rs
@@ -621,8 +621,11 @@ const TUPLE_CONS_API: SpecialAPI = SpecialAPI {
     description: "The `tuple` special form constructs a typed tuple from the supplied key and expression pairs.
 A `get` function can use typed tuples as input to select specific values from a given tuple.
 Key names may not appear multiple times in the same tuple definition. Supplied expressions are evaluated and
-associated with the expressions' paired key name.",
-    example: "(tuple (name \"blockstack\") (id 1337))",
+associated with the expressions' paired key name.
+
+There is a shorthand using curly brackets of the form {key0: expr0, key1: expr, ...}",
+    example: "(tuple (name \"blockstack\") (id 1337)) ;; using tuple
+    {name: \"blockstack\", id: 1337} ;; using curly brackets",
 };
 
 const TUPLE_GET_API: SpecialAPI = SpecialAPI {


### PR DESCRIPTION
## Description

As a developer, I want to know how to create a tuple in clarity. The signature spec and the given example contradict each other.

For details refer to issue https://github.com/blockstack/docs/issues/496

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [x] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No

## Are documentation updates required?

Rebuild docs once merged.

## Testing information

No

## Checklist
- [x] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [x] Changelog is updated
- [x] Tag 1 of @agraebe 
