### PR TITLE
Fix/2010

### DIFF
--- a/src/net/relay.rs
+++ b/src/net/relay.rs
@@ -714,7 +714,10 @@ impl Relayer {
                     ) {
                         Ok(accepted) => {
                             if accepted {
-                                debug!("Accepted block {}/{} from {}", &consensus_hash, &bhh, &neighbor_key);
+                                debug!(
+                                    "Accepted block {}/{} from {}",
+                                    &consensus_hash, &bhh, &neighbor_key
+                                );
                                 new_blocks.insert(consensus_hash.clone());
                             }
                         }
@@ -1442,7 +1445,13 @@ impl PeerNetwork {
     ) -> Result<(), net_error> {
         let (mut outbound_recipients, mut inbound_recipients) =
             self.find_block_recipients(&availability_data)?;
-        debug!("{:?}: Advertize {} blocks to {} inbound peers, {} outbound peers", &self.local_peer, availability_data.len(), outbound_recipients.len(), inbound_recipients.len());
+        debug!(
+            "{:?}: Advertize {} blocks to {} inbound peers, {} outbound peers",
+            &self.local_peer,
+            availability_data.len(),
+            outbound_recipients.len(),
+            inbound_recipients.len()
+        );
 
         for recipient in outbound_recipients.drain(..) {
             debug!(

--- a/src/net/relay.rs
+++ b/src/net/relay.rs
@@ -704,6 +704,7 @@ impl Relayer {
                         block.block_hash(),
                         neighbor_key
                     );
+                    let bhh = block.block_hash();
                     match Relayer::process_new_anchored_block(
                         sort_ic,
                         chainstate,
@@ -713,6 +714,7 @@ impl Relayer {
                     ) {
                         Ok(accepted) => {
                             if accepted {
+                                debug!("Accepted block {}/{} from {}", &consensus_hash, &bhh, &neighbor_key);
                                 new_blocks.insert(consensus_hash.clone());
                             }
                         }
@@ -1440,6 +1442,8 @@ impl PeerNetwork {
     ) -> Result<(), net_error> {
         let (mut outbound_recipients, mut inbound_recipients) =
             self.find_block_recipients(&availability_data)?;
+        debug!("{:?}: Advertize {} blocks to {} inbound peers, {} outbound peers", &self.local_peer, availability_data.len(), outbound_recipients.len(), inbound_recipients.len());
+
         for recipient in outbound_recipients.drain(..) {
             debug!(
                 "{:?}: Advertize {} blocks to outbound peer {}",
@@ -1474,6 +1478,8 @@ impl PeerNetwork {
     ) -> Result<(), net_error> {
         let (mut outbound_recipients, mut inbound_recipients) =
             self.find_block_recipients(&availability_data)?;
+        debug!("{:?}: Advertize {} confirmed microblock streams to {} inbound peers, {} outbound peers", &self.local_peer, availability_data.len(), outbound_recipients.len(), inbound_recipients.len());
+
         for recipient in outbound_recipients.drain(..) {
             debug!(
                 "{:?}: Advertize {} confirmed microblock streams to outbound peer {}",

--- a/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
+++ b/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
@@ -664,7 +664,7 @@ impl BitcoinRegtestController {
 
         // RBF
         let tx_fee = self.config.burnchain.burnchain_op_tx_fee
-            + ((attempt.saturating_sub(1) * self.last_tx_len * self.min_relay_fee) / 1024);
+            + ((attempt.saturating_sub(1) * self.last_tx_len * self.min_relay_fee) / 1000);
 
         let public_key = signer.get_public_key();
         let mut total_consumed = 0;


### PR DESCRIPTION
This fixes a regression introduced by #2010 that didn't quite calculate the new RBF relay fee correctly.

It also makes the anti-entropy p2p work step a little less aggressive, only allowing it to run once per burnchain block instead of once per p2p cycle.