### PR TITLE
fix: `mstx_balance` to `ustx_balance` in tomls and readmes

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ cargo testnet start --config=./testnet/stacks-node/Stacks.toml
 `Stacks.toml` is a configuration file that you can use for setting genesis balances or configuring Event observers.  You can grant an address an initial account balance by adding the following entries:
 
 ```
-[[mstx_balance]]
+[[ustx_balance]]
 address = "ST2VHM28V9E5QCRD6C73215KAPSBKQGPWTEE5CMQT"
 amount = 100000000
 ```

--- a/deployment/helm/stacks-blockchain/README.md
+++ b/deployment/helm/stacks-blockchain/README.md
@@ -86,7 +86,7 @@ The following tables lists the configurable parameters of the stacks-blockchain 
 | node.volumeMounts | Additional volumeMounts for the node | [] |
 | node.extraContainers | Additional containers to run alongside the node. Useful if adding a sidecar | [] |
 | node.initContainers | Containers which are run before the node container is started | [] |
-| config | More configs can be added than what's shown below.All children fields under the node, burnchain, and mstx_balance fields will be converted from YAML to valid TOML format in the Configmap.<br><br>For info on more available config fields, please reference to our [example config files located here](https://github.com/blockstack/stacks-blockchain/tree/master/testnet/stacks-node/conf). |  |
+| config | More configs can be added than what's shown below.All children fields under the node, burnchain, and ustx_balance fields will be converted from YAML to valid TOML format in the Configmap.<br><br>For info on more available config fields, please reference to our [example config files located here](https://github.com/blockstack/stacks-blockchain/tree/master/testnet/stacks-node/conf). |  |
 | config.node.rpc_bind |  | 0.0.0.0:20443 |
 | config.node.p2p_bind |  | 0.0.0.0:20444 |
 | config.node.seed | Replace with your private key if deploying a miner node | nil |
@@ -96,7 +96,7 @@ The following tables lists the configurable parameters of the stacks-blockchain 
 | config.burnchain.peer_host |  | bitcoind.blockstack.org |
 | config.burnchain.rpc_port |  | 18443 |
 | config.burnchain.peer_port |  | 18444 |
-| config.mstx_balance |  | See values.yaml |
+| config.ustx_balance |  | See values.yaml |
 | config.raw | Uncommenting this block will give you greater control over the settings in the Configmap | nil |
 | config.annotations | Annotations to be added to the Configmap | {} |
 | service.type | The service type to create.<br>If creating a public node for others to connect to, use Loadbalancer to ensure the advertised IP is reachable. | ClusterIP |

--- a/deployment/helm/stacks-blockchain/templates/configmap.yaml
+++ b/deployment/helm/stacks-blockchain/templates/configmap.yaml
@@ -32,8 +32,8 @@ data:
       {{- $key | nindent 4 }} = {{ $val | quote }}
     {{- end }}
   {{- end }}
-  {{ range $key, $val := .Values.config.mstx_balance }}
-    [[mstx_balance]]
+  {{ range $key, $val := .Values.config.ustx_balance }}
+    [[ustx_balance]]
     {{- range $inner_key, $inner_val := $val }}
       {{- if regexMatch "^[0-9]+$" ($inner_val | toString) }}
         {{- $inner_key | nindent 4 }} = {{ $inner_val }}

--- a/deployment/helm/stacks-blockchain/values.yaml
+++ b/deployment/helm/stacks-blockchain/values.yaml
@@ -206,7 +206,7 @@ node:
 ## You can choose to either configure the node via the following YAML fields:
 ##   * config.node
 ##   * config.burnchain
-##   * config.mstx_balance
+##   * config.ustx_balance
 ##
 ## OR you can uncomment the config.raw field, which will take precedence over the aforementationed config fields
 ##
@@ -216,7 +216,7 @@ node:
 ##
 config:
   # More configs can be added than what's shown below.
-  # All children fields under the node, burnchain, and mstx_balance fields will be converted from YAML to valid TOML format in the configmap
+  # All children fields under the node, burnchain, and ustx_balance fields will be converted from YAML to valid TOML format in the configmap
   node:
     rpc_bind: 0.0.0.0:20443 # Port should match node.rpcPort
     p2p_bind: 0.0.0.0:20444 # Port should match node.p2pPort
@@ -231,7 +231,7 @@ config:
     # commit_anchor_block_within: 10000
     rpc_port: 18443
     peer_port: 18444
-  mstx_balance:
+  ustx_balance:
     - address: STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6
       amount: "10000000000000000"
     - address: ST11NJTTKGVT6D1HY4NJRVQWMQM7TVAR091EJ8P2Y
@@ -263,16 +263,16 @@ config:
   #   rpc_port = 18443
   #   peer_port = 18444
 
-  #   [[mstx_balance]]
+  #   [[ustx_balance]]
   #   address = "STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6"
   #   amount = 10000000000000000
-  #   [[mstx_balance]]
+  #   [[ustx_balance]]
   #   address = "ST11NJTTKGVT6D1HY4NJRVQWMQM7TVAR091EJ8P2Y"
   #   amount = 10000000000000000
-  #   [[mstx_balance]]
+  #   [[ustx_balance]]
   #   address = "ST1HB1T8WRNBYB0Y3T7WXZS38NKKPTBR3EG9EPJKR"
   #   amount = 10000000000000000
-  #   [[mstx_balance]]
+  #   [[ustx_balance]]
   #   address = "STRYYQQ9M8KAF4NS7WNZQYY59X93XEKR31JP64CP"
   #   amount = 10000000000000000
 

