### PR TITLE
Implement transaction fees

### DIFF
--- a/src/blockstack_cli.rs
+++ b/src/blockstack_cli.rs
@@ -276,13 +276,13 @@ fn make_standard_single_sig_tx(
     payload: TransactionPayload,
     publicKey: &StacksPublicKey,
     nonce: u64,
-    fee_rate: u64,
+    tx_fee: u64,
 ) -> StacksTransaction {
     let mut spending_condition =
         TransactionSpendingCondition::new_singlesig_p2pkh(publicKey.clone())
             .expect("Failed to create p2pkh spending condition from public key.");
     spending_condition.set_nonce(nonce);
-    spending_condition.set_fee_rate(fee_rate);
+    spending_condition.set_tx_fee(tx_fee);
     let auth = TransactionAuth::Standard(spending_condition);
     let mut tx = StacksTransaction::new(version, auth, payload);
     tx.chain_id = chain_id;
@@ -360,7 +360,7 @@ fn handle_contract_publish(
     }
     let anchor_mode = parse_anchor_mode(&mut args, PUBLISH_USAGE)?;
     let sk_publisher = &args[0];
-    let fee_rate = args[1].parse()?;
+    let tx_fee = args[1].parse()?;
     let nonce = args[2].parse()?;
     let contract_name = &args[3];
     let contract_file = &args[4];
@@ -382,7 +382,7 @@ fn handle_contract_publish(
         payload.into(),
         &StacksPublicKey::from_private(&sk_publisher),
         nonce,
-        fee_rate,
+        tx_fee,
     );
     unsigned_tx.anchor_mode = anchor_mode;
 
@@ -417,7 +417,7 @@ fn handle_contract_call(
     }
     let anchor_mode = parse_anchor_mode(&mut args, CALL_USAGE)?;
     let sk_origin = &args[0];
-    let fee_rate = args[1].parse()?;
+    let tx_fee = args[1].parse()?;
     let nonce = args[2].parse()?;
     let contract_address = &args[3];
     let contract_name = &args[4];
@@ -468,7 +468,7 @@ fn handle_contract_call(
         payload.into(),
         &StacksPublicKey::from_private(&sk_origin),
         nonce,
-        fee_rate,
+        tx_fee,
     );
     unsigned_tx.anchor_mode = anchor_mode;
 
@@ -506,7 +506,7 @@ fn handle_token_transfer(
 
     let anchor_mode = parse_anchor_mode(&mut args, TOKEN_TRANSFER_USAGE)?;
     let sk_origin = StacksPrivateKey::from_hex(&args[0])?;
-    let fee_rate = args[1].parse()?;
+    let tx_fee = args[1].parse()?;
     let nonce = args[2].parse()?;
     let recipient_address =
         PrincipalData::parse(&args[3]).map_err(|_e| "Failed to parse recipient")?;
@@ -530,7 +530,7 @@ fn handle_token_transfer(
         payload,
         &StacksPublicKey::from_private(&sk_origin),
         nonce,
-        fee_rate,
+        tx_fee,
     );
     unsigned_tx.anchor_mode = anchor_mode;
 

--- a/src/burnchains/mod.rs
+++ b/src/burnchains/mod.rs
@@ -679,7 +679,8 @@ pub mod test {
         pub block_commits: Vec<LeaderBlockCommitOp>,
         pub id: usize,
         pub nonce: u64,
-        pub spent_at_nonce: HashMap<u64, u128>,
+        pub spent_at_nonce: HashMap<u64, u128>, // how much uSTX this miner paid in a given tx's nonce
+        pub test_with_tx_fees: bool, // set to true to make certain helper methods attach a pre-defined tx fee
     }
 
     pub struct TestMinerFactory {
@@ -706,6 +707,7 @@ pub mod test {
                 id: 0,
                 nonce: 0,
                 spent_at_nonce: HashMap::new(),
+                test_with_tx_fees: true,
             }
         }
 

--- a/src/burnchains/mod.rs
+++ b/src/burnchains/mod.rs
@@ -679,6 +679,7 @@ pub mod test {
         pub block_commits: Vec<LeaderBlockCommitOp>,
         pub id: usize,
         pub nonce: u64,
+        pub spent_at_nonce: HashMap<u64, u128>,
     }
 
     pub struct TestMinerFactory {
@@ -704,6 +705,7 @@ pub mod test {
                 block_commits: vec![],
                 id: 0,
                 nonce: 0,
+                spent_at_nonce: HashMap::new(),
             }
         }
 

--- a/src/chainstate/stacks/auth.rs
+++ b/src/chainstate/stacks/auth.rs
@@ -127,7 +127,7 @@ impl StacksMessageCodec for MultisigSpendingCondition {
         write_next(fd, &(self.hash_mode.clone() as u8))?;
         write_next(fd, &self.signer)?;
         write_next(fd, &self.nonce)?;
-        write_next(fd, &self.fee_rate)?;
+        write_next(fd, &self.tx_fee)?;
         write_next(fd, &self.fields)?;
         write_next(fd, &self.signatures_required)?;
         Ok(())
@@ -143,7 +143,7 @@ impl StacksMessageCodec for MultisigSpendingCondition {
 
         let signer: Hash160 = read_next(fd)?;
         let nonce: u64 = read_next(fd)?;
-        let fee_rate: u64 = read_next(fd)?;
+        let tx_fee: u64 = read_next(fd)?;
         let fields: Vec<TransactionAuthField> = {
             let mut bound_read = BoundReader::from_reader(fd, MAX_MESSAGE_LEN as u64);
             read_next(&mut bound_read)
@@ -203,7 +203,7 @@ impl StacksMessageCodec for MultisigSpendingCondition {
         Ok(MultisigSpendingCondition {
             signer,
             nonce,
-            fee_rate,
+            tx_fee,
             hash_mode,
             fields,
             signatures_required,
@@ -272,7 +272,7 @@ impl MultisigSpendingCondition {
                     let (pubkey, next_sighash) = TransactionSpendingCondition::next_verification(
                         &cur_sighash,
                         cond_code,
-                        self.fee_rate,
+                        self.tx_fee,
                         self.nonce,
                         pubkey_encoding,
                         sigbuf,
@@ -329,7 +329,7 @@ impl StacksMessageCodec for SinglesigSpendingCondition {
         write_next(fd, &(self.hash_mode.clone() as u8))?;
         write_next(fd, &self.signer)?;
         write_next(fd, &self.nonce)?;
-        write_next(fd, &self.fee_rate)?;
+        write_next(fd, &self.tx_fee)?;
         write_next(fd, &(self.key_encoding.clone() as u8))?;
         write_next(fd, &self.signature)?;
         Ok(())
@@ -346,7 +346,7 @@ impl StacksMessageCodec for SinglesigSpendingCondition {
 
         let signer: Hash160 = read_next(fd)?;
         let nonce: u64 = read_next(fd)?;
-        let fee_rate: u64 = read_next(fd)?;
+        let tx_fee: u64 = read_next(fd)?;
 
         let key_encoding_u8: u8 = read_next(fd)?;
         let key_encoding = TransactionPublicKeyEncoding::from_u8(key_encoding_u8).ok_or(
@@ -369,7 +369,7 @@ impl StacksMessageCodec for SinglesigSpendingCondition {
         Ok(SinglesigSpendingCondition {
             signer: signer,
             nonce: nonce,
-            fee_rate: fee_rate,
+            tx_fee: tx_fee,
             hash_mode: hash_mode,
             key_encoding: key_encoding,
             signature: signature,
@@ -430,7 +430,7 @@ impl SinglesigSpendingCondition {
         let (pubkey, next_sighash) = TransactionSpendingCondition::next_verification(
             initial_sighash,
             cond_code,
-            self.fee_rate,
+            self.tx_fee,
             self.nonce,
             &self.key_encoding,
             &self.signature,
@@ -514,7 +514,7 @@ impl TransactionSpendingCondition {
             SinglesigSpendingCondition {
                 signer: signer_addr.bytes.clone(),
                 nonce: 0,
-                fee_rate: 0,
+                tx_fee: 0,
                 hash_mode: SinglesigHashMode::P2PKH,
                 key_encoding: key_encoding,
                 signature: MessageSignature::empty(),
@@ -534,7 +534,7 @@ impl TransactionSpendingCondition {
             SinglesigSpendingCondition {
                 signer: signer_addr.bytes.clone(),
                 nonce: 0,
-                fee_rate: 0,
+                tx_fee: 0,
                 hash_mode: SinglesigHashMode::P2WPKH,
                 key_encoding: TransactionPublicKeyEncoding::Compressed,
                 signature: MessageSignature::empty(),
@@ -557,7 +557,7 @@ impl TransactionSpendingCondition {
             MultisigSpendingCondition {
                 signer: signer_addr.bytes.clone(),
                 nonce: 0,
-                fee_rate: 0,
+                tx_fee: 0,
                 hash_mode: MultisigHashMode::P2SH,
                 fields: vec![],
                 signatures_required: num_sigs,
@@ -580,7 +580,7 @@ impl TransactionSpendingCondition {
             MultisigSpendingCondition {
                 signer: signer_addr.bytes.clone(),
                 nonce: 0,
-                fee_rate: 0,
+                tx_fee: 0,
                 hash_mode: MultisigHashMode::P2WSH,
                 fields: vec![],
                 signatures_required: num_sigs,
@@ -595,7 +595,7 @@ impl TransactionSpendingCondition {
         TransactionSpendingCondition::Singlesig(SinglesigSpendingCondition {
             signer: Hash160([0u8; 20]),
             nonce: 0,
-            fee_rate: 0,
+            tx_fee: 0,
             hash_mode: SinglesigHashMode::P2PKH,
             key_encoding: TransactionPublicKeyEncoding::Compressed,
             signature: MessageSignature::empty(),
@@ -641,10 +641,10 @@ impl TransactionSpendingCondition {
         }
     }
 
-    pub fn fee_rate(&self) -> u64 {
+    pub fn tx_fee(&self) -> u64 {
         match *self {
-            TransactionSpendingCondition::Singlesig(ref data) => data.fee_rate,
-            TransactionSpendingCondition::Multisig(ref data) => data.fee_rate,
+            TransactionSpendingCondition::Singlesig(ref data) => data.tx_fee,
+            TransactionSpendingCondition::Multisig(ref data) => data.tx_fee,
         }
     }
 
@@ -659,21 +659,21 @@ impl TransactionSpendingCondition {
         }
     }
 
-    pub fn set_fee_rate(&mut self, fee_rate: u64) -> () {
+    pub fn set_tx_fee(&mut self, tx_fee: u64) -> () {
         match *self {
             TransactionSpendingCondition::Singlesig(ref mut singlesig_data) => {
-                singlesig_data.fee_rate = fee_rate;
+                singlesig_data.tx_fee = tx_fee;
             }
             TransactionSpendingCondition::Multisig(ref mut multisig_data) => {
-                multisig_data.fee_rate = fee_rate;
+                multisig_data.tx_fee = tx_fee;
             }
         }
     }
 
-    pub fn get_fee_rate(&self) -> u64 {
+    pub fn get_tx_fee(&self) -> u64 {
         match *self {
-            TransactionSpendingCondition::Singlesig(ref singlesig_data) => singlesig_data.fee_rate,
-            TransactionSpendingCondition::Multisig(ref multisig_data) => multisig_data.fee_rate,
+            TransactionSpendingCondition::Singlesig(ref singlesig_data) => singlesig_data.tx_fee,
+            TransactionSpendingCondition::Multisig(ref multisig_data) => multisig_data.tx_fee,
         }
     }
 
@@ -697,12 +697,12 @@ impl TransactionSpendingCondition {
     pub fn clear(&mut self) -> () {
         match *self {
             TransactionSpendingCondition::Singlesig(ref mut singlesig_data) => {
-                singlesig_data.fee_rate = 0;
+                singlesig_data.tx_fee = 0;
                 singlesig_data.nonce = 0;
                 singlesig_data.signature = MessageSignature::empty();
             }
             TransactionSpendingCondition::Multisig(ref mut multisig_data) => {
-                multisig_data.fee_rate = 0;
+                multisig_data.tx_fee = 0;
                 multisig_data.nonce = 0;
                 multisig_data.fields.clear();
             }
@@ -712,7 +712,7 @@ impl TransactionSpendingCondition {
     pub fn make_sighash_presign(
         cur_sighash: &Txid,
         cond_code: &TransactionAuthFlags,
-        fee_rate: u64,
+        tx_fee: u64,
         nonce: u64,
     ) -> Txid {
         // new hash combines the previous hash and all the new data this signature will add.  This
@@ -726,7 +726,7 @@ impl TransactionSpendingCondition {
 
         new_tx_hash_bits.extend_from_slice(cur_sighash.as_bytes());
         new_tx_hash_bits.extend_from_slice(&[*cond_code as u8]);
-        new_tx_hash_bits.extend_from_slice(&fee_rate.to_be_bytes());
+        new_tx_hash_bits.extend_from_slice(&tx_fee.to_be_bytes());
         new_tx_hash_bits.extend_from_slice(&nonce.to_be_bytes());
 
         assert!(new_tx_hash_bits.len() == new_tx_hash_bits_len as usize);
@@ -771,14 +771,14 @@ impl TransactionSpendingCondition {
     pub fn next_signature(
         cur_sighash: &Txid,
         cond_code: &TransactionAuthFlags,
-        fee_rate: u64,
+        tx_fee: u64,
         nonce: u64,
         privk: &StacksPrivateKey,
     ) -> Result<(MessageSignature, Txid), net_error> {
         let sighash_presign = TransactionSpendingCondition::make_sighash_presign(
             cur_sighash,
             cond_code,
-            fee_rate,
+            tx_fee,
             nonce,
         );
 
@@ -801,7 +801,7 @@ impl TransactionSpendingCondition {
     pub fn next_verification(
         cur_sighash: &Txid,
         cond_code: &TransactionAuthFlags,
-        fee_rate: u64,
+        tx_fee: u64,
         nonce: u64,
         key_encoding: &TransactionPublicKeyEncoding,
         sig: &MessageSignature,
@@ -809,7 +809,7 @@ impl TransactionSpendingCondition {
         let sighash_presign = TransactionSpendingCondition::make_sighash_presign(
             cur_sighash,
             cond_code,
-            fee_rate,
+            tx_fee,
             nonce,
         );
 
@@ -1028,17 +1028,17 @@ impl TransactionAuth {
         }
     }
 
-    pub fn set_fee_rate(&mut self, fee_rate: u64) -> () {
+    pub fn set_tx_fee(&mut self, tx_fee: u64) -> () {
         match *self {
-            TransactionAuth::Standard(ref mut s) => s.set_fee_rate(fee_rate),
-            TransactionAuth::Sponsored(_, ref mut s) => s.set_fee_rate(fee_rate),
+            TransactionAuth::Standard(ref mut s) => s.set_tx_fee(tx_fee),
+            TransactionAuth::Sponsored(_, ref mut s) => s.set_tx_fee(tx_fee),
         }
     }
 
-    pub fn get_fee_rate(&self) -> u64 {
+    pub fn get_tx_fee(&self) -> u64 {
         match *self {
-            TransactionAuth::Standard(ref s) => s.get_fee_rate(),
-            TransactionAuth::Sponsored(_, ref s) => s.get_fee_rate(),
+            TransactionAuth::Standard(ref s) => s.get_tx_fee(),
+            TransactionAuth::Sponsored(_, ref s) => s.get_tx_fee(),
         }
     }
 
@@ -1094,7 +1094,7 @@ mod test {
             hash_mode: SinglesigHashMode::P2PKH,
             key_encoding: TransactionPublicKeyEncoding::Uncompressed,
             nonce: 123,
-            fee_rate: 456,
+            tx_fee: 456,
             signature: MessageSignature::from_raw(&vec![0xff; 65]),
         };
 
@@ -1215,7 +1215,7 @@ mod test {
             hash_mode: SinglesigHashMode::P2PKH,
             key_encoding: TransactionPublicKeyEncoding::Compressed,
             nonce: 345,
-            fee_rate: 456,
+            tx_fee: 456,
             signature: MessageSignature::from_raw(&vec![0xfe; 65]),
         };
 
@@ -1355,7 +1355,7 @@ mod test {
             signer: Hash160([0x11; 20]),
             hash_mode: MultisigHashMode::P2SH,
             nonce: 123,
-            fee_rate: 456,
+            tx_fee: 456,
             fields: vec![
                 TransactionAuthField::Signature(TransactionPublicKeyEncoding::Uncompressed, MessageSignature::from_raw(&vec![0xff; 65])),
                 TransactionAuthField::Signature(TransactionPublicKeyEncoding::Uncompressed, MessageSignature::from_raw(&vec![0xfe; 65])),
@@ -1592,7 +1592,7 @@ mod test {
             signer: Hash160([0x11; 20]),
             hash_mode: MultisigHashMode::P2SH,
             nonce: 456,
-            fee_rate: 567,
+            tx_fee: 567,
             fields: vec![
                 TransactionAuthField::Signature(
                     TransactionPublicKeyEncoding::Compressed,
@@ -1860,7 +1860,7 @@ mod test {
             hash_mode: SinglesigHashMode::P2WPKH,
             key_encoding: TransactionPublicKeyEncoding::Compressed,
             nonce: 345,
-            fee_rate: 567,
+            tx_fee: 567,
             signature: MessageSignature::from_raw(&vec![0xfe; 65]),
         };
 
@@ -1993,7 +1993,7 @@ mod test {
             signer: Hash160([0x11; 20]),
             hash_mode: MultisigHashMode::P2WSH,
             nonce: 456,
-            fee_rate: 567,
+            tx_fee: 567,
             fields: vec![
                 TransactionAuthField::Signature(
                     TransactionPublicKeyEncoding::Compressed,
@@ -2257,7 +2257,7 @@ mod test {
                 hash_mode: SinglesigHashMode::P2PKH,
                 key_encoding: TransactionPublicKeyEncoding::Uncompressed,
                 nonce: 123,
-                fee_rate: 567,
+                tx_fee: 567,
                 signature: MessageSignature::from_raw(&vec![0xff; 65])
             }),
             TransactionSpendingCondition::Singlesig(SinglesigSpendingCondition {
@@ -2265,14 +2265,14 @@ mod test {
                 hash_mode: SinglesigHashMode::P2PKH,
                 key_encoding: TransactionPublicKeyEncoding::Compressed,
                 nonce: 345,
-                fee_rate: 567,
+                tx_fee: 567,
                 signature: MessageSignature::from_raw(&vec![0xff; 65])
             }),
             TransactionSpendingCondition::Multisig(MultisigSpendingCondition {
                 signer: Hash160([0x11; 20]),
                 hash_mode: MultisigHashMode::P2SH,
                 nonce: 123,
-                fee_rate: 567,
+                tx_fee: 567,
                 fields: vec![
                     TransactionAuthField::Signature(TransactionPublicKeyEncoding::Uncompressed, MessageSignature::from_raw(&vec![0xff; 65])),
                     TransactionAuthField::Signature(TransactionPublicKeyEncoding::Uncompressed, MessageSignature::from_raw(&vec![0xfe; 65])),
@@ -2284,7 +2284,7 @@ mod test {
                 signer: Hash160([0x11; 20]),
                 hash_mode: MultisigHashMode::P2SH,
                 nonce: 456,
-                fee_rate: 567,
+                tx_fee: 567,
                 fields: vec![
                     TransactionAuthField::Signature(TransactionPublicKeyEncoding::Compressed, MessageSignature::from_raw(&vec![0xff; 65])),
                     TransactionAuthField::Signature(TransactionPublicKeyEncoding::Compressed, MessageSignature::from_raw(&vec![0xfe; 65])),
@@ -2297,14 +2297,14 @@ mod test {
                 hash_mode: SinglesigHashMode::P2WPKH,
                 key_encoding: TransactionPublicKeyEncoding::Compressed,
                 nonce: 345,
-                fee_rate: 567,
+                tx_fee: 567,
                 signature: MessageSignature::from_raw(&vec![0xfe; 65]),
             }),
             TransactionSpendingCondition::Multisig(MultisigSpendingCondition {
                 signer: Hash160([0x11; 20]),
                 hash_mode: MultisigHashMode::P2WSH,
                 nonce: 456,
-                fee_rate: 567,
+                tx_fee: 567,
                 fields: vec![
                     TransactionAuthField::Signature(TransactionPublicKeyEncoding::Compressed, MessageSignature::from_raw(&vec![0xff; 65])),
                     TransactionAuthField::Signature(TransactionPublicKeyEncoding::Compressed, MessageSignature::from_raw(&vec![0xfe; 65])),
@@ -3150,7 +3150,7 @@ mod test {
                 signer: Hash160([0x11; 20]),
                 hash_mode: SinglesigHashMode::P2WPKH,
                 nonce: 123,
-                fee_rate: 567,
+                tx_fee: 567,
                 key_encoding: TransactionPublicKeyEncoding::Uncompressed,
                 signature: MessageSignature::from_raw(&vec![0xff; 65]),
             });
@@ -3272,7 +3272,7 @@ mod test {
             signer: Hash160([0x11; 20]),
             hash_mode: MultisigHashMode::P2WSH,
             nonce: 456,
-            fee_rate: 567,
+            tx_fee: 567,
             fields: vec![
                 TransactionAuthField::Signature(TransactionPublicKeyEncoding::Uncompressed, MessageSignature::from_raw(&vec![0xff; 65])),
                 TransactionAuthField::Signature(TransactionPublicKeyEncoding::Uncompressed, MessageSignature::from_raw(&vec![0xfe; 65])),
@@ -3581,7 +3581,7 @@ mod test {
             TransactionAuthFlags::AuthSponsored,
         ];
 
-        let fee_rates = vec![123, 456, 123, 456];
+        let tx_fees = vec![123, 456, 123, 456];
 
         let nonces: Vec<u64> = vec![1, 2, 3, 4];
 
@@ -3589,7 +3589,7 @@ mod test {
             let (sig, next_sighash) = TransactionSpendingCondition::next_signature(
                 &cur_sighash,
                 &auth_flags[i],
-                fee_rates[i],
+                tx_fees[i],
                 nonces[i],
                 &keys[i],
             )
@@ -3600,7 +3600,7 @@ mod test {
             expected_sighash_bytes.clear();
             expected_sighash_bytes.extend_from_slice(cur_sighash.as_bytes());
             expected_sighash_bytes.extend_from_slice(&[auth_flags[i] as u8]);
-            expected_sighash_bytes.extend_from_slice(&fee_rates[i].to_be_bytes());
+            expected_sighash_bytes.extend_from_slice(&tx_fees[i].to_be_bytes());
             expected_sighash_bytes.extend_from_slice(&nonces[i].to_be_bytes());
             let expected_sighash_presign = Txid::from_sighash_bytes(&expected_sighash_bytes[..]);
 
@@ -3622,7 +3622,7 @@ mod test {
                 TransactionSpendingCondition::next_verification(
                     &cur_sighash,
                     &auth_flags[i],
-                    fee_rates[i],
+                    tx_fees[i],
                     nonces[i],
                     &key_encoding,
                     &sig,

--- a/src/chainstate/stacks/boot/mod.rs
+++ b/src/chainstate/stacks/boot/mod.rs
@@ -747,7 +747,7 @@ pub mod test {
     fn make_tx(
         key: &StacksPrivateKey,
         nonce: u64,
-        fee_rate: u64,
+        tx_fee: u64,
         payload: TransactionPayload,
     ) -> StacksTransaction {
         let auth = TransactionAuth::from_p2pkh(key).unwrap();
@@ -756,7 +756,7 @@ pub mod test {
         tx.chain_id = 0x80000000;
         tx.auth.set_origin_nonce(nonce);
         tx.set_post_condition_mode(TransactionPostConditionMode::Allow);
-        tx.set_fee_rate(fee_rate);
+        tx.set_tx_fee(tx_fee);
 
         let mut tx_signer = StacksTransactionSigner::new(&tx);
         tx_signer.sign_origin(key).unwrap();
@@ -845,23 +845,23 @@ pub mod test {
     fn make_bare_contract(
         key: &StacksPrivateKey,
         nonce: u64,
-        fee_rate: u64,
+        tx_fee: u64,
         name: &str,
         code: &str,
     ) -> StacksTransaction {
         let payload = TransactionPayload::new_smart_contract(name, code).unwrap();
-        make_tx(key, nonce, fee_rate, payload)
+        make_tx(key, nonce, tx_fee, payload)
     }
 
     fn make_token_transfer(
         key: &StacksPrivateKey,
         nonce: u64,
-        fee_rate: u64,
+        tx_fee: u64,
         dest: PrincipalData,
         amount: u64,
     ) -> StacksTransaction {
         let payload = TransactionPayload::TokenTransfer(dest, amount, TokenTransferMemo([0u8; 34]));
-        make_tx(key, nonce, fee_rate, payload)
+        make_tx(key, nonce, tx_fee, payload)
     }
 
     fn make_pox_lockup_contract(

--- a/src/chainstate/stacks/db/accounts.rs
+++ b/src/chainstate/stacks/db/accounts.rs
@@ -57,7 +57,6 @@ impl FromRow<MinerPaymentSchedule> for MinerPaymentSchedule {
         let burns_text: String = row.get("stx_burns");
         let burnchain_commit_burn = u64::from_column(row, "burnchain_commit_burn")?;
         let burnchain_sortition_burn = u64::from_column(row, "burnchain_sortition_burn")?;
-        let fill_text: String = row.get("fill");
         let miner: bool = row.get("miner");
         let stacks_block_height = u64::from_column(row, "stacks_block_height")?;
         let vtxindex: u32 = row.get("vtxindex");
@@ -74,9 +73,6 @@ impl FromRow<MinerPaymentSchedule> for MinerPaymentSchedule {
         let stx_burns = burns_text
             .parse::<u128>()
             .map_err(|_e| db_error::ParseError)?;
-        let fill = fill_text
-            .parse::<u64>()
-            .map_err(|_e| db_error::ParseError)?;
 
         let payment_data = MinerPaymentSchedule {
             address,
@@ -90,7 +86,6 @@ impl FromRow<MinerPaymentSchedule> for MinerPaymentSchedule {
             stx_burns,
             burnchain_commit_burn,
             burnchain_sortition_burn,
-            fill,
             miner,
             stacks_block_height,
             vtxindex,
@@ -105,6 +100,40 @@ impl MinerReward {
             + self.tx_fees_anchored
             + self.tx_fees_streamed_produced
             + self.tx_fees_streamed_confirmed
+    }
+}
+
+impl MinerPaymentSchedule {
+    /// If this is a MinerPaymentSchedule for a miner who _confirmed_ a microblock stream, then
+    /// this calculates the percentage of that stream this miner is entitled to
+    pub fn streamed_tx_fees_confirmed(&self) -> u128 {
+        (self.tx_fees_streamed * 3) / 5
+    }
+
+    /// If this is a MinerPaymentSchedule for a miner who _produced_ a microblock stream, then
+    /// this calculates the percentage of that stream this miner is entitled to
+    pub fn streamed_tx_fees_produced(&self) -> u128 {
+        (self.tx_fees_streamed * 2) / 5
+    }
+
+    /// Empty miner payment schedule -- i.e. for the genesis block
+    pub fn genesis(mainnet: bool) -> MinerPaymentSchedule {
+        MinerPaymentSchedule {
+            address: StacksAddress::burn_address(mainnet),
+            block_hash: FIRST_STACKS_BLOCK_HASH.clone(),
+            consensus_hash: FIRST_BURNCHAIN_CONSENSUS_HASH.clone(),
+            parent_block_hash: FIRST_STACKS_BLOCK_HASH.clone(),
+            parent_consensus_hash: FIRST_BURNCHAIN_CONSENSUS_HASH.clone(),
+            coinbase: 0,
+            tx_fees_anchored: 0,
+            tx_fees_streamed: 0,
+            stx_burns: 0,
+            burnchain_commit_burn: 0,
+            burnchain_sortition_burn: 0,
+            miner: true,
+            stacks_block_height: 0,
+            vtxindex: 0,
+        }
     }
 }
 
@@ -304,7 +333,6 @@ impl StacksChainState {
             &format!("{}", block_reward.stx_burns),
             &u64_to_sql(block_reward.burnchain_commit_burn)?,
             &u64_to_sql(block_reward.burnchain_sortition_burn)?,
-            &format!("{}", block_reward.fill),
             &u64_to_sql(block_reward.stacks_block_height)?,
             &true,
             &0i64,
@@ -324,12 +352,11 @@ impl StacksChainState {
                         stx_burns,
                         burnchain_commit_burn,
                         burnchain_sortition_burn,
-                        fill,
                         stacks_block_height,
                         miner,
                         vtxindex,
                         index_block_hash) \
-                    VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16)",
+                    VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15)",
             args,
         )
         .map_err(|e| Error::DBError(db_error::SqliteError(e)))?;
@@ -349,7 +376,6 @@ impl StacksChainState {
                 &"0".to_string(),
                 &u64_to_sql(user_support.burn_amount)?,
                 &u64_to_sql(block_reward.burnchain_sortition_burn)?,
-                &format!("{}", block_reward.fill),
                 &u64_to_sql(block_reward.stacks_block_height)?,
                 &false,
                 &user_support.vtxindex,
@@ -369,12 +395,11 @@ impl StacksChainState {
                             stx_burns,
                             burnchain_commit_burn,
                             burnchain_sortition_burn,
-                            fill,
                             stacks_block_height,
                             miner,
                             vtxindex,
                             index_block_hash) \
-                        VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16)",
+                        VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15)",
                 args,
             )
             .map_err(|e| Error::DBError(db_error::SqliteError(e)))?;
@@ -396,6 +421,19 @@ impl StacksChainState {
             .map_err(Error::ClarityError)?;
 
         Ok(principal_seq_opt.map(|(principal, seq)| (principal.into(), seq)))
+    }
+
+    /// Get the scheduled miner rewards at a particular index hash
+    pub fn get_scheduled_block_rewards_at_block<'a>(
+        tx: &mut StacksDBTx<'a>,
+        index_block_hash: &StacksBlockId,
+    ) -> Result<Vec<MinerPaymentSchedule>, Error> {
+        let qry =
+            "SELECT * FROM payments WHERE index_block_hash = ?1 ORDER BY vtxindex ASC".to_string();
+        let args: &[&dyn ToSql] = &[index_block_hash];
+        let rows = query_rows::<MinerPaymentSchedule, _>(tx, &qry, args).map_err(Error::DBError)?;
+        test_debug!("{} rewards in {}", rows.len(), index_block_hash);
+        Ok(rows)
     }
 
     /// Get the scheduled miner rewards in a particular Stacks fork at a particular height.
@@ -485,20 +523,17 @@ impl StacksChainState {
     ///
     /// If poison_reporter_opt is not None, then the returned MinerReward will reward the _poison reporter_,
     /// not the miner, for reporting the microblock stream fork.
-    ///
-    /// TODO: this is incomplete -- it does not calculate transaction fees.  This is just stubbed
-    /// out for now -- it only grants miners and user burn supports their coinbases.
-    ///
     fn calculate_miner_reward(
         mainnet: bool,
         participant: &MinerPaymentSchedule,
         miner: &MinerPaymentSchedule,
         users: &Vec<MinerPaymentSchedule>,
+        parent: &MinerPaymentSchedule,
         poison_reporter_opt: Option<&StacksAddress>,
-    ) -> MinerReward {
+    ) -> (MinerReward, MinerReward) {
         ////////////////////// coinbase reward total /////////////////////////////////
         let (this_burn_total, other_burn_total) = {
-            if participant.address == miner.address {
+            if participant.miner {
                 // we're calculating the miner's reward
                 let mut total_user: u128 = 0;
                 for user_support in users.iter() {
@@ -547,50 +582,80 @@ impl StacksChainState {
         // process poison -- someone can steal a fraction of the total coinbase if they can present
         // evidence that the miner forked the microblock stream.  The remainder of the coinbase is
         // destroyed if this happens.
-        let (recipient, coinbase_reward) = if let Some(reporter_address) = poison_reporter_opt {
-            if participant.address == miner.address {
-                // the poison-reporter, not the miner, gets a (fraction of the) reward
-                debug!(
-                    "{:?} will recieve poison-microblock commission {}",
-                    &reporter_address.to_string(),
-                    StacksChainState::poison_microblock_commission(coinbase_reward)
-                );
+        let (recipient, coinbase_reward, punished) =
+            if let Some(reporter_address) = poison_reporter_opt {
+                if participant.miner {
+                    // the poison-reporter, not the miner, gets a (fraction of the) reward
+                    debug!(
+                        "{:?} will recieve poison-microblock commission {}",
+                        &reporter_address.to_string(),
+                        StacksChainState::poison_microblock_commission(coinbase_reward)
+                    );
+                    (
+                        reporter_address.clone(),
+                        StacksChainState::poison_microblock_commission(coinbase_reward),
+                        true,
+                    )
+                } else {
+                    // users that helped a miner that reported a poison-microblock get nothing
+                    (StacksAddress::burn_address(mainnet), coinbase_reward, false)
+                }
+            } else {
+                // no poison microblock reported
+                (participant.address, coinbase_reward, false)
+            };
+
+        let (tx_fees_anchored, parent_tx_fees_streamed_produced, tx_fees_streamed_confirmed) =
+            if participant.miner {
+                // only award tx fees to the miner, and only if the miner was not punished.
+                // parent gets its produced tx fees regardless of punishment.
                 (
-                    reporter_address.clone(),
-                    StacksChainState::poison_microblock_commission(coinbase_reward),
+                    if !punished {
+                        participant.tx_fees_anchored
+                    } else {
+                        0
+                    },
+                    parent.streamed_tx_fees_produced(),
+                    if !punished {
+                        participant.streamed_tx_fees_confirmed()
+                    } else {
+                        0
+                    },
                 )
             } else {
-                // users that helped a miner that reported a poison-microblock get nothing
-                (StacksAddress::burn_address(mainnet), coinbase_reward)
-            }
-        } else {
-            // no poison microblock reported
-            (participant.address, coinbase_reward)
-        };
+                // users get no tx fees
+                (0, 0, 0)
+            };
 
-        // TODO: missing transaction fee calculation
-        let tx_fees_anchored = 0;
-        let tx_fees_streamed_produced = 0;
-        let tx_fees_streamed_confirmed = 0;
         debug!(
-            "{}: {} coinbase, {} anchored fees, {} streamed fees, {} confirmed fees",
+            "{}: {} coinbase, {} anchored fees, {} streamed fees confirmed; {} has produced {} fees",
             &recipient.to_string(),
             coinbase_reward,
             tx_fees_anchored,
-            tx_fees_streamed_produced,
-            tx_fees_streamed_confirmed
+            tx_fees_streamed_confirmed,
+            &parent.address.to_string(),
+            parent_tx_fees_streamed_produced,
         );
 
-        // ("bad miner! no coinbase!")
+        let parent_miner_reward = MinerReward {
+            address: parent.address.clone(),
+            coinbase: 0,
+            tx_fees_anchored: 0,
+            tx_fees_streamed_produced: parent_tx_fees_streamed_produced,
+            tx_fees_streamed_confirmed: 0,
+            vtxindex: parent.vtxindex,
+        };
+
         let miner_reward = MinerReward {
             address: recipient,
             coinbase: coinbase_reward,
             tx_fees_anchored: tx_fees_anchored,
-            tx_fees_streamed_produced: tx_fees_streamed_produced,
+            tx_fees_streamed_produced: 0,
             tx_fees_streamed_confirmed: tx_fees_streamed_confirmed,
             vtxindex: miner.vtxindex,
         };
-        miner_reward
+
+        (parent_miner_reward, miner_reward)
     }
 
     /// Find the latest miner reward to mature, assuming that there are mature rewards.
@@ -599,7 +664,8 @@ impl StacksChainState {
         clarity_tx: &mut ClarityTx<'a>,
         tip: &StacksHeaderInfo,
         mut latest_matured_miners: Vec<MinerPaymentSchedule>,
-    ) -> Result<Option<(MinerReward, Vec<MinerReward>, MinerRewardInfo)>, Error> {
+        parent_miner: MinerPaymentSchedule,
+    ) -> Result<Option<(MinerReward, Vec<MinerReward>, MinerReward, MinerRewardInfo)>, Error> {
         let mainnet = clarity_tx.config.mainnet;
         if tip.block_height <= MINER_REWARD_MATURITY {
             // no mature rewards exist
@@ -639,28 +705,36 @@ impl StacksChainState {
         }
 
         // calculate miner reward
-        let miner_reward = StacksChainState::calculate_miner_reward(
+        let (parent_miner_reward, miner_reward) = StacksChainState::calculate_miner_reward(
             mainnet,
             &miner,
             &miner,
             &users,
+            &parent_miner,
             poison_recipient_opt.as_ref(),
         );
 
         // calculate reward for each user-support-burn
         let mut user_rewards = vec![];
         for user_reward in users.iter() {
-            let reward = StacksChainState::calculate_miner_reward(
+            let (parent_reward, reward) = StacksChainState::calculate_miner_reward(
                 mainnet,
                 user_reward,
                 &miner,
                 &users,
+                &parent_miner,
                 poison_recipient_opt.as_ref(),
             );
+            assert_eq!(parent_reward.total(), 0);
             user_rewards.push(reward);
         }
 
-        Ok(Some((miner_reward, user_rewards, reward_info)))
+        Ok(Some((
+            miner_reward,
+            user_rewards,
+            parent_miner_reward,
+            reward_info,
+        )))
     }
 }
 
@@ -696,7 +770,6 @@ mod test {
             stx_burns: 0,
             burnchain_commit_burn: commit_burn,
             burnchain_sortition_burn: sortition_burn,
-            fill: 0xffffffffffffffff,
             miner: true,
             stacks_block_height: 0,
             vtxindex: 0,
@@ -935,101 +1008,6 @@ mod test {
         };
     }
 
-    /*
-    #[test]
-    fn find_mature_miner_rewards() {
-        let mut chainstate = instantiate_chainstate(false, 0x80000000, "find_mature_miner_rewards");
-        let miner_1 =
-            StacksAddress::from_string(&"SP1A2K3ENNA6QQ7G8DVJXM24T6QMBDVS7D0TRTAR5".to_string())
-                .unwrap();
-        let user_1 =
-            StacksAddress::from_string(&"SP2837ZMC89J40K4YTS64B00M7065C6X46JX6ARG0".to_string())
-                .unwrap();
-
-        let mut parent_tip = StacksHeaderInfo::regtest_genesis(0);
-
-        let mut matured_miners = (make_dummy_miner_payment_schedule(&miner_1, 0, 0, 0, 0, 0), vec![]);
-
-        for i in 0..(MINER_REWARD_MATURITY + 1) {
-            let mut miner_reward = make_dummy_miner_payment_schedule(
-                &miner_1,
-                500,
-                (2 * i) as u128,
-                (2 * i) as u128,
-                1000,
-                1000,
-            );
-            let user_reward = make_dummy_user_payment_schedule(
-                &user_1,
-                500,
-                (2 * i) as u128,
-                (2 * i) as u128,
-                100,
-                100,
-                1,
-            );
-            let user_support = StagingUserBurnSupport::from_miner_payment_schedule(&user_reward);
-
-            if i == 0 {
-                matured_miners = (miner_reward.clone(), vec![user_reward.clone()]);
-            }
-
-            let mut user_supports = vec![user_support];
-
-            let next_tip = advance_tip(
-                &mut chainstate,
-                &parent_tip,
-                &mut miner_reward,
-                &mut user_supports,
-            );
-
-            if i < MINER_REWARD_MATURITY {
-                let mut tx = chainstate.chainstate_tx_begin().unwrap();
-                let rewards_opt =
-                    StacksChainState::find_mature_miner_rewards(&mut tx, &parent_tip, vec![])
-                        .unwrap();
-                assert!(rewards_opt.is_none()); // not mature yet
-            }
-            test_debug!("next tip = {:?}", &next_tip);
-            parent_tip = next_tip;
-        }
-
-        let mut tx = chainstate.chainstate_tx_begin().unwrap().0;
-
-        test_debug!("parent tip = {:?}", &parent_tip);
-        let miner_reward = StacksChainState::calculate_miner_reward(
-            false,
-            &matured_miners.0,
-            &matured_miners.0,
-            &matured_miners.1,
-            None
-        );
-        let mut user_rewards = vec![];
-        for user_reward in matured_miners.1.iter() {
-            let rw = StacksChainState::calculate_miner_reward(
-                false,
-                user_reward,
-                &matured_miners.0,
-                &matured_miners.1,
-                None
-            );
-            user_rewards.push(rw);
-        }
-
-        let mut matured_rewards = vec![];
-        matured_rewards.push(miner_reward.clone());
-        matured_rewards.append(&mut user_rewards.clone());
-
-        let rewards_opt =
-            StacksChainState::find_mature_miner_rewards(&mut tx, &parent_tip, &matured_rewards).unwrap();
-        assert!(rewards_opt.is_some());
-
-        let rewards = rewards_opt.unwrap();
-        assert_eq!(rewards.0, miner_reward);
-        assert_eq!(rewards.1, user_rewards);
-    }
-    */
-
     #[test]
     fn miner_reward_one_miner_no_tx_fees_no_users() {
         let miner_1 =
@@ -1037,11 +1015,12 @@ mod test {
                 .unwrap();
         let participant = make_dummy_miner_payment_schedule(&miner_1, 500, 0, 0, 1000, 1000);
 
-        let miner_reward = StacksChainState::calculate_miner_reward(
+        let (parent_reward, miner_reward) = StacksChainState::calculate_miner_reward(
             false,
             &participant,
             &participant,
             &vec![],
+            &MinerPaymentSchedule::genesis(true),
             None,
         );
 
@@ -1050,6 +1029,12 @@ mod test {
         assert_eq!(miner_reward.tx_fees_anchored, 0);
         assert_eq!(miner_reward.tx_fees_streamed_produced, 0);
         assert_eq!(miner_reward.tx_fees_streamed_confirmed, 0);
+
+        // parent gets nothing -- no tx fees
+        assert_eq!(parent_reward.coinbase, 0);
+        assert_eq!(parent_reward.tx_fees_anchored, 0);
+        assert_eq!(parent_reward.tx_fees_streamed_produced, 0);
+        assert_eq!(parent_reward.tx_fees_streamed_confirmed, 0);
     }
 
     #[test]
@@ -1064,18 +1049,20 @@ mod test {
         let miner = make_dummy_miner_payment_schedule(&miner_1, 500, 0, 0, 250, 1000);
         let user = make_dummy_user_payment_schedule(&user_1, 500, 0, 0, 750, 1000, 1);
 
-        let reward_miner_1 = StacksChainState::calculate_miner_reward(
+        let (parent_miner_1, reward_miner_1) = StacksChainState::calculate_miner_reward(
             false,
             &miner,
             &miner,
             &vec![user.clone()],
+            &MinerPaymentSchedule::genesis(true),
             None,
         );
-        let reward_user_1 = StacksChainState::calculate_miner_reward(
+        let (parent_user_1, reward_user_1) = StacksChainState::calculate_miner_reward(
             false,
             &user,
             &miner,
             &vec![user.clone()],
+            &MinerPaymentSchedule::genesis(true),
             None,
         );
 
@@ -1085,260 +1072,50 @@ mod test {
         assert_eq!(reward_miner_1.tx_fees_streamed_produced, 0);
         assert_eq!(reward_miner_1.tx_fees_streamed_confirmed, 0);
 
+        assert_eq!(parent_miner_1.total(), 0);
+
         // user should have received 3/4 the coinbase
         assert_eq!(reward_user_1.coinbase, 375);
         assert_eq!(reward_user_1.tx_fees_anchored, 0);
         assert_eq!(reward_user_1.tx_fees_streamed_produced, 0);
         assert_eq!(reward_user_1.tx_fees_streamed_confirmed, 0);
+
+        assert_eq!(parent_user_1.total(), 0);
     }
 
-    /*
-    // TODO: broken; needs to be rewritten once transaction fee processing is added
     #[test]
-    fn miner_reward_one_miner_one_user_anchored_tx_fees_unfull() {
-        let mut sample = vec![];
-        let miner_1 = StacksAddress::from_string(&"SP1A2K3ENNA6QQ7G8DVJXM24T6QMBDVS7D0TRTAR5".to_string()).unwrap();
-        let user_1 = StacksAddress::from_string(&"SP2837ZMC89J40K4YTS64B00M7065C6X46JX6ARG0".to_string()).unwrap();
-        let mut participant = make_dummy_miner_payment_schedule(&miner_1, 500, 100, 0, 250, 1000);
-        let mut user = make_dummy_user_payment_schedule(&user_1, 500, 0, 0, 750, 1000, 1);
+    fn miner_reward_tx_fees() {
+        let miner_1 =
+            StacksAddress::from_string(&"SP1A2K3ENNA6QQ7G8DVJXM24T6QMBDVS7D0TRTAR5".to_string())
+                .unwrap();
 
-        // blocks are NOT full
-        let fill_cutoff = (((MINER_FEE_MINIMUM_BLOCK_USAGE as u128) << 64) / 100u128) as u64;
-        participant.fill = fill_cutoff - 1;
-        user.fill = fill_cutoff - 1;
+        let parent_miner_1 =
+            StacksAddress::from_string(&"SP2QDF700V0FWXVNQJJ4XFGBWE6R2Y4APTSFQNBVE".to_string())
+                .unwrap();
 
-        sample.push((participant.clone(), vec![user.clone()]));
+        let participant = make_dummy_miner_payment_schedule(&miner_1, 500, 100, 105, 1000, 1000);
+        let parent_participant =
+            make_dummy_miner_payment_schedule(&parent_miner_1, 500, 100, 395, 1000, 1000);
 
-        for i in 0..9 {
-            let mut next_participant = make_dummy_miner_payment_schedule(&miner_1, 250, 100, 0, 250, 1000);
-            let mut next_user = make_dummy_user_payment_schedule(&user_1, 750, 0, 0, 750, 1000, 1);
+        let (parent_reward, miner_reward) = StacksChainState::calculate_miner_reward(
+            false,
+            &participant,
+            &participant,
+            &vec![],
+            &parent_participant,
+            None,
+        );
 
-            next_participant.fill = fill_cutoff - 1;
-            next_user.fill = fill_cutoff - 1;
+        // miner should have received the entire coinbase
+        assert_eq!(miner_reward.coinbase, 500);
+        assert_eq!(miner_reward.tx_fees_anchored, 100);
+        assert_eq!(miner_reward.tx_fees_streamed_produced, 0); // not rewarded yet
+        assert_eq!(miner_reward.tx_fees_streamed_confirmed, (105 * 3) / 5);
 
-            sample.push((next_participant, vec![next_user]));
-        }
-
-        let reward_miner_1 = StacksChainState::calculate_miner_reward(&participant, &sample);
-        let reward_user_1 = StacksChainState::calculate_miner_reward(&user, &sample);
-
-        // miner should have received 1/4 the coinbase, and miner should have received only shared
-        assert_eq!(reward_miner_1.coinbase, 125);
-        assert_eq!(reward_miner_1.tx_fees_anchored, 1000);        // same miner, so they get everything
-        assert_eq!(reward_miner_1.tx_fees_streamed_produced, 0);
-        assert_eq!(reward_miner_1.tx_fees_streamed_confirmed, 0);
-
-        // user should have received 3/4 the coinbase, but no tx fees
-        assert_eq!(reward_user_1.coinbase, 375);
-        assert_eq!(reward_user_1.tx_fees_anchored, 0);
-        assert_eq!(reward_user_1.tx_fees_streamed_produced, 0);
-        assert_eq!(reward_user_1.tx_fees_streamed_confirmed, 0);
+        // parent gets produced stream fees
+        assert_eq!(parent_reward.coinbase, 0);
+        assert_eq!(parent_reward.tx_fees_anchored, 0);
+        assert_eq!(parent_reward.tx_fees_streamed_produced, (395 * 2) / 5);
+        assert_eq!(parent_reward.tx_fees_streamed_confirmed, 0);
     }
-
-    // TODO: broken; needs to be rewritten once transaction fee processing is added
-    #[test]
-    fn miner_reward_two_miners_one_user_anchored_tx_fees_unfull() {
-        let mut sample = vec![];
-        let miner_1 = StacksAddress::from_string(&"SP1A2K3ENNA6QQ7G8DVJXM24T6QMBDVS7D0TRTAR5".to_string()).unwrap();
-        let miner_2 = StacksAddress::from_string(&"SP8WWTGMNCCSB88QF4VYWN69PAMQRMF34FCT498G".to_string()).unwrap();
-        let user_1 = StacksAddress::from_string(&"SP2837ZMC89J40K4YTS64B00M7065C6X46JX6ARG0".to_string()).unwrap();
-        let mut participant_1 = make_dummy_miner_payment_schedule(&miner_1, 500, 100, 0, 250, 1000);
-        let mut participant_2 = make_dummy_miner_payment_schedule(&miner_2, 500, 0, 0, 1000, 1000);
-        let mut user = make_dummy_user_payment_schedule(&user_1, 500, 0, 0, 750, 1000, 1);
-
-        // blocks are NOT full
-        let fill_cutoff = (((MINER_FEE_MINIMUM_BLOCK_USAGE as u128) << 64) / 100u128) as u64;
-        participant_1.fill = fill_cutoff - 1;
-        participant_2.fill = fill_cutoff - 1;
-        user.fill = fill_cutoff - 1;
-
-        sample.push((participant_1.clone(), vec![user.clone()]));
-
-        for i in 0..4 {
-            let mut next_participant = make_dummy_miner_payment_schedule(&miner_1, 250, 100, 0, 250, 1000);
-            let mut next_user = make_dummy_user_payment_schedule(&user_1, 750, 0, 0, 750, 1000, 1);
-
-            next_participant.fill = fill_cutoff - 1;
-            next_user.fill = fill_cutoff - 1;
-
-            sample.push((next_participant, vec![next_user]));
-        }
-
-        for i in 0..5 {
-            let mut next_participant = make_dummy_miner_payment_schedule(&miner_2, 250, 100, 0, 250, 1000);
-            let mut next_user = make_dummy_user_payment_schedule(&user_1, 750, 0, 0, 750, 1000, 1);
-
-            next_participant.fill = fill_cutoff - 1;
-            next_user.fill = fill_cutoff - 1;
-
-            sample.push((next_participant, vec![next_user]));
-        }
-
-        let reward_miner_1 = StacksChainState::calculate_miner_reward(&participant_1, &sample);
-        let reward_miner_2 = StacksChainState::calculate_miner_reward(&participant_2, &sample);
-        let reward_user_1 = StacksChainState::calculate_miner_reward(&user, &sample);
-
-        // if miner 1 won, then it should have received 1/4 the coinbase, and miner should have received only shared tx fees
-        assert_eq!(reward_miner_1.coinbase, 125);
-        assert_eq!(reward_miner_1.tx_fees_anchored, 500);        // did half the work over the sample
-        assert_eq!(reward_miner_1.tx_fees_streamed_produced, 0);
-        assert_eq!(reward_miner_1.tx_fees_streamed_confirmed, 0);
-
-        // miner 2 didn't mine this block
-        assert_eq!(reward_miner_2.coinbase, 0);
-        assert_eq!(reward_miner_2.tx_fees_anchored, 500);        // did half the work over the sample
-        assert_eq!(reward_miner_2.tx_fees_streamed_produced, 0);
-        assert_eq!(reward_miner_2.tx_fees_streamed_confirmed, 0);
-
-        // user should have received 3/4 the coinbase, but no tx fees
-        assert_eq!(reward_user_1.coinbase, 375);
-        assert_eq!(reward_user_1.tx_fees_anchored, 0);
-        assert_eq!(reward_user_1.tx_fees_streamed_produced, 0);
-        assert_eq!(reward_user_1.tx_fees_streamed_confirmed, 0);
-    }
-
-    // TODO: broken; needs to be rewritten once transaction fee processing is added
-    #[test]
-    fn miner_reward_two_miners_one_user_anchored_tx_fees_full() {
-        let mut sample = vec![];
-        let miner_1 = StacksAddress::from_string(&"SP1A2K3ENNA6QQ7G8DVJXM24T6QMBDVS7D0TRTAR5".to_string()).unwrap();
-        let miner_2 = StacksAddress::from_string(&"SP8WWTGMNCCSB88QF4VYWN69PAMQRMF34FCT498G".to_string()).unwrap();
-        let user_1 = StacksAddress::from_string(&"SP2837ZMC89J40K4YTS64B00M7065C6X46JX6ARG0".to_string()).unwrap();
-        let mut participant_1 = make_dummy_miner_payment_schedule(&miner_1, 500, 100, 0, 250, 1000);
-        let mut participant_2 = make_dummy_miner_payment_schedule(&miner_2, 500, 0, 0, 1000, 1000);
-        let mut user = make_dummy_user_payment_schedule(&user_1, 500, 0, 0, 750, 1000, 1);
-
-        let fill_cutoff = ((MINER_FEE_MINIMUM_BLOCK_USAGE as u128) << 64) / 100u128;
-
-        // blocks are full to 90%
-        let fill = ((90u128 << 64) / (100u128)) as u64;
-        participant_1.fill = fill;
-        participant_2.fill = fill;
-        user.fill = fill;
-
-        sample.push((participant_1.clone(), vec![user.clone()]));
-
-        for i in 0..4 {
-            let mut next_participant = make_dummy_miner_payment_schedule(&miner_1, 250, 100, 0, 250, 1000);
-            let mut next_user = make_dummy_user_payment_schedule(&user_1, 750, 0, 0, 750, 1000, 1);
-
-            next_participant.fill = fill;
-            next_user.fill = fill;
-
-            sample.push((next_participant, vec![next_user]));
-        }
-
-        for i in 0..5 {
-            let mut next_participant = make_dummy_miner_payment_schedule(&miner_2, 250, 100, 0, 250, 1000);
-            let mut next_user = make_dummy_user_payment_schedule(&user_1, 750, 0, 0, 750, 1000, 1);
-
-            next_participant.fill = fill;
-            next_user.fill = fill;
-
-            sample.push((next_participant, vec![next_user]));
-        }
-
-        let reward_miner_1 = StacksChainState::calculate_miner_reward(&participant_1, &sample);
-        let reward_miner_2 = StacksChainState::calculate_miner_reward(&participant_2, &sample);
-        let reward_user_1 = StacksChainState::calculate_miner_reward(&user, &sample);
-
-        let expected_shared =
-            if (500 * fill_cutoff) & 0x0000000000000000ffffffffffffffff > 0x00000000000000007fffffffffffffff {
-                ((500 * fill_cutoff) >> 64) + 1
-            }
-            else {
-                (500 * fill_cutoff) >> 64
-            };
-
-        // miner 1 should have received 1/4 the coinbase
-        assert_eq!(reward_miner_1.coinbase, 125);
-        assert_eq!(reward_miner_1.tx_fees_anchored, expected_shared);        // did half the work over the sample
-        assert_eq!(reward_miner_1.tx_fees_streamed_produced, 0);
-        assert_eq!(reward_miner_1.tx_fees_streamed_confirmed, 0);
-
-        // miner 2 didn't win this block, so it gets no coinbase
-        assert_eq!(reward_miner_2.coinbase, 0);
-        assert_eq!(reward_miner_2.tx_fees_anchored, expected_shared);        // did half the work over the sample
-        assert_eq!(reward_miner_2.tx_fees_streamed_produced, 0);
-        assert_eq!(reward_miner_2.tx_fees_streamed_confirmed, 0);
-
-        // user should have received 3/4 the coinbase, but no tx fees
-        assert_eq!(reward_user_1.coinbase, 375);
-        assert_eq!(reward_user_1.tx_fees_anchored, 0);
-        assert_eq!(reward_user_1.tx_fees_streamed_produced, 0);
-        assert_eq!(reward_user_1.tx_fees_streamed_confirmed, 0);
-    }
-
-    // TODO: broken; needs to be rewritten once transaction fee processing is added
-    #[test]
-    fn miner_reward_two_miners_one_user_anchored_tx_fees_full_streamed() {
-        let mut sample = vec![];
-        let miner_1 = StacksAddress::from_string(&"SP1A2K3ENNA6QQ7G8DVJXM24T6QMBDVS7D0TRTAR5".to_string()).unwrap();
-        let miner_2 = StacksAddress::from_string(&"SP8WWTGMNCCSB88QF4VYWN69PAMQRMF34FCT498G".to_string()).unwrap();
-        let user_1 = StacksAddress::from_string(&"SP2837ZMC89J40K4YTS64B00M7065C6X46JX6ARG0".to_string()).unwrap();
-        let mut participant_1 = make_dummy_miner_payment_schedule(&miner_1, 500, 100, 100, 250, 1000);
-        let mut participant_2 = make_dummy_miner_payment_schedule(&miner_2, 500, 0, 0, 1000, 1000);
-        let mut user = make_dummy_user_payment_schedule(&user_1, 500, 0, 0, 750, 1000, 1);
-
-        let fill_cutoff = ((MINER_FEE_MINIMUM_BLOCK_USAGE as u128) << 64) / 100u128;
-
-        // blocks are full to 90%
-        let fill = ((90u128 << 64) / (100u128)) as u64;
-        participant_1.fill = fill;
-        participant_2.fill = fill;
-        user.fill = fill;
-
-        sample.push((participant_1.clone(), vec![user.clone()]));
-
-        for i in 0..4 {
-            let mut next_participant = make_dummy_miner_payment_schedule(&miner_1, 250, 100, 100, 250, 1000);
-            let mut next_user = make_dummy_user_payment_schedule(&user_1, 750, 0, 0, 750, 1000, 1);
-
-            next_participant.fill = fill;
-            next_user.fill = fill;
-
-            sample.push((next_participant, vec![next_user]));
-        }
-
-        for i in 0..5 {
-            let mut next_participant = make_dummy_miner_payment_schedule(&miner_2, 250, 100, 100, 250, 1000);
-            let mut next_user = make_dummy_user_payment_schedule(&user_1, 750, 0, 0, 750, 1000, 1);
-
-            next_participant.fill = fill;
-            next_user.fill = fill;
-
-            sample.push((next_participant, vec![next_user]));
-        }
-
-        let reward_miner_1 = StacksChainState::calculate_miner_reward(&participant_1, &sample);
-        let reward_miner_2 = StacksChainState::calculate_miner_reward(&participant_2, &sample);
-        let reward_user_1 = StacksChainState::calculate_miner_reward(&user, &sample);
-
-        let expected_shared =
-            if (500 * fill_cutoff) & 0x0000000000000000ffffffffffffffff > 0x00000000000000007fffffffffffffff {
-                ((500 * fill_cutoff) >> 64) + 1
-            }
-            else {
-                (500 * fill_cutoff) >> 64
-            };
-
-        // miner 1 produced this block with the help from users 3x as interested, so it gets 1/4 of the coinbase
-        assert_eq!(reward_miner_1.coinbase, 125);
-        assert_eq!(reward_miner_1.tx_fees_anchored, expected_shared);        // did half the work over the sample
-        assert_eq!(reward_miner_1.tx_fees_streamed_produced, 240);                  // produced half of the microblocks, should get half the 2/5 of the reward
-        assert_eq!(reward_miner_1.tx_fees_streamed_confirmed, 240);                 // confirmed half of the microblocks, should get half of the 3/5 reward
-
-        // miner 2 didn't produce this block, so no coinbase
-        assert_eq!(reward_miner_2.coinbase, 0);
-        assert_eq!(reward_miner_2.tx_fees_anchored, expected_shared);        // did half the work over the sample
-        assert_eq!(reward_miner_2.tx_fees_streamed_produced, 200);
-        assert_eq!(reward_miner_2.tx_fees_streamed_confirmed, 300);
-
-        // user should have received 3/4 the coinbase, but no tx fees
-        assert_eq!(reward_user_1.coinbase, 375);
-        assert_eq!(reward_user_1.tx_fees_anchored, 0);
-        assert_eq!(reward_user_1.tx_fees_streamed_produced, 0);
-        assert_eq!(reward_user_1.tx_fees_streamed_confirmed, 0);
-    }
-    */
 }

--- a/src/chainstate/stacks/db/mod.rs
+++ b/src/chainstate/stacks/db/mod.rs
@@ -129,7 +129,6 @@ pub struct MinerPaymentSchedule {
     pub stx_burns: u128,
     pub burnchain_commit_burn: u64,
     pub burnchain_sortition_burn: u64,
-    pub fill: u64, // fixed-point fraction of how full this block is, scaled up between 0 and 2**64 - 1 (i.e. 0x8000000000000000 == 50% full)
     pub miner: bool, // is this a schedule payment for the block's miner?
     pub stacks_block_height: u64,
     pub vtxindex: u32,
@@ -523,7 +522,6 @@ const STACKS_CHAIN_STATE_SQL: &'static [&'static str] = &[
         stx_burns TEXT NOT NULL,            -- encodes u128
         burnchain_commit_burn INT NOT NULL,
         burnchain_sortition_burn INT NOT NULL,
-        fill TEXT NOT NULL,                 -- encodes u64 
         miner INT NOT NULL,
         
         -- internal use
@@ -832,7 +830,7 @@ impl StacksChainState {
                 hash_mode: SinglesigHashMode::P2PKH,
                 key_encoding: TransactionPublicKeyEncoding::Uncompressed,
                 nonce: 0,
-                fee_rate: 0,
+                tx_fee: 0,
                 signature: MessageSignature::empty(),
             },
         ));

--- a/src/chainstate/stacks/db/transactions.rs
+++ b/src/chainstate/stacks/db/transactions.rs
@@ -1096,7 +1096,7 @@ impl StacksChainState {
         // TODO: this field is the fee *rate*, not the absolute fee.  This code is broken until we have
         // the true block reward system built.
         let new_payer_account = StacksChainState::get_payer_account(&mut transaction, tx);
-        let fee = tx.get_fee_rate();
+        let fee = tx.get_tx_fee();
         StacksChainState::pay_transaction_fee(&mut transaction, fee, new_payer_account)?;
 
         // update the account nonces
@@ -1168,7 +1168,7 @@ pub mod test {
 
         tx_stx_transfer.chain_id = 0x80000000;
         tx_stx_transfer.post_condition_mode = TransactionPostConditionMode::Allow;
-        tx_stx_transfer.set_fee_rate(0);
+        tx_stx_transfer.set_tx_fee(0);
 
         let mut signer = StacksTransactionSigner::new(&tx_stx_transfer);
         signer.sign_origin(&privk).unwrap();
@@ -1226,7 +1226,7 @@ pub mod test {
 
         tx_stx_transfer.chain_id = 0x80000000;
         tx_stx_transfer.post_condition_mode = TransactionPostConditionMode::Allow;
-        tx_stx_transfer.set_fee_rate(0);
+        tx_stx_transfer.set_tx_fee(0);
         tx_stx_transfer.set_origin_nonce(1);
 
         let mut signer = StacksTransactionSigner::new(&tx_stx_transfer);
@@ -1373,12 +1373,12 @@ pub mod test {
         tx_stx_transfer_wrong_nonce_sponsored.post_condition_mode =
             TransactionPostConditionMode::Allow;
 
-        tx_stx_transfer_same_receiver.set_fee_rate(0);
-        tx_stx_transfer_wrong_network.set_fee_rate(0);
-        tx_stx_transfer_wrong_chain_id.set_fee_rate(0);
-        tx_stx_transfer_postconditions.set_fee_rate(0);
-        tx_stx_transfer_wrong_nonce.set_fee_rate(0);
-        tx_stx_transfer_wrong_nonce_sponsored.set_fee_rate(0);
+        tx_stx_transfer_same_receiver.set_tx_fee(0);
+        tx_stx_transfer_wrong_network.set_tx_fee(0);
+        tx_stx_transfer_wrong_chain_id.set_tx_fee(0);
+        tx_stx_transfer_postconditions.set_tx_fee(0);
+        tx_stx_transfer_wrong_nonce.set_tx_fee(0);
+        tx_stx_transfer_wrong_nonce_sponsored.set_tx_fee(0);
 
         let error_frags = vec![
             "address tried to send to itself".to_string(),
@@ -1490,7 +1490,7 @@ pub mod test {
 
         tx_stx_transfer.chain_id = 0x80000000;
         tx_stx_transfer.post_condition_mode = TransactionPostConditionMode::Allow;
-        tx_stx_transfer.set_fee_rate(0);
+        tx_stx_transfer.set_tx_fee(0);
 
         let mut signer = StacksTransactionSigner::new(&tx_stx_transfer);
         signer.sign_origin(&privk_origin).unwrap();
@@ -1573,7 +1573,7 @@ pub mod test {
         );
 
         tx_contract_call.chain_id = 0x80000000;
-        tx_contract_call.set_fee_rate(0);
+        tx_contract_call.set_tx_fee(0);
 
         let mut signer = StacksTransactionSigner::new(&tx_contract_call);
         signer.sign_origin(&privk).unwrap();
@@ -1670,7 +1670,7 @@ pub mod test {
             );
 
             tx_contract.chain_id = 0x80000000;
-            tx_contract.set_fee_rate(0);
+            tx_contract.set_tx_fee(0);
             tx_contract.set_origin_nonce(next_nonce);
 
             let mut signer = StacksTransactionSigner::new(&tx_contract);
@@ -1769,7 +1769,7 @@ pub mod test {
             );
 
             tx_contract.chain_id = 0x80000000;
-            tx_contract.set_fee_rate(0);
+            tx_contract.set_tx_fee(0);
             tx_contract.set_origin_nonce(i as u64);
 
             let mut signer = StacksTransactionSigner::new(&tx_contract);
@@ -1843,7 +1843,7 @@ pub mod test {
         );
 
         tx_contract_call.chain_id = 0x80000000;
-        tx_contract_call.set_fee_rate(0);
+        tx_contract_call.set_tx_fee(0);
 
         let mut signer = StacksTransactionSigner::new(&tx_contract_call);
         signer.sign_origin(&privk_origin).unwrap();
@@ -1919,7 +1919,7 @@ pub mod test {
         );
 
         tx_contract.chain_id = 0x80000000;
-        tx_contract.set_fee_rate(0);
+        tx_contract.set_tx_fee(0);
 
         let mut signer = StacksTransactionSigner::new(&tx_contract);
         signer.sign_origin(&privk).unwrap();
@@ -1947,7 +1947,7 @@ pub mod test {
         );
 
         tx_contract_call.chain_id = 0x80000000;
-        tx_contract_call.set_fee_rate(0);
+        tx_contract_call.set_tx_fee(0);
 
         let mut signer_2 = StacksTransactionSigner::new(&tx_contract_call);
         signer_2.sign_origin(&privk_2).unwrap();
@@ -2041,7 +2041,7 @@ pub mod test {
         );
 
         tx_contract.chain_id = 0x80000000;
-        tx_contract.set_fee_rate(0);
+        tx_contract.set_tx_fee(0);
 
         let mut signer = StacksTransactionSigner::new(&tx_contract);
         signer.sign_origin(&privk).unwrap();
@@ -2094,7 +2094,7 @@ pub mod test {
             );
 
             tx_contract_call.chain_id = 0x80000000;
-            tx_contract_call.set_fee_rate(0);
+            tx_contract_call.set_tx_fee(0);
             tx_contract_call.set_origin_nonce(next_nonce);
 
             let mut signer_2 = StacksTransactionSigner::new(&tx_contract_call);
@@ -2165,7 +2165,7 @@ pub mod test {
         );
 
         tx_contract.chain_id = 0x80000000;
-        tx_contract.set_fee_rate(0);
+        tx_contract.set_tx_fee(0);
 
         let mut signer = StacksTransactionSigner::new(&tx_contract);
         signer.sign_origin(&privk).unwrap();
@@ -2240,7 +2240,7 @@ pub mod test {
             );
 
             tx_contract_call.chain_id = 0x80000000;
-            tx_contract_call.set_fee_rate(0);
+            tx_contract_call.set_tx_fee(0);
 
             let mut signer_2 = StacksTransactionSigner::new(&tx_contract_call);
             signer_2.sign_origin(&privk_2).unwrap();
@@ -2298,7 +2298,7 @@ pub mod test {
         );
 
         tx_contract.chain_id = 0x80000000;
-        tx_contract.set_fee_rate(0);
+        tx_contract.set_tx_fee(0);
 
         let mut signer = StacksTransactionSigner::new(&tx_contract);
         signer.sign_origin(&privk).unwrap();
@@ -2336,7 +2336,7 @@ pub mod test {
         );
 
         tx_contract_call.chain_id = 0x80000000;
-        tx_contract_call.set_fee_rate(0);
+        tx_contract_call.set_tx_fee(0);
 
         let mut signer_2 = StacksTransactionSigner::new(&tx_contract_call);
         signer_2.sign_origin(&privk_origin).unwrap();
@@ -2516,7 +2516,7 @@ pub mod test {
         );
 
         tx_contract.chain_id = 0x80000000;
-        tx_contract.set_fee_rate(0);
+        tx_contract.set_tx_fee(0);
 
         let mut signer = StacksTransactionSigner::new(&tx_contract);
         signer.sign_origin(&privk_origin).unwrap();
@@ -2546,7 +2546,7 @@ pub mod test {
         );
 
         tx_contract_call_stackaroos.chain_id = 0x80000000;
-        tx_contract_call_stackaroos.set_fee_rate(0);
+        tx_contract_call_stackaroos.set_tx_fee(0);
 
         // mint 100 stackaroos to recv_addr, and set a post-condition on the contract-principal
         // to check it.
@@ -2647,7 +2647,7 @@ pub mod test {
         );
 
         tx_contract_call_user_stackaroos.chain_id = 0x80000000;
-        tx_contract_call_user_stackaroos.set_fee_rate(0);
+        tx_contract_call_user_stackaroos.set_tx_fee(0);
 
         // recv_addr sends 100 stackaroos back to addr_publisher.
         // assert recv_addr sent ==, <=, or >= 100 stackaroos
@@ -2733,7 +2733,7 @@ pub mod test {
             );
 
             tx_contract_call_names.chain_id = 0x80000000;
-            tx_contract_call_names.set_fee_rate(0);
+            tx_contract_call_names.set_tx_fee(0);
             tx_contract_call_names.set_origin_nonce(nonce);
 
             tx_contract_call_names.add_post_condition(TransactionPostCondition::Nonfungible(
@@ -2852,7 +2852,7 @@ pub mod test {
             );
 
             tx_contract_call_names.chain_id = 0x80000000;
-            tx_contract_call_names.set_fee_rate(0);
+            tx_contract_call_names.set_tx_fee(0);
             tx_contract_call_names.set_origin_nonce(nonce);
 
             tx_contract_call_names.add_post_condition(TransactionPostCondition::Nonfungible(
@@ -3209,7 +3209,7 @@ pub mod test {
         );
 
         tx_contract.chain_id = 0x80000000;
-        tx_contract.set_fee_rate(0);
+        tx_contract.set_tx_fee(0);
 
         let mut signer = StacksTransactionSigner::new(&tx_contract);
         signer.sign_origin(&privk_origin).unwrap();
@@ -3252,7 +3252,7 @@ pub mod test {
             );
 
             tx_contract_call_both.chain_id = 0x80000000;
-            tx_contract_call_both.set_fee_rate(0);
+            tx_contract_call_both.set_tx_fee(0);
             tx_contract_call_both.set_origin_nonce(nonce);
 
             tx_contract_call_both.post_condition_mode = TransactionPostConditionMode::Deny;
@@ -3295,7 +3295,7 @@ pub mod test {
 
             tx_contract_call_both.post_condition_mode = TransactionPostConditionMode::Allow;
             tx_contract_call_both.chain_id = 0x80000000;
-            tx_contract_call_both.set_fee_rate(0);
+            tx_contract_call_both.set_tx_fee(0);
             tx_contract_call_both.set_origin_nonce(nonce);
 
             let mut signer = StacksTransactionSigner::new(&tx_contract_call_both);
@@ -3333,7 +3333,7 @@ pub mod test {
             );
 
             tx_contract_call_both.chain_id = 0x80000000;
-            tx_contract_call_both.set_fee_rate(0);
+            tx_contract_call_both.set_tx_fee(0);
             tx_contract_call_both.set_origin_nonce(recv_nonce);
 
             tx_contract_call_both.post_condition_mode = TransactionPostConditionMode::Deny;
@@ -3384,7 +3384,7 @@ pub mod test {
             );
 
             tx_contract_call_both.chain_id = 0x80000000;
-            tx_contract_call_both.set_fee_rate(0);
+            tx_contract_call_both.set_tx_fee(0);
             tx_contract_call_both.set_origin_nonce(nonce);
 
             tx_contract_call_both.post_condition_mode = TransactionPostConditionMode::Deny;
@@ -3430,7 +3430,7 @@ pub mod test {
             );
 
             tx_contract_call_both.chain_id = 0x80000000;
-            tx_contract_call_both.set_fee_rate(0);
+            tx_contract_call_both.set_tx_fee(0);
             tx_contract_call_both.set_origin_nonce(nonce);
 
             tx_contract_call_both.post_condition_mode = TransactionPostConditionMode::Deny;
@@ -3475,7 +3475,7 @@ pub mod test {
             );
 
             tx_contract_call_both.chain_id = 0x80000000;
-            tx_contract_call_both.set_fee_rate(0);
+            tx_contract_call_both.set_tx_fee(0);
             tx_contract_call_both.set_origin_nonce(recv_nonce);
 
             tx_contract_call_both.post_condition_mode = TransactionPostConditionMode::Deny;
@@ -3522,7 +3522,7 @@ pub mod test {
             );
 
             tx_contract_call_both.chain_id = 0x80000000;
-            tx_contract_call_both.set_fee_rate(0);
+            tx_contract_call_both.set_tx_fee(0);
             tx_contract_call_both.set_origin_nonce(recv_nonce);
 
             tx_contract_call_both.post_condition_mode = TransactionPostConditionMode::Deny;
@@ -3846,7 +3846,7 @@ pub mod test {
         );
 
         tx_contract.chain_id = 0x80000000;
-        tx_contract.set_fee_rate(0);
+        tx_contract.set_tx_fee(0);
 
         let mut signer = StacksTransactionSigner::new(&tx_contract);
         signer.sign_origin(&privk_origin).unwrap();
@@ -3866,7 +3866,7 @@ pub mod test {
         );
 
         tx_contract_call.chain_id = 0x80000000;
-        tx_contract_call.set_fee_rate(0);
+        tx_contract_call.set_tx_fee(0);
         tx_contract_call.set_origin_nonce(1);
 
         tx_contract_call.post_condition_mode = TransactionPostConditionMode::Deny;
@@ -6969,7 +6969,7 @@ pub mod test {
         );
 
         tx_contract_create.chain_id = 0x80000000;
-        tx_contract_create.set_fee_rate(0);
+        tx_contract_create.set_tx_fee(0);
 
         let mut signer = StacksTransactionSigner::new(&tx_contract_create);
         signer.sign_origin(&privk).unwrap();
@@ -6995,7 +6995,7 @@ pub mod test {
         );
 
         tx_contract_call.chain_id = 0x80000000;
-        tx_contract_call.set_fee_rate(1);
+        tx_contract_call.set_tx_fee(1);
         tx_contract_call.set_origin_nonce(1);
         tx_contract_call.post_condition_mode = TransactionPostConditionMode::Allow;
 
@@ -7054,7 +7054,7 @@ pub mod test {
         );
 
         tx_contract_create.chain_id = 0x80000000;
-        tx_contract_create.set_fee_rate(0);
+        tx_contract_create.set_tx_fee(0);
 
         let mut signer = StacksTransactionSigner::new(&tx_contract_create);
         signer.sign_origin(&tx_privk).unwrap();
@@ -7145,7 +7145,7 @@ pub mod test {
         );
 
         tx_poison_microblock.chain_id = 0x80000000;
-        tx_poison_microblock.set_fee_rate(0);
+        tx_poison_microblock.set_tx_fee(0);
 
         let mut signer = StacksTransactionSigner::new(&tx_poison_microblock);
         signer.sign_origin(&reporter_privk).unwrap();
@@ -7255,7 +7255,7 @@ pub mod test {
         );
 
         tx_poison_microblock.chain_id = 0x80000000;
-        tx_poison_microblock.set_fee_rate(0);
+        tx_poison_microblock.set_tx_fee(0);
 
         let mut signer = StacksTransactionSigner::new(&tx_poison_microblock);
         signer.sign_origin(&reporter_privk).unwrap();
@@ -7349,7 +7349,7 @@ pub mod test {
         );
 
         tx_poison_microblock_1.chain_id = 0x80000000;
-        tx_poison_microblock_1.set_fee_rate(0);
+        tx_poison_microblock_1.set_tx_fee(0);
 
         let mut signer = StacksTransactionSigner::new(&tx_poison_microblock_1);
         signer.sign_origin(&reporter_privk_1).unwrap();
@@ -7373,7 +7373,7 @@ pub mod test {
         );
 
         tx_poison_microblock_2.chain_id = 0x80000000;
-        tx_poison_microblock_2.set_fee_rate(0);
+        tx_poison_microblock_2.set_tx_fee(0);
 
         let mut signer = StacksTransactionSigner::new(&tx_poison_microblock_2);
         signer.sign_origin(&reporter_privk_2).unwrap();

--- a/src/chainstate/stacks/db/unconfirmed.rs
+++ b/src/chainstate/stacks/db/unconfirmed.rs
@@ -582,7 +582,7 @@ mod test {
 
                     tx_stx_transfer.chain_id = 0x80000000;
                     tx_stx_transfer.post_condition_mode = TransactionPostConditionMode::Allow;
-                    tx_stx_transfer.set_fee_rate(0);
+                    tx_stx_transfer.set_tx_fee(0);
                     tx_stx_transfer.set_origin_nonce(tenure_id as u64);
 
                     let mut signer = StacksTransactionSigner::new(&tx_stx_transfer);
@@ -812,7 +812,7 @@ mod test {
 
                         tx_stx_transfer.chain_id = 0x80000000;
                         tx_stx_transfer.post_condition_mode = TransactionPostConditionMode::Allow;
-                        tx_stx_transfer.set_fee_rate(0);
+                        tx_stx_transfer.set_tx_fee(0);
                         tx_stx_transfer.set_origin_nonce((100 * tenure_id + 10 * i + j) as u64);
 
                         let mut signer = StacksTransactionSigner::new(&tx_stx_transfer);

--- a/src/chainstate/stacks/miner.rs
+++ b/src/chainstate/stacks/miner.rs
@@ -765,10 +765,15 @@ impl StacksBlockBuilder {
         assert!(!self.anchored_done);
 
         // add miner payments
-        if let Some((ref miner_reward, ref user_rewards)) = self.miner_payouts {
+        if let Some((ref miner_reward, ref user_rewards, ref parent_reward)) = self.miner_payouts {
             // grant in order by miner, then users
-            StacksChainState::process_matured_miner_rewards(clarity_tx, miner_reward, user_rewards)
-                .expect("FATAL: failed to process miner rewards");
+            StacksChainState::process_matured_miner_rewards(
+                clarity_tx,
+                miner_reward,
+                user_rewards,
+                parent_reward,
+            )
+            .expect("FATAL: failed to process miner rewards");
         }
 
         // process unlocks
@@ -888,10 +893,16 @@ impl StacksBlockBuilder {
         chainstate: &'a mut StacksChainState,
         burn_dbconn: &'a SortitionDBConn,
     ) -> Result<ClarityTx<'a>, Error> {
+        let mainnet = chainstate.config().mainnet;
+
         // find matured miner rewards, so we can grant them within the Clarity DB tx.
-        let latest_matured_miners = {
+        let (latest_matured_miners, matured_miner_parent) = {
             let mut tx = chainstate.index_tx_begin()?;
-            StacksChainState::get_scheduled_block_rewards(&mut tx, &self.chain_tip)?
+            let latest_miners =
+                StacksChainState::get_scheduled_block_rewards(&mut tx, &self.chain_tip)?;
+            let parent_miner =
+                StacksChainState::get_parent_matured_miner(&mut tx, mainnet, &latest_miners)?;
+            (latest_miners, parent_miner)
         };
 
         // there's no way the miner can learn either the burn block hash or the stacks block hash,
@@ -906,11 +917,13 @@ impl StacksBlockBuilder {
                                     self.header.parent_block)
         );
 
-        if let Some((ref _miner_payout, ref _user_payouts)) = self.miner_payouts {
+        if let Some((ref _miner_payout, ref _user_payouts, ref _parent_reward)) = self.miner_payouts
+        {
             test_debug!(
-                "Miner payout to process: {:?}; user payouts: {:?}",
+                "Miner payout to process: {:?}; user payouts: {:?}; parent payout: {:?}",
                 _miner_payout,
-                _user_payouts
+                _user_payouts,
+                _parent_reward
             );
         }
 
@@ -969,9 +982,11 @@ impl StacksBlockBuilder {
             &mut tx,
             &self.chain_tip,
             latest_matured_miners,
+            matured_miner_parent,
         )?;
 
-        self.miner_payouts = matured_miner_rewards_opt.map(|(miner, users, _)| (miner, users));
+        self.miner_payouts =
+            matured_miner_rewards_opt.map(|(miner, users, parent, _)| (miner, users, parent));
 
         test_debug!(
             "Miner {}: Apply {} parent microblocks",
@@ -1503,8 +1518,23 @@ pub mod test {
     }
 
     impl TestStacksNode {
-        pub fn new(mainnet: bool, chain_id: u32, test_name: &str) -> TestStacksNode {
-            let chainstate = instantiate_chainstate(mainnet, chain_id, test_name);
+        pub fn new(
+            mainnet: bool,
+            chain_id: u32,
+            test_name: &str,
+            mut initial_balance_recipients: Vec<StacksAddress>,
+        ) -> TestStacksNode {
+            initial_balance_recipients.sort();
+            let initial_balances = initial_balance_recipients
+                .into_iter()
+                .map(|addr| (addr, 10_000_000_000))
+                .collect();
+            let chainstate = instantiate_chainstate_with_balances(
+                mainnet,
+                chain_id,
+                test_name,
+                initial_balances,
+            );
             TestStacksNode {
                 chainstate: chainstate,
                 prev_keys: vec![],
@@ -2029,22 +2059,107 @@ pub mod test {
         block_height: u64,
         prev_block_rewards: &Vec<Vec<MinerPaymentSchedule>>,
     ) -> bool {
-        let mut total: u128 = 0;
+        let mut block_rewards = HashMap::new();
+        let mut stream_rewards = HashMap::new();
+        let mut heights = HashMap::new();
+        let mut confirmed = HashSet::new();
+        for (i, reward_list) in prev_block_rewards.iter().enumerate() {
+            for reward in reward_list.iter() {
+                let ibh = StacksBlockHeader::make_index_block_hash(
+                    &reward.consensus_hash,
+                    &reward.block_hash,
+                );
+                if reward.coinbase > 0 {
+                    block_rewards.insert(ibh.clone(), reward.clone());
+                }
+                if reward.tx_fees_streamed > 0 {
+                    stream_rewards.insert(ibh.clone(), reward.clone());
+                }
+                heights.insert(ibh.clone(), i);
+                confirmed.insert((
+                    StacksBlockHeader::make_index_block_hash(
+                        &reward.parent_consensus_hash,
+                        &reward.parent_block_hash,
+                    ),
+                    i,
+                ));
+            }
+        }
+
+        // what was the miner's total spend?
+        let miner_nonce = clarity_tx.with_clarity_db_readonly(|db| {
+            db.get_account_nonce(
+                &StandardPrincipalData::from(miner.origin_address().unwrap()).into(),
+            )
+        });
+
+        let mut spent_total = 0;
+        for (nonce, spent) in miner.spent_at_nonce.iter() {
+            if *nonce < miner_nonce {
+                spent_total += *spent;
+            }
+        }
+
+        let mut total: u128 = 10_000_000_000 - spent_total;
+        test_debug!(
+            "Miner {} has spent {} in total so far",
+            &miner.origin_address().unwrap(),
+            spent_total
+        );
+
         if block_height >= MINER_REWARD_MATURITY {
             for (i, prev_block_reward) in prev_block_rewards.iter().enumerate() {
                 if i as u64 > block_height - MINER_REWARD_MATURITY {
                     break;
                 }
+                let mut found = false;
                 for recipient in prev_block_reward {
                     if recipient.address == miner.origin_address().unwrap() {
-                        let reward: u128 = recipient.coinbase; // TODO: expand to cover tx fees
+                        let mut reward: u128 = recipient.coinbase
+                            + recipient.tx_fees_anchored
+                            + (3 * recipient.tx_fees_streamed / 5);
+
                         test_debug!(
-                            "Miner {} received a reward {} at block {}",
+                            "Miner {} received a reward {} = {} + {} + {} at block {}",
                             &recipient.address.to_string(),
                             reward,
+                            recipient.coinbase,
+                            recipient.tx_fees_anchored,
+                            (3 * recipient.tx_fees_streamed / 5),
                             i
                         );
                         total += reward;
+                        found = true;
+                    }
+                }
+                if !found {
+                    test_debug!(
+                        "Miner {} received no reward at block {}",
+                        miner.origin_address().unwrap(),
+                        i
+                    );
+                }
+            }
+
+            for (parent_block, confirmed_block_height) in confirmed.into_iter() {
+                if confirmed_block_height as u64 > block_height - MINER_REWARD_MATURITY {
+                    continue;
+                }
+                if let Some(ref parent_reward) = stream_rewards.get(&parent_block) {
+                    if parent_reward.address == miner.origin_address().unwrap() {
+                        let parent_streamed = (2 * parent_reward.tx_fees_streamed) / 5;
+                        let parent_ibh = StacksBlockHeader::make_index_block_hash(
+                            &parent_reward.consensus_hash,
+                            &parent_reward.block_hash,
+                        );
+                        test_debug!(
+                            "Miner {} received a produced-stream reward {} from {} confirmed at {}",
+                            miner.origin_address().unwrap().to_string(),
+                            parent_streamed,
+                            heights.get(&parent_ibh).unwrap(),
+                            confirmed_block_height
+                        );
+                        total += parent_streamed;
                     }
                 }
             }
@@ -2149,11 +2264,17 @@ pub mod test {
         G: FnMut(&StacksBlock, &Vec<StacksMicroblock>) -> bool,
     {
         let full_test_name = format!("{}-1_fork_1_miner_1_burnchain", test_name);
-        let mut node = TestStacksNode::new(false, 0x80000000, &full_test_name);
         let mut burn_node = TestBurnchainNode::new();
         let mut miner_factory = TestMinerFactory::new();
         let mut miner =
             miner_factory.next_miner(&burn_node.burnchain, 1, 1, AddressHashMode::SerializeP2PKH);
+
+        let mut node = TestStacksNode::new(
+            false,
+            0x80000000,
+            &full_test_name,
+            vec![miner.origin_address().unwrap()],
+        );
 
         let first_snapshot =
             SortitionDB::get_first_block_snapshot(burn_node.sortdb.conn()).unwrap();
@@ -2315,13 +2436,22 @@ pub mod test {
         ) -> (StacksBlock, Vec<StacksMicroblock>),
     {
         let full_test_name = format!("{}-1_fork_2_miners_1_burnchain", test_name);
-        let mut node = TestStacksNode::new(false, 0x80000000, &full_test_name);
         let mut burn_node = TestBurnchainNode::new();
         let mut miner_factory = TestMinerFactory::new();
         let mut miner_1 =
             miner_factory.next_miner(&burn_node.burnchain, 1, 1, AddressHashMode::SerializeP2PKH);
         let mut miner_2 =
             miner_factory.next_miner(&burn_node.burnchain, 1, 1, AddressHashMode::SerializeP2PKH);
+
+        let mut node = TestStacksNode::new(
+            false,
+            0x80000000,
+            &full_test_name,
+            vec![
+                miner_1.origin_address().unwrap(),
+                miner_2.origin_address().unwrap(),
+            ],
+        );
 
         let mut sortition_winners = vec![];
 
@@ -2742,13 +2872,22 @@ pub mod test {
         ) -> (StacksBlock, Vec<StacksMicroblock>),
     {
         let full_test_name = format!("{}-2_forks_2_miners_1_burnchain", test_name);
-        let mut node = TestStacksNode::new(false, 0x80000000, &full_test_name);
         let mut burn_node = TestBurnchainNode::new();
         let mut miner_factory = TestMinerFactory::new();
         let mut miner_1 =
             miner_factory.next_miner(&burn_node.burnchain, 1, 1, AddressHashMode::SerializeP2PKH);
         let mut miner_2 =
             miner_factory.next_miner(&burn_node.burnchain, 1, 1, AddressHashMode::SerializeP2PKH);
+
+        let mut node = TestStacksNode::new(
+            false,
+            0x80000000,
+            &full_test_name,
+            vec![
+                miner_1.origin_address().unwrap(),
+                miner_2.origin_address().unwrap(),
+            ],
+        );
 
         let mut sortition_winners = vec![];
 
@@ -3322,12 +3461,21 @@ pub mod test {
     {
         let full_test_name = format!("{}-1_fork_2_miners_2_burnchain", test_name);
         let mut burn_node = TestBurnchainNode::new();
-        let mut node = TestStacksNode::new(false, 0x80000000, &full_test_name);
         let mut miner_factory = TestMinerFactory::new();
         let mut miner_1 =
             miner_factory.next_miner(&burn_node.burnchain, 1, 1, AddressHashMode::SerializeP2PKH);
         let mut miner_2 =
             miner_factory.next_miner(&burn_node.burnchain, 1, 1, AddressHashMode::SerializeP2PKH);
+
+        let mut node = TestStacksNode::new(
+            false,
+            0x80000000,
+            &full_test_name,
+            vec![
+                miner_1.origin_address().unwrap(),
+                miner_2.origin_address().unwrap(),
+            ],
+        );
 
         let first_snapshot =
             SortitionDB::get_first_block_snapshot(burn_node.sortdb.conn()).unwrap();
@@ -3852,12 +4000,21 @@ pub mod test {
     {
         let full_test_name = format!("{}-2_forks_2_miner_2_burnchains", test_name);
         let mut burn_node = TestBurnchainNode::new();
-        let mut node = TestStacksNode::new(false, 0x80000000, &full_test_name);
         let mut miner_factory = TestMinerFactory::new();
         let mut miner_1 =
             miner_factory.next_miner(&burn_node.burnchain, 1, 1, AddressHashMode::SerializeP2PKH);
         let mut miner_2 =
             miner_factory.next_miner(&burn_node.burnchain, 1, 1, AddressHashMode::SerializeP2PKH);
+
+        let mut node = TestStacksNode::new(
+            false,
+            0x80000000,
+            &full_test_name,
+            vec![
+                miner_1.origin_address().unwrap(),
+                miner_2.origin_address().unwrap(),
+            ],
+        );
 
         let first_snapshot =
             SortitionDB::get_first_block_snapshot(burn_node.sortdb.conn()).unwrap();
@@ -4525,7 +4682,16 @@ pub mod test {
         let mut nodes = HashMap::new();
         for (i, test_name) in test_names.iter().enumerate() {
             let rnd_test_name = format!("{}-replay_randomized", test_name);
-            let next_node = TestStacksNode::new(false, 0x80000000, &rnd_test_name);
+            let next_node = TestStacksNode::new(
+                false,
+                0x80000000,
+                &rnd_test_name,
+                miner_trace
+                    .miners
+                    .iter()
+                    .map(|ref miner| miner.origin_address().unwrap())
+                    .collect(),
+            );
             nodes.insert(test_name, next_node);
         }
 
@@ -4801,7 +4967,9 @@ pub mod test {
 
         tx_contract.chain_id = 0x80000000;
         tx_contract.auth.set_origin_nonce(miner.get_nonce());
-        tx_contract.set_fee_rate(0);
+        tx_contract.set_tx_fee(123);
+
+        miner.spent_at_nonce.insert(miner.get_nonce(), 123);
 
         let mut tx_signer = StacksTransactionSigner::new(&tx_contract);
         miner.sign_as_origin(&mut tx_signer);
@@ -4833,7 +5001,9 @@ pub mod test {
 
         tx_contract_call.chain_id = 0x80000000;
         tx_contract_call.auth.set_origin_nonce(miner.get_nonce());
-        tx_contract_call.set_fee_rate(0);
+        tx_contract_call.set_tx_fee(456);
+
+        miner.spent_at_nonce.insert(miner.get_nonce(), 456);
 
         let mut tx_signer = StacksTransactionSigner::new(&tx_contract_call);
         miner.sign_as_origin(&mut tx_signer);
@@ -4861,7 +5031,7 @@ pub mod test {
         tx_stx_transfer
             .auth
             .set_origin_nonce(nonce.unwrap_or(miner.get_nonce()));
-        tx_stx_transfer.set_fee_rate(0);
+        tx_stx_transfer.set_tx_fee(0);
 
         let mut tx_signer = StacksTransactionSigner::new(&tx_stx_transfer);
         miner.sign_as_origin(&mut tx_signer);
@@ -5725,7 +5895,7 @@ pub mod test {
     pub fn make_user_contract_publish(
         sender: &StacksPrivateKey,
         nonce: u64,
-        fee_rate: u64,
+        tx_fee: u64,
         contract_name: &str,
         contract_content: &str,
     ) -> StacksTransaction {
@@ -5734,13 +5904,13 @@ pub mod test {
 
         let payload = TransactionSmartContract { name, code_body };
 
-        sign_standard_singlesig_tx(payload.into(), sender, nonce, fee_rate)
+        sign_standard_singlesig_tx(payload.into(), sender, nonce, tx_fee)
     }
 
     pub fn make_user_stacks_transfer(
         sender: &StacksPrivateKey,
         nonce: u64,
-        fee_rate: u64,
+        tx_fee: u64,
         recipient: &PrincipalData,
         amount: u64,
     ) -> StacksTransaction {
@@ -5749,39 +5919,39 @@ pub mod test {
             amount,
             TokenTransferMemo([0; 34]),
         );
-        sign_standard_singlesig_tx(payload.into(), sender, nonce, fee_rate)
+        sign_standard_singlesig_tx(payload.into(), sender, nonce, tx_fee)
     }
 
     pub fn make_user_coinbase(
         sender: &StacksPrivateKey,
         nonce: u64,
-        fee_rate: u64,
+        tx_fee: u64,
     ) -> StacksTransaction {
         let payload = TransactionPayload::Coinbase(CoinbasePayload([0; 32]));
-        sign_standard_singlesig_tx(payload.into(), sender, nonce, fee_rate)
+        sign_standard_singlesig_tx(payload.into(), sender, nonce, tx_fee)
     }
 
     pub fn make_user_poison_microblock(
         sender: &StacksPrivateKey,
         nonce: u64,
-        fee_rate: u64,
+        tx_fee: u64,
         payload: TransactionPayload,
     ) -> StacksTransaction {
-        sign_standard_singlesig_tx(payload.into(), sender, nonce, fee_rate)
+        sign_standard_singlesig_tx(payload.into(), sender, nonce, tx_fee)
     }
 
     pub fn sign_standard_singlesig_tx(
         payload: TransactionPayload,
         sender: &StacksPrivateKey,
         nonce: u64,
-        fee_rate: u64,
+        tx_fee: u64,
     ) -> StacksTransaction {
         let mut spending_condition = TransactionSpendingCondition::new_singlesig_p2pkh(
             StacksPublicKey::from_private(sender),
         )
         .expect("Failed to create p2pkh spending condition from public key.");
         spending_condition.set_nonce(nonce);
-        spending_condition.set_fee_rate(fee_rate);
+        spending_condition.set_tx_fee(tx_fee);
         let auth = TransactionAuth::Standard(spending_condition);
         let mut unsigned_tx = StacksTransaction::new(TransactionVersion::Testnet, auth, payload);
 

--- a/src/chainstate/stacks/mod.rs
+++ b/src/chainstate/stacks/mod.rs
@@ -547,8 +547,8 @@ impl MultisigHashMode {
 pub struct MultisigSpendingCondition {
     pub hash_mode: MultisigHashMode,
     pub signer: Hash160,
-    pub nonce: u64,    // nth authorization from this account
-    pub fee_rate: u64, // microSTX/compute rate offered by this account
+    pub nonce: u64,  // nth authorization from this account
+    pub tx_fee: u64, // microSTX/compute rate offered by this account
     pub fields: Vec<TransactionAuthField>,
     pub signatures_required: u16,
 }
@@ -557,8 +557,8 @@ pub struct MultisigSpendingCondition {
 pub struct SinglesigSpendingCondition {
     pub hash_mode: SinglesigHashMode,
     pub signer: Hash160,
-    pub nonce: u64,    // nth authorization from this account
-    pub fee_rate: u64, // microSTX/compute rate offerred by this account
+    pub nonce: u64,  // nth authorization from this account
+    pub tx_fee: u64, // microSTX/compute rate offerred by this account
     pub key_encoding: TransactionPublicKeyEncoding,
     pub signature: MessageSignature,
 }
@@ -891,7 +891,7 @@ pub struct StacksBlockBuilder {
     bytes_so_far: u64,
     prev_microblock_header: StacksMicroblockHeader,
     miner_privkey: StacksPrivateKey,
-    miner_payouts: Option<(MinerReward, Vec<MinerReward>)>,
+    miner_payouts: Option<(MinerReward, Vec<MinerReward>, MinerReward)>,
     parent_microblock_hash: Option<BlockHeaderHash>,
     miner_id: usize,
 }
@@ -964,7 +964,7 @@ pub mod test {
                 hash_mode: SinglesigHashMode::P2PKH,
                 key_encoding: TransactionPublicKeyEncoding::Uncompressed,
                 nonce: 123,
-                fee_rate: 456,
+                tx_fee: 456,
                 signature: MessageSignature::from_raw(&vec![0xff; 65])
             }),
             TransactionSpendingCondition::Singlesig(SinglesigSpendingCondition {
@@ -972,14 +972,14 @@ pub mod test {
                 hash_mode: SinglesigHashMode::P2PKH,
                 key_encoding: TransactionPublicKeyEncoding::Compressed,
                 nonce: 234,
-                fee_rate: 567,
+                tx_fee: 567,
                 signature: MessageSignature::from_raw(&vec![0xff; 65])
             }),
             TransactionSpendingCondition::Multisig(MultisigSpendingCondition {
                 signer: Hash160([0x11; 20]),
                 hash_mode: MultisigHashMode::P2SH,
                 nonce: 345,
-                fee_rate: 678,
+                tx_fee: 678,
                 fields: vec![
                     TransactionAuthField::Signature(TransactionPublicKeyEncoding::Uncompressed, MessageSignature::from_raw(&vec![0xff; 65])),
                     TransactionAuthField::Signature(TransactionPublicKeyEncoding::Uncompressed, MessageSignature::from_raw(&vec![0xfe; 65])),
@@ -991,7 +991,7 @@ pub mod test {
                 signer: Hash160([0x11; 20]),
                 hash_mode: MultisigHashMode::P2SH,
                 nonce: 456,
-                fee_rate: 789,
+                tx_fee: 789,
                 fields: vec![
                     TransactionAuthField::Signature(TransactionPublicKeyEncoding::Compressed, MessageSignature::from_raw(&vec![0xff; 65])),
                     TransactionAuthField::Signature(TransactionPublicKeyEncoding::Compressed, MessageSignature::from_raw(&vec![0xfe; 65])),
@@ -1004,14 +1004,14 @@ pub mod test {
                 hash_mode: SinglesigHashMode::P2WPKH,
                 key_encoding: TransactionPublicKeyEncoding::Compressed,
                 nonce: 567,
-                fee_rate: 890,
+                tx_fee: 890,
                 signature: MessageSignature::from_raw(&vec![0xfe; 65]),
             }),
             TransactionSpendingCondition::Multisig(MultisigSpendingCondition {
                 signer: Hash160([0x11; 20]),
                 hash_mode: MultisigHashMode::P2WSH,
                 nonce: 678,
-                fee_rate: 901,
+                tx_fee: 901,
                 fields: vec![
                     TransactionAuthField::Signature(TransactionPublicKeyEncoding::Compressed, MessageSignature::from_raw(&vec![0xff; 65])),
                     TransactionAuthField::Signature(TransactionPublicKeyEncoding::Compressed, MessageSignature::from_raw(&vec![0xfe; 65])),

--- a/src/chainstate/stacks/transaction.rs
+++ b/src/chainstate/stacks/transaction.rs
@@ -558,13 +558,13 @@ impl StacksTransaction {
     }
 
     /// Get fee rate
-    pub fn get_fee_rate(&self) -> u64 {
-        self.auth.get_fee_rate()
+    pub fn get_tx_fee(&self) -> u64 {
+        self.auth.get_tx_fee()
     }
 
     /// Set fee rate
-    pub fn set_fee_rate(&mut self, fee_rate: u64) -> () {
-        self.auth.set_fee_rate(fee_rate);
+    pub fn set_tx_fee(&mut self, tx_fee: u64) -> () {
+        self.auth.set_tx_fee(tx_fee);
     }
 
     /// Get origin nonce
@@ -650,7 +650,7 @@ impl StacksTransaction {
         let (next_sig, next_sighash) = TransactionSpendingCondition::next_signature(
             cur_sighash,
             auth_flag,
-            condition.fee_rate(),
+            condition.tx_fee(),
             condition.nonce(),
             privk,
         )?;
@@ -1402,7 +1402,7 @@ mod test {
 
         // mess with transaction fee
         let mut corrupt_tx_fee = signed_tx.clone();
-        corrupt_tx_fee.set_fee_rate(corrupt_tx_fee.get_fee_rate() + 1);
+        corrupt_tx_fee.set_tx_fee(corrupt_tx_fee.get_tx_fee() + 1);
         assert!(corrupt_tx_fee.txid() != signed_tx.txid());
 
         // mess with anchor mode
@@ -3401,7 +3401,7 @@ mod test {
 
             // tx and signed_tx are otherwise equal
             assert_eq!(tx.version, signed_tx.version);
-            assert_eq!(tx.get_fee_rate(), signed_tx.get_fee_rate());
+            assert_eq!(tx.get_tx_fee(), signed_tx.get_tx_fee());
             assert_eq!(tx.get_origin_nonce(), signed_tx.get_origin_nonce());
             assert_eq!(tx.get_sponsor_nonce(), signed_tx.get_sponsor_nonce());
             assert_eq!(tx.anchor_mode, signed_tx.anchor_mode);
@@ -3480,7 +3480,7 @@ mod test {
             assert_eq!(tx.auth().origin().num_signatures(), 0);
             assert_eq!(tx.auth().sponsor().unwrap().num_signatures(), 0);
 
-            tx.set_fee_rate(123);
+            tx.set_tx_fee(123);
             tx.set_sponsor_nonce(456).unwrap();
             let mut tx_signer = StacksTransactionSigner::new(&tx);
 
@@ -3494,7 +3494,7 @@ mod test {
                 StacksPublicKey::from_private(&privk_diff_sponsor),
             )
             .unwrap();
-            sponsor_auth.set_fee_rate(456);
+            sponsor_auth.set_tx_fee(456);
             sponsor_auth.set_nonce(789);
 
             let mut tx_sponsor_signer =
@@ -3504,7 +3504,7 @@ mod test {
             tx_sponsor_signer.sign_sponsor(&privk_diff_sponsor).unwrap();
 
             // make comparable
-            tx.set_fee_rate(456);
+            tx.set_tx_fee(456);
             tx.set_sponsor_nonce(789).unwrap();
             let mut signed_tx = tx_sponsor_signer.get_tx().unwrap();
 
@@ -3518,7 +3518,7 @@ mod test {
             // tx and signed_tx are otherwise equal
             assert_eq!(tx.version, signed_tx.version);
             assert_eq!(tx.chain_id, signed_tx.chain_id);
-            assert_eq!(tx.get_fee_rate(), 456);
+            assert_eq!(tx.get_tx_fee(), 456);
             assert_eq!(tx.get_origin_nonce(), signed_tx.get_origin_nonce());
             assert_eq!(tx.get_sponsor_nonce(), signed_tx.get_sponsor_nonce());
             assert_eq!(tx.anchor_mode, signed_tx.anchor_mode);
@@ -3596,7 +3596,7 @@ mod test {
 
             // tx and signed_tx are otherwise equal
             assert_eq!(tx.version, signed_tx.version);
-            assert_eq!(tx.get_fee_rate(), signed_tx.get_fee_rate());
+            assert_eq!(tx.get_tx_fee(), signed_tx.get_tx_fee());
             assert_eq!(tx.get_origin_nonce(), signed_tx.get_origin_nonce());
             assert_eq!(tx.get_sponsor_nonce(), signed_tx.get_sponsor_nonce());
             assert_eq!(tx.anchor_mode, signed_tx.anchor_mode);
@@ -3677,7 +3677,7 @@ mod test {
             assert_eq!(tx.auth().origin().num_signatures(), 0);
             assert_eq!(tx.auth().sponsor().unwrap().num_signatures(), 0);
 
-            tx.set_fee_rate(123);
+            tx.set_tx_fee(123);
             tx.set_sponsor_nonce(456).unwrap();
 
             let mut tx_signer = StacksTransactionSigner::new(&tx);
@@ -3686,13 +3686,13 @@ mod test {
             // sponsor sets and pays fee after origin signs
             let mut origin_tx = tx_signer.get_tx_incomplete();
             origin_tx.auth.set_sponsor(real_sponsor.clone()).unwrap();
-            origin_tx.set_fee_rate(456);
+            origin_tx.set_tx_fee(456);
             origin_tx.set_sponsor_nonce(789).unwrap();
             tx_signer.resume(&origin_tx);
 
             tx_signer.sign_sponsor(&privk_sponsored).unwrap();
 
-            tx.set_fee_rate(456);
+            tx.set_tx_fee(456);
             tx.set_sponsor_nonce(789).unwrap();
             let mut signed_tx = tx_signer.get_tx().unwrap();
 
@@ -3706,7 +3706,7 @@ mod test {
             // tx and signed_tx are otherwise equal
             assert_eq!(tx.version, signed_tx.version);
             assert_eq!(tx.chain_id, signed_tx.chain_id);
-            assert_eq!(tx.get_fee_rate(), signed_tx.get_fee_rate());
+            assert_eq!(tx.get_tx_fee(), signed_tx.get_tx_fee());
             assert_eq!(tx.get_origin_nonce(), signed_tx.get_origin_nonce());
             assert_eq!(tx.get_sponsor_nonce(), signed_tx.get_sponsor_nonce());
             assert_eq!(tx.anchor_mode, signed_tx.anchor_mode);
@@ -3797,7 +3797,7 @@ mod test {
 
             // tx and signed_tx are otherwise equal
             assert_eq!(tx.version, signed_tx.version);
-            assert_eq!(tx.get_fee_rate(), signed_tx.get_fee_rate());
+            assert_eq!(tx.get_tx_fee(), signed_tx.get_tx_fee());
             assert_eq!(tx.get_origin_nonce(), signed_tx.get_origin_nonce());
             assert_eq!(tx.get_sponsor_nonce(), signed_tx.get_sponsor_nonce());
             assert_eq!(tx.anchor_mode, signed_tx.anchor_mode);
@@ -3902,7 +3902,7 @@ mod test {
             assert_eq!(tx.auth().origin().num_signatures(), 0);
             assert_eq!(tx.auth().sponsor().unwrap().num_signatures(), 0);
 
-            tx.set_fee_rate(123);
+            tx.set_tx_fee(123);
             tx.set_sponsor_nonce(456).unwrap();
             let mut tx_signer = StacksTransactionSigner::new(&tx);
 
@@ -3911,7 +3911,7 @@ mod test {
             // sponsor sets and pays fee after origin signs
             let mut origin_tx = tx_signer.get_tx_incomplete();
             origin_tx.auth.set_sponsor(real_sponsor.clone()).unwrap();
-            origin_tx.set_fee_rate(456);
+            origin_tx.set_tx_fee(456);
             origin_tx.set_sponsor_nonce(789).unwrap();
             tx_signer.resume(&origin_tx);
 
@@ -3919,7 +3919,7 @@ mod test {
             tx_signer.sign_sponsor(&privk_2).unwrap();
             tx_signer.append_sponsor(&pubk_3).unwrap();
 
-            tx.set_fee_rate(456);
+            tx.set_tx_fee(456);
             tx.set_sponsor_nonce(789).unwrap();
             let mut signed_tx = tx_signer.get_tx().unwrap();
 
@@ -3932,7 +3932,7 @@ mod test {
             // tx and signed_tx are otherwise equal
             assert_eq!(tx.version, signed_tx.version);
             assert_eq!(tx.chain_id, signed_tx.chain_id);
-            assert_eq!(tx.get_fee_rate(), signed_tx.get_fee_rate());
+            assert_eq!(tx.get_tx_fee(), signed_tx.get_tx_fee());
             assert_eq!(tx.get_origin_nonce(), signed_tx.get_origin_nonce());
             assert_eq!(tx.get_sponsor_nonce(), signed_tx.get_sponsor_nonce());
             assert_eq!(tx.anchor_mode, signed_tx.anchor_mode);
@@ -4038,7 +4038,7 @@ mod test {
             // tx and signed_tx are otherwise equal
             assert_eq!(tx.version, signed_tx.version);
             assert_eq!(tx.chain_id, signed_tx.chain_id);
-            assert_eq!(tx.get_fee_rate(), signed_tx.get_fee_rate());
+            assert_eq!(tx.get_tx_fee(), signed_tx.get_tx_fee());
             assert_eq!(tx.get_origin_nonce(), signed_tx.get_origin_nonce());
             assert_eq!(tx.get_sponsor_nonce(), signed_tx.get_sponsor_nonce());
             assert_eq!(tx.anchor_mode, signed_tx.anchor_mode);
@@ -4143,7 +4143,7 @@ mod test {
             assert_eq!(tx.auth().origin().num_signatures(), 0);
             assert_eq!(tx.auth().sponsor().unwrap().num_signatures(), 0);
 
-            tx.set_fee_rate(123);
+            tx.set_tx_fee(123);
             tx.set_sponsor_nonce(456).unwrap();
             let mut tx_signer = StacksTransactionSigner::new(&tx);
 
@@ -4152,7 +4152,7 @@ mod test {
             // sponsor sets and pays fee after origin signs
             let mut origin_tx = tx_signer.get_tx_incomplete();
             origin_tx.auth.set_sponsor(real_sponsor.clone()).unwrap();
-            origin_tx.set_fee_rate(456);
+            origin_tx.set_tx_fee(456);
             origin_tx.set_sponsor_nonce(789).unwrap();
             tx_signer.resume(&origin_tx);
 
@@ -4160,7 +4160,7 @@ mod test {
             tx_signer.sign_sponsor(&privk_2).unwrap();
             tx_signer.append_sponsor(&pubk_3).unwrap();
 
-            tx.set_fee_rate(456);
+            tx.set_tx_fee(456);
             tx.set_sponsor_nonce(789).unwrap();
             let mut signed_tx = tx_signer.get_tx().unwrap();
 
@@ -4172,7 +4172,7 @@ mod test {
 
             // tx and signed_tx are otherwise equal
             assert_eq!(tx.version, signed_tx.version);
-            assert_eq!(tx.get_fee_rate(), signed_tx.get_fee_rate());
+            assert_eq!(tx.get_tx_fee(), signed_tx.get_tx_fee());
             assert_eq!(tx.get_origin_nonce(), signed_tx.get_origin_nonce());
             assert_eq!(tx.get_sponsor_nonce(), signed_tx.get_sponsor_nonce());
             assert_eq!(tx.anchor_mode, signed_tx.anchor_mode);
@@ -4274,7 +4274,7 @@ mod test {
 
             // tx and signed_tx are otherwise equal
             assert_eq!(tx.version, signed_tx.version);
-            assert_eq!(tx.get_fee_rate(), signed_tx.get_fee_rate());
+            assert_eq!(tx.get_tx_fee(), signed_tx.get_tx_fee());
             assert_eq!(tx.get_origin_nonce(), signed_tx.get_origin_nonce());
             assert_eq!(tx.get_sponsor_nonce(), signed_tx.get_sponsor_nonce());
             assert_eq!(tx.anchor_mode, signed_tx.anchor_mode);
@@ -4379,7 +4379,7 @@ mod test {
             assert_eq!(tx.auth().origin().num_signatures(), 0);
             assert_eq!(tx.auth().sponsor().unwrap().num_signatures(), 0);
 
-            tx.set_fee_rate(123);
+            tx.set_tx_fee(123);
             tx.set_sponsor_nonce(456).unwrap();
             let mut tx_signer = StacksTransactionSigner::new(&tx);
 
@@ -4388,7 +4388,7 @@ mod test {
             // sponsor sets and pays fee after origin signs
             let mut origin_tx = tx_signer.get_tx_incomplete();
             origin_tx.auth.set_sponsor(real_sponsor.clone()).unwrap();
-            origin_tx.set_fee_rate(456);
+            origin_tx.set_tx_fee(456);
             origin_tx.set_sponsor_nonce(789).unwrap();
             tx_signer.resume(&origin_tx);
 
@@ -4396,7 +4396,7 @@ mod test {
             tx_signer.append_sponsor(&pubk_2).unwrap();
             tx_signer.sign_sponsor(&privk_3).unwrap();
 
-            tx.set_fee_rate(456);
+            tx.set_tx_fee(456);
             tx.set_sponsor_nonce(789).unwrap();
             let mut signed_tx = tx_signer.get_tx().unwrap();
 
@@ -4409,7 +4409,7 @@ mod test {
             // tx and signed_tx are otherwise equal
             assert_eq!(tx.version, signed_tx.version);
             assert_eq!(tx.chain_id, signed_tx.chain_id);
-            assert_eq!(tx.get_fee_rate(), signed_tx.get_fee_rate());
+            assert_eq!(tx.get_tx_fee(), signed_tx.get_tx_fee());
             assert_eq!(tx.get_origin_nonce(), signed_tx.get_origin_nonce());
             assert_eq!(tx.get_sponsor_nonce(), signed_tx.get_sponsor_nonce());
             assert_eq!(tx.anchor_mode, signed_tx.anchor_mode);
@@ -4496,7 +4496,7 @@ mod test {
 
             // tx and signed_tx are otherwise equal
             assert_eq!(tx.version, signed_tx.version);
-            assert_eq!(tx.get_fee_rate(), signed_tx.get_fee_rate());
+            assert_eq!(tx.get_tx_fee(), signed_tx.get_tx_fee());
             assert_eq!(tx.get_origin_nonce(), signed_tx.get_origin_nonce());
             assert_eq!(tx.get_sponsor_nonce(), signed_tx.get_sponsor_nonce());
             assert_eq!(tx.anchor_mode, signed_tx.anchor_mode);
@@ -4573,7 +4573,7 @@ mod test {
             assert_eq!(tx.auth().origin().num_signatures(), 0);
             assert_eq!(tx.auth().sponsor().unwrap().num_signatures(), 0);
 
-            tx.set_fee_rate(123);
+            tx.set_tx_fee(123);
             tx.set_sponsor_nonce(456).unwrap();
             let mut tx_signer = StacksTransactionSigner::new(&tx);
 
@@ -4582,13 +4582,13 @@ mod test {
             // sponsor sets and pays fee after origin signs
             let mut origin_tx = tx_signer.get_tx_incomplete();
             origin_tx.auth.set_sponsor(real_sponsor.clone()).unwrap();
-            origin_tx.set_fee_rate(456);
+            origin_tx.set_tx_fee(456);
             origin_tx.set_sponsor_nonce(789).unwrap();
             tx_signer.resume(&origin_tx);
 
             tx_signer.sign_sponsor(&privk).unwrap();
 
-            tx.set_fee_rate(456);
+            tx.set_tx_fee(456);
             tx.set_sponsor_nonce(789).unwrap();
             let mut signed_tx = tx_signer.get_tx().unwrap();
 
@@ -4601,7 +4601,7 @@ mod test {
 
             // tx and signed_tx are otherwise equal
             assert_eq!(tx.version, signed_tx.version);
-            assert_eq!(tx.get_fee_rate(), signed_tx.get_fee_rate());
+            assert_eq!(tx.get_tx_fee(), signed_tx.get_tx_fee());
             assert_eq!(tx.get_origin_nonce(), signed_tx.get_origin_nonce());
             assert_eq!(tx.get_sponsor_nonce(), signed_tx.get_sponsor_nonce());
             assert_eq!(tx.anchor_mode, signed_tx.anchor_mode);
@@ -4690,7 +4690,7 @@ mod test {
 
             // tx and signed_tx are otherwise equal
             assert_eq!(tx.version, signed_tx.version);
-            assert_eq!(tx.get_fee_rate(), signed_tx.get_fee_rate());
+            assert_eq!(tx.get_tx_fee(), signed_tx.get_tx_fee());
             assert_eq!(tx.get_origin_nonce(), signed_tx.get_origin_nonce());
             assert_eq!(tx.get_sponsor_nonce(), signed_tx.get_sponsor_nonce());
             assert_eq!(tx.anchor_mode, signed_tx.anchor_mode);
@@ -4795,7 +4795,7 @@ mod test {
             assert_eq!(tx.auth().origin().num_signatures(), 0);
             assert_eq!(tx.auth().sponsor().unwrap().num_signatures(), 0);
 
-            tx.set_fee_rate(123);
+            tx.set_tx_fee(123);
             tx.set_sponsor_nonce(456).unwrap();
             let mut tx_signer = StacksTransactionSigner::new(&tx);
 
@@ -4804,7 +4804,7 @@ mod test {
             // sponsor sets and pays fee after origin signs
             let mut origin_tx = tx_signer.get_tx_incomplete();
             origin_tx.auth.set_sponsor(real_sponsor.clone()).unwrap();
-            origin_tx.set_fee_rate(456);
+            origin_tx.set_tx_fee(456);
             origin_tx.set_sponsor_nonce(789).unwrap();
             tx_signer.resume(&origin_tx);
 
@@ -4812,7 +4812,7 @@ mod test {
             tx_signer.sign_sponsor(&privk_2).unwrap();
             tx_signer.append_sponsor(&pubk_3).unwrap();
 
-            tx.set_fee_rate(456);
+            tx.set_tx_fee(456);
             tx.set_sponsor_nonce(789).unwrap();
             let mut signed_tx = tx_signer.get_tx().unwrap();
 
@@ -4826,7 +4826,7 @@ mod test {
             // tx and signed_tx are otherwise equal
             assert_eq!(tx.version, signed_tx.version);
             assert_eq!(tx.chain_id, signed_tx.chain_id);
-            assert_eq!(tx.get_fee_rate(), signed_tx.get_fee_rate());
+            assert_eq!(tx.get_tx_fee(), signed_tx.get_tx_fee());
             assert_eq!(tx.get_origin_nonce(), signed_tx.get_origin_nonce());
             assert_eq!(tx.get_sponsor_nonce(), signed_tx.get_sponsor_nonce());
             assert_eq!(tx.anchor_mode, signed_tx.anchor_mode);

--- a/src/core/mempool.rs
+++ b/src/core/mempool.rs
@@ -97,7 +97,7 @@ pub struct MemPoolTxInfo {
 pub struct MemPoolTxMetadata {
     pub txid: Txid,
     pub len: u64,
-    pub fee_rate: u64,
+    pub tx_fee: u64,
     pub estimated_fee: u64, // upper bound on what the fee to pay will be
     pub consensus_hash: ConsensusHash,
     pub block_header_hash: BlockHeaderHash,
@@ -115,7 +115,7 @@ impl FromRow<MemPoolTxMetadata> for MemPoolTxMetadata {
         let consensus_hash = ConsensusHash::from_column(row, "consensus_hash")?;
         let block_header_hash = BlockHeaderHash::from_column(row, "block_header_hash")?;
         let estimated_fee = u64::from_column(row, "estimated_fee")?;
-        let fee_rate = u64::from_column(row, "fee_rate")?;
+        let tx_fee = u64::from_column(row, "tx_fee")?;
         let height = u64::from_column(row, "height")?;
         let len = u64::from_column(row, "length")?;
         let ts = u64::from_column(row, "accept_time")?;
@@ -127,7 +127,7 @@ impl FromRow<MemPoolTxMetadata> for MemPoolTxMetadata {
         Ok(MemPoolTxMetadata {
             txid: txid,
             estimated_fee: estimated_fee,
-            fee_rate: fee_rate,
+            tx_fee: tx_fee,
             len: len,
             consensus_hash: consensus_hash,
             block_header_hash: block_header_hash,
@@ -168,7 +168,7 @@ const MEMPOOL_SQL: &'static [&'static str] = &[
         sponsor_address TEXT NOT NULL,
         sponsor_nonce INTEGER NOT NULL,
         estimated_fee INTEGER NOT NULL,
-        fee_rate INTEGER NOT NULL,
+        tx_fee INTEGER NOT NULL,
         length INTEGER NOT NULL,
         consensus_hash TEXT NOT NULL,
         block_header_hash TEXT NOT NULL,
@@ -277,7 +277,7 @@ impl MemPoolTxInfo {
         let metadata = MemPoolTxMetadata {
             txid: txid,
             len: tx_data.len() as u64,
-            fee_rate: tx.get_fee_rate(),
+            tx_fee: tx.get_tx_fee(),
             estimated_fee: estimated_fee,
             consensus_hash: consensus_hash,
             block_header_hash: block_header_hash,
@@ -709,7 +709,7 @@ impl MemPoolDB {
                           sponsor_address,
                           sponsor_nonce,
                           estimated_fee,
-                          fee_rate,
+                          tx_fee,
                           length,
                           consensus_hash,
                           block_header_hash,
@@ -759,7 +759,7 @@ impl MemPoolDB {
         txid: Txid,
         tx_bytes: Vec<u8>,
         estimated_fee: u64,
-        fee_rate: u64,
+        tx_fee: u64,
         height: u64,
         origin_address: &StacksAddress,
         origin_nonce: u64,
@@ -824,7 +824,7 @@ impl MemPoolDB {
             sponsor_address,
             sponsor_nonce,
             estimated_fee,
-            fee_rate,
+            tx_fee,
             length,
             consensus_hash,
             block_header_hash,
@@ -840,7 +840,7 @@ impl MemPoolDB {
             &sponsor_address.to_string(),
             &u64_to_sql(sponsor_nonce)?,
             &u64_to_sql(estimated_fee)?,
-            &u64_to_sql(fee_rate)?,
+            &u64_to_sql(tx_fee)?,
             &u64_to_sql(length)?,
             consensus_hash,
             block_header_hash,
@@ -941,7 +941,7 @@ impl MemPoolDB {
             .map_err(MemPoolRejection::SerializationFailure)?;
 
         let len = tx_data.len() as u64;
-        let fee_rate = tx.get_fee_rate();
+        let tx_fee = tx.get_tx_fee();
         let origin_address = tx.origin_address();
         let origin_nonce = tx.get_origin_nonce();
         let (sponsor_address, sponsor_nonce) =
@@ -951,8 +951,8 @@ impl MemPoolDB {
                 (origin_address.clone(), origin_nonce)
             };
 
-        // TODO; estimate the true fee using Clarity analysis data.  For now, just do fee_rate
-        let estimated_fee = fee_rate
+        // TODO; estimate the true fee using Clarity analysis data.  For now, just do tx_fee
+        let estimated_fee = tx_fee
             .checked_mul(len)
             .ok_or(MemPoolRejection::Other("Fee numeric overflow".to_string()))?;
 
@@ -971,7 +971,7 @@ impl MemPoolDB {
             txid,
             tx_data,
             estimated_fee,
-            fee_rate,
+            tx_fee,
             height,
             &origin_address,
             origin_nonce,
@@ -1189,14 +1189,14 @@ mod tests {
             bytes: Hash160::from_data(&[1; 32]),
         };
 
-        tx.set_fee_rate(123);
+        tx.set_tx_fee(123);
 
         // test insert
         let txid = tx.txid();
         let tx_bytes = tx.serialize_to_vec();
 
         let len = tx_bytes.len() as u64;
-        let estimated_fee = tx.get_fee_rate() * len; //TODO: use clarity analysis data to make this estimate
+        let estimated_fee = tx.get_tx_fee() * len; //TODO: use clarity analysis data to make this estimate
         let height = 100;
 
         let origin_nonce = tx.get_origin_nonce();
@@ -1215,7 +1215,7 @@ mod tests {
             txid,
             tx_bytes,
             estimated_fee,
-            tx.get_fee_rate(),
+            tx.get_tx_fee(),
             height,
             &origin_address,
             origin_nonce,
@@ -1229,11 +1229,11 @@ mod tests {
         let prior_txid = txid.clone();
 
         // now, let's try inserting again, with a lower fee, but at a different block hash
-        tx.set_fee_rate(100);
+        tx.set_tx_fee(100);
         let txid = tx.txid();
         let tx_bytes = tx.serialize_to_vec();
         let len = tx_bytes.len() as u64;
-        let estimated_fee = tx.get_fee_rate() * len; //TODO: use clarity analysis data to make this estimate
+        let estimated_fee = tx.get_tx_fee() * len; //TODO: use clarity analysis data to make this estimate
         let height = 100;
 
         let err_resp = MemPoolDB::try_add_tx(
@@ -1244,7 +1244,7 @@ mod tests {
             txid,
             tx_bytes,
             estimated_fee,
-            tx.get_fee_rate(),
+            tx.get_tx_fee(),
             height,
             &origin_address,
             origin_nonce,
@@ -1290,7 +1290,7 @@ mod tests {
                 bytes: Hash160::from_data(&(i + 1).to_be_bytes()),
             };
 
-            tx.set_fee_rate(123);
+            tx.set_tx_fee(123);
 
             // test insert
             let txid = tx.txid();
@@ -1299,7 +1299,7 @@ mod tests {
             let expected_tx = tx.clone();
 
             let len = tx_bytes.len() as u64;
-            let estimated_fee = tx.get_fee_rate() * len; //TODO: use clarity analysis data to make this estimate
+            let estimated_fee = tx.get_tx_fee() * len; //TODO: use clarity analysis data to make this estimate
             let height = 100;
 
             let origin_nonce = tx.get_origin_nonce();
@@ -1318,7 +1318,7 @@ mod tests {
                 txid,
                 tx_bytes,
                 estimated_fee,
-                tx.get_fee_rate(),
+                tx.get_tx_fee(),
                 height,
                 &origin_address,
                 origin_nonce,
@@ -1336,7 +1336,7 @@ mod tests {
             assert_eq!(tx_info.tx, expected_tx);
             assert_eq!(tx_info.metadata.len, len);
             assert_eq!(tx_info.metadata.estimated_fee, estimated_fee);
-            assert_eq!(tx_info.metadata.fee_rate, 123);
+            assert_eq!(tx_info.metadata.tx_fee, 123);
             assert_eq!(tx_info.metadata.origin_address, origin_address);
             assert_eq!(tx_info.metadata.origin_nonce, origin_nonce);
             assert_eq!(tx_info.metadata.sponsor_address, sponsor_address);
@@ -1351,14 +1351,14 @@ mod tests {
             // test replace-by-fee with a higher fee
             let old_txid = txid;
 
-            tx.set_fee_rate(124);
+            tx.set_tx_fee(124);
             assert!(txid != tx.txid());
 
             let txid = tx.txid();
             let mut tx_bytes = vec![];
             tx.consensus_serialize(&mut tx_bytes).unwrap();
             let expected_tx = tx.clone();
-            let estimated_fee = tx.get_fee_rate() * len; // TODO: use clarity analysis data to make this estimate
+            let estimated_fee = tx.get_tx_fee() * len; // TODO: use clarity analysis data to make this estimate
 
             assert!(!MemPoolDB::db_has_tx(&mempool_tx, &txid).unwrap());
 
@@ -1380,7 +1380,7 @@ mod tests {
                 txid,
                 tx_bytes,
                 estimated_fee,
-                tx.get_fee_rate(),
+                tx.get_tx_fee(),
                 height,
                 &origin_address,
                 origin_nonce,
@@ -1413,7 +1413,7 @@ mod tests {
             assert_eq!(tx_info.tx, expected_tx);
             assert_eq!(tx_info.metadata.len, len);
             assert_eq!(tx_info.metadata.estimated_fee, estimated_fee);
-            assert_eq!(tx_info.metadata.fee_rate, 124);
+            assert_eq!(tx_info.metadata.tx_fee, 124);
             assert_eq!(tx_info.metadata.origin_address, origin_address);
             assert_eq!(tx_info.metadata.origin_nonce, origin_nonce);
             assert_eq!(tx_info.metadata.sponsor_address, sponsor_address);
@@ -1428,14 +1428,14 @@ mod tests {
             // test replace-by-fee with a lower fee
             let old_txid = txid;
 
-            tx.set_fee_rate(122);
+            tx.set_tx_fee(122);
             assert!(txid != tx.txid());
 
             let txid = tx.txid();
             let mut tx_bytes = vec![];
             tx.consensus_serialize(&mut tx_bytes).unwrap();
             let _expected_tx = tx.clone();
-            let estimated_fee = tx.get_fee_rate() * len; // TODO: use clarity analysis metadata to make this estimate
+            let estimated_fee = tx.get_tx_fee() * len; // TODO: use clarity analysis metadata to make this estimate
 
             assert!(match MemPoolDB::try_add_tx(
                 &mut mempool_tx,
@@ -1445,7 +1445,7 @@ mod tests {
                 txid,
                 tx_bytes,
                 estimated_fee,
-                tx.get_fee_rate(),
+                tx.get_tx_fee(),
                 height,
                 &origin_address,
                 origin_nonce,

--- a/src/net/http.rs
+++ b/src/net/http.rs
@@ -4950,7 +4950,7 @@ mod test {
         );
         tx_stx_transfer.chain_id = 0x80000000;
         tx_stx_transfer.post_condition_mode = TransactionPostConditionMode::Allow;
-        tx_stx_transfer.set_fee_rate(0);
+        tx_stx_transfer.set_tx_fee(0);
         tx_stx_transfer
     }
 

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -2309,7 +2309,7 @@ pub mod test {
                                 hash_mode: SinglesigHashMode::P2PKH,
                                 key_encoding: TransactionPublicKeyEncoding::Uncompressed,
                                 nonce: 0,
-                                fee_rate: 0,
+                                tx_fee: 0,
                                 signature: MessageSignature::empty(),
                             }),
                         );

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -2102,12 +2102,13 @@ pub mod test {
             burnchain.pox_constants =
                 PoxConstants::new(5, 3, 3, 25, 5, u64::max_value(), u64::max_value());
 
-            let spending_account = TestMinerFactory::new().next_miner(
+            let mut spending_account = TestMinerFactory::new().next_miner(
                 &burnchain,
                 1,
                 1,
                 AddressHashMode::SerializeP2PKH,
             );
+            spending_account.test_with_tx_fees = false; // manually set transaction fees
 
             TestPeerConfig {
                 network_id: 0x80000000,
@@ -2238,6 +2239,9 @@ pub mod test {
             let mut miner_factory = TestMinerFactory::new();
             let mut miner =
                 miner_factory.next_miner(&config.burnchain, 1, 1, AddressHashMode::SerializeP2PKH);
+
+            // manually set fees
+            miner.test_with_tx_fees = false;
 
             let mut burnchain = get_burnchain(&test_path, None);
             burnchain.first_block_height = config.burnchain.first_block_height;

--- a/src/net/relay.rs
+++ b/src/net/relay.rs
@@ -2567,7 +2567,7 @@ mod test {
 
                     tx_contract.chain_id = 0x80000000;
                     tx_contract.auth.set_origin_nonce(cur_nonce);
-                    tx_contract.set_fee_rate(MINIMUM_TX_FEE_RATE_PER_BYTE * 500);
+                    tx_contract.set_tx_fee(MINIMUM_TX_FEE_RATE_PER_BYTE * 500);
 
                     let mut tx_signer = StacksTransactionSigner::new(&tx_contract);
                     spending_account.sign_as_origin(&mut tx_signer);

--- a/src/net/rpc.rs
+++ b/src/net/rpc.rs
@@ -2691,7 +2691,7 @@ mod test {
 
         tx_contract.chain_id = 0x80000000;
         tx_contract.auth.set_origin_nonce(1);
-        tx_contract.set_fee_rate(0);
+        tx_contract.set_tx_fee(0);
 
         let mut tx_signer = StacksTransactionSigner::new(&tx_contract);
         tx_signer.sign_origin(&privk1).unwrap();
@@ -2707,7 +2707,7 @@ mod test {
 
         tx_cc.chain_id = 0x80000000;
         tx_cc.auth.set_origin_nonce(2);
-        tx_cc.set_fee_rate(123);
+        tx_cc.set_tx_fee(123);
 
         let mut tx_signer = StacksTransactionSigner::new(&tx_cc);
         tx_signer.sign_origin(&privk1).unwrap();
@@ -2732,7 +2732,7 @@ mod test {
 
         tx_unconfirmed_contract.chain_id = 0x80000000;
         tx_unconfirmed_contract.auth.set_origin_nonce(3);
-        tx_unconfirmed_contract.set_fee_rate(0);
+        tx_unconfirmed_contract.set_tx_fee(0);
 
         let mut tx_signer = StacksTransactionSigner::new(&tx_unconfirmed_contract);
         tx_signer.sign_origin(&privk1).unwrap();

--- a/src/net/server.rs
+++ b/src/net/server.rs
@@ -1216,7 +1216,7 @@ mod test {
                 );
 
                 tx_contract.chain_id = chainstate.config().chain_id;
-                tx_contract.set_fee_rate(0);
+                tx_contract.set_tx_fee(0);
 
                 let mut signer = StacksTransactionSigner::new(&tx_contract);
                 signer.sign_origin(&privk_origin).unwrap();

--- a/src/vm/clarity.rs
+++ b/src/vm/clarity.rs
@@ -1594,7 +1594,7 @@ mod tests {
             hash_mode: SinglesigHashMode::P2PKH,
             key_encoding: TransactionPublicKeyEncoding::Compressed,
             nonce: 0,
-            fee_rate: 1,
+            tx_fee: 1,
             signature: MessageSignature::from_raw(&vec![0xfe; 65]),
         });
 

--- a/testnet/stacks-node/src/run_loop/mod.rs
+++ b/testnet/stacks-node/src/run_loop/mod.rs
@@ -110,7 +110,7 @@ impl RunLoopCallbacks {
                 TransactionAuth::Standard(TransactionSpendingCondition::Singlesig(auth)) => {
                     println!(
                         "-> Tx issued by {:?} (fee: {}, nonce: {})",
-                        auth.signer, auth.fee_rate, auth.nonce
+                        auth.signer, auth.tx_fee, auth.nonce
                     )
                 }
                 _ => println!("-> Tx {:?}", tx.auth),

--- a/testnet/stacks-node/src/tests/mempool.rs
+++ b/testnet/stacks-node/src/tests/mempool.rs
@@ -40,7 +40,7 @@ const BAD_TRAIT_CONTRACT: &'static str = "(define-public (foo-bar) (ok u1))";
 pub fn make_bad_stacks_transfer(
     sender: &StacksPrivateKey,
     nonce: u64,
-    fee_rate: u64,
+    tx_fee: u64,
     recipient: &PrincipalData,
     amount: u64,
 ) -> Vec<u8> {
@@ -51,7 +51,7 @@ pub fn make_bad_stacks_transfer(
         TransactionSpendingCondition::new_singlesig_p2pkh(StacksPublicKey::from_private(sender))
             .expect("Failed to create p2pkh spending condition from public key.");
     spending_condition.set_nonce(nonce);
-    spending_condition.set_fee_rate(fee_rate);
+    spending_condition.set_tx_fee(tx_fee);
     let auth = TransactionAuth::Standard(spending_condition);
 
     let mut unsigned_tx = StacksTransaction::new(TransactionVersion::Testnet, auth, payload);

--- a/testnet/stacks-node/src/tests/mod.rs
+++ b/testnet/stacks-node/src/tests/mod.rs
@@ -68,13 +68,13 @@ pub fn serialize_sign_standard_single_sig_tx(
     payload: TransactionPayload,
     sender: &StacksPrivateKey,
     nonce: u64,
-    fee_rate: u64,
+    tx_fee: u64,
 ) -> Vec<u8> {
     serialize_sign_standard_single_sig_tx_anchor_mode(
         payload,
         sender,
         nonce,
-        fee_rate,
+        tx_fee,
         TransactionAnchorMode::OnChainOnly,
     )
 }
@@ -83,14 +83,14 @@ pub fn serialize_sign_standard_single_sig_tx_anchor_mode(
     payload: TransactionPayload,
     sender: &StacksPrivateKey,
     nonce: u64,
-    fee_rate: u64,
+    tx_fee: u64,
     anchor_mode: TransactionAnchorMode,
 ) -> Vec<u8> {
     let mut spending_condition =
         TransactionSpendingCondition::new_singlesig_p2pkh(StacksPublicKey::from_private(sender))
             .expect("Failed to create p2pkh spending condition from public key.");
     spending_condition.set_nonce(nonce);
-    spending_condition.set_fee_rate(fee_rate);
+    spending_condition.set_tx_fee(tx_fee);
     let auth = TransactionAuth::Standard(spending_condition);
     let mut unsigned_tx = StacksTransaction::new(TransactionVersion::Testnet, auth, payload);
     unsigned_tx.anchor_mode = anchor_mode;
@@ -112,7 +112,7 @@ pub fn serialize_sign_standard_single_sig_tx_anchor_mode(
 pub fn make_contract_publish(
     sender: &StacksPrivateKey,
     nonce: u64,
-    fee_rate: u64,
+    tx_fee: u64,
     contract_name: &str,
     contract_content: &str,
 ) -> Vec<u8> {
@@ -121,13 +121,13 @@ pub fn make_contract_publish(
 
     let payload = TransactionSmartContract { name, code_body };
 
-    serialize_sign_standard_single_sig_tx(payload.into(), sender, nonce, fee_rate)
+    serialize_sign_standard_single_sig_tx(payload.into(), sender, nonce, tx_fee)
 }
 
 pub fn make_contract_publish_microblock_only(
     sender: &StacksPrivateKey,
     nonce: u64,
-    fee_rate: u64,
+    tx_fee: u64,
     contract_name: &str,
     contract_content: &str,
 ) -> Vec<u8> {
@@ -140,7 +140,7 @@ pub fn make_contract_publish_microblock_only(
         payload.into(),
         sender,
         nonce,
-        fee_rate,
+        tx_fee,
         TransactionAnchorMode::OffChainOnly,
     )
 }
@@ -186,19 +186,19 @@ pub fn to_addr(sk: &StacksPrivateKey) -> StacksAddress {
 pub fn make_stacks_transfer(
     sender: &StacksPrivateKey,
     nonce: u64,
-    fee_rate: u64,
+    tx_fee: u64,
     recipient: &PrincipalData,
     amount: u64,
 ) -> Vec<u8> {
     let payload =
         TransactionPayload::TokenTransfer(recipient.clone(), amount, TokenTransferMemo([0; 34]));
-    serialize_sign_standard_single_sig_tx(payload.into(), sender, nonce, fee_rate)
+    serialize_sign_standard_single_sig_tx(payload.into(), sender, nonce, tx_fee)
 }
 
 pub fn make_stacks_transfer_mblock_only(
     sender: &StacksPrivateKey,
     nonce: u64,
-    fee_rate: u64,
+    tx_fee: u64,
     recipient: &PrincipalData,
     amount: u64,
 ) -> Vec<u8> {
@@ -208,7 +208,7 @@ pub fn make_stacks_transfer_mblock_only(
         payload.into(),
         sender,
         nonce,
-        fee_rate,
+        tx_fee,
         TransactionAnchorMode::OffChainOnly,
     )
 }
@@ -216,23 +216,23 @@ pub fn make_stacks_transfer_mblock_only(
 pub fn make_poison(
     sender: &StacksPrivateKey,
     nonce: u64,
-    fee_rate: u64,
+    tx_fee: u64,
     header_1: StacksMicroblockHeader,
     header_2: StacksMicroblockHeader,
 ) -> Vec<u8> {
     let payload = TransactionPayload::PoisonMicroblock(header_1, header_2);
-    serialize_sign_standard_single_sig_tx(payload.into(), sender, nonce, fee_rate)
+    serialize_sign_standard_single_sig_tx(payload.into(), sender, nonce, tx_fee)
 }
 
-pub fn make_coinbase(sender: &StacksPrivateKey, nonce: u64, fee_rate: u64) -> Vec<u8> {
+pub fn make_coinbase(sender: &StacksPrivateKey, nonce: u64, tx_fee: u64) -> Vec<u8> {
     let payload = TransactionPayload::Coinbase(CoinbasePayload([0; 32]));
-    serialize_sign_standard_single_sig_tx(payload.into(), sender, nonce, fee_rate)
+    serialize_sign_standard_single_sig_tx(payload.into(), sender, nonce, tx_fee)
 }
 
 pub fn make_contract_call(
     sender: &StacksPrivateKey,
     nonce: u64,
-    fee_rate: u64,
+    tx_fee: u64,
     contract_addr: &StacksAddress,
     contract_name: &str,
     function_name: &str,
@@ -248,7 +248,7 @@ pub fn make_contract_call(
         function_args: function_args.iter().map(|x| x.clone()).collect(),
     };
 
-    serialize_sign_standard_single_sig_tx(payload.into(), sender, nonce, fee_rate)
+    serialize_sign_standard_single_sig_tx(payload.into(), sender, nonce, tx_fee)
 }
 
 fn make_microblock(


### PR DESCRIPTION
This PR adds transaction fees to the miner's block reward.  Per SIP-001, each miner gets all of its anchored block's transaction fees, as well as 40% of the microblocks it produces (awarded in each Stacks fork in which a subsequent anchored block confirms them), as well as 60% of the microblocks it confirms.  It also renames `fee_rate` to `tx_fee`, now that we're making it so transactions pay the fee they advertise (instead of a Kth-highest fee per epoch).