### PR TITLE
Fix: Clarity `(at-block)` behavior

### DIFF
--- a/src/vm/contexts.rs
+++ b/src/vm/contexts.rs
@@ -840,12 +840,12 @@ impl<'a, 'b> Environment<'a, 'b> {
         let result = self
             .global_context
             .database
-            .set_block_hash(bhh)
+            .set_block_hash(bhh, false)
             .and_then(|prior_bhh| {
                 let result = eval(closure, self, local);
                 self.global_context
                     .database
-                    .set_block_hash(prior_bhh)
+                    .set_block_hash(prior_bhh, true)
                     .expect(
                     "ERROR: Failed to restore prior active block after time-shifted evaluation.",
                 );

--- a/src/vm/database/clarity_db.rs
+++ b/src/vm/database/clarity_db.rs
@@ -377,8 +377,12 @@ impl<'a> ClarityDatabase<'a> {
         self.store.rollback();
     }
 
-    pub fn set_block_hash(&mut self, bhh: StacksBlockId) -> Result<StacksBlockId> {
-        self.store.set_block_hash(bhh)
+    pub fn set_block_hash(
+        &mut self,
+        bhh: StacksBlockId,
+        query_pending_data: bool,
+    ) -> Result<StacksBlockId> {
+        self.store.set_block_hash(bhh, query_pending_data)
     }
 
     pub fn put<T: ClaritySerializable>(&mut self, key: &str, value: &T) {

--- a/src/vm/database/key_value_wrapper.rs
+++ b/src/vm/database/key_value_wrapper.rs
@@ -117,6 +117,7 @@ pub struct RollbackWrapper<'a> {
     //  TODO: The solution to this is to just have a _single_ edit stack, and merely store indexes
     //   to indicate a given contexts "start depth".
     stack: Vec<RollbackContext>,
+    query_pending_data: bool,
 }
 
 // This is used for preserving rollback data longer
@@ -186,6 +187,7 @@ impl<'a> RollbackWrapper<'a> {
             lookup_map: HashMap::new(),
             metadata_lookup_map: HashMap::new(),
             stack: Vec::new(),
+            query_pending_data: true,
         }
     }
 
@@ -198,6 +200,7 @@ impl<'a> RollbackWrapper<'a> {
             lookup_map: log.lookup_map,
             metadata_lookup_map: log.metadata_lookup_map,
             stack: log.stack,
+            query_pending_data: true,
         }
     }
 
@@ -297,7 +300,17 @@ impl<'a> RollbackWrapper<'a> {
         )
     }
 
-    pub fn set_block_hash(&mut self, bhh: StacksBlockId) -> Result<StacksBlockId> {
+    ///
+    /// `query_pending_data` indicates whether the rollback wrapper should query the rollback
+    ///    wrapper's pending data on reads. This is set to `false` during (at-block ...) closures,
+    ///    and `true` otherwise.
+    ///
+    pub fn set_block_hash(
+        &mut self,
+        bhh: StacksBlockId,
+        query_pending_data: bool,
+    ) -> Result<StacksBlockId> {
+        self.query_pending_data = query_pending_data;
         self.store.set_block_hash(bhh)
     }
 
@@ -320,11 +333,14 @@ impl<'a> RollbackWrapper<'a> {
             .last()
             .expect("ERROR: Clarity VM attempted GET on non-nested context.");
 
-        let lookup_result = self
-            .lookup_map
-            .get(key)
-            .and_then(|x| x.last())
-            .map(|x| T::deserialize(x));
+        let lookup_result = if self.query_pending_data {
+            self.lookup_map
+                .get(key)
+                .and_then(|x| x.last())
+                .map(|x| T::deserialize(x))
+        } else {
+            None
+        };
 
         lookup_result.or_else(|| self.store.get(key).map(|x| T::deserialize(&x)))
     }
@@ -334,11 +350,14 @@ impl<'a> RollbackWrapper<'a> {
             .last()
             .expect("ERROR: Clarity VM attempted GET on non-nested context.");
 
-        let lookup_result = self
-            .lookup_map
-            .get(key)
-            .and_then(|x| x.last())
-            .map(|x| Value::deserialize(x, expected));
+        let lookup_result = if self.query_pending_data {
+            self.lookup_map
+                .get(key)
+                .and_then(|x| x.last())
+                .map(|x| Value::deserialize(x, expected))
+        } else {
+            None
+        };
 
         lookup_result.or_else(|| {
             self.store
@@ -400,10 +419,13 @@ impl<'a> RollbackWrapper<'a> {
         // This is THEORETICALLY a spurious clone, but it's hard to turn something like
         //  (&A, &B) into &(A, B).
         let metadata_key = (contract.clone(), key.to_string());
-        let lookup_result = self
-            .metadata_lookup_map
-            .get(&metadata_key)
-            .and_then(|x| x.last().cloned());
+        let lookup_result = if self.query_pending_data {
+            self.metadata_lookup_map
+                .get(&metadata_key)
+                .and_then(|x| x.last().cloned())
+        } else {
+            None
+        };
 
         match lookup_result {
             Some(x) => Ok(Some(x)),
@@ -415,7 +437,7 @@ impl<'a> RollbackWrapper<'a> {
         self.stack
             .last()
             .expect("ERROR: Clarity VM attempted GET on non-nested context.");
-        if self.lookup_map.contains_key(key) {
+        if self.query_pending_data && self.lookup_map.contains_key(key) {
             true
         } else {
             self.store.has_entry(key)

--- a/src/vm/tests/forking.rs
+++ b/src/vm/tests/forking.rs
@@ -66,8 +66,11 @@ fn test_at_block_mutations() {
         owned_env.initialize_contract(c.clone(), &contract).unwrap();
     }
 
-
-    fn branch(owned_env: &mut OwnedEnvironment, expected_value: i128, to_exec: &str) -> Result<Value> {
+    fn branch(
+        owned_env: &mut OwnedEnvironment,
+        expected_value: i128,
+        to_exec: &str,
+    ) -> Result<Value> {
         let c = QualifiedContractIdentifier::local("contract").unwrap();
         let p1 = execute(p1_str);
         eprintln!("Branched execution...");
@@ -79,30 +82,40 @@ fn test_at_block_mutations() {
             assert_eq!(value, Value::Int(expected_value));
         }
 
-        owned_env.execute_transaction(p1, c, to_exec, &vec![])
+        owned_env
+            .execute_transaction(p1, c, to_exec, &vec![])
             .map(|(x, _, _)| x)
     }
 
     with_separate_forks_environment(
         initialize,
         |x| {
-            assert_eq!(branch(x, 1, "working").unwrap(),
-                       Value::okay(Value::Int(1)).unwrap());
-            assert_eq!(branch(x, 1, "broken").unwrap(),
-                       Value::okay(Value::Int(10)).unwrap());
-            assert_eq!(branch(x, 10, "working").unwrap(),
-                       Value::okay(Value::Int(1)).unwrap());
+            assert_eq!(
+                branch(x, 1, "working").unwrap(),
+                Value::okay(Value::Int(1)).unwrap()
+            );
+            assert_eq!(
+                branch(x, 1, "broken").unwrap(),
+                Value::okay(Value::Int(1)).unwrap()
+            );
+            assert_eq!(
+                branch(x, 10, "working").unwrap(),
+                Value::okay(Value::Int(1)).unwrap()
+            );
             // make this test fail: this assertion _should_ be
             //  true, but at-block is broken. when a context
             //  switches to an at-block context, _any_ of the db
             //  wrapping that the Clarity VM does needs to be
             //  ignored.
-            assert_eq!(branch(x, 10, "broken").unwrap(),
-                       Value::okay(Value::Int(1)).unwrap());
+            assert_eq!(
+                branch(x, 10, "broken").unwrap(),
+                Value::okay(Value::Int(1)).unwrap()
+            );
         },
-        |_x| {}, |_x| {});
+        |_x| {},
+        |_x| {},
+    );
 }
-
 
 #[test]
 fn test_at_block_good() {

--- a/src/vm/tests/forking.rs
+++ b/src/vm/tests/forking.rs
@@ -48,6 +48,63 @@ fn test_forking_simple() {
 }
 
 #[test]
+fn test_at_block_mutations() {
+    // test how at-block works when a mutation has occurred
+    fn initialize(owned_env: &mut OwnedEnvironment) {
+        let c = QualifiedContractIdentifier::local("contract").unwrap();
+        let contract =
+            "(define-data-var datum int 1)
+             (define-public (working)
+               (ok (at-block 0x0101010101010101010101010101010101010101010101010101010101010101 (var-get datum))))
+             (define-public (broken)
+               (begin
+                 (var-set datum 10)
+                 ;; this should return 1, not 10!
+                 (ok (at-block 0x0101010101010101010101010101010101010101010101010101010101010101 (var-get datum)))))";
+
+        eprintln!("Initializing contract...");
+        owned_env.initialize_contract(c.clone(), &contract).unwrap();
+    }
+
+
+    fn branch(owned_env: &mut OwnedEnvironment, expected_value: i128, to_exec: &str) -> Result<Value> {
+        let c = QualifiedContractIdentifier::local("contract").unwrap();
+        let p1 = execute(p1_str);
+        eprintln!("Branched execution...");
+
+        {
+            let mut env = owned_env.get_exec_environment(None);
+            let command = format!("(var-get datum)");
+            let value = env.eval_read_only(&c, &command).unwrap();
+            assert_eq!(value, Value::Int(expected_value));
+        }
+
+        owned_env.execute_transaction(p1, c, to_exec, &vec![])
+            .map(|(x, _, _)| x)
+    }
+
+    with_separate_forks_environment(
+        initialize,
+        |x| {
+            assert_eq!(branch(x, 1, "working").unwrap(),
+                       Value::okay(Value::Int(1)).unwrap());
+            assert_eq!(branch(x, 1, "broken").unwrap(),
+                       Value::okay(Value::Int(10)).unwrap());
+            assert_eq!(branch(x, 10, "working").unwrap(),
+                       Value::okay(Value::Int(1)).unwrap());
+            // make this test fail: this assertion _should_ be
+            //  true, but at-block is broken. when a context
+            //  switches to an at-block context, _any_ of the db
+            //  wrapping that the Clarity VM does needs to be
+            //  ignored.
+            assert_eq!(branch(x, 10, "broken").unwrap(),
+                       Value::okay(Value::Int(1)).unwrap());
+        },
+        |_x| {}, |_x| {});
+}
+
+
+#[test]
 fn test_at_block_good() {
     fn initialize(owned_env: &mut OwnedEnvironment) {
         let c = QualifiedContractIdentifier::local("contract").unwrap();


### PR DESCRIPTION
## Description

This address #1840 (see the description in that issue, or the added unit test for more information about the prior buggy behavior.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?

Yes, this is a consensus-breaking change, because it changes Clarity behavior.

## Are documentation updates required?

No documentation updates needed.

## Testing information

A witnessing unit test for the formerly bad behavior is included here.