--- a/net-test/etc/stacks-follower.toml.in
+++ b/net-test/etc/stacks-follower.toml.in
@@ -21,19 +21,19 @@ walk_interval = 10
 disable_inbound_handshakes = @@DISABLE_INBOUND_HANDSHAKES@@
 disable_inbound_walks = @@DISABLE_INBOUND_WALKS@@
 
-[[mstx_balance]]
+[[ustx_balance]]
 # Private key: b8d99fd45da58038d630d9855d3ca2466e8e0f89d3894c4724f0efc9ff4b51f001
 address = "ST2ZRX0K27GW0SP3GJCEMHD95TQGJMKB7G9Y0X1MH"
 amount = 10000000000000000
-[[mstx_balance]]
+[[ustx_balance]]
 # Private key: 3a4e84abb8abe0c1ba37cef4b604e73c82b1fe8d99015cb36b029a65099d373601
 address = "ST26FVX16539KKXZKJN098Q08HRX3XBAP541MFS0P"
 amount = 10000000000000000
-[[mstx_balance]]
+[[ustx_balance]]
 # Private key: 052cc5b8f25b1e44a65329244066f76c8057accd5316c889f476d0ea0329632c01
 address = "ST3CECAKJ4BH08JYY7W53MC81BYDT4YDA5M7S5F53"
 amount = 10000000000000000
-[[mstx_balance]]
+[[ustx_balance]]
 # Private key: 9aef533e754663a453984b69d36f109be817e9940519cc84979419e2be00864801
 address = "ST31HHVBKYCYQQJ5AQ25ZHA6W2A548ZADDQ6S16GP"
 amount = 10000000000000000

--- a/net-test/etc/stacks-master.toml.in
+++ b/net-test/etc/stacks-master.toml.in
@@ -28,19 +28,19 @@ walk_interval = 10
 disable_inbound_handshakes = @@DISABLE_INBOUND_HANDSHAKES@@
 disable_inbound_walks = @@DISABLE_INBOUND_WALKS@@
 
-[[mstx_balance]]
+[[ustx_balance]]
 # Private key: b8d99fd45da58038d630d9855d3ca2466e8e0f89d3894c4724f0efc9ff4b51f001
 address = "ST2ZRX0K27GW0SP3GJCEMHD95TQGJMKB7G9Y0X1MH"
 amount = 10000000000000000
-[[mstx_balance]]
+[[ustx_balance]]
 # Private key: 3a4e84abb8abe0c1ba37cef4b604e73c82b1fe8d99015cb36b029a65099d373601
 address = "ST26FVX16539KKXZKJN098Q08HRX3XBAP541MFS0P"
 amount = 10000000000000000
-[[mstx_balance]]
+[[ustx_balance]]
 # Private key: 052cc5b8f25b1e44a65329244066f76c8057accd5316c889f476d0ea0329632c01
 address = "ST3CECAKJ4BH08JYY7W53MC81BYDT4YDA5M7S5F53"
 amount = 10000000000000000
-[[mstx_balance]]
+[[ustx_balance]]
 # Private key: 9aef533e754663a453984b69d36f109be817e9940519cc84979419e2be00864801
 address = "ST31HHVBKYCYQQJ5AQ25ZHA6W2A548ZADDQ6S16GP"
 amount = 10000000000000000

--- a/net-test/etc/stacks-miner.toml.in
+++ b/net-test/etc/stacks-miner.toml.in
@@ -29,19 +29,19 @@ walk_interval = 10
 disable_inbound_handshakes = @@DISABLE_INBOUND_HANDSHAKES@@
 disable_inbound_walks = @@DISABLE_INBOUND_WALKS@@
 
-[[mstx_balance]]
+[[ustx_balance]]
 # Private key: b8d99fd45da58038d630d9855d3ca2466e8e0f89d3894c4724f0efc9ff4b51f001
 address = "ST2ZRX0K27GW0SP3GJCEMHD95TQGJMKB7G9Y0X1MH"
 amount = 10000000000000000
-[[mstx_balance]]
+[[ustx_balance]]
 # Private key: 3a4e84abb8abe0c1ba37cef4b604e73c82b1fe8d99015cb36b029a65099d373601
 address = "ST26FVX16539KKXZKJN098Q08HRX3XBAP541MFS0P"
 amount = 10000000000000000
-[[mstx_balance]]
+[[ustx_balance]]
 # Private key: 052cc5b8f25b1e44a65329244066f76c8057accd5316c889f476d0ea0329632c01
 address = "ST3CECAKJ4BH08JYY7W53MC81BYDT4YDA5M7S5F53"
 amount = 10000000000000000
-[[mstx_balance]]
+[[ustx_balance]]
 # Private key: 9aef533e754663a453984b69d36f109be817e9940519cc84979419e2be00864801
 address = "ST31HHVBKYCYQQJ5AQ25ZHA6W2A548ZADDQ6S16GP"
 amount = 10000000000000000

--- a/testnet/stacks-node/Stacks.toml
+++ b/testnet/stacks-node/Stacks.toml
@@ -47,22 +47,22 @@ mode = "mocknet"
 commit_anchor_block_within = 5000
 
 # These are addresses from the README.md
-[[mstx_balance]]
+[[ustx_balance]]
 # Private key: b8d99fd45da58038d630d9855d3ca2466e8e0f89d3894c4724f0efc9ff4b51f001
 address = "ST2ZRX0K27GW0SP3GJCEMHD95TQGJMKB7G9Y0X1MH"
 amount = 100000000
 
