### PR TITLE
Fix 1934: mix burn block height into microblock pubkey

### DIFF
--- a/src/vm/docs/mod.rs
+++ b/src/vm/docs/mod.rs
@@ -545,7 +545,7 @@ const PRINT_API: SpecialAPI = SpecialAPI {
     input_type: "A",
     output_type: "A",
     signature: "(print expr)",
-    description: "The `print` function evaluates and returns its input expression. On Blockstack Core
+    description: "The `print` function evaluates and returns its input expression. On Stacks Core
 nodes configured for development (as opposed to production mining nodes), this function prints the resulting value to `STDOUT` (standard output).",
     example: "(print (+ 1 2 3)) ;; Returns 6",
 };

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -1033,7 +1033,20 @@ impl InitializedNeonNode {
 
         // Generates a new secret key for signing the trail of microblocks
         // of the upcoming tenure.
-        let microblock_secret_key = keychain.rotate_microblock_keypair();
+        let microblock_secret_key = if attempt > 1 {
+            match keychain.get_microblock_key() {
+                Some(k) => k,
+                None => {
+                    error!(
+                        "Failed to obtain microblock key for mining attempt";
+                        "attempt" => %attempt
+                    );
+                    return None;
+                }
+            }
+        } else {
+            keychain.rotate_microblock_keypair(burn_block.block_height)
+        };
         let mblock_pubkey_hash =
             Hash160::from_node_public_key(&StacksPublicKey::from_private(&microblock_secret_key));
 

--- a/testnet/stacks-node/src/node.rs
+++ b/testnet/stacks-node/src/node.rs
@@ -475,7 +475,9 @@ impl Node {
 
         // Generates a new secret key for signing the trail of microblocks
         // of the upcoming tenure.
-        let microblock_secret_key = self.keychain.rotate_microblock_keypair();
+        let microblock_secret_key = self
+            .keychain
+            .rotate_microblock_keypair(block_to_build_upon.block_snapshot.block_height);
 
         // Get the stack's chain tip
         let chain_tip = match self.bootstraping_chain {

--- a/testnet/stacks-node/src/tests/mempool.rs
+++ b/testnet/stacks-node/src/tests/mempool.rs
@@ -637,8 +637,8 @@ fn mempool_setup_chainstate() {
                 conf.node.seed = vec![0x00];
 
                 let mut keychain = Keychain::default(conf.node.seed.clone());
-                for _i in 0..4 {
-                    let microblock_secret_key = keychain.rotate_microblock_keypair();
+                for i in 0..4 {
+                    let microblock_secret_key = keychain.rotate_microblock_keypair(1 + i);
                     let mut microblock_pubkey =
                         Secp256k1PublicKey::from_private(&microblock_secret_key);
                     microblock_pubkey.set_compressed(true);

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -197,8 +197,9 @@ fn find_microblock_privkey(
     max_tries: u64,
 ) -> Option<StacksPrivateKey> {
     let mut keychain = Keychain::default(conf.node.seed.clone());
-    for _ in 0..max_tries {
-        let privk = keychain.rotate_microblock_keypair();
+    for ix in 0..max_tries {
+        // the first rotation occurs at 203.
+        let privk = keychain.rotate_microblock_keypair(203 + ix);
         let pubkh = Hash160::from_node_public_key(&StacksPublicKey::from_private(&privk));
         if pubkh == *pubkey_hash {
             return Some(privk);


### PR DESCRIPTION
## Description

Fix #1934 by mixing the burn block height into the microblock private key rotation. When attempting RBF, don't rotate the private key (this is just to make testing more deterministic).

## Type of Change

Bug fix

## Does this introduce a breaking change?

No

## Are documentation updates required?

No

## Testing information

These changes are covered in existing tests, and required updating two tests' "find_microblock_key" logic.
