### PR TITLE
Fix: #2053, apply should not add functions to stack while evaling args

### DIFF
--- a/src/vm/contexts.rs
+++ b/src/vm/contexts.rs
@@ -123,6 +123,7 @@ pub struct LocalContext<'a> {
 pub struct CallStack {
     stack: Vec<FunctionIdentifier>,
     set: HashSet<FunctionIdentifier>,
+    apply_depth: usize,
 }
 
 pub type StackTrace = Vec<FunctionIdentifier>;
@@ -1368,11 +1369,12 @@ impl CallStack {
         CallStack {
             stack: Vec::new(),
             set: HashSet::new(),
+            apply_depth: 0,
         }
     }
 
     pub fn depth(&self) -> usize {
-        self.stack.len()
+        self.stack.len() + self.apply_depth
     }
 
     pub fn contains(&self, function: &FunctionIdentifier) -> bool {
@@ -1384,6 +1386,14 @@ impl CallStack {
         if track {
             self.set.insert(function.clone());
         }
+    }
+
+    pub fn incr_apply_depth(&mut self) {
+        self.apply_depth += 1;
+    }
+
+    pub fn decr_apply_depth(&mut self) {
+        self.apply_depth -= 1;
     }
 
     pub fn remove(&mut self, function: &FunctionIdentifier, tracked: bool) -> Result<()> {

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -149,16 +149,15 @@ pub fn apply(
         env.call_stack.remove(&identifier, track_recursion)?;
         resp
     } else {
-        env.call_stack.insert(&identifier, track_recursion);
-
         let mut used_memory = 0;
         let mut evaluated_args = vec![];
+        env.call_stack.incr_apply_depth();
         for arg_x in args.iter() {
             let arg_value = match eval(arg_x, env, context) {
                 Ok(x) => x,
                 Err(e) => {
                     env.drop_memory(used_memory);
-                    env.call_stack.remove(&identifier, track_recursion)?;
+                    env.call_stack.decr_apply_depth();
                     return Err(e);
                 }
             };
@@ -167,13 +166,16 @@ pub fn apply(
                 Ok(_x) => {}
                 Err(e) => {
                     env.drop_memory(used_memory);
-                    env.call_stack.remove(&identifier, track_recursion)?;
+                    env.call_stack.decr_apply_depth();
                     return Err(Error::from(e));
                 }
             };
             used_memory += arg_value.get_memory_use();
             evaluated_args.push(arg_value);
         }
+        env.call_stack.decr_apply_depth();
+
+        env.call_stack.insert(&identifier, track_recursion);
         let mut resp = match function {
             CallableType::NativeFunction(_, function, cost_function) => {
                 let arg_size = evaluated_args.len();

--- a/src/vm/tests/simple_apply_eval.rs
+++ b/src/vm/tests/simple_apply_eval.rs
@@ -912,6 +912,18 @@ fn test_lets() {
 }
 
 #[test]
+fn test_2053_stacked_user_funcs() {
+    let test = "
+(define-read-only (identity (n int)) n)
+(begin (identity (identity 1)))
+";
+
+    let expectation = Value::Int(1);
+
+    assert_eq!(expectation, execute(test));
+}
+
+#[test]
 fn test_asserts() {
     let tests = [
         "(begin (asserts! (is-eq 1 1) (err 0)) (ok 1))",


### PR DESCRIPTION
## Description

Fixes #2053, by waiting until after eval'ing function arguments to put an applied function on the stack. To prevent excessive apply/eval recursion, the call stack needs to track apply-depth in addition to stack depth.

## Type of Change
- Bug fix

## Does this introduce a breaking change?
Yes, this is a consensus breaking change.

## Testing information

This includes a test that witnesses the original issue #2053, which now passes. The apply-depth change is covered by the existing tests:

```
    vm::tests::contracts::test_arg_stack_depth
    vm::tests::contracts::test_cc_stack_depth
    vm::tests::contracts::test_cc_trait_stack_depth
```