-[[mstx_balance]]
+[[ustx_balance]]
 # Private key: 3a4e84abb8abe0c1ba37cef4b604e73c82b1fe8d99015cb36b029a65099d373601
 address = "ST26FVX16539KKXZKJN098Q08HRX3XBAP541MFS0P"
 amount = 100000000
 
-[[mstx_balance]]
+[[ustx_balance]]
 # Private key: 052cc5b8f25b1e44a65329244066f76c8057accd5316c889f476d0ea0329632c01
 address = "ST3CECAKJ4BH08JYY7W53MC81BYDT4YDA5M7S5F53"
 amount = 100000000
 
-[[mstx_balance]]
+[[ustx_balance]]
 # Private key: 9aef533e754663a453984b69d36f109be817e9940519cc84979419e2be00864801
 address = "ST31HHVBKYCYQQJ5AQ25ZHA6W2A548ZADDQ6S16GP"
 amount = 100000000

--- a/testnet/stacks-node/conf/argon-follower-conf.toml
+++ b/testnet/stacks-node/conf/argon-follower-conf.toml
@@ -18,18 +18,18 @@ download_interval = 10
 walk_interval = 30
 
 
-[[mstx_balance]]
+[[ustx_balance]]
 address = "STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6"
 amount = 10000000000000000
 
-[[mstx_balance]]
+[[ustx_balance]]
 address = "ST11NJTTKGVT6D1HY4NJRVQWMQM7TVAR091EJ8P2Y"
 amount = 10000000000000000
 
-[[mstx_balance]]
+[[ustx_balance]]
 address = "ST1HB1T8WRNBYB0Y3T7WXZS38NKKPTBR3EG9EPJKR"
 amount = 10000000000000000
 
-[[mstx_balance]]
+[[ustx_balance]]
 address = "STRYYQQ9M8KAF4NS7WNZQYY59X93XEKR31JP64CP"
 amount = 10000000000000000

--- a/testnet/stacks-node/conf/krypton-follower-conf.toml
+++ b/testnet/stacks-node/conf/krypton-follower-conf.toml
@@ -11,18 +11,18 @@ rpc_port = 18443
 peer_port = 18444
 process_exit_at_block_height = 5130
 
-[[mstx_balance]]
+[[ustx_balance]]
 address = "STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6"
 amount = 10000000000000000
 
-[[mstx_balance]]
+[[ustx_balance]]
 address = "ST11NJTTKGVT6D1HY4NJRVQWMQM7TVAR091EJ8P2Y"
 amount = 10000000000000000
 
-[[mstx_balance]]
+[[ustx_balance]]
 address = "ST1HB1T8WRNBYB0Y3T7WXZS38NKKPTBR3EG9EPJKR"
 amount = 10000000000000000
 
-[[mstx_balance]]
+[[ustx_balance]]
 address = "STRYYQQ9M8KAF4NS7WNZQYY59X93XEKR31JP64CP"
 amount = 10000000000000000

--- a/testnet/stacks-node/conf/local-follower-conf.toml
+++ b/testnet/stacks-node/conf/local-follower-conf.toml
@@ -14,123 +14,123 @@ rpc_port = 28443
 peer_port = 18444
 poll_time_secs = 5
 
-[[mstx_balance]]
+[[ustx_balance]]
 # Private key: b8d99fd45da58038d630d9855d3ca2466e8e0f89d3894c4724f0efc9ff4b51f001
 address = "ST2ZRX0K27GW0SP3GJCEMHD95TQGJMKB7G9Y0X1MH"
 amount = 100000000000000
-[[mstx_balance]]
+[[ustx_balance]]
 # Private key: 3a4e84abb8abe0c1ba37cef4b604e73c82b1fe8d99015cb36b029a65099d373601
 address = "ST26FVX16539KKXZKJN098Q08HRX3XBAP541MFS0P"
 amount = 100000000000000
-[[mstx_balance]]
+[[ustx_balance]]
 # Private key: 052cc5b8f25b1e44a65329244066f76c8057accd5316c889f476d0ea0329632c01
 address = "ST3CECAKJ4BH08JYY7W53MC81BYDT4YDA5M7S5F53"
 amount = 100000000000000
-[[mstx_balance]]
+[[ustx_balance]]
 # Private key: 9aef533e754663a453984b69d36f109be817e9940519cc84979419e2be00864801
 address = "ST31HHVBKYCYQQJ5AQ25ZHA6W2A548ZADDQ6S16GP"
 amount = 100000000000000
-[[mstx_balance]]
+[[ustx_balance]]
 # Private key: be1900077e55d9b9a922f957503a8513d65db45c79a6b00c337e90bc7a3a369501
 address = "ST15RR51GKMB5A52GP5XRT1KT9B42M7NF2VHYS96F"
 amount = 100000000000000
-[[mstx_balance]]
+[[ustx_balance]]
 # Private key: 88cc08c47fe8fbe18709bff5801eaa1dd8a4fe71dc35c264089aa3525092194701
 address = "ST6HQACZN5HN9RNK57PK4MH84GT3EV9FW5A6MA6G"
 amount = 100000000000000
-[[mstx_balance]]
+[[ustx_balance]]
 # Private key: 2ee7a062be3435be1ab4e4a58c9780e9df82a250f92501ad216571b0531f456a01
 address = "ST30ZKFVB3NYTA5RWPFGK9MJ6XZDRQ5SY3QDY51RD"
 amount = 100000000000000
