### PR TITLE
Cost-tracking: #2042, intercepting contract-call costs

### DIFF
--- a/src/vm/analysis/type_checker/mod.rs
+++ b/src/vm/analysis/type_checker/mod.rs
@@ -33,7 +33,7 @@ use vm::representations::{depth_traverse, ClarityName, SymbolicExpression};
 use vm::types::signatures::{FunctionSignature, BUFF_20};
 use vm::types::{
     parse_name_type_pairs, FixedFunction, FunctionArg, FunctionType, PrincipalData,
-    TupleTypeSignature, TypeSignature, Value,
+    QualifiedContractIdentifier, TupleTypeSignature, TypeSignature, Value,
 };
 use vm::variables::NativeVariables;
 
@@ -97,6 +97,15 @@ impl CostTracker for TypeChecker<'_, '_> {
     }
     fn reset_memory(&mut self) {
         self.cost_track.reset_memory()
+    }
+    fn short_circuit_contract_call(
+        &mut self,
+        contract: &QualifiedContractIdentifier,
+        function: &ClarityName,
+        input: &[u64],
+    ) -> std::result::Result<bool, CostErrors> {
+        self.cost_track
+            .short_circuit_contract_call(contract, function, input)
     }
 }
 

--- a/src/vm/callables.rs
+++ b/src/vm/callables.rs
@@ -43,14 +43,14 @@ pub enum CallableType {
     ),
 }
 
-#[derive(Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum DefineType {
     ReadOnly,
     Public,
     Private,
 }
 
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DefinedFunction {
     identifier: FunctionIdentifier,
     name: ClarityName,

--- a/src/vm/contexts.rs
+++ b/src/vm/contexts.rs
@@ -60,7 +60,7 @@ pub struct Environment<'a, 'b> {
 }
 
 pub struct OwnedEnvironment<'a> {
-    pub context: GlobalContext<'a>,
+    context: GlobalContext<'a>,
     default_contract: ContractContext,
     call_stack: CallStack,
 }

--- a/src/vm/contexts.rs
+++ b/src/vm/contexts.rs
@@ -17,6 +17,7 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::convert::TryInto;
 use std::fmt;
+use std::mem::replace;
 
 use vm::ast;
 use vm::ast::ContractAST;
@@ -59,7 +60,7 @@ pub struct Environment<'a, 'b> {
 }
 
 pub struct OwnedEnvironment<'a> {
-    context: GlobalContext<'a>,
+    pub context: GlobalContext<'a>,
     default_contract: ContractContext,
     call_stack: CallStack,
 }
@@ -644,6 +645,16 @@ impl CostTracker for Environment<'_, '_> {
     fn reset_memory(&mut self) {
         self.global_context.cost_track.reset_memory()
     }
+    fn short_circuit_contract_call(
+        &mut self,
+        contract: &QualifiedContractIdentifier,
+        function: &ClarityName,
+        input: &[u64],
+    ) -> std::result::Result<bool, CostErrors> {
+        self.global_context
+            .cost_track
+            .short_circuit_contract_call(contract, function, input)
+    }
 }
 
 impl CostTracker for GlobalContext<'_> {
@@ -666,6 +677,15 @@ impl CostTracker for GlobalContext<'_> {
     }
     fn reset_memory(&mut self) {
         self.cost_track.reset_memory()
+    }
+    fn short_circuit_contract_call(
+        &mut self,
+        contract: &QualifiedContractIdentifier,
+        function: &ClarityName,
+        input: &[u64],
+    ) -> std::result::Result<bool, CostErrors> {
+        self.cost_track
+            .short_circuit_contract_call(contract, function, input)
     }
 }
 
@@ -776,6 +796,23 @@ impl<'a, 'b> Environment<'a, 'b> {
         }
         let local_context = LocalContext::new();
         let result = { eval(&parsed[0], self, &local_context) };
+        result
+    }
+
+    /// Used only for contract-call! cost short-circuiting. Once the short-circuited cost
+    ///  has been evaluated and assessed, the contract-call! itself is executed "for free".
+    pub fn run_free<F, A>(&mut self, to_run: F) -> A
+    where
+        F: FnOnce(&mut Environment) -> A,
+    {
+        let original_tracker = replace(
+            &mut self.global_context.cost_track,
+            LimitedCostTracker::new_free(),
+        );
+        // note: it is important that this method not return until original_tracker has been
+        //  restored. DO NOT use the try syntax (?).
+        let result = to_run(self);
+        self.global_context.cost_track = original_tracker;
         result
     }
 

