### PR TITLE
fix --features=tx-log which no longer builds

### DIFF
--- a/src/chainstate/stacks/events.rs
+++ b/src/chainstate/stacks/events.rs
@@ -43,6 +43,12 @@ impl TransactionOrigin {
             TransactionOrigin::Stacks(tx) => tx.txid(),
         }
     }
+    pub fn serialize_to_vec(&self) -> Vec<u8> {
+        match self {
+            TransactionOrigin::Burn(txid) => txid.as_bytes().to_vec(),
+            TransactionOrigin::Stacks(tx) => tx.txid().as_bytes().to_vec(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]


### PR DESCRIPTION
with the addition of `TransactionOrigin`, `transaction.serialize_to_vec()` fails to build because it does not know how to process the new field.  This fixes that.