-[[mstx_balance]]
+[[ustx_balance]]
 # Private key: aac4323ed8cebc2013839311c866b515a46113760edc891ed6edccdc23769aed01
 address = "STYNFVCF5BZE2WPK7624MYXR6YK6J5MY7A28D98M"
 amount = 100000000000000
-[[mstx_balance]]
+[[ustx_balance]]
 # Private key: e69f8aa175c953f422e80572c8b9479dedf4ad5c3d1ec9b111cef6f5fd3a925401
 address = "ST3S1W41KKFWE8P8JF7B37KK1AR3MBQ6ZKF7YWBHC"
 amount = 100000000000000
-[[mstx_balance]]
+[[ustx_balance]]
 # Private key: b8a34f36799eb095ce8ee24b65dd39e7ce142f7a908392e8b6e35f610310166d01
 address = "ST39717K9SRNXJ2H5SCJRRTXEPWKVZ4Z3AYQ29A6G"
 amount = 100000000000000
-[[mstx_balance]]
+[[ustx_balance]]
 # Private key: 8be9599e2e885e0a0fc765576bd21a7a0c220fe136aeecf98f228e9ca5e9bddc01
 address = "STDK22H9BWH9XX0WFAXM38FAN0YMX0ZN0V4H345G"
 amount = 100000000000000
-[[mstx_balance]]
+[[ustx_balance]]
 # Private key: 6f2a023bb0a6ee7ea8a477df97ce516c81fa50c5f0da52b54f35fcbc81539b8701
 address = "STNYXHB0E8F6476WPKGV9VNWX81Y00C47K39FK6B"
 amount = 100000000000000
-[[mstx_balance]]
+[[ustx_balance]]
 # Private key: 2f3f8d96a51a7e2e9908b81c328cfcebc9e2ca55cbcd62d1a9e37875afb8510101
 address = "ST3X93K538MYBXTK509Z3XN0DQN7SD4Q9TXYVF8JF"
 amount = 100000000000000
-[[mstx_balance]]
+[[ustx_balance]]
 # Private key: 42f24206d6b73fcb5120c927340b06b08f38233837ec7a7423d7067453e4902d01 
 address = "ST2VZ8CH12MGJXVAF54PKE3D7K4HVRVEJX11WBGXR"
 amount = 100000000000000
-[[mstx_balance]]
+[[ustx_balance]]
 # Private key: 1b5fddefb32d2bf3ea9ca1a0b9c8c5d8e0e82c101e94f30a417ac64ae402218701
 address = "ST33M0BJQN169PDVFVT7Z7T83V86903A32KBKQYZ5"
 amount = 100000000000000
-[[mstx_balance]]
+[[ustx_balance]]
 # Private key: 5a1e7817bc62ce5abea4f27b8002c7de02055bcf04a6e567a065ab06842fe34e01
 address = "ST12WEE0Y5HSSVRM8XS4TCEQVPYCVKSW8SVNNGYME"
 amount = 100000000000000
-[[mstx_balance]]
+[[ustx_balance]]
 # Private key: 4bfcb79c3383519386b807eda574324f146044effc3cbb53e5648e05d820e8e701
 address = "ST3VEP0E2HJBTX6HY5TB9CC3G4CQNKF4RCNW7WWDS"
 amount = 100000000000000
-[[mstx_balance]]
+[[ustx_balance]]
 # Private key: 1a1453957427a0eaa0f064845750ab0930abea764d060e37a0a90065e0cfab6a01
 address = "ST15NWBK91FTCGKQZ6JGDYJ5H12FRRSP3CFFNE5P6"
 amount = 100000000000000
-[[mstx_balance]]
+[[ustx_balance]]
 # Private key: b6495e7953b4e61baa6377e424de6d4d2723bb0a3006a5189c4eb3acce739a7601
 address = "ST1D0XTBR7WVNSYBJ7M26XSJAXMDJGJQKNEXAM6JH"
 amount = 100000000000000
-[[mstx_balance]]
+[[ustx_balance]]
 # Private key: 5ab899130953826ac53235a633eef111c1e213ad8f62a2c8485317fc21b8eef801
 address = "ST14KHGDNAX1R5Q7V4P0S3KSQRWZ4P10W0DH7V170"
 amount = 100000000000000
-[[mstx_balance]]
+[[ustx_balance]]
 # Private key: 29643a52a7c4a054878601dc5e6dc93ef6db0dcae059e91b2657d495efaafddd01
 address = "ST17H7G0D8ZDQWCSAPEMJD7ZHRESWKFEDCZ039G7S"
 amount = 100000000000000
-[[mstx_balance]]
+[[ustx_balance]]
 # Private key: 72badaf3be5ceaa1b453fcf04eed27711a3ffed95fbe79df06eedc11ae185b9801
 address = "ST3Z4WNZEHJBNRBKY7X6ENXRH583YS6FVH4S89SCE"
 amount = 100000000000000
-[[mstx_balance]]
+[[ustx_balance]]
 # Private key: 0d75216d199f90968fd8c779c9e7ace6a8979a9f9a246a97defc6e7a5eebd0a601
 address = "ST4TKY7QFS5C3X23628PQGT3910ZA53HSWZQ76MG"
 amount = 100000000000000
-[[mstx_balance]]
+[[ustx_balance]]
 # Private key: d4c3068518da81fdf0c5b7bcdc10a6eceeb1b1ee9b711d038bed6eda0a6ab22501
 address = "ST37VVF50JVE2QJZR4DXP1Y9EDYZC2CMZJXMJ2SHQ"
 amount = 100000000000000