--- a/src/vm/costs/mod.rs
+++ b/src/vm/costs/mod.rs
@@ -33,7 +33,7 @@ use vm::database::{marf::NullBackingStore, ClarityDatabase, MemoryBackingStore};
 use vm::errors::{Error, InterpreterResult};
 use vm::types::Value::UInt;
 use vm::types::{QualifiedContractIdentifier, TypeSignature, NONE};
-use vm::{ast, eval_all, SymbolicExpression, Value};
+use vm::{ast, eval_all, ClarityName, SymbolicExpression, Value};
 
 type Result<T> = std::result::Result<T, CostErrors>;
 
@@ -92,6 +92,15 @@ pub trait CostTracker {
     fn add_memory(&mut self, memory: u64) -> Result<()>;
     fn drop_memory(&mut self, memory: u64);
     fn reset_memory(&mut self);
+    /// Check if the given contract-call should be short-circuited.
+    ///  If so: this charges the cost to the CostTracker, and return true
+    ///  If not: return false
+    fn short_circuit_contract_call(
+        &mut self,
+        contract: &QualifiedContractIdentifier,
+        function: &ClarityName,
+        input: &[u64],
+    ) -> Result<bool>;
 }
 
 // Don't track!
@@ -111,6 +120,14 @@ impl CostTracker for () {
     }
     fn drop_memory(&mut self, _memory: u64) {}
     fn reset_memory(&mut self) {}
+    fn short_circuit_contract_call(
+        &mut self,
+        _contract: &QualifiedContractIdentifier,
+        _function: &ClarityName,
+        _input: &[u64],
+    ) -> Result<bool> {
+        Ok(false)
+    }
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
@@ -134,12 +151,12 @@ impl ClarityCostFunctionReference {
     }
 }
 
