### PR TITLE
Minor event dispatcher updates

### DIFF
--- a/docs/event-dispatcher.md
+++ b/docs/event-dispatcher.md
@@ -36,6 +36,7 @@ Example:
   "burn_block_time": 1591301733,
   "events": [
     {
+      "event_index": 1,
       "committed": true,
       "stx_transfer_event": {
         "amount": "1000",

--- a/src/chainstate/stacks/events.rs
+++ b/src/chainstate/stacks/events.rs
@@ -44,58 +44,72 @@ pub enum StacksTransactionEvent {
 }
 
 impl StacksTransactionEvent {
-    pub fn json_serialize(&self, txid: &Txid, committed: bool) -> serde_json::Value {
+    pub fn json_serialize(
+        &self,
+        event_index: usize,
+        txid: &Txid,
+        committed: bool,
+    ) -> serde_json::Value {
         match self {
             StacksTransactionEvent::SmartContractEvent(event_data) => json!({
                 "txid": format!("0x{:?}", txid),
+                "event_index": event_index,
                 "committed": committed,
                 "type": "contract_event",
                 "contract_event": event_data.json_serialize()
             }),
             StacksTransactionEvent::STXEvent(STXEventType::STXTransferEvent(event_data)) => json!({
                 "txid": format!("0x{:?}", txid),
+                "event_index": event_index,
                 "committed": committed,
                 "type": "stx_transfer_event",
                 "stx_transfer_event": event_data.json_serialize()
             }),
             StacksTransactionEvent::STXEvent(STXEventType::STXMintEvent(event_data)) => json!({
                 "txid": format!("0x{:?}", txid),
+                "event_index": event_index,
                 "committed": committed,
                 "type": "stx_mint_event",
                 "stx_mint_event": event_data.json_serialize()
             }),
             StacksTransactionEvent::STXEvent(STXEventType::STXBurnEvent(event_data)) => json!({
                 "txid": format!("0x{:?}", txid),
+                "event_index": event_index,
                 "committed": committed,
                 "type": "stx_burn_event",
                 "stx_burn_event": event_data.json_serialize()
             }),
             StacksTransactionEvent::STXEvent(STXEventType::STXLockEvent(event_data)) => json!({
                 "txid": format!("0x{:?}", txid),
+                "event_index": event_index,
                 "committed": committed,
                 "type": "stx_lock_event",
                 "stx_lock_event": event_data.json_serialize()
             }),
             StacksTransactionEvent::NFTEvent(NFTEventType::NFTTransferEvent(event_data)) => json!({
                 "txid": format!("0x{:?}", txid),
+                "event_index": event_index,
                 "committed": committed,
                 "type": "nft_transfer_event",
                 "nft_transfer_event": event_data.json_serialize()
             }),
             StacksTransactionEvent::NFTEvent(NFTEventType::NFTMintEvent(event_data)) => json!({
                 "txid": format!("0x{:?}", txid),
+                "event_index": event_index,
                 "committed": committed,
                 "type": "nft_mint_event",
                 "nft_mint_event": event_data.json_serialize()
             }),
             StacksTransactionEvent::FTEvent(FTEventType::FTTransferEvent(event_data)) => json!({
                 "txid": format!("0x{:?}", txid),
+                "event_index": event_index,
                 "committed": committed,
                 "type": "ft_transfer_event",
                 "ft_transfer_event": event_data.json_serialize()
             }),
             StacksTransactionEvent::FTEvent(FTEventType::FTMintEvent(event_data)) => json!({
                 "txid": format!("0x{:?}", txid),
+                "event_index": event_index,
                 "committed": committed,
                 "type": "ft_mint_event",
                 "ft_mint_event": event_data.json_serialize()
@@ -160,6 +174,7 @@ impl STXMintEventData {
 pub struct STXLockEventData {
     pub locked_amount: u128,
     pub unlock_height: u64,
+    pub locked_address: PrincipalData,
 }
 
 impl STXLockEventData {
@@ -167,6 +182,7 @@ impl STXLockEventData {
         json!({
             "locked_amount": format!("{}",self.locked_amount),
             "unlock_height": format!("{}", self.unlock_height),
+            "locked_address": format!("{}", self.locked_address),
         })
     }
 }
@@ -180,7 +196,7 @@ pub struct STXBurnEventData {
 impl STXBurnEventData {
     pub fn json_serialize(&self) -> serde_json::Value {
         json!({
-            "sender": format!("{}",self.sender),
+            "sender": format!("{}", self.sender),
             "amount": format!("{}", self.amount),
         })
     }

--- a/src/vm/functions/special.rs
+++ b/src/vm/functions/special.rs
@@ -92,6 +92,7 @@ fn handle_pox_api_contract_call(
                                 STXEventType::STXLockEvent(STXLockEventData {
                                     locked_amount,
                                     unlock_height,
+                                    locked_address: stacker,
                                 }),
                             ));
                         }

--- a/testnet/stacks-node/src/event_dispatcher.rs
+++ b/testnet/stacks-node/src/event_dispatcher.rs
@@ -197,7 +197,7 @@ impl EventObserver {
 
     fn send(
         &self,
-        filtered_events: Vec<&(bool, Txid, &StacksTransactionEvent)>,
+        filtered_events: Vec<(usize, &(bool, Txid, &StacksTransactionEvent))>,
         chain_tip: &ChainTip,
         parent_index_hash: &StacksBlockId,
         boot_receipts: Option<&Vec<StacksTransactionReceipt>>,
@@ -207,7 +207,9 @@ impl EventObserver {
         // Serialize events to JSON
         let serialized_events: Vec<serde_json::Value> = filtered_events
             .iter()
-            .map(|(committed, txid, event)| event.json_serialize(txid, *committed))
+            .map(|(event_index, (committed, txid, event))| {
+                event.json_serialize(*event_index, txid, *committed)
+            })
             .collect();
 
         let mut tx_index: u32 = 0;
@@ -449,7 +451,7 @@ impl EventDispatcher {
             for (observer_id, filtered_events_ids) in dispatch_matrix.iter().enumerate() {
                 let filtered_events: Vec<_> = filtered_events_ids
                     .iter()
-                    .map(|event_id| &events[*event_id])
+                    .map(|event_id| (*event_id, &events[*event_id]))
                     .collect();
 
                 self.registered_observers[observer_id].send(


### PR DESCRIPTION
## Description

1. Add event_index for ordering events (the dispatch matrix scrambles the event order).
2. Add `locked_address` field to stx_lock_event

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?

No.

## Are documentation updates required?

No -- the sample event payload in `event-dispatcher.md` has been updated.

