### PR TITLE
Fix/2108

### DIFF
--- a/src/burnchains/burnchain.rs
+++ b/src/burnchains/burnchain.rs
@@ -971,7 +971,6 @@ impl Burnchain {
                 sync_height
             );
             indexer.drop_headers(sync_height)?;
-            //            burnchain_db.invalidate_headers(sync_height)?;
         }
 
         // get latest headers.

--- a/src/burnchains/burnchain.rs
+++ b/src/burnchains/burnchain.rs
@@ -971,6 +971,7 @@ impl Burnchain {
                 sync_height
             );
             indexer.drop_headers(sync_height)?;
+            //            burnchain_db.invalidate_headers(sync_height)?;
         }
 
         // get latest headers.

--- a/src/burnchains/db.rs
+++ b/src/burnchains/db.rs
@@ -117,7 +117,6 @@ CREATE TABLE burnchain_db_block_headers (
     parent_block_hash TEXT NOT NULL,
     num_txs INTEGER NOT NULL,
     timestamp INTEGER NOT NULL,
-    valid INTEGER NOT NULL,
 
     PRIMARY KEY(block_hash)
 );
@@ -136,8 +135,8 @@ impl<'a> BurnchainDBTransaction<'a> {
         header: &BurnchainBlockHeader,
     ) -> Result<i64, BurnchainError> {
         let sql = "INSERT INTO burnchain_db_block_headers
-                   (block_height, block_hash, parent_block_hash, num_txs, timestamp, valid)
-                   VALUES (?, ?, ?, ?, ?, 1)";
+                   (block_height, block_hash, parent_block_hash, num_txs, timestamp)
+                   VALUES (?, ?, ?, ?, ?)";
         let args: &[&dyn ToSql] = &[
             &u64_to_sql(header.block_height)?,
             &header.block_hash,
@@ -250,15 +249,9 @@ impl BurnchainDB {
     }
 
     pub fn get_canonical_chain_tip(&self) -> Result<BurnchainBlockHeader, BurnchainError> {
-        let qry = "SELECT * FROM burnchain_db_block_headers WHERE valid = 1 ORDER BY block_height DESC, block_hash ASC LIMIT 1";
+        let qry = "SELECT * FROM burnchain_db_block_headers ORDER BY block_height DESC, block_hash ASC LIMIT 1";
         let opt = query_row(&self.conn, qry, NO_PARAMS)?;
         Ok(opt.expect("CORRUPTION: No canonical burnchain tip"))
-    }
-
-    pub fn invalidate_headers(&self, greater_than_height: u64) -> Result<(), BurnchainError> {
-        let qry = "UPDATE burnchain_db_block_headers SET valid = 0 WHERE block_height > ?";
-        self.conn.execute(qry, &[greater_than_height as i64])?;
-        Ok(())
     }
 
     pub fn get_burnchain_block(

--- a/src/chainstate/coordinator/mod.rs
+++ b/src/chainstate/coordinator/mod.rs
@@ -466,22 +466,20 @@ impl<'a, T: BlockEventDispatcher, N: CoordinatorNotices, U: RewardSetProvider>
     pub fn handle_new_burnchain_block(&mut self) -> Result<(), Error> {
         // Retrieve canonical burnchain chain tip from the BurnchainBlocksDB
         let canonical_burnchain_tip = self.burnchain_blocks_db.get_canonical_chain_tip()?;
-
-        // Retrieve canonical pox id (<=> reward cycle id)
-        let mut canonical_sortition_tip = self
-            .canonical_sortition_tip
-            .clone()
-            .expect("FAIL: no canonical sortition tip");
+        debug!("Handle new canonical burnchain tip";
+               "height" => %canonical_burnchain_tip.block_height,
+               "block_hash" => %canonical_burnchain_tip.block_hash.to_string());
 
         // Retrieve all the direct ancestors of this block with an unprocessed sortition
         let mut cursor = canonical_burnchain_tip.block_hash.clone();
         let mut sortitions_to_process = VecDeque::new();
 
         // We halt the ancestry research as soon as we find a processed parent
-        while !(self
-            .sortition_db
-            .is_sortition_processed(&cursor, &canonical_sortition_tip)?)
-        {
+        let mut last_processed_ancestor = loop {
+            if let Some(found_sortition) = self.sortition_db.is_sortition_processed(&cursor)? {
+                break found_sortition;
+            }
+
             let current_block = self
                 .burnchain_blocks_db
                 .get_burnchain_block(&cursor)
@@ -496,20 +494,24 @@ impl<'a, T: BlockEventDispatcher, N: CoordinatorNotices, U: RewardSetProvider>
             let parent = current_block.header.parent_block_hash.clone();
             sortitions_to_process.push_front(current_block);
             cursor = parent;
-        }
+        };
 
-        for unprocessed_block in sortitions_to_process.drain(..) {
+        let burn_header_hashes: Vec<_> = sortitions_to_process
+            .iter()
+            .map(|block| block.header.block_hash.to_string())
+            .collect();
+
+        debug!(
+            "Unprocessed burn chain blocks [{}]",
+            burn_header_hashes.join(", ")
+        );
+
+        for unprocessed_block in sortitions_to_process.into_iter() {
             let BurnchainBlockData { header, ops } = unprocessed_block;
 
             if let Some(dispatcher) = self.dispatcher {
                 dispatcher_announce_burn_ops(dispatcher, &header, &ops);
             }
-
-            let sortition_tip_snapshot = SortitionDB::get_block_snapshot(
-                self.sortition_db.conn(),
-                &canonical_sortition_tip,
-            )?
-            .expect("BUG: no data for sortition");
 
             // at this point, we need to figure out if the sortition we are
             //  about to process is the first block in reward cycle.
@@ -520,7 +522,7 @@ impl<'a, T: BlockEventDispatcher, N: CoordinatorNotices, U: RewardSetProvider>
                     &header,
                     ops,
                     &self.burnchain,
-                    &canonical_sortition_tip,
+                    &last_processed_ancestor,
                     reward_cycle_info,
                 )
                 .map_err(|e| {
@@ -534,15 +536,17 @@ impl<'a, T: BlockEventDispatcher, N: CoordinatorNotices, U: RewardSetProvider>
             self.notifier.notify_sortition_processed();
 
             debug!(
-                "Sortition processed: {} (tip {} height {})",
-                &sortition_id, &next_snapshot.burn_header_hash, next_snapshot.block_height
+                "Sortition processed";
+                "sortition_id" => &sortition_id.to_string(),
+                "burn_header_hash" => &next_snapshot.burn_header_hash.to_string(),
+                "burn_height" => next_snapshot.block_height
             );
 
-            if sortition_tip_snapshot.block_height < header.block_height {
-                // bump canonical sortition...
-                self.canonical_sortition_tip = Some(sortition_id.clone());
-                canonical_sortition_tip = sortition_id;
-            }
+            // always bump canonical sortition tip:
+            //   if this code path is invoked, the canonical burnchain tip
+            //   has moved, so we should move our canonical sortition tip as well.
+            self.canonical_sortition_tip = Some(sortition_id.clone());
+            last_processed_ancestor = sortition_id;
 
             if let Some(pox_anchor) = self.process_ready_blocks()? {
                 return self.process_new_pox_anchor(pox_anchor);

--- a/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
+++ b/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
@@ -47,6 +47,9 @@ use stacks::util::sleep_ms;
 
 use stacks::monitoring::{increment_btc_blocks_received_counter, increment_btc_ops_sent_counter};
 
+#[cfg(test)]
+use stacks::burnchains::BurnchainHeaderHash;
+
 pub struct BitcoinRegtestController {
     config: Config,
     indexer_config: BitcoinIndexerConfig,
@@ -850,6 +853,40 @@ impl BitcoinRegtestController {
             Ok(_) => {}
             Err(e) => {
                 error!("Bitcoin RPC failure: error generating block {:?}", e);
+                panic!();
+            }
+        }
+    }
+
+    #[cfg(test)]
+    pub fn invalidate_block(&self, block: &BurnchainHeaderHash) {
+        info!("Invalidating block {}", &block);
+        let request = BitcoinRPCRequest {
+            method: "invalidateblock".into(),
+            params: vec![json!(&block.to_string())],
+            id: "stacks-forker".into(),
+            jsonrpc: "2.0".into(),
+        };
+        if let Err(e) = BitcoinRPCRequest::send(&self.config, request) {
+            error!("Bitcoin RPC failure: error invalidating block {:?}", e);
+            panic!();
+        }
+    }
+
+    #[cfg(test)]
+    pub fn get_block_hash(&self, height: u64) -> BurnchainHeaderHash {
+        let request = BitcoinRPCRequest {
+            method: "getblockhash".into(),
+            params: vec![json!(height)],
+            id: "stacks-forker".into(),
+            jsonrpc: "2.0".into(),
+        };
+        match BitcoinRPCRequest::send(&self.config, request) {
+            Ok(v) => {
+                BurnchainHeaderHash::from_hex(v.get("result").unwrap().as_str().unwrap()).unwrap()
+            }
+            Err(e) => {
+                error!("Bitcoin RPC failure: error invalidating block {:?}", e);
                 panic!();
             }
         }

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -1,6 +1,7 @@
 use super::{BurnchainController, BurnchainTip, Config, EventDispatcher, Keychain};
 use crate::config::HELIUM_BLOCK_LIMIT;
 use crate::run_loop::RegisteredKey;
+use std::collections::HashMap;
 
 use std::cmp;
 use std::collections::VecDeque;
@@ -401,7 +402,8 @@ fn spawn_miner_relayer(
     let mut mem_pool = MemPoolDB::open(false, TESTNET_CHAIN_ID, &stacks_chainstate_path)
         .map_err(NetError::DBError)?;
 
-    let mut last_mined_blocks = vec![];
+    let mut last_mined_blocks: HashMap<BurnchainHeaderHash, Vec<AssembledAnchorBlock>> =
+        HashMap::new();
     let burn_fee_cap = config.burnchain.burn_fee_cap;
     let mine_microblocks = config.node.mine_microblocks;
 
@@ -432,155 +434,172 @@ fn spawn_miner_relayer(
                 }
                 RelayerDirective::ProcessTenure(consensus_hash, burn_hash, block_header_hash) => {
                     debug!("Relayer: Process tenure");
-                    for last_mined_block in last_mined_blocks.drain(..) {
-                        let AssembledAnchorBlock {
-                            parent_consensus_hash,
-                            anchored_block: mined_block,
-                            my_burn_hash: mined_burn_hash,
-                            consumed_execution,
-                            bytes_so_far,
-                            attempt: _,
-                        } = last_mined_block;
-                        if mined_block.block_hash() == block_header_hash
-                            && burn_hash == mined_burn_hash
-                        {
-                            // we won!
-                            info!(
-                                "Won sortition! stacks_header={}, burn_hash={}",
-                                block_header_hash, mined_burn_hash
-                            );
-
-                            increment_stx_blocks_mined_counter();
-
-                            match inner_process_tenure(
-                                &mined_block,
-                                &consensus_hash,
-                                &parent_consensus_hash,
-                                &mut sortdb,
-                                &mut chainstate,
-                                &coord_comms,
-                            ) {
-                                Ok(coordinator_running) => {
-                                    if !coordinator_running {
-                                        warn!("Coordinator stopped, stopping relayer thread...");
-                                        return;
-                                    }
-                                }
-                                Err(e) => {
-                                    warn!("Error processing my tenure, bad block produced: {}", e);
-                                    warn!(
-                                        "Bad block stacks_header={}, data={}",
-                                        block_header_hash,
-                                        to_hex(&mined_block.serialize_to_vec())
-                                    );
-                                    continue;
-                                }
-                            };
-
-                            // advertize _and_ push blocks for now
-                            let blocks_available = Relayer::load_blocks_available_data(
-                                &sortdb,
-                                vec![consensus_hash.clone()],
-                            )
-                            .expect("Failed to obtain block information for a block we mined.");
-                            if let Err(e) = relayer.advertize_blocks(blocks_available) {
-                                warn!("Failed to advertise new block: {}", e);
-                            }
-
-                            let snapshot = SortitionDB::get_block_snapshot_consensus(
-                                sortdb.conn(),
-                                &consensus_hash,
-                            )
-                            .expect("Failed to obtain snapshot for block")
-                            .expect("Failed to obtain snapshot for block");
-
-                            if !snapshot.pox_valid {
-                                warn!(
-                                    "Snapshot for {} is no longer valid; discarding {}...",
-                                    &consensus_hash,
-                                    &mined_block.block_hash()
+                    if let Some(last_mined_blocks_at_burn_hash) =
+                        last_mined_blocks.remove(&burn_hash)
+                    {
+                        for last_mined_block in last_mined_blocks_at_burn_hash.into_iter() {
+                            let AssembledAnchorBlock {
+                                parent_consensus_hash,
+                                anchored_block: mined_block,
+                                my_burn_hash: mined_burn_hash,
+                                consumed_execution,
+                                bytes_so_far,
+                                attempt: _,
+                            } = last_mined_block;
+                            if mined_block.block_hash() == block_header_hash
+                                && burn_hash == mined_burn_hash
+                            {
+                                // we won!
+                                info!("Won sortition!";
+                                      "stacks_header" => %block_header_hash,
+                                      "burn_hash" => %mined_burn_hash,
                                 );
-                            } else {
-                                if let Err(e) =
-                                    relayer.broadcast_block(snapshot.consensus_hash, mined_block)
-                                {
-                                    warn!("Failed to push new block: {}", e);
-                                } else {
-                                    // should we broadcast microblocks?
-                                    if mine_microblocks {
-                                        let mint_result =
-                                            InitializedNeonNode::relayer_mint_microblocks(
-                                                &consensus_hash,
-                                                &block_header_hash,
-                                                &mut chainstate,
-                                                &sortdb.index_conn(),
-                                                &keychain,
-                                                consumed_execution,
-                                                bytes_so_far,
-                                                &mem_pool,
+
+                                increment_stx_blocks_mined_counter();
+
+                                match inner_process_tenure(
+                                    &mined_block,
+                                    &consensus_hash,
+                                    &parent_consensus_hash,
+                                    &mut sortdb,
+                                    &mut chainstate,
+                                    &coord_comms,
+                                ) {
+                                    Ok(coordinator_running) => {
+                                        if !coordinator_running {
+                                            warn!(
+                                                "Coordinator stopped, stopping relayer thread..."
                                             );
-                                        let mined_microblock = match mint_result {
-                                            Ok(mined_microblock) => mined_microblock,
-                                            Err(e) => {
-                                                warn!("Failed to mine microblock: {}", e);
-                                                continue;
-                                            }
-                                        };
-                                        // preprocess the microblock locally
-                                        match chainstate.preprocess_streamed_microblock(
-                                            &consensus_hash,
-                                            &block_header_hash,
-                                            &mined_microblock,
-                                        ) {
-                                            Ok(res) => {
-                                                if !res {
-                                                    warn!("Unhandled error while pre-processing microblock {}",
-                                                          mined_microblock.header.block_hash());
+                                            return;
+                                        }
+                                    }
+                                    Err(e) => {
+                                        warn!(
+                                            "Error processing my tenure, bad block produced: {}",
+                                            e
+                                        );
+                                        warn!(
+                                            "Bad block";
+                                            "stacks_header" => %block_header_hash,
+                                            "data" => %to_hex(&mined_block.serialize_to_vec()),
+                                        );
+                                        continue;
+                                    }
+                                };
+
+                                // advertize _and_ push blocks for now
+                                let blocks_available = Relayer::load_blocks_available_data(
+                                    &sortdb,
+                                    vec![consensus_hash.clone()],
+                                )
+                                .expect("Failed to obtain block information for a block we mined.");
+                                if let Err(e) = relayer.advertize_blocks(blocks_available) {
+                                    warn!("Failed to advertise new block: {}", e);
+                                }
+
+                                let snapshot = SortitionDB::get_block_snapshot_consensus(
+                                    sortdb.conn(),
+                                    &consensus_hash,
+                                )
+                                .expect("Failed to obtain snapshot for block")
+                                .expect("Failed to obtain snapshot for block");
+
+                                if !snapshot.pox_valid {
+                                    warn!(
+                                        "Snapshot for {} is no longer valid; discarding {}...",
+                                        &consensus_hash,
+                                        &mined_block.block_hash()
+                                    );
+                                } else {
+                                    if let Err(e) = relayer
+                                        .broadcast_block(snapshot.consensus_hash, mined_block)
+                                    {
+                                        warn!("Failed to push new block: {}", e);
+                                    } else {
+                                        // should we broadcast microblocks?
+                                        if mine_microblocks {
+                                            let mint_result =
+                                                InitializedNeonNode::relayer_mint_microblocks(
+                                                    &consensus_hash,
+                                                    &block_header_hash,
+                                                    &mut chainstate,
+                                                    &sortdb.index_conn(),
+                                                    &keychain,
+                                                    consumed_execution,
+                                                    bytes_so_far,
+                                                    &mem_pool,
+                                                );
+                                            let mined_microblock = match mint_result {
+                                                Ok(mined_microblock) => mined_microblock,
+                                                Err(e) => {
+                                                    warn!("Failed to mine microblock: {}", e);
                                                     continue;
                                                 }
-                                            }
-                                            Err(e) => {
-                                                error!(
+                                            };
+                                            // preprocess the microblock locally
+                                            match chainstate.preprocess_streamed_microblock(
+                                                &consensus_hash,
+                                                &block_header_hash,
+                                                &mined_microblock,
+                                            ) {
+                                                Ok(res) => {
+                                                    if !res {
+                                                        warn!("Unhandled error while pre-processing microblock {}",
+                                                          mined_microblock.header.block_hash());
+                                                        continue;
+                                                    }
+                                                }
+                                                Err(e) => {
+                                                    error!(
                                                     "Error while pre-processing microblock {}: {}",
                                                     mined_microblock.header.block_hash(),
                                                     e
                                                 );
-                                                continue;
+                                                    continue;
+                                                }
                                             }
-                                        }
-                                        // update unconfirmed state
-                                        if let Err(e) = chainstate
-                                            .refresh_unconfirmed_state(&sortdb.index_conn())
-                                        {
-                                            warn!("Failed to refresh unconfirmed state after processing microblock {}/{}-{}: {:?}", &mined_burn_hash, &block_header_hash, mined_microblock.block_hash(), &e);
-                                        }
-                                        // broadcast to peers
-                                        let microblock_hash = mined_microblock.header.block_hash();
-                                        if let Err(e) = relayer.broadcast_microblock(
-                                            &consensus_hash,
-                                            &block_header_hash,
-                                            mined_microblock,
-                                        ) {
-                                            error!(
-                                                "Failure trying to broadcast microblock {}: {}",
-                                                microblock_hash, e
-                                            );
+                                            // update unconfirmed state
+                                            if let Err(e) = chainstate
+                                                .refresh_unconfirmed_state(&sortdb.index_conn())
+                                            {
+                                                warn!("Failed to refresh unconfirmed state after processing microblock {}/{}-{}: {:?}", &mined_burn_hash, &block_header_hash, mined_microblock.block_hash(), &e);
+                                            }
+                                            // broadcast to peers
+                                            let microblock_hash =
+                                                mined_microblock.header.block_hash();
+                                            if let Err(e) = relayer.broadcast_microblock(
+                                                &consensus_hash,
+                                                &block_header_hash,
+                                                mined_microblock,
+                                            ) {
+                                                error!(
+                                                    "Failure trying to broadcast microblock {}: {}",
+                                                    microblock_hash, e
+                                                );
+                                            }
                                         }
                                     }
                                 }
-                            }
-                        } else {
-                            debug!("Did not win sortition, my blocks [burn_hash= {}, block_hash= {}], their blocks [parent_consenus_hash= {}, burn_hash= {}, block_hash ={}]",
+                            } else {
+                                debug!("Did not win sortition, my blocks [burn_hash= {}, block_hash= {}], their blocks [parent_consenus_hash= {}, burn_hash= {}, block_hash ={}]",
                                   mined_burn_hash, mined_block.block_hash(), parent_consensus_hash, burn_hash, block_header_hash);
+                            }
                         }
                     }
-                    last_mined_blocks.clear();
                 }
                 RelayerDirective::RunTenure(registered_key, last_burn_block) => {
+                    let burn_header_hash = last_burn_block.burn_header_hash.clone();
+
                     debug!(
-                        "Relayer: Run tenure at height {} ({})",
-                        last_burn_block.block_height, &last_burn_block.burn_header_hash
+                        "Relayer: Run tenure";
+                        "height" => last_burn_block.block_height,
+                        "burn_header_hash" => %burn_header_hash
                     );
+
+                    let mut last_mined_blocks_vec = last_mined_blocks
+                        .remove(&burn_header_hash)
+                        .unwrap_or_default();
+
                     let last_mined_block_opt = InitializedNeonNode::relayer_run_tenure(
                         &config,
                         registered_key,
@@ -592,15 +611,18 @@ fn spawn_miner_relayer(
                         &mut mem_pool,
                         burn_fee_cap,
                         &mut bitcoin_controller,
-                        &last_mined_blocks,
+                        &last_mined_blocks_vec,
                     );
+
                     if let Some(last_mined_block) = last_mined_block_opt {
-                        if last_mined_blocks.len() == 0 {
+                        if last_mined_blocks_vec.len() == 0 {
                             // (for testing) only bump once per epoch
                             bump_processed_counter(&blocks_processed);
                         }
-                        last_mined_blocks.push(last_mined_block);
+                        last_mined_blocks_vec.push(last_mined_block);
                     }
+
+                    last_mined_blocks.insert(burn_header_hash, last_mined_blocks_vec);
                 }
                 RelayerDirective::RegisterKey(ref last_burn_block) => {
                     // Ensure that we're submitting this one time per block.
@@ -1155,7 +1177,9 @@ impl InitializedNeonNode {
             sunset_burn,
         );
         let mut op_signer = keychain.generate_op_signer();
-        bitcoin_controller.submit_operation(op, &mut op_signer, attempt);
+        if !bitcoin_controller.submit_operation(op, &mut op_signer, attempt) {
+            return None;
+        }
 
         Some(AssembledAnchorBlock {
             parent_consensus_hash: parent_consensus_hash,


### PR DESCRIPTION
## Description

Fixes #2108 through 2 changes in the ChainsCoordinator:

1. `is_sortition_processed` searches all sortitions for a _still_ `pox_valid` sortition at the given burnchain header hash. Previously, it only looked in the current "sortition fork" -- that's what led to the chains coordinator incorrectly concluding that a block hadn't been processed yet.
2. `canonical_sortition_tip` is _always_ updated based on the canonical burnchain tip. 

This additionally required a slight re-working of the RBF logic in the neon_node. The previous RBF logic would keep all the mined blocks in the same vec regardless of the burnchain tip at which they mined -- if a burnchain fork occurred, the "attempts" should be reset. This PR does this by keeping a map of the mined blocks at each burnchain tip. When a burnchain tip is processed, the vec for that tip is removed from the map.

## Type of Change
- [x] Bug fix

## Does this introduce a breaking change?
No -- this corrects a previously (thread) panic inducing bug, which would not create a fork, but rather just halt chain processing.

## Are documentation updates required?
No

## Testing information

This PR adds a new integration test to `neon_integrations` which uses the `invalidateblock` command to trigger a reorg in the spawned regtest bitcoind node. Without the changes in this PR, this test would cause the same behavior witnessed by the Xenon miner in #2108.