### PR TITLE
adding gh workflow for v1 -> v2 migration

### DIFF
--- a/.github/workflows/clarity-js-sdk-pr.yml
+++ b/.github/workflows/clarity-js-sdk-pr.yml
@@ -12,6 +12,7 @@ on:
   release:
     types:
       - published
+  workflow_dispatch:
 
 jobs:      
   run:

--- a/.github/workflows/stacks-blockchain.yml
+++ b/.github/workflows/stacks-blockchain.yml
@@ -166,7 +166,9 @@ jobs:
         id: create_release
         uses: actions/create-release@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Use custom secrets.GH_TOKEN instead of default secrets.GITHUB_TOKEN because the custom token will trigger the
+          # clarity-js-sdk-pr workflow. As events caused by default tokens do not trigger subsequent workflow runs to avoid loops.
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         with:
           tag_name: ${{ github.event.inputs.tag || github.ref }}
           release_name: Release ${{ github.event.inputs.tag || github.ref }}

--- a/.github/workflows/v1-v2-migration.yml
+++ b/.github/workflows/v1-v2-migration.yml
@@ -1,0 +1,74 @@
+##
+## This workflow is used to help facilitate the V1 -> V2 migration. 
+## It pulls down the latest V1 export, commits the new chainstate file to a feature branch,
+## and opens a PR against the master branch.
+##
+
+name: V1 to V2 Migration
+
+env:
+  COMMIT_USER: Hiro DevOps
+  COMMIT_EMAIL: 45208873+blockstack-devops@users.noreply.github.com
+  UPDATE_BRANCH: auto/v1-v2-migration
+  CHAINSTATE_URL: https://storage.googleapis.com/blockstack-v1-migration-data/chainstate.txt
+  CHAINSTATE_METADATA_URL: https://storage.googleapis.com/storage/v1/b/blockstack-v1-migration-data/o/chainstate.txt
+  CHAINSTATE_HASH_URL: https://storage.googleapis.com/blockstack-v1-migration-data/chainstate.txt.sha256
+  CHAINSTATE_HASH_METADATA_URL: https://storage.googleapis.com/storage/v1/b/blockstack-v1-migration-data/o/chainstate.txt.sha256
+on:
+  repository_dispatch:
+    types:
+      - migration
+
+jobs:      
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout stacks-blockchain
+        uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GH_TOKEN }}
+          ref: master
+
+      - name: Update files
+        run: |
+          curl -s ${CHAINSTATE_URL} > testnet/stacks-node/chainstate.txt
+          echo "CHAINSTATE_TIME_CREATED=$(curl -s ${CHAINSTATE_METADATA_URL} | jq -r '.timeCreated')" >> $GITHUB_ENV
+          echo "CHAINSTATE_SIZE=$(curl -s ${CHAINSTATE_METADATA_URL} | jq -r '.size')" >> $GITHUB_ENV
+          echo "CHAINSTATE_MD5=$(curl -s ${CHAINSTATE_METADATA_URL} | jq -r '.md5Hash')" >> $GITHUB_ENV
+          echo "CHAINSTATE_DOWNLOAD_LINK=$(curl -s ${CHAINSTATE_METADATA_URL} | jq -r '.mediaLink')" >> $GITHUB_ENV
+
+          curl -s ${CHAINSTATE_HASH_URL} > testnet/stacks-node/chainstate.txt.sha256
+          echo "CHAINSTATE_HASH_TIME_CREATED=$(curl -s ${CHAINSTATE_HASH_METADATA_URL} | jq -r '.timeCreated')" >> $GITHUB_ENV
+          echo "CHAINSTATE_HASH_SIZE=$(curl -s ${CHAINSTATE_HASH_METADATA_URL} | jq -r '.size')" >> $GITHUB_ENV
+          echo "CHAINSTATE_HASH_MD5=$(curl -s ${CHAINSTATE_HASH_METADATA_URL} | jq -r '.md5Hash')" >> $GITHUB_ENV
+          echo "CHAINSTATE_HASH_DOWNLOAD_LINK=$(curl -s ${CHAINSTATE_HASH_METADATA_URL} | jq -r '.mediaLink')" >> $GITHUB_ENV
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          token: ${{ secrets.GH_TOKEN }}
+          commit-message: Update v2 chainstate files
+          committer: ${{ env.COMMIT_USER }} <${{ env.COMMIT_EMAIL }}>
+          author: ${{ env.COMMIT_USER }} <${{ env.COMMIT_EMAIL }}>
+          branch: ${{ env.UPDATE_BRANCH }}
+          title: "[Stacks v1 → v2 Upgrade] Final update to chainstate files"
+          body: |
+            :robot: This is an automated pull request created from reaching the threshold of BNS names registered under the `.miner` namespace.
+
+            This PR updates the chainstate and chainstate consensus hash files to be used in the creation of the genesis block in the Stacks V2 network:
+            * [chainstate.txt](https://storage.googleapis.com/blockstack-v1-migration-data/chainstate.txt)
+                * Time created: `${{ env.CHAINSTATE_TIME_CREATED }}`
+                * File size: `${{ env.CHAINSTATE_SIZE }} bytes`
+                * MD5 Hash: `${{ env.CHAINSTATE_MD5 }}`
+                * [Download file](${{ env.CHAINSTATE_DOWNLOAD_LINK }})
+            * [chainstate.txt.sha256](https://storage.googleapis.com/blockstack-v1-migration-data/chainstate.txt.sha256)
+                * Time created: `${{ env.CHAINSTATE_HASH_TIME_CREATED }}`
+                * File size: `${{ env.CHAINSTATE_HASH_SIZE }} bytes`
+                * MD5 Hash: `${{ env.CHAINSTATE_HASH_MD5 }}`
+                * [Download file](${{ env.CHAINSTATE_HASH_DOWNLOAD_LINK }})
+
+            Once merged, a new tag will need to be created. This can be done one of two ways:
+            * Trigger this [Github workflow](https://github.com/blockstack/stacks-blockchain/actions?query=workflow%3Astacks-blockchain) from the `master` branch by selecting "Run Workflow", passing in the desired tag to be created as an argument
+            * Create the new tag from the `master` branch locally and push it up
+          assignees: jcnelson,kantai,lgalabru,diwakergupta
+          reviewers: CharlieC3,wileyj,zone117x,jcnelson,kantai,lgalabru,diwakergupta

--- a/.github/workflows/v1-v2-migration.yml
+++ b/.github/workflows/v1-v2-migration.yml
@@ -10,6 +10,7 @@ env:
   COMMIT_USER: Hiro DevOps
   COMMIT_EMAIL: 45208873+blockstack-devops@users.noreply.github.com
   UPDATE_BRANCH: auto/v1-v2-migration
+  CHAINSTATE_DIR: stx-genesis
   CHAINSTATE_URL: https://storage.googleapis.com/blockstack-v1-migration-data/chainstate.txt
   CHAINSTATE_METADATA_URL: https://storage.googleapis.com/storage/v1/b/blockstack-v1-migration-data/o/chainstate.txt
   CHAINSTATE_HASH_URL: https://storage.googleapis.com/blockstack-v1-migration-data/chainstate.txt.sha256
@@ -32,13 +33,13 @@ jobs:
 
       - name: Update files
         run: |
-          curl -s ${CHAINSTATE_URL} > testnet/stacks-node/chainstate.txt
+          curl -s ${CHAINSTATE_URL} > ${CHAINSTATE_DIR}/chainstate.txt
           echo "CHAINSTATE_TIME_CREATED=$(curl -s ${CHAINSTATE_METADATA_URL} | jq -r '.timeCreated')" >> $GITHUB_ENV
           echo "CHAINSTATE_SIZE=$(curl -s ${CHAINSTATE_METADATA_URL} | jq -r '.size')" >> $GITHUB_ENV
           echo "CHAINSTATE_MD5=$(curl -s ${CHAINSTATE_METADATA_URL} | jq -r '.md5Hash')" >> $GITHUB_ENV
           echo "CHAINSTATE_DOWNLOAD_LINK=$(curl -s ${CHAINSTATE_METADATA_URL} | jq -r '.mediaLink')" >> $GITHUB_ENV
 
-          curl -s ${CHAINSTATE_HASH_URL} > testnet/stacks-node/chainstate.txt.sha256
+          curl -s ${CHAINSTATE_HASH_URL} > ${CHAINSTATE_DIR}/chainstate.txt.sha256
           echo "CHAINSTATE_HASH_TIME_CREATED=$(curl -s ${CHAINSTATE_HASH_METADATA_URL} | jq -r '.timeCreated')" >> $GITHUB_ENV
           echo "CHAINSTATE_HASH_SIZE=$(curl -s ${CHAINSTATE_HASH_METADATA_URL} | jq -r '.size')" >> $GITHUB_ENV
           echo "CHAINSTATE_HASH_MD5=$(curl -s ${CHAINSTATE_HASH_METADATA_URL} | jq -r '.md5Hash')" >> $GITHUB_ENV

--- a/.github/workflows/v1-v2-migration.yml
+++ b/.github/workflows/v1-v2-migration.yml
@@ -33,6 +33,7 @@ jobs:
 
       - name: Update files
         run: |
+          mkdir -p ${CHAINSTATE_DIR}
           curl -s ${CHAINSTATE_URL} > ${CHAINSTATE_DIR}/chainstate.txt
           echo "CHAINSTATE_TIME_CREATED=$(curl -s ${CHAINSTATE_METADATA_URL} | jq -r '.timeCreated')" >> $GITHUB_ENV
           echo "CHAINSTATE_SIZE=$(curl -s ${CHAINSTATE_METADATA_URL} | jq -r '.size')" >> $GITHUB_ENV

--- a/.github/workflows/v1-v2-migration.yml
+++ b/.github/workflows/v1-v2-migration.yml
@@ -14,6 +14,7 @@ env:
   CHAINSTATE_METADATA_URL: https://storage.googleapis.com/storage/v1/b/blockstack-v1-migration-data/o/chainstate.txt
   CHAINSTATE_HASH_URL: https://storage.googleapis.com/blockstack-v1-migration-data/chainstate.txt.sha256
   CHAINSTATE_HASH_METADATA_URL: https://storage.googleapis.com/storage/v1/b/blockstack-v1-migration-data/o/chainstate.txt.sha256
+  MD5_VERIFY_SCRIPT_URL: https://gist.github.com/wileyj/93b4222576cb702053ebfcd3cf9f570b
 on:
   repository_dispatch:
     types:
@@ -56,15 +57,17 @@ jobs:
             :robot: This is an automated pull request created from reaching the threshold of BNS names registered under the `.miner` namespace.
 
             This PR updates the chainstate and chainstate consensus hash files to be used in the creation of the genesis block in the Stacks V2 network:
-            * [chainstate.txt](https://storage.googleapis.com/blockstack-v1-migration-data/chainstate.txt)
+            * [chainstate.txt](${{ env.CHAINSTATE_URL }})
                 * Time created: `${{ env.CHAINSTATE_TIME_CREATED }}`
                 * File size: `${{ env.CHAINSTATE_SIZE }} bytes`
                 * MD5 Hash: `${{ env.CHAINSTATE_MD5 }}`
+                    * [Verify the MD5 hash with this script](${{ env.MD5_VERIFY_SCRIPT_URL }})
                 * [Download file](${{ env.CHAINSTATE_DOWNLOAD_LINK }})
-            * [chainstate.txt.sha256](https://storage.googleapis.com/blockstack-v1-migration-data/chainstate.txt.sha256)
+            * [chainstate.txt.sha256](${{ env.CHAINSTATE_HASH_URL }})
                 * Time created: `${{ env.CHAINSTATE_HASH_TIME_CREATED }}`
                 * File size: `${{ env.CHAINSTATE_HASH_SIZE }} bytes`
                 * MD5 Hash: `${{ env.CHAINSTATE_HASH_MD5 }}`
+                    * [Verify the MD5 hash with this script](${{ env.MD5_VERIFY_SCRIPT_URL }})
                 * [Download file](${{ env.CHAINSTATE_HASH_DOWNLOAD_LINK }})
 
             Once merged, a new tag will need to be created. This can be done one of two ways:


### PR DESCRIPTION
## Description

Adds a new Github workflow to automate the change, commit, and PR creation of updating the chainstate and chainstate consensus files for the V1 -> V2 migration.

Upon an authorized `repo_dispatch` POST to this repo, the workflow will kick off. It'll download the chainstate files from GCS, commit that to a new branch created from `master`, and create a new PR displaying those changes and some metadata of the files, while assigning multiple people as reviewers and assignees.

[An example of the PR can be found here](https://github.com/blockstack/gh-action-testing/pull/1).

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [X] Other

## Does this introduce a breaking change?
No

## Are documentation updates required?
No

## Checklist
- [X] Tag 1 of @person1 or @person2
