### PR TITLE
#1315: Min/Median Block Mining

### DIFF
--- a/src/burnchains/burnchain.rs
+++ b/src/burnchains/burnchain.rs
@@ -2114,6 +2114,7 @@ pub mod tests {
                 block_122_snapshot.consensus_hash.clone(),
                 ConsensusHash::from_hex("0000000000000000000000000000000000000000").unwrap(),
             ];
+
             let burn_total = block_ops_124.iter().fold(0u64, |mut acc, op| {
                 let bf = match op {
                     BlockstackOperationType::LeaderBlockCommit(ref op) => op.burn_fee,

--- a/src/burnchains/burnchain.rs
+++ b/src/burnchains/burnchain.rs
@@ -1753,6 +1753,14 @@ pub mod tests {
 
             burn_fee: 12345,
             input: (Txid([0; 32]), 0),
+            apparent_sender: BurnchainSigner {
+                public_keys: vec![StacksPublicKey::from_hex(
+                    "02d8015134d9db8178ac93acbc43170a2f20febba5087a5b0437058765ad5133d0",
+                )
+                .unwrap()],
+                num_sigs: 1,
+                hash_mode: AddressHashMode::SerializeP2PKH,
+            },
 
             txid: Txid::from_bytes(
                 &hex_bytes("3c07a0a93360bc85047bbaadd49e30c8af770f73a37e10fec400174d2e5f27cf")
@@ -1785,6 +1793,14 @@ pub mod tests {
 
             burn_fee: 12345,
             input: (Txid([0; 32]), 0),
+            apparent_sender: BurnchainSigner {
+                public_keys: vec![StacksPublicKey::from_hex(
+                    "02d8015134d9db8178ac93acbc43170a2f20febba5087a5b0437058765ad5133d0",
+                )
+                .unwrap()],
+                num_sigs: 1,
+                hash_mode: AddressHashMode::SerializeP2PKH,
+            },
 
             txid: Txid::from_bytes(
                 &hex_bytes("3c07a0a93360bc85047bbaadd49e30c8af770f73a37e10fec400174d2e5f27d0")
@@ -1817,6 +1833,14 @@ pub mod tests {
 
             burn_fee: 23456,
             input: (Txid([0; 32]), 0),
+            apparent_sender: BurnchainSigner {
+                public_keys: vec![StacksPublicKey::from_hex(
+                    "0283d603abdd2392646dbdd0dc80beb39c25bfab96a8a921ea5e7517ce533f8cd5",
+                )
+                .unwrap()],
+                num_sigs: 1,
+                hash_mode: AddressHashMode::SerializeP2PKH,
+            },
 
             txid: Txid::from_bytes(
                 &hex_bytes("301dc687a9f06a1ae87a013f27133e9cec0843c2983567be73e185827c7c13de")
@@ -2251,6 +2275,14 @@ pub mod tests {
 
                 burn_fee: (i + 1) as u64,
                 input: (Txid([0; 32]), 0),
+                apparent_sender: BurnchainSigner {
+                    public_keys: vec![StacksPublicKey::from_hex(
+                        "02113c274c05ed0b7f9d08f41ca674b22e42188408caaff82a350b024442de353c",
+                    )
+                    .unwrap()],
+                    num_sigs: 1,
+                    hash_mode: AddressHashMode::SerializeP2PKH,
+                },
 
                 txid: Txid::from_bytes(&vec![
                     i, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -2277,6 +2309,14 @@ pub mod tests {
 
             burn_fee: 256,
             input: (Txid([0; 32]), 0),
+            apparent_sender: BurnchainSigner {
+                public_keys: vec![StacksPublicKey::from_hex(
+                    "02113c274c05ed0b7f9d08f41ca674b22e42188408caaff82a350b024442de353c",
+                )
+                .unwrap()],
+                num_sigs: 1,
+                hash_mode: AddressHashMode::SerializeP2PKH,
+            },
 
             txid: Txid([0xdd; 32]),
             vtxindex: 1,
@@ -2493,6 +2533,14 @@ pub mod tests {
 
                     burn_fee: i as u64,
                     input: (Txid([0; 32]), 0),
+                    apparent_sender: BurnchainSigner {
+                        public_keys: vec![StacksPublicKey::from_hex(
+                            &leader_bitcoin_public_keys[(i - 1) as usize].clone(),
+                        )
+                        .unwrap()],
+                        num_sigs: 1,
+                        hash_mode: AddressHashMode::SerializeP2PKH,
+                    },
 
                     txid: Txid::from_bytes(&vec![
                         i, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,

--- a/src/burnchains/burnchain.rs
+++ b/src/burnchains/burnchain.rs
@@ -1708,14 +1708,7 @@ pub mod tests {
             memo: vec![0x80],
 
             burn_fee: 12345,
-            input: BurnchainSigner {
-                public_keys: vec![StacksPublicKey::from_hex(
-                    "02d8015134d9db8178ac93acbc43170a2f20febba5087a5b0437058765ad5133d0",
-                )
-                .unwrap()],
-                num_sigs: 1,
-                hash_mode: AddressHashMode::SerializeP2PKH,
-            },
+            input: (Txid([0; 32]), 0),
 
             txid: Txid::from_bytes(
                 &hex_bytes("3c07a0a93360bc85047bbaadd49e30c8af770f73a37e10fec400174d2e5f27cf")
@@ -1747,14 +1740,7 @@ pub mod tests {
             memo: vec![0x80],
 
             burn_fee: 12345,
-            input: BurnchainSigner {
-                public_keys: vec![StacksPublicKey::from_hex(
-                    "02d8015134d9db8178ac93acbc43170a2f20febba5087a5b0437058765ad5133d0",
-                )
-                .unwrap()],
-                num_sigs: 1,
-                hash_mode: AddressHashMode::SerializeP2PKH,
-            },
+            input: (Txid([0; 32]), 0),
 
             txid: Txid::from_bytes(
                 &hex_bytes("3c07a0a93360bc85047bbaadd49e30c8af770f73a37e10fec400174d2e5f27d0")
@@ -1786,14 +1772,7 @@ pub mod tests {
             memo: vec![0x80],
 
             burn_fee: 23456,
-            input: BurnchainSigner {
-                public_keys: vec![StacksPublicKey::from_hex(
-                    "0283d603abdd2392646dbdd0dc80beb39c25bfab96a8a921ea5e7517ce533f8cd5",
-                )
-                .unwrap()],
-                num_sigs: 1,
-                hash_mode: AddressHashMode::SerializeP2PKH,
-            },
+            input: (Txid([0; 32]), 0),
 
             txid: Txid::from_bytes(
                 &hex_bytes("301dc687a9f06a1ae87a013f27133e9cec0843c2983567be73e185827c7c13de")
@@ -2226,14 +2205,7 @@ pub mod tests {
                 memo: vec![i],
 
                 burn_fee: (i + 1) as u64,
-                input: BurnchainSigner {
-                    public_keys: vec![StacksPublicKey::from_hex(
-                        "02113c274c05ed0b7f9d08f41ca674b22e42188408caaff82a350b024442de353c",
-                    )
-                    .unwrap()],
-                    num_sigs: 1,
-                    hash_mode: AddressHashMode::SerializeP2PKH,
-                },
+                input: (Txid([0; 32]), 0),
 
                 txid: Txid::from_bytes(&vec![
                     i, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -2259,14 +2231,7 @@ pub mod tests {
             memo: vec![0x00],
 
             burn_fee: 256,
-            input: BurnchainSigner {
-                public_keys: vec![StacksPublicKey::from_hex(
-                    "02113c274c05ed0b7f9d08f41ca674b22e42188408caaff82a350b024442de353c",
-                )
-                .unwrap()],
-                num_sigs: 1,
-                hash_mode: AddressHashMode::SerializeP2PKH,
-            },
+            input: (Txid([0; 32]), 0),
 
             txid: Txid([0xdd; 32]),
             vtxindex: 1,
@@ -2482,14 +2447,7 @@ pub mod tests {
                     memo: vec![i],
 
                     burn_fee: i as u64,
-                    input: BurnchainSigner {
-                        public_keys: vec![StacksPublicKey::from_hex(
-                            &leader_bitcoin_public_keys[(i - 1) as usize].clone(),
-                        )
-                        .unwrap()],
-                        num_sigs: 1,
-                        hash_mode: AddressHashMode::SerializeP2PKH,
-                    },
+                    input: (Txid([0; 32]), 0),
 
                     txid: Txid::from_bytes(&vec![
                         i, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,

--- a/src/burnchains/mod.rs
+++ b/src/burnchains/mod.rs
@@ -925,16 +925,7 @@ pub mod test {
             fork_snapshot: Option<&BlockSnapshot>,
             parent_block_snapshot: Option<&BlockSnapshot>,
         ) -> LeaderBlockCommitOp {
-            let pubks = miner
-                .privks
-                .iter()
-                .map(|ref pk| StacksPublicKey::from_private(pk))
-                .collect();
-            let input = BurnchainSigner {
-                hash_mode: miner.hash_mode.clone(),
-                num_sigs: miner.num_sigs as usize,
-                public_keys: pubks,
-            };
+            let input = (Txid([0; 32]), 0);
 
             let last_snapshot = match fork_snapshot {
                 Some(sn) => sn.clone(),

--- a/src/chainstate/burn/db/processing.rs
+++ b/src/chainstate/burn/db/processing.rs
@@ -138,7 +138,7 @@ impl<'a> SortitionHandleTx<'a> {
         let this_block_hash = block_header.block_hash.clone();
 
         // make the burn distribution, and in doing so, identify the user burns that we'll keep
-        let state_transition = BurnchainStateTransition::from_block_ops(self, parent_snapshot, this_block_ops)
+        let state_transition = BurnchainStateTransition::from_block_ops(self, parent_snapshot, this_block_ops, burnchain.pox_constants.sunset_end)
             .map_err(|e| {
                 error!("TRANSACTION ABORTED when converting {} blockstack operations in block {} ({}) to a burn distribution: {:?}", this_block_ops.len(), this_block_height, &this_block_hash, e);
                 e

--- a/src/chainstate/burn/db/sortdb.rs
+++ b/src/chainstate/burn/db/sortdb.rs
@@ -1150,7 +1150,7 @@ impl<'a> SortitionHandleTx<'a> {
         return Ok(false);
     }
 
-    fn get_block_snapshot_by_height(
+    pub fn get_block_snapshot_by_height(
         &mut self,
         block_height: u64,
     ) -> Result<Option<BlockSnapshot>, db_error> {

--- a/src/chainstate/burn/db/sortdb.rs
+++ b/src/chainstate/burn/db/sortdb.rs
@@ -56,7 +56,7 @@ use chainstate::burn::operations::{
 use burnchains::{Address, BurnchainHeaderHash, PublicKey, Txid};
 
 use burnchains::{
-    Burnchain, BurnchainBlockHeader, BurnchainRecipient, BurnchainSigner, BurnchainStateTransition,
+    Burnchain, BurnchainBlockHeader, BurnchainRecipient, BurnchainStateTransition,
     BurnchainStateTransitionOps, BurnchainTransaction, BurnchainView, Error as BurnchainError,
     PoxConstants,
 };
@@ -244,7 +244,7 @@ impl FromRow<LeaderBlockCommitOp> for LeaderBlockCommitOp {
 
         let memo = memo_bytes.to_vec();
 
-        let input = serde_json::from_str::<BurnchainSigner>(&input_json)
+        let input = serde_json::from_str::<(Txid, u32)>(&input_json)
             .map_err(|e| db_error::SerializationError(e))?;
 
         let burn_fee = burn_fee_str
@@ -3795,14 +3795,7 @@ mod tests {
 
             commit_outs: vec![],
             burn_fee: 12345,
-            input: BurnchainSigner {
-                public_keys: vec![StacksPublicKey::from_hex(
-                    "02d8015134d9db8178ac93acbc43170a2f20febba5087a5b0437058765ad5133d0",
-                )
-                .unwrap()],
-                num_sigs: 1,
-                hash_mode: AddressHashMode::SerializeP2PKH,
-            },
+            input: (Txid([0; 32]), 0),
 
             txid: Txid::from_bytes_be(
                 &hex_bytes("3c07a0a93360bc85047bbaadd49e30c8af770f73a37e10fec400174d2e5f27cf")
@@ -4581,14 +4574,7 @@ mod tests {
             commit_outs: vec![],
 
             burn_fee: 12345,
-            input: BurnchainSigner {
-                public_keys: vec![StacksPublicKey::from_hex(
-                    "02d8015134d9db8178ac93acbc43170a2f20febba5087a5b0437058765ad5133d0",
-                )
-                .unwrap()],
-                num_sigs: 1,
-                hash_mode: AddressHashMode::SerializeP2PKH,
-            },
+            input: (Txid([0; 32]), 0),
 
             txid: Txid::from_bytes_be(
                 &hex_bytes("3c07a0a93360bc85047bbaadd49e30c8af770f73a37e10fec400174d2e5f27cf")

--- a/src/chainstate/burn/distribution.rs
+++ b/src/chainstate/burn/distribution.rs
@@ -66,34 +66,10 @@ struct UserBurnIdentifier {
 }
 
 impl BurnSamplePoint {
-    /// Make a burn distribution -- a list of (burn total, block candidate) pairs -- from a block's
-    /// block commits and user support burns.
-    ///
-    /// All operations need to be supplied in an ordered Vec of Vecs containing
-    ///   the ops at each block height in MINING_COMMITMENT_WINDOW
-    ///
-    /// If a burn refers to more than one commitment, its burn amount is *split* between those
-    ///   commitments
-    ///
-    /// Returns the distribution, which consumes the given lists of operations.
-    ///
-    /// * `block_commits`: this is a mapping from relative block_height to the block
-    ///     commits that occurred at that height. These relative block heights start
-    ///     at 0 and increment towards the present. When the mining window is 6, the
-    ///     "current" sortition's block commits would be in index 5.
-    /// * `block_commits`: this is a mapping from relative block_height to the user
-    ///     burns that occurred at that height. When the mining window is 6, the
-    ///     "current" sortition's user burns would be in index 5.
-    /// * `sunset_finished_at`: if set, this indicates that the PoX sunset finished before or
-    ///     during the mining window. This value is the first index in the block_commits
-    ///     for which PoX is fully disabled (i.e., the block commit has a single burn output).
-    pub fn make_min_median_distribution(
-        mut block_commits: Vec<Vec<LeaderBlockCommitOp>>,
-        user_burns: Vec<Vec<UserBurnSupportOp>>,
-        sunset_finished_at: Option<u8>,
-    ) -> Vec<BurnSamplePoint> {
-        // sanity check
-        assert!(MINING_COMMITMENT_WINDOW > 0);
+    fn sanity_check_window(
+        block_commits: &Vec<Vec<LeaderBlockCommitOp>>,
+        user_burns: &Vec<Vec<UserBurnSupportOp>>,
+    ) {
         assert_eq!(block_commits.len(), user_burns.len());
         assert!(block_commits.len() <= (MINING_COMMITMENT_WINDOW as usize));
         let mut block_height_at_index = None;
@@ -122,8 +98,38 @@ impl BurnSamplePoint {
                 }
             }
         }
+    }
 
+    /// Make a burn distribution -- a list of (burn total, block candidate) pairs -- from a block's
+    /// block commits and user support burns.
+    ///
+    /// All operations need to be supplied in an ordered Vec of Vecs containing
+    ///   the ops at each block height in MINING_COMMITMENT_WINDOW
+    ///
+    /// If a burn refers to more than one commitment, its burn amount is *split* between those
+    ///   commitments
+    ///
+    /// Returns the distribution, which consumes the given lists of operations.
+    ///
+    /// * `block_commits`: this is a mapping from relative block_height to the block
+    ///     commits that occurred at that height. These relative block heights start
+    ///     at 0 and increment towards the present. When the mining window is 6, the
+    ///     "current" sortition's block commits would be in index 5.
+    /// * `user_burns`: this is a mapping from relative block_height to the user
+    ///     burns that occurred at that height. When the mining window is 6, the
+    ///     "current" sortition's user burns would be in index 5.
+    /// * `sunset_finished_at`: if set, this indicates that the PoX sunset finished before or
+    ///     during the mining window. This value is the first index in the block_commits
+    ///     for which PoX is fully disabled (i.e., the block commit has a single burn output).
+    pub fn make_min_median_distribution(
+        mut block_commits: Vec<Vec<LeaderBlockCommitOp>>,
+        user_burns: Vec<Vec<UserBurnSupportOp>>,
+        sunset_finished_at: Option<u8>,
+    ) -> Vec<BurnSamplePoint> {
+        // sanity check
+        assert!(MINING_COMMITMENT_WINDOW > 0);
         let window_size = block_commits.len() as u8;
+        BurnSamplePoint::sanity_check_window(&block_commits, &user_burns);
 
         // first, let's link all of the current block commits to the priors
         let mut commits_with_priors: Vec<_> =
@@ -513,6 +519,109 @@ mod tests {
             block_height: block_ht,
             burn_header_hash: BurnchainHeaderHash([0; 32]),
         }
+    }
+
+    #[test]
+    fn make_mean_min_median_sunset_in_window() {
+        //    miner 1:  3 4 5 4 5 4
+        //       ub  :  1 0 0 0 0 0
+        //                    | sunset end
+        //    miner 2:  1 3 3 3 3 3
+        //       ub  :  1 0 0 0 0 0
+        //              0 1 0 0 0 0
+        //                   ..
+
+        // miner 1 => min = 1, median = 1.
+        // miner 2 => min = 1, median = 1.
+
+        let mut commits = vec![
+            vec![
+                make_block_commit(3, 1, 1, 1, None, 1),
+                make_block_commit(1, 2, 2, 2, None, 1),
+            ],
+            vec![
+                make_block_commit(4, 3, 3, 3, Some(1), 2),
+                make_block_commit(3, 4, 4, 4, Some(2), 2),
+            ],
+            vec![
+                make_block_commit(5, 5, 5, 5, Some(3), 3),
+                make_block_commit(3, 6, 6, 6, Some(4), 3),
+            ],
+            vec![
+                make_block_commit(4, 7, 7, 7, Some(5), 4),
+                make_block_commit(3, 8, 8, 8, Some(6), 4),
+            ],
+            vec![
+                make_block_commit(5, 9, 9, 9, Some(7), 5),
+                make_block_commit(3, 10, 10, 10, Some(8), 5),
+            ],
+            vec![
+                make_block_commit(4, 11, 11, 11, Some(9), 6),
+                make_block_commit(3, 12, 12, 12, Some(10), 6),
+            ],
+        ];
+        let user_burns = vec![
+            vec![make_user_burn(1, 1, 1, 1, 1), make_user_burn(1, 2, 2, 2, 1)],
+            vec![make_user_burn(1, 4, 4, 4, 2)],
+            vec![make_user_burn(1, 6, 6, 6, 3)],
+            vec![make_user_burn(1, 8, 8, 8, 4)],
+            vec![make_user_burn(1, 10, 10, 10, 5)],
+            vec![make_user_burn(1, 12, 12, 12, 6)],
+        ];
+
+        let mut result = BurnSamplePoint::make_min_median_distribution(
+            commits.clone(),
+            user_burns.clone(),
+            Some(3),
+        );
+
+        assert_eq!(result.len(), 2, "Should be two miners");
+
+        result.sort_by_key(|sample| sample.candidate.txid);
+
+        assert_eq!(result[0].burns, 1);
+        assert_eq!(result[1].burns, 1);
+
+        // make sure that we're associating with the last commit in the window.
+        assert_eq!(result[0].candidate.txid, commits[5][0].txid);
+        assert_eq!(result[1].candidate.txid, commits[5][1].txid);
+
+        assert_eq!(result[0].user_burns.len(), 0);
+        assert_eq!(result[1].user_burns.len(), 1);
+
+        assert_eq!(result[1].user_burns[0].txid, user_burns[5][0].txid);
+
+        // now correct the back pointers so that they point
+        //   at the correct UTXO position *post-sunset*
+        for (ix, window_slice) in commits.iter_mut().enumerate() {
+            if ix >= 4 {
+                for commit in window_slice.iter_mut() {
+                    commit.input.1 = 2;
+                }
+            }
+        }
+
+        let mut result = BurnSamplePoint::make_min_median_distribution(
+            commits.clone(),
+            user_burns.clone(),
+            Some(3),
+        );
+
+        assert_eq!(result.len(), 2, "Should be two miners");
+
+        result.sort_by_key(|sample| sample.candidate.txid);
+
+        assert_eq!(result[0].burns, 4);
+        assert_eq!(result[1].burns, 3);
+
+        // make sure that we're associating with the last commit in the window.
+        assert_eq!(result[0].candidate.txid, commits[5][0].txid);
+        assert_eq!(result[1].candidate.txid, commits[5][1].txid);
+
+        assert_eq!(result[0].user_burns.len(), 0);
+        assert_eq!(result[1].user_burns.len(), 1);
+
+        assert_eq!(result[1].user_burns[0].txid, user_burns[5][0].txid);
     }
 
     #[test]

--- a/src/chainstate/burn/operations/leader_block_commit.rs
+++ b/src/chainstate/burn/operations/leader_block_commit.rs
@@ -70,7 +70,7 @@ impl LeaderBlockCommitOp {
         new_seed: &VRFSeed,
         paired_key: &LeaderKeyRegisterOp,
         burn_fee: u64,
-        input: &BurnchainSigner,
+        input: &(Txid, u32),
     ) -> LeaderBlockCommitOp {
         LeaderBlockCommitOp {
             sunset_burn: 0,
@@ -102,7 +102,7 @@ impl LeaderBlockCommitOp {
         key_block_ptr: u32,
         key_vtxindex: u16,
         burn_fee: u64,
-        input: &BurnchainSigner,
+        input: &(Txid, u32),
     ) -> LeaderBlockCommitOp {
         LeaderBlockCommitOp {
             sunset_burn: 0,
@@ -122,6 +122,15 @@ impl LeaderBlockCommitOp {
             vtxindex: 0,
             block_height: 0,
             burn_header_hash: BurnchainHeaderHash([0u8; 32]),
+        }
+    }
+
+    pub fn expected_chained_utxo(sunset_finished: bool) -> u32 {
+        if sunset_finished {
+            2 // if sunset has occurred, chained commits should spend the output after the burn commit
+        } else {
+            // otherwise, it's the output after the last PoX output
+            (OUTPUTS_PER_COMMIT as u32) + 1
         }
     }
 
@@ -190,13 +199,12 @@ impl LeaderBlockCommitOp {
         pox_sunset_ht: u64,
     ) -> Result<LeaderBlockCommitOp, op_error> {
         // can't be too careful...
-        let inputs = tx.get_signers();
         let mut outputs = tx.get_recipients();
 
-        if inputs.len() == 0 {
+        if tx.num_signers() == 0 {
             warn!(
                 "Invalid tx: inputs: {}, outputs: {}",
-                inputs.len(),
+                tx.num_signers(),
                 outputs.len()
             );
             return Err(op_error::InvalidInput);
@@ -205,7 +213,7 @@ impl LeaderBlockCommitOp {
         if outputs.len() == 0 {
             warn!(
                 "Invalid tx: inputs: {}, outputs: {}",
-                inputs.len(),
+                tx.num_signers(),
                 outputs.len()
             );
             return Err(op_error::InvalidInput);
@@ -302,6 +310,11 @@ impl LeaderBlockCommitOp {
             (commit_outs, sunset_burn, burn_fee)
         };
 
+        let input = tx
+            .get_input_tx_ref(0)
+            .expect("UNREACHABLE: checked that inputs > 0")
+            .clone();
+
         Ok(LeaderBlockCommitOp {
             block_header_hash: data.block_header_hash,
             new_seed: data.new_seed,
@@ -314,7 +327,7 @@ impl LeaderBlockCommitOp {
             commit_outs,
             sunset_burn,
             burn_fee,
-            input: inputs[0].clone(),
+            input,
 
             txid: tx.txid(),
             vtxindex: tx.vtxindex(),
@@ -614,27 +627,6 @@ impl LeaderBlockCommitOp {
                 warn!("Invalid block commit: no parent block in this fork");
                 return Err(op_error::BlockCommitNoParent);
             }
-        }
-
-        /////////////////////////////////////////////////////////////////////////////////////
-        // This LeaderBlockCommit's input public keys must match the address of its LeaderKeyRegister
-        // -- the hash of the inputs' public key(s) must equal the hash contained within the
-        // LeaderKeyRegister's address.  Note that we only need to check the address bytes,
-        // not the entire address (since finding two sets of different public keys that
-        // hash to the same address is considered intractible).
-        //
-        // Under the hood, the blockchain further ensures that the tx was signed with the
-        // associated private keys, so only the private key owner(s) are in a position to
-        // reveal the keys that hash to the address's hash.
-        /////////////////////////////////////////////////////////////////////////////////////
-
-        let input_address_bytes = self.input.to_address_bits();
-        let addr_bytes = register_key.address.to_bytes();
-
-        if input_address_bytes != addr_bytes {
-            warn!("Invalid block commit: leader key at ({},{}) has address bytes {}, but this tx input has address bytes {}",
-                  register_key.block_height, register_key.vtxindex, &to_hex(&addr_bytes), &to_hex(&input_address_bytes[..]));
-            return Err(op_error::BlockCommitBadInput);
         }
 
         Ok(())
@@ -1147,13 +1139,7 @@ mod tests {
                     ],
 
                     burn_fee: 24690,
-                    input: BurnchainSigner {
-                        public_keys: vec![
-                            StacksPublicKey::from_hex("02d8015134d9db8178ac93acbc43170a2f20febba5087a5b0437058765ad5133d0").unwrap(),
-                        ],
-                        num_sigs: 1,
-                        hash_mode: AddressHashMode::SerializeP2PKH
-                    },
+                    input: (Txid([0x11; 32]), 0),
 
                     txid: Txid::from_hex("b08d5d1bc81049a3957e9ff9a5882463811735fd5de985e6d894e9b3d5c49501").unwrap(),
                     vtxindex: vtxindex,
@@ -1374,14 +1360,7 @@ mod tests {
             commit_outs: vec![],
 
             burn_fee: 12345,
-            input: BurnchainSigner {
-                public_keys: vec![StacksPublicKey::from_hex(
-                    "02d8015134d9db8178ac93acbc43170a2f20febba5087a5b0437058765ad5133d0",
-                )
-                .unwrap()],
-                num_sigs: 1,
-                hash_mode: AddressHashMode::SerializeP2PKH,
-            },
+            input: (Txid([0; 32]), 0),
 
             txid: Txid::from_bytes_be(
                 &hex_bytes("3c07a0a93360bc85047bbaadd49e30c8af770f73a37e10fec400174d2e5f27cf")
@@ -1533,14 +1512,7 @@ mod tests {
                     commit_outs: vec![],
 
                     burn_fee: 12345,
-                    input: BurnchainSigner {
-                        public_keys: vec![StacksPublicKey::from_hex(
-                            "02d8015134d9db8178ac93acbc43170a2f20febba5087a5b0437058765ad5133d0",
-                        )
-                        .unwrap()],
-                        num_sigs: 1,
-                        hash_mode: AddressHashMode::SerializeP2PKH,
-                    },
+                    input: (Txid([0; 32]), 0),
 
                     txid: Txid::from_bytes_be(
                         &hex_bytes(
@@ -1581,14 +1553,7 @@ mod tests {
                     commit_outs: vec![],
 
                     burn_fee: 12345,
-                    input: BurnchainSigner {
-                        public_keys: vec![StacksPublicKey::from_hex(
-                            "02d8015134d9db8178ac93acbc43170a2f20febba5087a5b0437058765ad5133d0",
-                        )
-                        .unwrap()],
-                        num_sigs: 1,
-                        hash_mode: AddressHashMode::SerializeP2PKH,
-                    },
+                    input: (Txid([0; 32]), 0),
 
                     txid: Txid::from_bytes_be(
                         &hex_bytes(
@@ -1629,14 +1594,7 @@ mod tests {
                     memo: vec![0x80],
 
                     burn_fee: 12345,
-                    input: BurnchainSigner {
-                        public_keys: vec![StacksPublicKey::from_hex(
-                            "02d8015134d9db8178ac93acbc43170a2f20febba5087a5b0437058765ad5133d0",
-                        )
-                        .unwrap()],
-                        num_sigs: 1,
-                        hash_mode: AddressHashMode::SerializeP2PKH,
-                    },
+                    input: (Txid([0; 32]), 0),
 
                     txid: Txid::from_bytes_be(
                         &hex_bytes(
@@ -1677,14 +1635,7 @@ mod tests {
                     commit_outs: vec![],
 
                     burn_fee: 12345,
-                    input: BurnchainSigner {
-                        public_keys: vec![StacksPublicKey::from_hex(
-                            "02d8015134d9db8178ac93acbc43170a2f20febba5087a5b0437058765ad5133d0",
-                        )
-                        .unwrap()],
-                        num_sigs: 1,
-                        hash_mode: AddressHashMode::SerializeP2PKH,
-                    },
+                    input: (Txid([0; 32]), 0),
 
                     txid: Txid::from_bytes_be(
                         &hex_bytes(
@@ -1725,14 +1676,7 @@ mod tests {
                     commit_outs: vec![],
 
                     burn_fee: 12345,
-                    input: BurnchainSigner {
-                        public_keys: vec![StacksPublicKey::from_hex(
-                            "03984286096373539ae529bd997c92792d4e5b5967be72979a42f587a625394116",
-                        )
-                        .unwrap()],
-                        num_sigs: 1,
-                        hash_mode: AddressHashMode::SerializeP2PKH,
-                    },
+                    input: (Txid([0; 32]), 0),
 
                     txid: Txid::from_bytes_be(
                         &hex_bytes(
@@ -1745,7 +1689,7 @@ mod tests {
                     block_height: 126,
                     burn_header_hash: block_126_hash.clone(),
                 },
-                res: Err(op_error::BlockCommitBadInput),
+                res: Ok(()),
             },
             CheckFixture {
                 // reject -- fee is 0
@@ -1773,14 +1717,7 @@ mod tests {
                     commit_outs: vec![],
 
                     burn_fee: 0,
-                    input: BurnchainSigner {
-                        public_keys: vec![StacksPublicKey::from_hex(
-                            "02d8015134d9db8178ac93acbc43170a2f20febba5087a5b0437058765ad5133d0",
-                        )
-                        .unwrap()],
-                        num_sigs: 1,
-                        hash_mode: AddressHashMode::SerializeP2PKH,
-                    },
+                    input: (Txid([0; 32]), 0),
 
                     txid: Txid::from_bytes_be(
                         &hex_bytes(
@@ -1821,14 +1758,7 @@ mod tests {
                     commit_outs: vec![],
 
                     burn_fee: 12345,
-                    input: BurnchainSigner {
-                        public_keys: vec![StacksPublicKey::from_hex(
-                            "02d8015134d9db8178ac93acbc43170a2f20febba5087a5b0437058765ad5133d0",
-                        )
-                        .unwrap()],
-                        num_sigs: 1,
-                        hash_mode: AddressHashMode::SerializeP2PKH,
-                    },
+                    input: (Txid([0; 32]), 0),
 
                     txid: Txid::from_bytes_be(
                         &hex_bytes(
@@ -1869,14 +1799,7 @@ mod tests {
                     commit_outs: vec![],
 
                     burn_fee: 12345,
-                    input: BurnchainSigner {
-                        public_keys: vec![StacksPublicKey::from_hex(
-                            "02d8015134d9db8178ac93acbc43170a2f20febba5087a5b0437058765ad5133d0",
-                        )
-                        .unwrap()],
-                        num_sigs: 1,
-                        hash_mode: AddressHashMode::SerializeP2PKH,
-                    },
+                    input: (Txid([0; 32]), 0),
 
                     txid: Txid::from_bytes_be(
                         &hex_bytes(
@@ -1893,7 +1816,8 @@ mod tests {
             },
         ];
 
-        for fixture in fixtures {
+        for (ix, fixture) in fixtures.iter().enumerate() {
+            eprintln!("Processing {}", ix);
             let header = BurnchainBlockHeader {
                 block_height: fixture.op.block_height,
                 block_hash: fixture.op.burn_header_hash.clone(),

--- a/src/chainstate/burn/operations/leader_block_commit.rs
+++ b/src/chainstate/burn/operations/leader_block_commit.rs
@@ -71,6 +71,7 @@ impl LeaderBlockCommitOp {
         paired_key: &LeaderKeyRegisterOp,
         burn_fee: u64,
         input: &(Txid, u32),
+        apparent_sender: &BurnchainSigner,
     ) -> LeaderBlockCommitOp {
         LeaderBlockCommitOp {
             sunset_burn: 0,
@@ -85,6 +86,7 @@ impl LeaderBlockCommitOp {
             input: input.clone(),
             block_header_hash: block_header_hash.clone(),
             commit_outs: vec![],
+            apparent_sender: apparent_sender.clone(),
 
             // to be filled in
             txid: Txid([0u8; 32]),
@@ -103,6 +105,7 @@ impl LeaderBlockCommitOp {
         key_vtxindex: u16,
         burn_fee: u64,
         input: &(Txid, u32),
+        apparent_sender: &BurnchainSigner,
     ) -> LeaderBlockCommitOp {
         LeaderBlockCommitOp {
             sunset_burn: 0,
@@ -116,6 +119,7 @@ impl LeaderBlockCommitOp {
             input: input.clone(),
             block_header_hash: block_header_hash.clone(),
             commit_outs: vec![],
+            apparent_sender: apparent_sender.clone(),
 
             // to be filled in
             txid: Txid([0u8; 32]),
@@ -315,6 +319,10 @@ impl LeaderBlockCommitOp {
             .expect("UNREACHABLE: checked that inputs > 0")
             .clone();
 
+        let apparent_sender = tx
+            .get_signer(0)
+            .expect("UNREACHABLE: checked that inputs > 0");
+
         Ok(LeaderBlockCommitOp {
             block_header_hash: data.block_header_hash,
             new_seed: data.new_seed,
@@ -328,6 +336,7 @@ impl LeaderBlockCommitOp {
             sunset_burn,
             burn_fee,
             input,
+            apparent_sender,
 
             txid: tx.txid(),
             vtxindex: tx.vtxindex(),
@@ -597,7 +606,7 @@ impl LeaderBlockCommitOp {
             return Err(op_error::BlockCommitNoLeaderKey);
         }
 
-        let register_key = tx
+        let _register_key = tx
             .get_leader_key_at(leader_key_block_height, self.key_vtxindex.into(), &tx_tip)?
             .ok_or_else(|| {
                 warn!(
@@ -1140,6 +1149,13 @@ mod tests {
 
                     burn_fee: 24690,
                     input: (Txid([0x11; 32]), 0),
+                    apparent_sender: BurnchainSigner {
+                        public_keys: vec![
+                            StacksPublicKey::from_hex("02d8015134d9db8178ac93acbc43170a2f20febba5087a5b0437058765ad5133d0").unwrap(),
+                        ],
+                        num_sigs: 1,
+                        hash_mode: AddressHashMode::SerializeP2PKH
+                    },
 
                     txid: Txid::from_hex("b08d5d1bc81049a3957e9ff9a5882463811735fd5de985e6d894e9b3d5c49501").unwrap(),
                     vtxindex: vtxindex,
@@ -1361,6 +1377,14 @@ mod tests {
 
             burn_fee: 12345,
             input: (Txid([0; 32]), 0),
+            apparent_sender: BurnchainSigner {
+                public_keys: vec![StacksPublicKey::from_hex(
+                    "02d8015134d9db8178ac93acbc43170a2f20febba5087a5b0437058765ad5133d0",
+                )
+                .unwrap()],
+                num_sigs: 1,
+                hash_mode: AddressHashMode::SerializeP2PKH,
+            },
 
             txid: Txid::from_bytes_be(
                 &hex_bytes("3c07a0a93360bc85047bbaadd49e30c8af770f73a37e10fec400174d2e5f27cf")
@@ -1513,6 +1537,14 @@ mod tests {
 
                     burn_fee: 12345,
                     input: (Txid([0; 32]), 0),
+                    apparent_sender: BurnchainSigner {
+                        public_keys: vec![StacksPublicKey::from_hex(
+                            "02d8015134d9db8178ac93acbc43170a2f20febba5087a5b0437058765ad5133d0",
+                        )
+                        .unwrap()],
+                        num_sigs: 1,
+                        hash_mode: AddressHashMode::SerializeP2PKH,
+                    },
 
                     txid: Txid::from_bytes_be(
                         &hex_bytes(
@@ -1554,6 +1586,14 @@ mod tests {
 
                     burn_fee: 12345,
                     input: (Txid([0; 32]), 0),
+                    apparent_sender: BurnchainSigner {
+                        public_keys: vec![StacksPublicKey::from_hex(
+                            "02d8015134d9db8178ac93acbc43170a2f20febba5087a5b0437058765ad5133d0",
+                        )
+                        .unwrap()],
+                        num_sigs: 1,
+                        hash_mode: AddressHashMode::SerializeP2PKH,
+                    },
 
                     txid: Txid::from_bytes_be(
                         &hex_bytes(
@@ -1595,6 +1635,14 @@ mod tests {
 
                     burn_fee: 12345,
                     input: (Txid([0; 32]), 0),
+                    apparent_sender: BurnchainSigner {
+                        public_keys: vec![StacksPublicKey::from_hex(
+                            "02d8015134d9db8178ac93acbc43170a2f20febba5087a5b0437058765ad5133d0",
+                        )
+                        .unwrap()],
+                        num_sigs: 1,
+                        hash_mode: AddressHashMode::SerializeP2PKH,
+                    },
 
                     txid: Txid::from_bytes_be(
                         &hex_bytes(
@@ -1636,6 +1684,14 @@ mod tests {
 
                     burn_fee: 12345,
                     input: (Txid([0; 32]), 0),
+                    apparent_sender: BurnchainSigner {
+                        public_keys: vec![StacksPublicKey::from_hex(
+                            "02d8015134d9db8178ac93acbc43170a2f20febba5087a5b0437058765ad5133d0",
+                        )
+                        .unwrap()],
+                        num_sigs: 1,
+                        hash_mode: AddressHashMode::SerializeP2PKH,
+                    },
 
                     txid: Txid::from_bytes_be(
                         &hex_bytes(
@@ -1677,6 +1733,14 @@ mod tests {
 
                     burn_fee: 12345,
                     input: (Txid([0; 32]), 0),
+                    apparent_sender: BurnchainSigner {
+                        public_keys: vec![StacksPublicKey::from_hex(
+                            "03984286096373539ae529bd997c92792d4e5b5967be72979a42f587a625394116",
+                        )
+                        .unwrap()],
+                        num_sigs: 1,
+                        hash_mode: AddressHashMode::SerializeP2PKH,
+                    },
 
                     txid: Txid::from_bytes_be(
                         &hex_bytes(
@@ -1718,6 +1782,14 @@ mod tests {
 
                     burn_fee: 0,
                     input: (Txid([0; 32]), 0),
+                    apparent_sender: BurnchainSigner {
+                        public_keys: vec![StacksPublicKey::from_hex(
+                            "02d8015134d9db8178ac93acbc43170a2f20febba5087a5b0437058765ad5133d0",
+                        )
+                        .unwrap()],
+                        num_sigs: 1,
+                        hash_mode: AddressHashMode::SerializeP2PKH,
+                    },
 
                     txid: Txid::from_bytes_be(
                         &hex_bytes(
@@ -1759,6 +1831,14 @@ mod tests {
 
                     burn_fee: 12345,
                     input: (Txid([0; 32]), 0),
+                    apparent_sender: BurnchainSigner {
+                        public_keys: vec![StacksPublicKey::from_hex(
+                            "02d8015134d9db8178ac93acbc43170a2f20febba5087a5b0437058765ad5133d0",
+                        )
+                        .unwrap()],
+                        num_sigs: 1,
+                        hash_mode: AddressHashMode::SerializeP2PKH,
+                    },
 
                     txid: Txid::from_bytes_be(
                         &hex_bytes(
@@ -1800,6 +1880,14 @@ mod tests {
 
                     burn_fee: 12345,
                     input: (Txid([0; 32]), 0),
+                    apparent_sender: BurnchainSigner {
+                        public_keys: vec![StacksPublicKey::from_hex(
+                            "02d8015134d9db8178ac93acbc43170a2f20febba5087a5b0437058765ad5133d0",
+                        )
+                        .unwrap()],
+                        num_sigs: 1,
+                        hash_mode: AddressHashMode::SerializeP2PKH,
+                    },
 
                     txid: Txid::from_bytes_be(
                         &hex_bytes(

--- a/src/chainstate/burn/operations/mod.rs
+++ b/src/chainstate/burn/operations/mod.rs
@@ -184,10 +184,15 @@ pub struct LeaderBlockCommitOp {
     pub key_vtxindex: u16,    // offset in the block where the leader key can be found
     pub memo: Vec<u8>,        // extra unused byte
 
-    pub burn_fee: u64,
     /// how many burn tokens (e.g. satoshis) were committed to produce this block
-    pub input: (Txid, u32),
+    pub burn_fee: u64,
     /// the input transaction, used in mining commitment smoothing
+    pub input: (Txid, u32),
+
+    /// the apparent sender of the transaction. note: this
+    ///  is *not* authenticated, and should be used only
+    ///  for informational purposes (e.g., log messages)
+    pub apparent_sender: BurnchainSigner,
 
     /// PoX/Burn outputs
     pub commit_outs: Vec<StacksAddress>,

--- a/src/chainstate/burn/operations/mod.rs
+++ b/src/chainstate/burn/operations/mod.rs
@@ -184,8 +184,10 @@ pub struct LeaderBlockCommitOp {
     pub key_vtxindex: u16,    // offset in the block where the leader key can be found
     pub memo: Vec<u8>,        // extra unused byte
 
-    pub burn_fee: u64, // how many burn tokens (e.g. satoshis) were destroyed to produce this block
-    pub input: BurnchainSigner, // burn chain keys that must match the key registration
+    pub burn_fee: u64,
+    /// how many burn tokens (e.g. satoshis) were committed to produce this block
+    pub input: (Txid, u32),
+    /// the input transaction, used in mining commitment smoothing
 
     /// PoX/Burn outputs
     pub commit_outs: Vec<StacksAddress>,

--- a/src/chainstate/burn/sortition.rs
+++ b/src/chainstate/burn/sortition.rs
@@ -482,12 +482,7 @@ mod test {
                 &VRFSeed::initial(),
                 &key,
                 0,
-                &BurnchainSigner::new_p2pkh(
-                    &StacksPublicKey::from_hex(
-                        "03ef2340518b5867b23598a9cf74611f8b98064f7d55cdb8c107c67b5efcbc5c77",
-                    )
-                    .unwrap(),
-                ),
+                &(Txid([0; 32]), 0),
             ),
             key: LeaderKeyRegisterOp::new(
                 &StacksAddress::new(0, Hash160([0u8; 20])),

--- a/src/chainstate/burn/sortition.rs
+++ b/src/chainstate/burn/sortition.rs
@@ -511,6 +511,12 @@ mod test {
                 &key,
                 0,
                 &(Txid([0; 32]), 0),
+                &BurnchainSigner::new_p2pkh(
+                    &StacksPublicKey::from_hex(
+                        "03ef2340518b5867b23598a9cf74611f8b98064f7d55cdb8c107c67b5efcbc5c77",
+                    )
+                    .unwrap(),
+                ),
             ),
             user_burns: vec![],
         };

--- a/src/chainstate/burn/sortition.rs
+++ b/src/chainstate/burn/sortition.rs
@@ -95,7 +95,7 @@ impl BlockSnapshot {
     /// Given the weighted burns, VRF seed of the last winner, and sortition hash, pick the next
     /// winner.  Return the index into the distribution *if there is a sample to take*.
     fn sample_burn_distribution(
-        dist: &Vec<BurnSamplePoint>,
+        dist: &[BurnSamplePoint],
         VRF_seed: &VRFSeed,
         sortition_hash: &SortitionHash,
     ) -> Option<usize> {
@@ -138,7 +138,7 @@ impl BlockSnapshot {
         sort_tx: &mut SortitionHandleTx,
         block_header: &BurnchainBlockHeader,
         sortition_hash: &SortitionHash,
-        burn_dist: &Vec<BurnSamplePoint>,
+        burn_dist: &[BurnSamplePoint],
     ) -> Result<Option<LeaderBlockCommitOp>, db_error> {
         let burn_block_height = block_header.block_height;
 
@@ -251,8 +251,9 @@ impl BlockSnapshot {
         my_pox_id: &PoxId,
         parent_snapshot: &BlockSnapshot,
         block_header: &BurnchainBlockHeader,
-        burn_dist: &Vec<BurnSamplePoint>,
+        burn_dist: &[BurnSamplePoint],
         txids: &Vec<Txid>,
+        block_burn_total: Option<u64>,
     ) -> Result<BlockSnapshot, db_error> {
         assert_eq!(
             parent_snapshot.burn_header_hash,
@@ -287,21 +288,24 @@ impl BlockSnapshot {
         if burn_dist.len() == 0 {
             // no burns happened
             debug!(
-                "No burns happened in block {} {:?}",
-                block_height, &block_hash
+                "No burns happened in block";
+                "burn_block_height" => %block_height.to_string(),
+                "burn_block_hash" => %block_hash.to_string(),
             );
+
             return make_snapshot_no_sortition();
         }
 
         // NOTE: this only counts burns from leader block commits and user burns that match them.
         // It ignores user burns that don't match any block.
-        let block_burn_total = match BurnSamplePoint::get_total_burns(burn_dist) {
+        let block_burn_total = match block_burn_total {
             Some(total) => {
                 if total == 0 {
                     // no one burned, so no sortition
                     debug!(
-                        "No transactions submitted burns in block {} {:?}",
-                        block_height, &block_hash
+                        "No transactions submitted burns in block";
+                        "burn_block_height" => %block_height.to_string(),
+                        "burn_block_hash" => %block_hash.to_string(),
                     );
                     return make_snapshot_no_sortition();
                 } else {
@@ -402,6 +406,30 @@ mod test {
 
     use address::*;
 
+    fn test_make_snapshot(
+        sort_tx: &mut SortitionHandleTx,
+        burnchain: &Burnchain,
+        my_sortition_id: &SortitionId,
+        my_pox_id: &PoxId,
+        parent_snapshot: &BlockSnapshot,
+        block_header: &BurnchainBlockHeader,
+        burn_dist: &[BurnSamplePoint],
+        txids: &Vec<Txid>,
+    ) -> Result<BlockSnapshot, db_error> {
+        let total_burn = BurnSamplePoint::get_total_burns(burn_dist);
+        BlockSnapshot::make_snapshot(
+            sort_tx,
+            burnchain,
+            my_sortition_id,
+            my_pox_id,
+            parent_snapshot,
+            block_header,
+            burn_dist,
+            txids,
+            total_burn,
+        )
+    }
+
     #[test]
     fn make_snapshot_no_sortition() {
         let first_burn_hash = BurnchainHeaderHash::from_hex(
@@ -442,7 +470,7 @@ mod test {
             let pox_id = PoxId::stubbed();
             let sort_id = SortitionId::stubbed(&empty_block_header.block_hash);
             let mut ic = SortitionHandleTx::begin(&mut db, &sort_id).unwrap();
-            let sn = BlockSnapshot::make_snapshot(
+            let sn = test_make_snapshot(
                 &mut ic,
                 &burnchain,
                 &sort_id,
@@ -491,7 +519,7 @@ mod test {
             let sort_id = SortitionId::stubbed(&empty_block_header.block_hash);
             let pox_id = PoxId::stubbed();
             let mut ic = SortitionHandleTx::begin(&mut db, &sort_id).unwrap();
-            let sn = BlockSnapshot::make_snapshot(
+            let sn = test_make_snapshot(
                 &mut ic,
                 &burnchain,
                 &sort_id,

--- a/src/chainstate/burn/sortition.rs
+++ b/src/chainstate/burn/sortition.rs
@@ -484,14 +484,6 @@ mod test {
                 0,
                 &(Txid([0; 32]), 0),
             ),
-            key: LeaderKeyRegisterOp::new(
-                &StacksAddress::new(0, Hash160([0u8; 20])),
-                &VRFPublicKey::from_bytes(
-                    &hex_bytes("a366b51292bef4edd64063d9145c617fec373bceb0758e98cd72becd84d54c7a")
-                        .unwrap(),
-                )
-                .unwrap(),
-            ),
             user_burns: vec![],
         };
 

--- a/src/chainstate/coordinator/tests.rs
+++ b/src/chainstate/coordinator/tests.rs
@@ -435,11 +435,7 @@ fn make_genesis_block_with_recipients(
         sunset_burn: 0,
         block_header_hash: block.block_hash(),
         burn_fee: my_burn,
-        input: BurnchainSigner {
-            num_sigs: 1,
-            hash_mode: address::AddressHashMode::SerializeP2PKH,
-            public_keys: vec![StacksPublicKey::from_private(miner)],
-        },
+        input: (Txid([0; 32]), 0),
         key_block_ptr: 1, // all registers happen in block height 1
         key_vtxindex: (1 + key_index) as u16,
         memo: vec![],
@@ -595,11 +591,7 @@ fn make_stacks_block_with_recipients_and_sunset_burn(
         sunset_burn,
         block_header_hash: block.block_hash(),
         burn_fee: my_burn,
-        input: BurnchainSigner {
-            num_sigs: 1,
-            hash_mode: address::AddressHashMode::SerializeP2PKH,
-            public_keys: vec![StacksPublicKey::from_private(miner)],
-        },
+        input: (Txid([0; 32]), 0),
         key_block_ptr: 1, // all registers happen in block height 1
         key_vtxindex: (1 + key_index) as u16,
         memo: vec![],

--- a/src/chainstate/coordinator/tests.rs
+++ b/src/chainstate/coordinator/tests.rs
@@ -437,6 +437,11 @@ fn make_genesis_block_with_recipients(
         block_header_hash: block.block_hash(),
         burn_fee: my_burn,
         input: (Txid([0; 32]), 0),
+        apparent_sender: BurnchainSigner {
+            num_sigs: 1,
+            hash_mode: address::AddressHashMode::SerializeP2PKH,
+            public_keys: vec![StacksPublicKey::from_private(miner)],
+        },
         key_block_ptr: 1, // all registers happen in block height 1
         key_vtxindex: (1 + key_index) as u16,
         memo: vec![],
@@ -447,6 +452,7 @@ fn make_genesis_block_with_recipients(
         parent_vtxindex: 0,
 
         txid: next_txid(),
+
         vtxindex: 1,
         block_height: 0,
         burn_header_hash: BurnchainHeaderHash([0; 32]),
@@ -593,6 +599,11 @@ fn make_stacks_block_with_recipients_and_sunset_burn(
         block_header_hash: block.block_hash(),
         burn_fee: my_burn,
         input: (Txid([0; 32]), 0),
+        apparent_sender: BurnchainSigner {
+            num_sigs: 1,
+            hash_mode: address::AddressHashMode::SerializeP2PKH,
+            public_keys: vec![StacksPublicKey::from_private(miner)],
+        },
         key_block_ptr: 1, // all registers happen in block height 1
         key_vtxindex: (1 + key_index) as u16,
         memo: vec![],

--- a/src/chainstate/stacks/block.rs
+++ b/src/chainstate/stacks/block.rs
@@ -1381,14 +1381,7 @@ mod test {
             commit_outs: vec![],
 
             burn_fee: 12345,
-            input: BurnchainSigner {
-                public_keys: vec![StacksPublicKey::from_hex(
-                    "02d8015134d9db8178ac93acbc43170a2f20febba5087a5b0437058765ad5133d0",
-                )
-                .unwrap()],
-                num_sigs: 1,
-                hash_mode: AddressHashMode::SerializeP2PKH,
-            },
+            input: (Txid([0; 32]), 0),
 
             txid: Txid::from_bytes_be(
                 &hex_bytes("3c07a0a93360bc85047bbaadd49e30c8af770f73a37e10fec400174d2e5f27cf")

--- a/src/chainstate/stacks/block.rs
+++ b/src/chainstate/stacks/block.rs
@@ -1382,6 +1382,14 @@ mod test {
 
             burn_fee: 12345,
             input: (Txid([0; 32]), 0),
+            apparent_sender: BurnchainSigner {
+                public_keys: vec![StacksPublicKey::from_hex(
+                    "02d8015134d9db8178ac93acbc43170a2f20febba5087a5b0437058765ad5133d0",
+                )
+                .unwrap()],
+                num_sigs: 1,
+                hash_mode: AddressHashMode::SerializeP2PKH,
+            },
 
             txid: Txid::from_bytes_be(
                 &hex_bytes("3c07a0a93360bc85047bbaadd49e30c8af770f73a37e10fec400174d2e5f27cf")

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -37,6 +37,8 @@ pub const NETWORK_ID_TESTNET: u32 = 0xff000000;
 // default port
 pub const NETWORK_P2P_PORT: u16 = 6265;
 
+pub const MINING_COMMITMENT_WINDOW: u8 = 6;
+
 // first burnchain block hash
 // TODO: update once we know the true first burnchain block
 pub const FIRST_BURNCHAIN_CONSENSUS_HASH: ConsensusHash = ConsensusHash([0u8; 20]);

--- a/src/util/db.rs
+++ b/src/util/db.rs
@@ -345,7 +345,7 @@ where
 }
 
 /// Boilerplate for querying a single integer (first and only item of the query must be an int)
-pub fn query_int<P>(conn: &Connection, sql_query: &String, sql_args: P) -> Result<i64, Error>
+pub fn query_int<P>(conn: &Connection, sql_query: &str, sql_args: P) -> Result<i64, Error>
 where
     P: IntoIterator,
     P::Item: ToSql,
@@ -377,7 +377,7 @@ where
     Ok(row_data[0])
 }
 
-pub fn query_count<P>(conn: &Connection, sql_query: &String, sql_args: P) -> Result<i64, Error>
+pub fn query_count<P>(conn: &Connection, sql_query: &str, sql_args: P) -> Result<i64, Error>
 where
     P: IntoIterator,
     P::Item: ToSql,

--- a/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
+++ b/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
@@ -34,7 +34,6 @@ use stacks::chainstate::burn::operations::{
     BlockstackOperationType, LeaderBlockCommitOp, LeaderKeyRegisterOp, UserBurnSupportOp,
 };
 use stacks::chainstate::coordinator::comm::CoordinatorChannels;
-use stacks::chainstate::stacks::StacksAddress;
 use stacks::deps::bitcoin::blockdata::opcodes;
 use stacks::deps::bitcoin::blockdata::script::{Builder, Script};
 use stacks::deps::bitcoin::blockdata::transaction::{OutPoint, Transaction, TxIn, TxOut};

--- a/testnet/stacks-node/src/burnchains/mocknet_controller.rs
+++ b/testnet/stacks-node/src/burnchains/mocknet_controller.rs
@@ -170,6 +170,7 @@ impl BurnchainController for MocknetController {
                         key_vtxindex: payload.key_vtxindex,
                         memo: payload.memo,
                         burn_fee: payload.burn_fee,
+                        apparent_sender: payload.apparent_sender,
                         input: payload.input,
                         commit_outs: payload.commit_outs,
                         txid,

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -203,7 +203,7 @@ fn rotate_vrf_and_register(
 
 /// Constructs and returns a LeaderBlockCommitOp out of the provided params
 fn inner_generate_block_commit_op(
-    input: BurnchainSigner,
+    sender: BurnchainSigner,
     block_header_hash: BlockHeaderHash,
     burn_fee: u64,
     key: &RegisteredKey,
@@ -219,7 +219,8 @@ fn inner_generate_block_commit_op(
         sunset_burn,
         block_header_hash,
         burn_fee,
-        input,
+        input: (Txid([0; 32]), 0),
+        apparent_sender: sender,
         key_block_ptr: key.block_height as u32,
         key_vtxindex: key.op_vtxindex as u16,
         memo: vec![],
@@ -1142,9 +1143,8 @@ impl InitializedNeonNode {
         sortdb: &SortitionDB,
         sort_id: &SortitionId,
         ibd: bool,
-    ) -> (Option<BlockSnapshot>, bool) {
+    ) -> Option<BlockSnapshot> {
         let mut last_sortitioned_block = None;
-        let mut won_sortition = false;
 
         let ic = sortdb.index_conn();
 
@@ -1164,21 +1164,16 @@ impl InitializedNeonNode {
                 info!(
                     "Received burnchain block #{} including block_commit_op (winning) - {} ({})",
                     block_height,
-                    op.input.to_testnet_address(),
+                    op.apparent_sender.to_testnet_address(),
                     &op.block_header_hash
                 );
                 last_sortitioned_block = Some((block_snapshot.clone(), op.vtxindex));
-                // Release current registered key if leader won the sortition
-                // This will trigger a new registration
-                if op.input == self.burnchain_signer {
-                    won_sortition = true;
-                }
             } else {
                 if self.is_miner {
                     info!(
                         "Received burnchain block #{} including block_commit_op - {} ({})",
                         block_height,
-                        op.input.to_testnet_address(),
+                        op.apparent_sender.to_testnet_address(),
                         &op.block_header_hash
                     );
                 }
@@ -1212,7 +1207,7 @@ impl InitializedNeonNode {
         // no-op on UserBurnSupport ops are not supported / produced at this point.
         self.last_burn_block = Some(block_snapshot);
 
-        (last_sortitioned_block.map(|x| x.0), won_sortition)
+        last_sortitioned_block.map(|x| x.0)
     }
 }
 

--- a/testnet/stacks-node/src/node.rs
+++ b/testnet/stacks-node/src/node.rs
@@ -404,7 +404,7 @@ impl Node {
                 BlockstackOperationType::LeaderBlockCommit(ref op) => {
                     if op.txid == burnchain_tip.block_snapshot.winning_block_txid {
                         last_sortitioned_block = Some(burnchain_tip.clone());
-                        if op.input == self.keychain.get_burnchain_signer() {
+                        if op.apparent_sender == self.keychain.get_burnchain_signer() {
                             won_sortition = true;
                         }
                     }
@@ -724,7 +724,8 @@ impl Node {
             sunset_burn: 0,
             block_header_hash,
             burn_fee,
-            input: self.keychain.get_burnchain_signer(),
+            input: (Txid([0; 32]), 0),
+            apparent_sender: self.keychain.get_burnchain_signer(),
             key_block_ptr: key.block_height as u32,
             key_vtxindex: key.op_vtxindex as u16,
             memo: vec![],


### PR DESCRIPTION
## Description

This implements mean of min and median block mining #1315.

There's a couple things happening in this PR:

1. Identification of miners is done through UTXO chaining.
2. User burn operations may identify multiple block commits (the prior implementation relied on VRF key validation, which cannot be done before Stacks block reveal)
3. The burn distribution is calculated using a mean of min and median burns over a 6-block window.

## Type of Change
- New feature

## Does this introduce a breaking change?

Yes -- this is a consensus breaking change. Miners _do not_ need to change their behavior, though doing so would probably be advantageous.

## Testing information

There's unit test coverage for the new implementation of `BurnSamplePoint::make_min_median_distribution`. Integration with the sortdb / burnchain processing code is covered by existing integration tests (the integration itself is checked using panicking assertions in the new `BurnSamplePoint::make_min_median_distribution` function).