-[[mstx_balance]]
+[[ustx_balance]]
 # Private key: 9ba45056d1bb3bec571ad0901f143e204a7dc42c804554baffcc45d016726d9601
 address = "ST8931RAJX6KJCNY9GK2B9NEJT7Y4SAC4MAYC3KR"
 amount = 100000000000000
-[[mstx_balance]]
+[[ustx_balance]]
 # Private key: 6df704626c69738e0c45228c440884ab6fd91bca6a80b7e8fcb551bd7c19935f01
 address = "STPB5Z0E1G3AA264YHFCYD3Z2R5TEYCFFXMKXTC1"
 amount = 100000000000000
-[[mstx_balance]]
+[[ustx_balance]]
 # Private key: 1f5c6a6fe9616c071aa412442524023aa545cd20d0a83d7483a1ba6fda7a079601
 address = "ST3SY2ZJT26C0T948WWMG3XKGXXJXTW46XYPZG28H"
 amount = 100000000000000
-[[mstx_balance]]
+[[ustx_balance]]
 # Private key: bc5710d0548ac0a44903c29841c737f98f031147f071b372550029c3c7abc50201
 address = "ST2XKCRMJWF07NYRJP6GRATWC4G1D4ZJZ6GSS0WX0"
 amount = 100000000000000
-[[mstx_balance]]
+[[ustx_balance]]
 # Private key: f96349d0e4261abc7a5ef6b7d32c0f367612982c0cd995478defcd1e96e57ce201
 address = "ST1D663PR9RPVZH9X3JRFM5Z90ZR2Y91C5XAJTN3H"
 amount = 100000000000000
-[[mstx_balance]]
+[[ustx_balance]]
 # Private key: b4dc4945b57c9649ae2ef51aba46ad24f1ec45721969b096a4a9eabfff5e58df01
 address = "ST289WH00WPBAG852K4FRCBNFV7HQ76SZKBHQZ427"
 amount = 100000000000000

--- a/testnet/stacks-node/conf/local-leader-conf.toml
+++ b/testnet/stacks-node/conf/local-leader-conf.toml
@@ -17,123 +17,123 @@ rpc_port = 28443
 peer_port = 18444
 poll_time_secs = 5
 
-[[mstx_balance]]
+[[ustx_balance]]
 # Private key: b8d99fd45da58038d630d9855d3ca2466e8e0f89d3894c4724f0efc9ff4b51f001
 address = "ST2ZRX0K27GW0SP3GJCEMHD95TQGJMKB7G9Y0X1MH"
 amount = 100000000000000
-[[mstx_balance]]
+[[ustx_balance]]
 # Private key: 3a4e84abb8abe0c1ba37cef4b604e73c82b1fe8d99015cb36b029a65099d373601
 address = "ST26FVX16539KKXZKJN098Q08HRX3XBAP541MFS0P"
 amount = 100000000000000
-[[mstx_balance]]
+[[ustx_balance]]
 # Private key: 052cc5b8f25b1e44a65329244066f76c8057accd5316c889f476d0ea0329632c01
 address = "ST3CECAKJ4BH08JYY7W53MC81BYDT4YDA5M7S5F53"
 amount = 100000000000000
-[[mstx_balance]]
+[[ustx_balance]]
 # Private key: 9aef533e754663a453984b69d36f109be817e9940519cc84979419e2be00864801
 address = "ST31HHVBKYCYQQJ5AQ25ZHA6W2A548ZADDQ6S16GP"
 amount = 100000000000000
-[[mstx_balance]]
+[[ustx_balance]]
 # Private key: be1900077e55d9b9a922f957503a8513d65db45c79a6b00c337e90bc7a3a369501
 address = "ST15RR51GKMB5A52GP5XRT1KT9B42M7NF2VHYS96F"
 amount = 100000000000000
-[[mstx_balance]]
+[[ustx_balance]]
 # Private key: 88cc08c47fe8fbe18709bff5801eaa1dd8a4fe71dc35c264089aa3525092194701
 address = "ST6HQACZN5HN9RNK57PK4MH84GT3EV9FW5A6MA6G"
 amount = 100000000000000
-[[mstx_balance]]
+[[ustx_balance]]
 # Private key: 2ee7a062be3435be1ab4e4a58c9780e9df82a250f92501ad216571b0531f456a01
 address = "ST30ZKFVB3NYTA5RWPFGK9MJ6XZDRQ5SY3QDY51RD"
 amount = 100000000000000
-[[mstx_balance]]
+[[ustx_balance]]
 # Private key: aac4323ed8cebc2013839311c866b515a46113760edc891ed6edccdc23769aed01
 address = "STYNFVCF5BZE2WPK7624MYXR6YK6J5MY7A28D98M"
 amount = 100000000000000
-[[mstx_balance]]
+[[ustx_balance]]
 # Private key: e69f8aa175c953f422e80572c8b9479dedf4ad5c3d1ec9b111cef6f5fd3a925401
 address = "ST3S1W41KKFWE8P8JF7B37KK1AR3MBQ6ZKF7YWBHC"
 amount = 100000000000000
-[[mstx_balance]]
+[[ustx_balance]]
 # Private key: b8a34f36799eb095ce8ee24b65dd39e7ce142f7a908392e8b6e35f610310166d01
 address = "ST39717K9SRNXJ2H5SCJRRTXEPWKVZ4Z3AYQ29A6G"
 amount = 100000000000000
