### PR TITLE
Fix URL for simple follower mode

### DIFF
--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -176,7 +176,7 @@ impl ConfigFile {
             mode: Some("xenon".to_string()),
             rpc_port: Some(18332),
             peer_port: Some(18333),
-            peer_host: Some("xenon.blockstack.org".to_string()),
+            peer_host: Some("bitcoind.xenon.blockstack.org".to_string()),
             ..BurnchainConfigFile::default()
         };
 


### PR DESCRIPTION
Fixing

```bash
stacks-node xenon
```

so we have a one-liner for spinning up a follower node running on Xenon