### PR TITLE
bump MAXIMUM_MEMPOOL_TX_CHAINING to 25, make it configurable, resolves #2009

### DIFF
--- a/net-test/bin/txload.sh
+++ b/net-test/bin/txload.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 FEE_RATE=300
-MAX_CHAINING=5
+MAX_CHAINING=25
 CONFIRMATIONS=1
 
 exit_error() {

--- a/src/core/mempool.rs
+++ b/src/core/mempool.rs
@@ -57,7 +57,7 @@ use rusqlite::Error as SqliteError;
 
 // maximum number of confirmations a transaction can have before it's garbage-collected
 pub const MEMPOOL_MAX_TRANSACTION_AGE: u64 = 256;
-pub const MAXIMUM_MEMPOOL_TX_CHAINING: u64 = 5;
+pub const MAXIMUM_MEMPOOL_TX_CHAINING: u64 = 25;
 
 pub struct MemPoolAdmitter {
     // mempool admission should have its own chain state view.

--- a/testnet/stacks-node/src/tests/integrations.rs
+++ b/testnet/stacks-node/src/tests/integrations.rs
@@ -871,7 +871,7 @@ fn contract_stx_transfer() {
                                 })
                             }
                         ),
-                        5999
+                        25999
                     );
                     // check that 1000 stx _was_ debited from SK_3
                     let sk_3 = StacksPrivateKey::from_hex(SK_3).unwrap();

--- a/testnet/stacks-node/src/tests/integrations.rs
+++ b/testnet/stacks-node/src/tests/integrations.rs
@@ -886,7 +886,7 @@ fn contract_stx_transfer() {
                                 })
                             }
                         ),
-                        93000
+                        69000
                     );
                 }
 


### PR DESCRIPTION
## Description
Addresses #2009, including making MAXIMUM_MEMPOOL_TX_CHAINING by setting node.max_mempool_tx_chaining in the config file, new default is 25 (from 5)

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [x] Other

## Are documentation updates required?
- [x] Link to documentation updates: many configurations options are not documented in a consistent manner, yet, so consider documenting all possible configuration options in one location

## Checklist
- [x] Tag  @jcnelson