-[[mstx_balance]]
+[[ustx_balance]]
 # Private key: 8be9599e2e885e0a0fc765576bd21a7a0c220fe136aeecf98f228e9ca5e9bddc01
 address = "STDK22H9BWH9XX0WFAXM38FAN0YMX0ZN0V4H345G"
 amount = 100000000000000
-[[mstx_balance]]
+[[ustx_balance]]
 # Private key: 6f2a023bb0a6ee7ea8a477df97ce516c81fa50c5f0da52b54f35fcbc81539b8701
 address = "STNYXHB0E8F6476WPKGV9VNWX81Y00C47K39FK6B"
 amount = 100000000000000
-[[mstx_balance]]
+[[ustx_balance]]
 # Private key: 2f3f8d96a51a7e2e9908b81c328cfcebc9e2ca55cbcd62d1a9e37875afb8510101
 address = "ST3X93K538MYBXTK509Z3XN0DQN7SD4Q9TXYVF8JF"
 amount = 100000000000000
-[[mstx_balance]]
+[[ustx_balance]]
 # Private key: 42f24206d6b73fcb5120c927340b06b08f38233837ec7a7423d7067453e4902d01 
 address = "ST2VZ8CH12MGJXVAF54PKE3D7K4HVRVEJX11WBGXR"
 amount = 100000000000000
-[[mstx_balance]]
+[[ustx_balance]]
 # Private key: 1b5fddefb32d2bf3ea9ca1a0b9c8c5d8e0e82c101e94f30a417ac64ae402218701
 address = "ST33M0BJQN169PDVFVT7Z7T83V86903A32KBKQYZ5"
 amount = 100000000000000
-[[mstx_balance]]
+[[ustx_balance]]
 # Private key: 5a1e7817bc62ce5abea4f27b8002c7de02055bcf04a6e567a065ab06842fe34e01
 address = "ST12WEE0Y5HSSVRM8XS4TCEQVPYCVKSW8SVNNGYME"
 amount = 100000000000000
-[[mstx_balance]]
+[[ustx_balance]]
 # Private key: 4bfcb79c3383519386b807eda574324f146044effc3cbb53e5648e05d820e8e701
 address = "ST3VEP0E2HJBTX6HY5TB9CC3G4CQNKF4RCNW7WWDS"
 amount = 100000000000000
-[[mstx_balance]]
+[[ustx_balance]]
 # Private key: 1a1453957427a0eaa0f064845750ab0930abea764d060e37a0a90065e0cfab6a01
 address = "ST15NWBK91FTCGKQZ6JGDYJ5H12FRRSP3CFFNE5P6"
 amount = 100000000000000
-[[mstx_balance]]
+[[ustx_balance]]
 # Private key: b6495e7953b4e61baa6377e424de6d4d2723bb0a3006a5189c4eb3acce739a7601
 address = "ST1D0XTBR7WVNSYBJ7M26XSJAXMDJGJQKNEXAM6JH"
 amount = 100000000000000
-[[mstx_balance]]
+[[ustx_balance]]
 # Private key: 5ab899130953826ac53235a633eef111c1e213ad8f62a2c8485317fc21b8eef801
 address = "ST14KHGDNAX1R5Q7V4P0S3KSQRWZ4P10W0DH7V170"
 amount = 100000000000000
-[[mstx_balance]]
+[[ustx_balance]]
 # Private key: 29643a52a7c4a054878601dc5e6dc93ef6db0dcae059e91b2657d495efaafddd01
 address = "ST17H7G0D8ZDQWCSAPEMJD7ZHRESWKFEDCZ039G7S"
 amount = 100000000000000
-[[mstx_balance]]
+[[ustx_balance]]
 # Private key: 72badaf3be5ceaa1b453fcf04eed27711a3ffed95fbe79df06eedc11ae185b9801
 address = "ST3Z4WNZEHJBNRBKY7X6ENXRH583YS6FVH4S89SCE"
 amount = 100000000000000
-[[mstx_balance]]
+[[ustx_balance]]
 # Private key: 0d75216d199f90968fd8c779c9e7ace6a8979a9f9a246a97defc6e7a5eebd0a601
 address = "ST4TKY7QFS5C3X23628PQGT3910ZA53HSWZQ76MG"
 amount = 100000000000000
-[[mstx_balance]]
+[[ustx_balance]]
 # Private key: d4c3068518da81fdf0c5b7bcdc10a6eceeb1b1ee9b711d038bed6eda0a6ab22501
 address = "ST37VVF50JVE2QJZR4DXP1Y9EDYZC2CMZJXMJ2SHQ"
 amount = 100000000000000
-[[mstx_balance]]
+[[ustx_balance]]
 # Private key: 9ba45056d1bb3bec571ad0901f143e204a7dc42c804554baffcc45d016726d9601
 address = "ST8931RAJX6KJCNY9GK2B9NEJT7Y4SAC4MAYC3KR"
 amount = 100000000000000
-[[mstx_balance]]
+[[ustx_balance]]
 # Private key: 6df704626c69738e0c45228c440884ab6fd91bca6a80b7e8fcb551bd7c19935f01
 address = "STPB5Z0E1G3AA264YHFCYD3Z2R5TEYCFFXMKXTC1"
 amount = 100000000000000
-[[mstx_balance]]
+[[ustx_balance]]
 # Private key: 1f5c6a6fe9616c071aa412442524023aa545cd20d0a83d7483a1ba6fda7a079601
 address = "ST3SY2ZJT26C0T948WWMG3XKGXXJXTW46XYPZG28H"
 amount = 100000000000000
