### PR TITLE
Add public helm chart

### DIFF
--- a/deployment/helm/stacks-blockchain/.helmignore
+++ b/deployment/helm/stacks-blockchain/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/deployment/helm/stacks-blockchain/Chart.yaml
+++ b/deployment/helm/stacks-blockchain/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: stacks-blockchain
+description: A Helm chart for the Stacks Blockchain
+type: application
+version: 1.0.0
+appVersion: v23.0.0.10

--- a/deployment/helm/stacks-blockchain/README.md
+++ b/deployment/helm/stacks-blockchain/README.md
@@ -1,0 +1,136 @@
+# Stacks Blockchain
+
+[stacks-blockchain](https://github.com/blockstack/stacks-blockchain) is a layer-1 blockchain that connects to Bitcoin for security and enables decentralized apps and predictable smart contracts.
+
+## TL;DR
+
+```bash
+$ helm repo add blockstack https://charts.blockstack.xyz
+$ helm install my-release blockstack/stacks-blockchain
+```
+
+## Introduction
+
+This chart bootstraps a [stacks-blockchain](https://github.com/blockstack/stacks-blockchain) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+## Prerequisites
+
+- Kubernetes 1.12+
+- Helm 2.12+ or Helm 3.0-beta3+
+
+## Installing the Chart
+
+To install the chart with the release name `my-release` and run the node as a **follower**:
+
+```bash
+$ helm repo add blockstack https://charts.blockstack.xyz
+$ helm install my-release blockstack/stacks-blockchain
+```
+
+To install the chart with the release name `my-release` and run the node as a **miner** using your private key [generated from the instructions on this page](https://docs.blockstack.org/mining):
+
+```bash
+$ helm repo add blockstack https://charts.blockstack.xyz
+$ helm install my-release blockstack/stacks-blockchain --set config.node.miner=true --set config.node.seed="REPLACE-WITH-YOUR-PRIVATE-KEY"
+```
+
+These commands deploy the Stacks Blockchain node on a Kubernetes cluster in the default configuration.
+
+> **Tip**: List all releases using `helm list`
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```bash
+$ helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Parameters
+
+The following tables lists the configurable parameters of the stacks-blockchain chart and their default values.
+
+| Parameter | Description | Default |
+|-|-|-|
+| nameOverride | String to partially override stacks-blockchain.fullname template (will maintain the release name) | nil |
+| fullnameOverride | String to fully override stacks-blockchain.fullname template | nil |
+| node.image.repository | stacks-blockchain container image repository | blockstack/stacks-blockchain |
+| node.image.pullPolicy | stacks-blockchain container image pull policy | IfNotPresent |
+| node.image.tag | stacks-blockchain container image tag | latest |
+| node.imagePullSecrets | Docker registry secret names as an array | [] |
+| node.replicaCount | Number of stacks-blockchain nodes to run | 1 |
+| node.rpcPort | Port used for RPC connections | 20443 |
+| node.p2pPort | Port used for P2P connections | 20444 |
+| node.labels | Labels to be added to the node Deployment | {} |
+| node.annotations | Annotations to be added to the node Deployment | {} |
+| node.podAnnotations | Annotations to be added to the node pod(s) | {} |
+| node.podAnnotationConfigChecksum | Add Config Checksum to pod Annotations.<br>This will trigger Rolling Updates on configuration changes. | false |
+| node.podSecurityContext | Security Context policies for the node pod(s) | {} |
+| node.securityContext | Security Context policies for the node container | {} |
+| node.debug | Set to true for verbose logging. Set to false for normal verbosity | false |
+| node.jsonLogging | Set to true to enable json logging. Set to false for normal logging | false |
+| node.command | Overriding this is typically not necessary, unless you wish to run the node in a different way | ["/bin/stacks-node"] |
+| node.args | Overriding this is typically not necessary, unless you wish to run the node in a different way | ["start", "--config", "/src/stacks-node/config.toml"] |
+| node.extraEnv | Extra environment variables to add to the node's container | [] |
+| node.resources | Specify resource limits and requests for the node's container | {} |
+| node.revisionHistoryLimit | Rollback limit | 10 |
+| node.updateStrategy | The update strategy to apply | {} |
+| node.minReadySeconds | minReadySeconds to avoid killing pods before it's ready | 0 |
+| node.nodeSelector | Node labels for node pod assignment | {} |
+| node.tolerations | Node tolerations for server scheduling to nodes with taints | {} |
+| node.affinity | Affinity and anti-affinity | {} |
+| node.terminationGracePeriodSeconds | Total time it takes for the Container to stop normally | 60 |
+| node.volumes | Additional volumes for the node | [] |
+| node.volumeMounts | Additional volumeMounts for the node | [] |
+| node.extraContainers | Additional containers to run alongside the node. Useful if adding a sidecar | [] |
+| node.initContainers | Containers which are run before the node container is started | [] |
+| config | More configs can be added than what's shown below.All children fields under the node, burnchain, and mstx_balance fields will be converted from YAML to valid TOML format in the Configmap.<br><br>For info on more available config fields, please reference to our [example config files located here](https://github.com/blockstack/stacks-blockchain/tree/master/testnet/stacks-node/conf). |  |
+| config.node.rpc_bind |  | 0.0.0.0:20443 |
+| config.node.p2p_bind |  | 0.0.0.0:20444 |
+| config.node.seed | Replace with your private key if deploying a miner node | nil |
+| config.node.miner | Set this to `true` if deploying a miner node.<br>Set this to `false` if deploying a follower node. | false |
+| config.burnchain.chain |  | bitcoin |
+| config.burnchain.mode |  | krypton |
+| config.burnchain.peer_host |  | bitcoind.blockstack.org |
+| config.burnchain.rpc_port |  | 18443 |
+| config.burnchain.peer_port |  | 18444 |
+| config.mstx_balance |  | See values.yaml |
+| config.raw | Uncommenting this block will give you greater control over the settings in the Configmap | nil |
+| config.annotations | Annotations to be added to the Configmap | {} |
+| service.type | The service type to create.<br>If creating a public node for others to connect to, use Loadbalancer to ensure the advertised IP is reachable. | ClusterIP |
+| service.externalTrafficPolicy | Set external traffic policy to "Local" to preserve source IP on providers supporting it.<br>This field is only used when service.type is set to "NodePort" or "LoadBalancer".<br>Setting to "Local" can help the Stacks network if using service type NodePort or LoadBalancer. | Local |
+| service.rpcPort | Will use node.rpcPort if omitted | nil |
+| service.p2pPort | Will use node.p2pPort if omitted | nil |
+| service.annotations | Annotations to be added to the Service | {} |
+| serviceAccount.create | Specifies whether a ServiceAccount should be created.<br>If true, the stacks-blockchain node will be ran using this ServiceAccount. | true |
+| serviceAccount.annotations | Annotations to add to the service account | {} |
+| serviceAccount.name | The name of the service account to use.<br>If not set and create is true, a name is generated using the fullname template. | nil |
+| rbac.create | Specifies whether a Role should be created | false |
+| rbac.rules | Rules to add to the Role resource bound to the ServiceAccount | [] |
+| metrics.enabled | Specifies whether a ServiceMonitor should be created | false |
+| metrics.port | Port used by the ServiceMonitor to collect metrics from the node | 9153 |
+| metrics.interval | Interval at which metrics should be collected | 30s |
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```bash
+$ helm install my-release \
+    --set node.image.pullPolicy=Always \
+    blockstack/stacks-blockchain
+```
+
+The above command sets the `node.image.pullPolicy` to `Always`.
+
+Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
+
+```bash
+$ helm install my-release -f values.yaml blockstack/stacks-blockchain
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)
+
+## Troubleshooting
+
+If you encounter an issue with this Helm chart, please submit an issue to this Github repo [here](https://github.com/blockstack/stacks-blockchain/issues).

--- a/deployment/helm/stacks-blockchain/templates/NOTES.txt
+++ b/deployment/helm/stacks-blockchain/templates/NOTES.txt
@@ -1,0 +1,19 @@
+1. Get the stacks-blockchain node URL by running these commands:
+{{- if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "stacks-blockchain.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT/v2/info
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "stacks-blockchain.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "stacks-blockchain.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.rpcPort | default .Values.node.rpcPort }}/v2/info
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "stacks-blockchain.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:{{ .Values.node.rpcPort | default 20443 }}/v2/info to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME {{ .Values.node.rpcPort | default 20443 }}:{{ .Values.node.rpcPort | default 20443 }} {{ .Values.node.p2pPort | default 20444 }}:{{ .Values.node.p2pPort |default 20444 }}
+{{- end }}
+
+2. Test a connection to the stacks-blockchain node by running the following command:
+      NOTE: The stacks-blockchain node may take up to 5 minutes to enter a communicable state once its pod enters the "Running" phase.
+  helm test --namespace {{ .Release.Namespace }} {{ include "stacks-blockchain.fullname" . }}

--- a/deployment/helm/stacks-blockchain/templates/_helpers.tpl
+++ b/deployment/helm/stacks-blockchain/templates/_helpers.tpl
@@ -1,0 +1,63 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "stacks-blockchain.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "stacks-blockchain.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "stacks-blockchain.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "stacks-blockchain.labels" -}}
+helm.sh/chart: {{ include "stacks-blockchain.chart" . }}
+{{ include "stacks-blockchain.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "stacks-blockchain.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "stacks-blockchain.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "stacks-blockchain.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "stacks-blockchain.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/deployment/helm/stacks-blockchain/templates/configmap.yaml
+++ b/deployment/helm/stacks-blockchain/templates/configmap.yaml
@@ -1,0 +1,45 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "stacks-blockchain.fullname" . }}
+  labels: {{- include "stacks-blockchain.labels" . | nindent 4 }}
+  {{- if .Values.config.annotations }}
+  annotations: {{ toYaml .Values.config.annotations | nindent 4 }}
+  {{- end }}
+data:
+{{- if .Values.config.raw }}
+  config.toml: {{- toYaml .Values.config.raw | indent 2 }}
+{{- else }}
+  {{- if and (empty .Values.config.node.seed) (.Values.config.node.miner) }}
+    {{- fail "Please enter a private key under config.node.seed" }}
+  {{- end }}
+  config.toml: |
+    [node]
+  {{- range $key, $val := .Values.config.node }}
+    {{- if regexMatch "^(?i)(true|false)$" ($val | toString) }}
+      {{- $key | nindent 4 }} = {{ $val }}
+    {{- else }}
+      {{- $key | nindent 4 }} = {{ $val | quote }}
+    {{- end }}
+  {{- end }}
+
+    [burnchain]
+  {{- range $key, $val := .Values.config.burnchain }}
+    {{- if regexMatch "^[0-9]+$" ($val | toString) }}
+      {{- $key | nindent 4 }} = {{ $val }}
+    {{- else }}
+      {{- $key | nindent 4 }} = {{ $val | quote }}
+    {{- end }}
+  {{- end }}
+  {{ range $key, $val := .Values.config.mstx_balance }}
+    [[mstx_balance]]
+    {{- range $inner_key, $inner_val := $val }}
+      {{- if regexMatch "^[0-9]+$" ($inner_val | toString) }}
+        {{- $inner_key | nindent 4 }} = {{ $inner_val }}
+      {{- else }}
+        {{- $inner_key | nindent 4 }} = {{ $inner_val | quote }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/deployment/helm/stacks-blockchain/templates/deployment.yaml
+++ b/deployment/helm/stacks-blockchain/templates/deployment.yaml
@@ -1,0 +1,119 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "stacks-blockchain.fullname" . }}
+  labels: 
+    {{- include "stacks-blockchain.labels" . | nindent 4 }}
+    {{- if .Values.node.labels }}
+    {{- toYaml .Values.node.labels | nindent 4 }}
+    {{- end }}
+  {{- if .Values.node.annotations }}
+  annotations: {{- toYaml .Values.node.annotations | nindent 4 }}
+  {{- end }}
+spec:
+  replicas: {{ .Values.node.replicaCount }}
+  revisionHistoryLimit: {{ .Values.node.revisionHistoryLimit }}
+  {{- if .Values.node.updateStrategy }}
+  strategy: {{ toYaml .Values.node.updateStrategy | indent 4 }}
+  {{- end }}
+  minReadySeconds: {{ .Values.node.minReadySeconds }}
+  selector:
+    matchLabels: {{- include "stacks-blockchain.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- if or .Values.node.podAnnotations .Values.node.podAnnotationConfigChecksum }}
+      annotations:
+      {{- range $key, $value := .Values.node.podAnnotations }}
+        {{ $key }}: {{ $value }}
+      {{- end }}
+      {{- if .Values.node.podAnnotationConfigChecksum }}
+        checksum/config: {{ tpl (toYaml .Values.config) . | sha256sum }}
+      {{- end }}
+      {{- end }}
+      labels: {{- include "stacks-blockchain.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.node.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "stacks-blockchain.serviceAccountName" . }}
+      terminationGracePeriodSeconds: {{ .Values.node.terminationGracePeriodSeconds }}
+      {{- if .Values.node.podSecurityContext }}
+      securityContext: {{- toYaml .Values.node.podSecurityContext | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          {{- if .Values.node.securityContext }}
+          securityContext: {{- toYaml .Values.node.securityContext | nindent 12 }}
+          {{- end }}
+          image: {{ .Values.node.image.repository }}:{{ .Values.node.image.tag | default .Chart.AppVersion }}
+          imagePullPolicy: {{ .Values.node.image.pullPolicy }}
+          {{- with .Values.node.command }}
+          command: {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.node.args }}
+          args: {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: rpc
+              containerPort: {{ .Values.node.rpcPort | default 20443 }}
+              protocol: TCP
+            - name: p2p
+              containerPort: {{ .Values.node.p2pPort | default 20444 }}
+              protocol: TCP
+            {{- if .Values.metrics.enabled }}
+            - containerPort: {{ .Values.metrics.port | default 9153 }}
+              name: metrics
+            {{- end }}
+          volumeMounts:
+            - name: {{ include "stacks-blockchain.fullname" . }}-config
+              mountPath: /src/stacks-node
+          {{- with .Values.node.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if or .Values.node.debug .Values.node.jsonLogging .Values.node.extraEnv }}
+          env:
+            {{- if eq .Values.node.debug true }}
+            - name: RUST_BACKTRACE
+              value: "full"
+            - name: BLOCKSTACK_DEBUG
+              value: "1"
+            {{- end }}
+            {{- if eq .Values.node.jsonLogging true }}
+            - name: BLOCKSTACK_LOG_JSON
+              value: "1"
+            {{- end }}
+            {{- with .Values.node.extraEnv }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- end }}
+          {{- if .Values.node.resources }}
+          resources: {{- toYaml .Values.node.resources | nindent 12 }}
+          {{- end }}
+      {{- with .Values.node.extraContainers }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.node.initContainers }}
+      initContainers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: {{ include "stacks-blockchain.fullname" . }}-config
+          configMap:
+            name: {{ include "stacks-blockchain.fullname" . }}
+      {{- with .Values.node.volumes }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.node.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.node.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.node.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deployment/helm/stacks-blockchain/templates/metrics.yaml
+++ b/deployment/helm/stacks-blockchain/templates/metrics.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.metrics.enabled -}}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "stacks-blockchain.fullname" . }}
+  labels:
+    {{- include "stacks-blockchain.labels" . | nindent 4 }}
+spec:
+  endpoints:
+    - interval: {{ .Values.metrics.interval | default "30s" }}
+      port: metrics
+      path: /
+  jobLabel: {{ include "stacks-blockchain.fullname" . }}
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      {{- include "stacks-blockchain.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/deployment/helm/stacks-blockchain/templates/role.yaml
+++ b/deployment/helm/stacks-blockchain/templates/role.yaml
@@ -1,0 +1,10 @@
+{{- if and .Values.rbac.create .Values.rbac.rules -}}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "stacks-blockchain.fullname" . }}
+  labels: {{- include "stacks-blockchain.labels" . | nindent 4 }}
+rules:
+  {{- .Values.rbac.rules | toYaml | nindent 2}}
+{{- end }}

--- a/deployment/helm/stacks-blockchain/templates/rolebinding.yaml
+++ b/deployment/helm/stacks-blockchain/templates/rolebinding.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.rbac.create .Values.rbac.rules -}}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "stacks-blockchain.fullname" . }}
+  labels: {{- include "stacks-blockchain.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "stacks-blockchain.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "stacks-blockchain.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/deployment/helm/stacks-blockchain/templates/service.yaml
+++ b/deployment/helm/stacks-blockchain/templates/service.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "stacks-blockchain.fullname" . }}
+  labels: {{- include "stacks-blockchain.labels" . | nindent 4 }}
+  {{- if .Values.service.annotations }}
+  annotations: {{ toYaml .Values.service.annotations | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  {{- if and (.Values.service.externalTrafficPolicy) (not (eq .Values.service.type "ClusterIP")) }}
+  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
+  {{- end }}
+  ports:
+    - port: {{ .Values.service.rpcPort | default .Values.node.rpcPort }}
+      targetPort: rpc
+      protocol: TCP
+      name: rpc
+    - port: {{ .Values.service.p2pPort | default .Values.node.p2pPort }}
+      targetPort: p2p
+      protocol: TCP
+      name: p2p
+    {{- if .Values.metrics.enabled }}
+    - port: {{ .Values.metrics.port | default 9153 }}
+      targetPort: metrics
+      protocol: TCP
+      name: metrics
+    {{- end }}
+  selector: {{- include "stacks-blockchain.selectorLabels" . | nindent 4 }}

--- a/deployment/helm/stacks-blockchain/templates/serviceaccount.yaml
+++ b/deployment/helm/stacks-blockchain/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.serviceAccount.create -}}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "stacks-blockchain.serviceAccountName" . }}
+  labels: {{- include "stacks-blockchain.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations: {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/deployment/helm/stacks-blockchain/templates/tests/test-connection.yaml
+++ b/deployment/helm/stacks-blockchain/templates/tests/test-connection.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "stacks-blockchain.fullname" . }}-test-connection"
+  labels:
+    {{- include "stacks-blockchain.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command:
+        - wget
+      args:
+        - '{{ include "stacks-blockchain.fullname" . }}:{{ .Values.service.rpcPort | default .Values.node.rpcPort }}/v2/info'
+        - -qO
+        - '-'
+  restartPolicy: Never

--- a/deployment/helm/stacks-blockchain/values.yaml
+++ b/deployment/helm/stacks-blockchain/values.yaml
@@ -1,0 +1,365 @@
+################################
+####### Global Settings ########
+################################
+## String to partially override stacks-blockchain.fullname template (will maintain the release name)
+##
+nameOverride: ""
+
+## String to fully override stacks-blockchain.fullname template
+##
+fullnameOverride: ""
+
+###########################################
+##### Stacks Blockchain Node Settings #####
+###########################################
+node:
+  image:
+    repository: blockstack/stacks-blockchain
+    pullPolicy: IfNotPresent
+    ## stacks-blockchain image version
+    ## Set to 'latest' for now due to rapid changes until post-2.0 mainnet
+    ## ref: https://hub.docker.com/r/blockstack/stacks-blockchain/tags/
+    ##
+    tag: latest
+
+  ## Optional array of imagePullSecrets containing private registry credentials
+  ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  ##
+  imagePullSecrets: []
+  # - name: secretName
+
+  ## Number of stacks-blockchain nodes to run
+  ##
+  replicaCount: 1
+
+  ## Port used for RPC connections
+  ##
+  rpcPort: 20443
+
+  ## Port used for P2P connections
+  ##
+  p2pPort: 20444
+
+  ## Labels to be added to the node Deployment
+  ##
+  labels: {}
+
+  ## Annotations to be added to the node Deployment
+  ##
+  annotations: {}
+
+  ## Annotations to be added to the node pod(s)
+  ##
+  podAnnotations: {}
+
+  ## Add Config Checksum to pod Annotations
+  ## This will trigger Rolling Updates on configuration changes
+  ##
+  podAnnotationConfigChecksum: false
+
+  ## Security Context policies for the node pod(s)
+  ##
+  podSecurityContext: {}
+    # fsGroup: 2000
+
+  ## Security Context policies for the node container
+  ##
+  securityContext: {}
+    # capabilities:
+    #   drop:
+    #   - ALL
+    # readOnlyRootFilesystem: true
+    # runAsNonRoot: true
+    # runAsUser: 1000
+  
+  ## Set to true for verbose logging. Set to false for normal verbosity
+  ##
+  debug: false
+
+  ## Set to true to enable json logging. Set to false for normal logging
+  ##
+  jsonLogging: false
+
+  ## Overriding these is typically not necessary, unless you wish to run the node in a different way
+  ##
+  command:
+    - /bin/stacks-node
+  args:
+    - start
+    - --config
+    - /src/stacks-node/config.toml
+
+  ## Extra environment variables to add to the node's container
+  ##
+  extraEnv: []
+    # - name: FOO
+    #   value: "bar"
+
+  ## Specify resource limits and requests for the node's container
+  ##
+  resources: {}
+    # limits:
+    #   cpu: 500m
+    #   memory: 512Mi
+    # requests:
+    #   cpu: 250m
+    #   memory: 128Mi
+
+  ## Rollback limit
+  ##
+  revisionHistoryLimit: 10
+
+  # The update strategy to apply
+  ##
+  updateStrategy: {}
+  #  rollingUpdate:
+  #    maxUnavailable: 1
+  #  type: RollingUpdate
+
+  # minReadySeconds to avoid killing pods before it's ready
+  ##
+  minReadySeconds: 0
+
+  ## Node labels for node pod assignment
+  ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector: {}
+
+  ## Node tolerations for server scheduling to nodes with taints
+  ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+  ##
+  tolerations: []
+  #  - key: "key"
+  #    operator: "Equal|Exists"
+  #    value: "value"
+  #    effect: "NoSchedule|PreferNoSchedule|NoExecute(1.6 only)"
+
+  ## Affinity and anti-affinity
+  ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  ##
+  affinity: {}
+  # # An example of preferred pod anti-affinity, weight is in the range 1-100
+  # podAntiAffinity:
+  #   preferredDuringSchedulingIgnoredDuringExecution:
+  #   - weight: 100
+  #     podAffinityTerm:
+  #       labelSelector:
+  #         matchExpressions:
+  #         - key: app.kubernetes.io/name
+  #           operator: In
+  #           values:
+  #           - stacks-blockchain
+  #       topologyKey: kubernetes.io/hostname
+
+  # # An example of required pod anti-affinity
+  # podAntiAffinity:
+  #   requiredDuringSchedulingIgnoredDuringExecution:
+  #   - labelSelector:
+  #       matchExpressions:
+  #       - key: app.kubernetes.io/name
+  #         operator: In
+  #         values:
+  #         - stacks-blockchain
+  #     topologyKey: "kubernetes.io/hostname"
+
+  ## Total time it takes for the Container to stop normally
+  ##
+  terminationGracePeriodSeconds: 60
+  
+  ## Additional volumes for the node
+  ##
+  volumes: []
+  # - name: stacks-node-chain
+  #   persistentVolumeClaim:
+  #     claimName: stacks-node-chain
+
+  ## Additional volumeMounts for the node
+  ##
+  volumeMounts: []
+  # - name: stacks-node-chain
+  #   mountPath: /root/stacks-node
+
+  ## Additional containers to run alongside the node. Useful if adding a sidecar
+  ##
+  extraContainers: []
+  # - name: stacks-node-sidecar
+  #   image: my-sidecar-image:latest
+  #   imagePullPolicy: IfNotPresent
+  #   resources:
+  #     requests:
+  #       memory: "16Mi"
+  #       cpu: "50m"
+  #     limits:
+  #       memory: "32Mi"
+  #       cpu: "100m"
+
+  ## Containers which are run before the node container is started
+  ##
+  initContainers: []
+  # - name: init-myservice
+  #   image: busybox
+  #   command: ['sh', '-c', 'until nslookup myservice; do echo waiting for myservice; sleep 2; done;']
+
+################################
+###### Configmap Settings ######
+################################
+## You can choose to either configure the node via the following YAML fields:
+##   * config.node
+##   * config.burnchain
+##   * config.mstx_balance
+##
+## OR you can uncomment the config.raw field, which will take precedence over the aforementationed config fields
+##
+## For more info, please reference our docs and example config files:
+## https://docs.blockstack.org/stacks-blockchain/running-testnet-node
+## https://github.com/blockstack/stacks-blockchain/tree/master/testnet/stacks-node/conf
+##
+config:
+  # More configs can be added than what's shown below.
+  # All children fields under the node, burnchain, and mstx_balance fields will be converted from YAML to valid TOML format in the configmap
+  node:
+    rpc_bind: 0.0.0.0:20443 # Port should match node.rpcPort
+    p2p_bind: 0.0.0.0:20444 # Port should match node.p2pPort
+    seed: "" # REPLACE WITH YOUR PRIVATE KEY IF MINING
+    miner: false
+  burnchain:
+    chain: bitcoin
+    mode: krypton
+    peer_host: bitcoind.blockstack.org
+    # process_exit_at_block_height: 5340
+    # burnchain_op_tx_fee: 5500
+    # commit_anchor_block_within: 10000
+    rpc_port: 18443
+    peer_port: 18444
+  mstx_balance:
+    - address: STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6
+      amount: "10000000000000000"
+    - address: ST11NJTTKGVT6D1HY4NJRVQWMQM7TVAR091EJ8P2Y
+      amount: "10000000000000000"
+    - address: ST1HB1T8WRNBYB0Y3T7WXZS38NKKPTBR3EG9EPJKR
+      amount: "10000000000000000"
+    - address: STRYYQQ9M8KAF4NS7WNZQYY59X93XEKR31JP64CP
+      amount: "10000000000000000"
+
+  ## Uncommenting this block will give you greater control over the settings in the configmap
+  ## Don't forget to add your private key to the "seed" config under the "node" section if mining
+  ##
+  # raw: |
+  #   [node]
+  #   # Port should match node.rpcPort
+  #   rpc_bind = "0.0.0.0:20443"
+  #   # Port should match node.p2pPort
+  #   p2p_bind = "0.0.0.0:20444"
+  #   seed = "replace-with-your-private-key-if-mining"
+  #   miner = false
+
+  #   [burnchain]
+  #   chain = "bitcoin"
+  #   mode = "krypton"
+  #   peer_host = "bitcoind.blockstack.org"
+  #   #process_exit_at_block_height = 5340
+  #   #burnchain_op_tx_fee = 5500
+  #   #commit_anchor_block_within = 10000
+  #   rpc_port = 18443
+  #   peer_port = 18444
+
+  #   [[mstx_balance]]
+  #   address = "STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6"
+  #   amount = 10000000000000000
+  #   [[mstx_balance]]
+  #   address = "ST11NJTTKGVT6D1HY4NJRVQWMQM7TVAR091EJ8P2Y"
+  #   amount = 10000000000000000
+  #   [[mstx_balance]]
+  #   address = "ST1HB1T8WRNBYB0Y3T7WXZS38NKKPTBR3EG9EPJKR"
+  #   amount = 10000000000000000
+  #   [[mstx_balance]]
+  #   address = "STRYYQQ9M8KAF4NS7WNZQYY59X93XEKR31JP64CP"
+  #   amount = 10000000000000000
+
+  ## Annotations to be added to the Configmap
+  ##
+  annotations: {}
+
+################################
+####### Service Settings #######
+################################
+service:
+  ## The service type to create
+  ## If creating a public node for others to connect to, use Loadbalancer to ensure the advertised IP is reachable
+  ##
+  type: ClusterIP
+
+  ## Set external traffic policy to "Local" to preserve source IP on providers supporting it.
+  ## This field is only used when service.type is set to "NodePort" or "LoadBalancer".
+  ## Setting to "Local" can help the Stacks network if using service type NodePort or LoadBalancer.
+  ## Ref: https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-typeloadbalancer
+  ##
+  externalTrafficPolicy: Local
+
+  ## Will use node.rpcPort if omitted
+  ##
+  rpcPort:
+
+  ## Will use node.p2pPort if omitted
+  ##
+  p2pPort:
+
+  ## Annotations to be added to the Service
+  ##
+  annotations: {}
+
+################################
+### Service Account Settings ###
+################################
+serviceAccount:
+  
+  ## Specifies whether a ServiceAccount should be created
+  ## If true, the stacks-blockchain node will be ran using this ServiceAccount
+  ##
+  create: true
+  
+  ## Annotations to add to the service account
+  ##
+  annotations: {}
+  
+  ## The name of the service account to use.
+  ## If not set and create is true, a name is generated using the fullname template.
+  ##
+  name: ""
+
+################################
+######## RBAC Settings #########
+################################
+rbac:
+  ## Specifies whether a Role should be created
+  ##
+  create: false
+
+  ## Rules to add to the Role resource bound to the ServiceAccount
+  ##
+  rules: []
+    # - apiGroups:
+    #     - ""
+    #   verbs:
+    #     - get
+    #     - list
+    #     - watch
+    #   resources:
+    #     - pods
+
+################################
+####### Metrics Settings #######
+################################
+metrics:
+  ## Specifies whether a Prometheus ServiceMonitor should be created
+  ## ref: https://coreos.com/operators/prometheus/docs/latest/user-guides/getting-started.html#include-servicemonitors
+  ##
+  enabled: false
+
+  ## Port used by the ServiceMonitor to collect metrics from the node
+  ##
+  port: 9153
+
+  ## Interval at which metrics should be collected
+  ##
+  interval: 30s


### PR DESCRIPTION
## Description

To help make the stacks blockchain as easy as possible to run in a variety of ways, this PR adds a public Helm chart for the community to easily deploy a stacks node to a local or remote Kubernetes cluster.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [X] Other

## Test this locally with Minikube
```bash
# If you don't use brew or OSX, https://minikube.sigs.k8s.io/docs/start/
brew install minikube helm
minikube start
helm repo add blockstack https://charts.blockstack.xyz
helm repo update
# Deploys a follower node with basic defaults
helm install stacks-blockchain blockstack/stacks-blockchain
```

## Does this introduce a breaking change?
No

## Are documentation updates required?
Not required, but they will be added afterwards (likely this week as it's docs week)
- [X] Link to documentation updates: https://github.com/blockstack/docs/issues/848
