### PR TITLE
Fix: replace loses with wins

### DIFF
--- a/sip/sip-001-burn-election.md
+++ b/sip/sip-001-burn-election.md
@@ -111,7 +111,7 @@ the risk of operating in traditional mining pools.
 In addition to helping lots of small burners mine blocks, fair mining pools
 are also used to give different block leaders a way to hedge their bets on their
 chain tips:  they can burn some cryptocurrency to competing chain tips and
-receive some of the reward if their preferred chain tip loses.  This is
+receive some of the reward if their preferred chain tip wins.  This is
 important because it gives frequent leaders a way to reduce the variance of
 their block rewards.
 


### PR DESCRIPTION
## Description

User support burns cause payouts if the supported tip wins, not loses.

This PR
* changes this in the section 5. Fair mining pools. The detailed description is correct.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [x] API reference/documentation update
- [ ] Other

## Checklist
- [x] Tag 1 of @diwakergupta 