-[[mstx_balance]]
+[[ustx_balance]]
 # Private key: bc5710d0548ac0a44903c29841c737f98f031147f071b372550029c3c7abc50201
 address = "ST2XKCRMJWF07NYRJP6GRATWC4G1D4ZJZ6GSS0WX0"
 amount = 100000000000000
-[[mstx_balance]]
+[[ustx_balance]]
 # Private key: f96349d0e4261abc7a5ef6b7d32c0f367612982c0cd995478defcd1e96e57ce201
 address = "ST1D663PR9RPVZH9X3JRFM5Z90ZR2Y91C5XAJTN3H"
 amount = 100000000000000
-[[mstx_balance]]
+[[ustx_balance]]
 # Private key: b4dc4945b57c9649ae2ef51aba46ad24f1ec45721969b096a4a9eabfff5e58df01
 address = "ST289WH00WPBAG852K4FRCBNFV7HQ76SZKBHQZ427"
 amount = 100000000000000

--- a/testnet/stacks-node/conf/local-second-miner.toml
+++ b/testnet/stacks-node/conf/local-second-miner.toml
@@ -12,19 +12,19 @@ peer_host = "127.0.0.1"
 rpc_port = 28443
 peer_port = 18444
 
-[[mstx_balance]]
+[[ustx_balance]]
 # Private key: b8d99fd45da58038d630d9855d3ca2466e8e0f89d3894c4724f0efc9ff4b51f001
 address = "ST2ZRX0K27GW0SP3GJCEMHD95TQGJMKB7G9Y0X1MH"
 amount = 10000000000000000
-[[mstx_balance]]
+[[ustx_balance]]
 # Private key: 3a4e84abb8abe0c1ba37cef4b604e73c82b1fe8d99015cb36b029a65099d373601
 address = "ST26FVX16539KKXZKJN098Q08HRX3XBAP541MFS0P"
 amount = 10000000000000000
-[[mstx_balance]]
+[[ustx_balance]]
 # Private key: 052cc5b8f25b1e44a65329244066f76c8057accd5316c889f476d0ea0329632c01
 address = "ST3CECAKJ4BH08JYY7W53MC81BYDT4YDA5M7S5F53"
 amount = 10000000000000000
-[[mstx_balance]]
+[[ustx_balance]]
 # Private key: 9aef533e754663a453984b69d36f109be817e9940519cc84979419e2be00864801
 address = "ST31HHVBKYCYQQJ5AQ25ZHA6W2A548ZADDQ6S16GP"
 amount = 10000000000000000

--- a/testnet/stacks-node/conf/neon-follower-conf.toml
+++ b/testnet/stacks-node/conf/neon-follower-conf.toml
@@ -10,18 +10,18 @@ peer_host = "neon.blockstack.org"
 rpc_port = 18443
 peer_port = 18444
 
-[[mstx_balance]]
+[[ustx_balance]]
 address = "STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6"
 amount = 10000000000000000
 
-[[mstx_balance]]
+[[ustx_balance]]
 address = "ST11NJTTKGVT6D1HY4NJRVQWMQM7TVAR091EJ8P2Y"
 amount = 10000000000000000
 
-[[mstx_balance]]
+[[ustx_balance]]
 address = "ST1HB1T8WRNBYB0Y3T7WXZS38NKKPTBR3EG9EPJKR"
 amount = 10000000000000000
 
-[[mstx_balance]]
+[[ustx_balance]]
 address = "STRYYQQ9M8KAF4NS7WNZQYY59X93XEKR31JP64CP"
 amount = 10000000000000000

--- a/testnet/stacks-node/conf/xenon-autonomous-follower-conf.toml
+++ b/testnet/stacks-node/conf/xenon-autonomous-follower-conf.toml
@@ -15,19 +15,19 @@ peer_port = 18333
 username = "xenon"
 password = "password"
 
-[[mstx_balance]]
+[[ustx_balance]]
 address = "STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6"
 amount = 10000000000000000
 
-[[mstx_balance]]
+[[ustx_balance]]
 address = "ST11NJTTKGVT6D1HY4NJRVQWMQM7TVAR091EJ8P2Y"
 amount = 10000000000000000
 
-[[mstx_balance]]
+[[ustx_balance]]
 address = "ST1HB1T8WRNBYB0Y3T7WXZS38NKKPTBR3EG9EPJKR"
 amount = 10000000000000000
 
-[[mstx_balance]]
+[[ustx_balance]]
 address = "STRYYQQ9M8KAF4NS7WNZQYY59X93XEKR31JP64CP"
 amount = 10000000000000000
 

--- a/testnet/stacks-node/conf/xenon-follower-conf.toml
+++ b/testnet/stacks-node/conf/xenon-follower-conf.toml
@@ -15,19 +15,19 @@ password = "blockstacksystem"
 rpc_port = 18332
 peer_port = 18333
 
-[[mstx_balance]]
+[[ustx_balance]]
 address = "STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6"
 amount = 10000000000000000
 
-[[mstx_balance]]
+[[ustx_balance]]
 address = "ST11NJTTKGVT6D1HY4NJRVQWMQM7TVAR091EJ8P2Y"
 amount = 10000000000000000
 
-[[mstx_balance]]
+[[ustx_balance]]
 address = "ST1HB1T8WRNBYB0Y3T7WXZS38NKKPTBR3EG9EPJKR"
 amount = 10000000000000000
 
-[[mstx_balance]]
+[[ustx_balance]]
 address = "STRYYQQ9M8KAF4NS7WNZQYY59X93XEKR31JP64CP"
 amount = 10000000000000000
 