-type ClarityCostContract = &'static str;
-
 #[derive(Clone)]
 pub struct LimitedCostTracker {
     cost_function_references: HashMap<&'static ClarityCostFunction, ClarityCostFunctionReference>,
     cost_contracts: HashMap<QualifiedContractIdentifier, ContractContext>,
+    pub contract_call_circuits:
+        HashMap<(QualifiedContractIdentifier, ClarityName), ClarityCostFunctionReference>,
     total: ExecutionCost,
     limit: ExecutionCost,
     memory: u64,
@@ -185,6 +202,7 @@ impl LimitedCostTracker {
         let mut cost_tracker = LimitedCostTracker {
             cost_function_references: HashMap::new(),
             cost_contracts: HashMap::new(),
+            contract_call_circuits: HashMap::new(),
             limit,
             memory_limit: CLARITY_MEMORY_LIMIT,
             total: ExecutionCost::zero(),
@@ -195,22 +213,13 @@ impl LimitedCostTracker {
         Ok(cost_tracker)
     }
     pub fn new_max_limit(clarity_db: &mut ClarityDatabase) -> Result<LimitedCostTracker> {
-        let mut cost_tracker = LimitedCostTracker {
-            cost_function_references: HashMap::new(),
-            cost_contracts: HashMap::new(),
-            limit: ExecutionCost::max_value(),
-            total: ExecutionCost::zero(),
-            memory: 0,
-            memory_limit: CLARITY_MEMORY_LIMIT,
-            free: false,
-        };
-        cost_tracker.load_boot_costs(clarity_db)?;
-        Ok(cost_tracker)
+        LimitedCostTracker::new(ExecutionCost::max_value(), clarity_db)
     }
     pub fn new_free() -> LimitedCostTracker {
         LimitedCostTracker {
             cost_function_references: HashMap::new(),
             cost_contracts: HashMap::new(),
+            contract_call_circuits: HashMap::new(),
             limit: ExecutionCost::max_value(),
             total: ExecutionCost::zero(),
             memory: 0,
@@ -261,7 +270,7 @@ impl LimitedCostTracker {
 }
 
 fn parse_cost(
-    cost_function: ClarityCostFunction,
+    cost_function_name: &str,
     eval_result: InterpreterResult<Option<Value>>,
 ) -> Result<ExecutionCost> {
     match eval_result {
@@ -301,36 +310,26 @@ fn parse_cost(
         )),
         Err(e) => Err(CostErrors::CostComputationFailed(format!(
             "Error evaluating result of cost function {}: {}",
-            cost_function.get_name(),
-            e
+            cost_function_name, e
         ))),
     }
 }
 
 fn compute_cost(
     cost_tracker: &mut LimitedCostTracker,
-    cost_function: ClarityCostFunction,
+    cost_function_reference: ClarityCostFunctionReference,
     input_size: u64,
 ) -> Result<ExecutionCost> {
     let mut null_store = NullBackingStore::new();
     let conn = null_store.as_clarity_db();
     let mut global_context = GlobalContext::new(conn, LimitedCostTracker::new_free());
 
-    let cost_function_reference = cost_tracker
-        .cost_function_references
-        .get(&cost_function)
-        .ok_or(CostErrors::CostComputationFailed(format!(
-            "CostFunction not defined: {}",
-            &cost_function
-        )))?
-        .clone();
-
     let cost_contract = cost_tracker
         .cost_contracts
         .get_mut(&cost_function_reference.contract_id)
         .ok_or(CostErrors::CostComputationFailed(format!(
-            "CostFunction not found: {} at {}",
-            &cost_function, &cost_function_reference
+            "CostFunction not found: {}",
+            &cost_function_reference
         )))?;
 
     let program = vec![
@@ -342,7 +341,7 @@ fn compute_cost(
 
     let eval_result = eval_all(&function_invocation, cost_contract, &mut global_context);
 
-    parse_cost(cost_function, eval_result)
+    parse_cost(&cost_function_reference.to_string(), eval_result)
 }
 
 fn add_cost(
@@ -385,7 +384,16 @@ impl CostTracker for LimitedCostTracker {
         if self.free {
             return Ok(ExecutionCost::zero());
         }
-        compute_cost(self, cost_function, input)
+        let cost_function_ref = self
+            .cost_function_references
+            .get(&cost_function)
+            .ok_or(CostErrors::CostComputationFailed(format!(
+                "CostFunction not defined: {}",
+                &cost_function
+            )))?
+            .clone();
+
+        compute_cost(self, cost_function_ref, input)
     }
     fn add_cost(&mut self, cost: ExecutionCost) -> std::result::Result<(), CostErrors> {
         if self.free {
@@ -407,6 +415,26 @@ impl CostTracker for LimitedCostTracker {
     fn reset_memory(&mut self) {
         if !self.free {
             self.memory = 0;
+        }
+    }
+    fn short_circuit_contract_call(
+        &mut self,
+        contract: &QualifiedContractIdentifier,
+        function: &ClarityName,
+        input: &[u64],
+    ) -> Result<bool> {
+        if self.free {
+            // if we're already free, no need to worry about short circuiting contract-calls
+            return Ok(false);
+        }
+        // grr, if HashMap::get didn't require Borrow, we wouldn't need this cloning.
+        let lookup_key = (contract.clone(), function.clone());
+        if let Some(cost_function) = self.contract_call_circuits.get(&lookup_key).cloned() {
+            let input_size = input.iter().fold(0, |agg, cur| agg + cur);
+            compute_cost(self, cost_function, input_size)?;
+            Ok(true)
+        } else {
+            Ok(false)
         }
     }
 }
@@ -417,32 +445,27 @@ impl CostTracker for &mut LimitedCostTracker {
         cost_function: ClarityCostFunction,
         input: u64,
     ) -> std::result::Result<ExecutionCost, CostErrors> {
-        if self.free {
-            return Ok(ExecutionCost::zero());
-        }
-        compute_cost(self, cost_function, input)
+        LimitedCostTracker::compute_cost(self, cost_function, input)
     }
     fn add_cost(&mut self, cost: ExecutionCost) -> std::result::Result<(), CostErrors> {
-        if self.free {
-            return Ok(());
-        }
-        add_cost(self, cost)
+        LimitedCostTracker::add_cost(self, cost)
     }
     fn add_memory(&mut self, memory: u64) -> std::result::Result<(), CostErrors> {
-        if self.free {
-            return Ok(());
-        }
-        add_memory(self, memory)
+        LimitedCostTracker::add_memory(self, memory)
     }
     fn drop_memory(&mut self, memory: u64) {
-        if !self.free {
-            drop_memory(self, memory)
-        }
+        LimitedCostTracker::drop_memory(self, memory)
     }
     fn reset_memory(&mut self) {
-        if !self.free {
-            self.memory = 0;
-        }
+        LimitedCostTracker::reset_memory(self)
+    }
+    fn short_circuit_contract_call(
+        &mut self,
+        contract: &QualifiedContractIdentifier,
+        function: &ClarityName,
+        input: &[u64],
+    ) -> Result<bool> {
+        LimitedCostTracker::short_circuit_contract_call(self, contract, function, input)
     }
 }
 


### PR DESCRIPTION
## Description

This PR implements #2042 -- it allows a CostTracker to intercept the cost calculation of contract-call invocations when specific targets are used.

This will be used in the cost voting system to allow STX holders and miners to introduce new "native" Clarity functions by specifying a new cost for those functions.

## Type of Change
- New feature

## Does this introduce a breaking change?

No, this is not a breaking change.

## Are documentation updates required?

No.

## Testing information

This PR includes unit tests covering the behavior of the LimitedCostTracker with contract-call interceptions.
