### PR TITLE
add gh workflow for updating clarity-js-sdk

### DIFF
--- a/.github/workflows/clarity-js-sdk-pr.yml
+++ b/.github/workflows/clarity-js-sdk-pr.yml
@@ -1,0 +1,50 @@
+##
+## Auto-opens a PR on the clarity-js-sdk repo to update the binary reference when a new release is published.
+##
+
+name: Open Clarity JS SDK PR
+
+env:
+  CLARITY_JS_SDK_REPOSITORY: blockstack/clarity-js-sdk
+  COMMIT_USER: Hiro DevOps
+  COMMIT_EMAIL: 45208873+blockstack-devops@users.noreply.github.com
+on:
+  release:
+    types:
+      - published
+
+jobs:      
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout latest clarity js sdk
+        uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GH_TOKEN }}
+          repository: ${{ env.CLARITY_JS_SDK_REPOSITORY }}
+          ref: master
+
+      - name: Determine Release Version
+        run: |
+          RELEASE_VERSION=$(echo ${GITHUB_REF#refs/*/} | tr / -)
+          echo "RELEASE_VERSION=$RELEASE_VERSION" >> $GITHUB_ENV
+          echo "UPDATE_BRANCH=auto/update-bin-$RELEASE_VERSION" >> $GITHUB_ENV
+
+      - name: Update SDK Tag
+        run: sed -i "s@CORE_SDK_TAG = \".*\"@CORE_SDK_TAG = \"$RELEASE_VERSION\"@g" packages/clarity-native-bin/src/index.ts
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          token: ${{ secrets.GH_TOKEN }}
+          commit-message: Update clarity-native-bin tag
+          committer: ${{ env.COMMIT_USER }} <${{ env.COMMIT_EMAIL }}>
+          author: ${{ env.COMMIT_USER }} <${{ env.COMMIT_EMAIL }}>
+          branch: ${{ env.UPDATE_BRANCH }}
+          title: "clarity-native-bin tag update: ${{ env.RELEASE_VERSION }}"
+          body: |
+            :robot: This is an automated pull request created from a new release in [stacks-blockchain](https://github.com/blockstack/stacks-blockchain/releases).
+
+            Updates the clarity-native-bin tag.
+          assignees: zone117x,hstove
+          reviewers: zone117x,hstove


### PR DESCRIPTION
## Description

Adds a new GH Action workflow which creates a PR in the clarity-js-sdk repo to update the [clarity-native-bin tag reference](https://github.com/blockstack/clarity-js-sdk/blob/master/packages/clarity-native-bin/src/index.ts#L12) in source code. This GH action will run anytime a new release is published, so it should automatically hook into our current release process through the [stacks-blockchain GH workflow](https://github.com/blockstack/stacks-blockchain/actions?query=workflow%3Astacks-blockchain).

The PR created will be auto-assigned to @hstove and @zone117x, and will need to be approved & merged.

Contributes to closing https://github.com/blockstack/clarity-js-sdk/issues/99
Once this is merged, I'll need to work on automating the NPM publish for clarity-js-sdk to close the above ticket.

cc: @friedger 

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [X] Other

## Does this introduce a breaking change?
No

## Are documentation updates required?
No