--- a/testnet/stacks-node/conf/xenon-miner-conf.toml
+++ b/testnet/stacks-node/conf/xenon-miner-conf.toml
@@ -15,18 +15,18 @@ peer_port = 18333
 username = "xenon"
 password = "password"
 
-[[mstx_balance]]
+[[ustx_balance]]
 address = "STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6"
 amount = 10000000000000000
 
-[[mstx_balance]]
+[[ustx_balance]]
 address = "ST11NJTTKGVT6D1HY4NJRVQWMQM7TVAR091EJ8P2Y"
 amount = 10000000000000000
 
-[[mstx_balance]]
+[[ustx_balance]]
 address = "ST1HB1T8WRNBYB0Y3T7WXZS38NKKPTBR3EG9EPJKR"
 amount = 10000000000000000
 
-[[mstx_balance]]
+[[ustx_balance]]
 address = "STRYYQQ9M8KAF4NS7WNZQYY59X93XEKR31JP64CP"
 amount = 10000000000000000

--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -1,6 +1,5 @@
 use std::convert::TryInto;
-use std::fs::File;
-use std::io::{BufReader, Read};
+use std::fs;
 use std::net::{SocketAddr, ToSocketAddrs};
 
 use rand::RngCore;
@@ -30,17 +29,28 @@ pub struct ConfigFile {
     pub block_limit: Option<BlockLimitFile>,
 }
 
+#[derive(Clone, Deserialize, Default)]
+pub struct LegacyMstxConfigFile {
+    pub mstx_balance: Option<Vec<InitialBalanceFile>>,
+}
+
 impl ConfigFile {
     pub fn from_path(path: &str) -> ConfigFile {
-        let path = File::open(path).unwrap();
-        let mut config_file_reader = BufReader::new(path);
-        let mut config_file = vec![];
-        config_file_reader.read_to_end(&mut config_file).unwrap();
-        toml::from_slice(&config_file[..]).unwrap()
+        let content_str = fs::read_to_string(path).unwrap();
+        Self::from_str(&content_str)
     }
 
     pub fn from_str(content: &str) -> ConfigFile {
-        toml::from_slice(&content.as_bytes()).unwrap()
+        let mut config: ConfigFile = toml::from_str(content).unwrap();
+        let legacy_config: LegacyMstxConfigFile = toml::from_str(content).unwrap();
+        if let Some(mstx_balance) = legacy_config.mstx_balance {
+            warn!("'mstx_balance' inside toml config is deprecated, replace with 'ustx_balance'");
+            config.ustx_balance = match config.ustx_balance {
+                Some(balance) => Some([balance, mstx_balance].concat()),
+                None => Some(mstx_balance),
+            };
+        }
+        config
     }
 
     pub fn neon() -> ConfigFile {
@@ -315,11 +325,6 @@ pub const HELIUM_BLOCK_LIMIT: ExecutionCost = ExecutionCost {
 };
 
 impl Config {
-    pub fn from_config_file_path(path: &str) -> Config {
-        let config_file = ConfigFile::from_path(path);
-        Config::from_config_file(config_file)
-    }
-
     pub fn from_config_file(config_file: ConfigFile) -> Config {
         let default_node_config = NodeConfig::default();
         let node = match config_file.node {

--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -34,6 +34,55 @@ pub struct LegacyMstxConfigFile {
     pub mstx_balance: Option<Vec<InitialBalanceFile>>,
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_load_legacy_mstx_balances_toml() {
+        let config = ConfigFile::from_str(
+            r#"
+            [[ustx_balance]]
+            address = "STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6"
+            amount = 10000000000000000
+
+            [[ustx_balance]]
+            address = "ST11NJTTKGVT6D1HY4NJRVQWMQM7TVAR091EJ8P2Y"
+            amount = 10000000000000000
+
+            [[mstx_balance]] # legacy property name
+            address = "ST1HB1T8WRNBYB0Y3T7WXZS38NKKPTBR3EG9EPJKR"
+            amount = 10000000000000000
+
+            [[mstx_balance]] # legacy property name
+            address = "STRYYQQ9M8KAF4NS7WNZQYY59X93XEKR31JP64CP"
+            amount = 10000000000000000
+            "#,
+        );
+        assert!(config.ustx_balance.is_some());
+        let balances = config
+            .ustx_balance
+            .expect("Failed to parse stx balances from toml");
+        assert_eq!(balances.len(), 4);
+        assert_eq!(
+            balances[0].address,
+            "STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6"
+        );
+        assert_eq!(
+            balances[1].address,
+            "ST11NJTTKGVT6D1HY4NJRVQWMQM7TVAR091EJ8P2Y"
+        );
+        assert_eq!(
+            balances[2].address,
+            "ST1HB1T8WRNBYB0Y3T7WXZS38NKKPTBR3EG9EPJKR"
+        );
+        assert_eq!(
+            balances[3].address,
+            "STRYYQQ9M8KAF4NS7WNZQYY59X93XEKR31JP64CP"
+        );
+    }
+}
+
 impl ConfigFile {
     pub fn from_path(path: &str) -> ConfigFile {
         let content_str = fs::read_to_string(path).unwrap();


### PR DESCRIPTION
Closes https://github.com/blockstack/stacks-blockchain/issues/2151

We changed a config variable name from `mstx_balance` to `ustx_balance` in a previous PR. This PR fixes all the example tomls and readme references. 

For backwards compatibility, the `mstx_balance` option was fixed so that it still works but prints a deprecation notice -- added this after report of sudden broken balance config.