### PR TITLE
Xenon Magic Bytes

### DIFF
--- a/src/chainstate/stacks/block.rs
+++ b/src/chainstate/stacks/block.rs
@@ -947,7 +947,6 @@ mod test {
     use burnchains::BurnchainBlockHeader;
     use burnchains::BurnchainSigner;
     use burnchains::Txid;
-    use burnchains::BLOCKSTACK_MAGIC_MAINNET;
 
     use burnchains::bitcoin::BitcoinNetworkType;
 

--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -177,6 +177,7 @@ impl ConfigFile {
             rpc_port: Some(18332),
             peer_port: Some(18333),
             peer_host: Some("bitcoind.xenon.blockstack.org".to_string()),
+            magic_bytes: Some("Xe".into()),
             ..BurnchainConfigFile::default()
         };
 
@@ -416,7 +417,14 @@ impl Config {
                     spv_headers_path: burnchain
                         .spv_headers_path
                         .unwrap_or(node.get_default_spv_headers_path()),
-                    magic_bytes: default_burnchain_config.magic_bytes,
+                    magic_bytes: burnchain
+                        .magic_bytes
+                        .map(|magic_ascii| {
+                            assert_eq!(magic_ascii.len(), 2, "Magic bytes must be length-2");
+                            assert!(magic_ascii.is_ascii(), "Magic bytes must be ASCII");
+                            MagicBytes::from(magic_ascii.as_bytes())
+                        })
+                        .unwrap_or(default_burnchain_config.magic_bytes),
                     local_mining_public_key: burnchain.local_mining_public_key,
                     burnchain_op_tx_fee: burnchain
                         .burnchain_op_tx_fee

--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -377,8 +377,15 @@ impl Config {
         };
 
         let default_burnchain_config = BurnchainConfig::default();
+
         let burnchain = match config_file.burnchain {
-            Some(burnchain) => {
+            Some(mut burnchain) => {
+                if burnchain.mode.as_deref() == Some("xenon") {
+                    if burnchain.magic_bytes.is_none() {
+                        burnchain.magic_bytes = ConfigFile::xenon().burnchain.unwrap().magic_bytes;
+                    }
+                }
+
                 BurnchainConfig {
                     chain: burnchain.chain.unwrap_or(default_burnchain_config.chain),
                     mode: burnchain.mode.unwrap_or(default_burnchain_config.mode),

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -21,7 +21,8 @@ use stacks::vm::database::ClarityDeserializable;
 use super::bitcoin_regtest::BitcoinCoreController;
 use crate::{
     config::EventKeyType, config::EventObserverConfig, config::InitialBalance, neon,
-    node::TESTNET_CHAIN_ID, BitcoinRegtestController, BurnchainController, Config, Keychain,
+    node::TESTNET_CHAIN_ID, BitcoinRegtestController, BurnchainController, Config, ConfigFile,
+    Keychain,
 };
 use stacks::net::{AccountEntryResponse, RPCPeerInfoData};
 use stacks::util::hash::bytes_to_hex;
@@ -49,6 +50,12 @@ fn neon_integration_test_conf() -> (Config, StacksAddress) {
         Some(keychain.generate_op_signer().get_public_key().to_hex());
     conf.burnchain.commit_anchor_block_within = 0;
 
+    // test to make sure config file parsing is correct
+    let magic_bytes = Config::from_config_file(ConfigFile::xenon())
+        .burnchain
+        .magic_bytes;
+    assert_eq!(magic_bytes.as_bytes(), &['X' as u8, 'e' as u8]);
+    conf.burnchain.magic_bytes = magic_bytes;
     conf.burnchain.poll_time_secs = 1;
     conf.node.pox_sync_sample_secs = 1;
 


### PR DESCRIPTION
This PR makes `next`'s Xenon mode use `Xe` as the magic bytes for Bitcoin operations.

The PR implements this by doing two things:

1. Actually parsing the `magic_bytes` field in the burnchain config from the node config file.
2. Checking if the burnchain mode is set to xenon, and if so, using the default Xenon magic bytes (this makes it so that people don't need to update their config files if they aren't running just the default xenon config).

Related: #1926 