### PR TITLE
chore: git clone efficiency in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ _For building on Windows, follow the rustup installer instructions at https://ru
 From there, you can clone this repository:
 
 ```bash
-git clone https://github.com/blockstack/stacks-blockchain.git
+git clone --depth=1 https://github.com/blockstack/stacks-blockchain.git
 
 cd stacks-blockchain
 ```


### PR DESCRIPTION
Add `--depth=1` to the `git clone...` instructions. 
Reduces disk usage and network download time by around 80%.