### PR TITLE
Clarity DB Fixes

### DIFF
--- a/.github/actions/bitcoin-int-tests/Dockerfile.large-genesis
+++ b/.github/actions/bitcoin-int-tests/Dockerfile.large-genesis
@@ -12,4 +12,4 @@ RUN cd / && tar -xvzf bitcoin-0.20.0-x86_64-linux-gnu.tar.gz
 RUN ln -s /bitcoin-0.20.0/bin/bitcoind /bin/
 
 ENV BITCOIND_TEST 1
-RUN cd testnet/stacks-node && cargo test -- --test-threads 1 --ignored
+RUN cd testnet/stacks-node && cargo test --release --features prod-genesis-chainstate -- --test-threads 1 --ignored neon_integrations::bitcoind_integration_test

--- a/.github/workflows/stacks-blockchain.yml
+++ b/.github/workflows/stacks-blockchain.yml
@@ -35,22 +35,22 @@ jobs:
           status: STARTING
           color: warning
 
-  # Run large genesis test
-  large-genesis:
+  # Run full genesis test
+  full-genesis:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Run bitcoin tests
+      - name: Single full genesis integration test
         env:
           DOCKER_BUILDKIT: 1
         run: docker build -f ./.github/actions/bitcoin-int-tests/Dockerfile.large-genesis .
 
-  # Run bitcoind tests
-  bitcoin-tests:
+  # Run sampled genesis tests
+  sampled-genesis:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Run bitcoin tests
+      - name: All integration tests with sampled genesis
         env:
           DOCKER_BUILDKIT: 1
         run: docker build -f ./.github/actions/bitcoin-int-tests/Dockerfile.bitcoin-tests .
@@ -166,8 +166,8 @@ jobs:
     outputs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}
     needs:
-      - bitcoin-tests
-      - large-genesis
+      - sampled-genesis
+      - full-genesis
       - dist
       - build-publish
       - build-publish-stretch
@@ -219,8 +219,8 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - notify-start
-      - bitcoin-tests
-      - large-genesis
+      - sampled-genesis
+      - full-genesis
       - dist
       - build-publish
       - build-publish-stretch

--- a/.github/workflows/stacks-blockchain.yml
+++ b/.github/workflows/stacks-blockchain.yml
@@ -35,8 +35,18 @@ jobs:
           status: STARTING
           color: warning
 
-  # Run tests
-  test:
+  # Run large genesis test
+  large-genesis:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run bitcoin tests
+        env:
+          DOCKER_BUILDKIT: 1
+        run: docker build -f ./.github/actions/bitcoin-int-tests/Dockerfile.large-genesis .
+
+  # Run bitcoind tests
+  bitcoin-tests:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -156,7 +166,8 @@ jobs:
     outputs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}
     needs:
-      - test
+      - bitcoin-tests
+      - large-genesis
       - dist
       - build-publish
       - build-publish-stretch
@@ -208,7 +219,8 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - notify-start
-      - test
+      - bitcoin-tests
+      - large-genesis
       - dist
       - build-publish
       - build-publish-stretch

--- a/src/address/c32.rs
+++ b/src/address/c32.rs
@@ -80,6 +80,11 @@ fn c32_normalize(input_str: &str) -> String {
 }
 
 fn c32_decode(input_str: &str) -> Result<Vec<u8>, Error> {
+    // must be ASCII
+    if !input_str.is_ascii() {
+        return Err(Error::InvalidCrockford32);
+    }
+
     let mut result = vec![];
     let mut carry: u16 = 0;
     let mut carry_bits = 0; // can be up to 5
@@ -173,6 +178,11 @@ fn c32_check_encode(version: u8, data: &[u8]) -> Result<String, Error> {
 }
 
 fn c32_check_decode(check_data_unsanitized: &str) -> Result<(u8, Vec<u8>), Error> {
+    // must be ASCII
+    if !check_data_unsanitized.is_ascii() {
+        return Err(Error::InvalidCrockford32);
+    }
+
     if check_data_unsanitized.len() < 2 {
         return Err(Error::InvalidCrockford32);
     }
@@ -384,6 +394,16 @@ mod test {
             let (decoded_version, decoded_bytes) = c32_address_decode(addr).unwrap();
             assert_eq!(decoded_version, expected_version);
             assert_eq!(decoded_bytes, expected_bytes);
+        }
+    }
+
+    #[test]
+    fn test_ascii_only() {
+        match c32_address_decode("S\u{1D7D8}2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKPVKG2CE") {
+            Err(Error::InvalidCrockford32) => {}
+            _ => {
+                assert!(false);
+            }
         }
     }
 }

--- a/src/blockstack_cli.rs
+++ b/src/blockstack_cli.rs
@@ -770,6 +770,7 @@ fn main_handler(mut argv: Vec<String>) -> Result<String, CliError> {
             "addresses" => get_addresses(args, tx_version),
             "decode-tx" => decode_transaction(args, tx_version),
             "decode-block" => decode_block(args, tx_version),
+            "decode-microblock" => decode_microblock(args, tx_version),
             _ => Err(CliError::Usage),
         }
     } else {

--- a/src/chainstate/burn/operations/mod.rs
+++ b/src/chainstate/burn/operations/mod.rs
@@ -118,12 +118,10 @@ impl fmt::Display for Error {
             Error::BlockCommitBadModulus => {
                 write!(f, "Block commit included a bad burn block height modulus")
             }
-            Error::MissedBlockCommit(_) => {
-                write!(
-                    f,
-                    "Block commit included in a burn block that was not intended"
-                )
-            }
+            Error::MissedBlockCommit(_) => write!(
+                f,
+                "Block commit included in a burn block that was not intended"
+            ),
             Error::LeaderKeyAlreadyRegistered => {
                 write!(f, "Leader key has already been registered")
             }

--- a/src/chainstate/coordinator/comm.rs
+++ b/src/chainstate/coordinator/comm.rs
@@ -133,13 +133,13 @@ impl CoordinatorReceivers {
     }
 
     /// TODO: remove before mainnet
-    pub fn kludgy_clarity_db_lock(&self) -> LockResult<MutexGuard<'_, ()>> {
-        self.kludgy_temporary_clarity_db_lock.lock()
+    pub fn kludgy_clarity_db_lock(&self) -> LockResult<()> {
+        Ok(())
     }
 
     /// TODO: remove before mainnet
-    pub fn kludgy_clarity_db_trylock(&self) -> TryLockResult<MutexGuard<'_, ()>> {
-        self.kludgy_temporary_clarity_db_lock.try_lock()
+    pub fn kludgy_clarity_db_trylock(&self) -> TryLockResult<()> {
+        Ok(())
     }
 }
 

--- a/src/chainstate/coordinator/mod.rs
+++ b/src/chainstate/coordinator/mod.rs
@@ -289,19 +289,8 @@ impl<'a, T: BlockEventDispatcher>
             match comms.wait_on() {
                 CoordinatorEvents::NEW_STACKS_BLOCK => {
                     debug!("Received new stacks block notice");
-                    match comms.kludgy_clarity_db_lock() {
-                        Ok(_) => {
-                            if let Err(e) = inst.handle_new_stacks_block() {
-                                warn!("Error processing new stacks block: {:?}", e);
-                            }
-                        }
-                        Err(e) => {
-                            error!(
-                                "FATAL: kludgy temporary Clarity DB lock is poisoned: {:?}",
-                                &e
-                            );
-                            panic!();
-                        }
+                    if let Err(e) = inst.handle_new_stacks_block() {
+                        warn!("Error processing new stacks block: {:?}", e);
                     }
                 }
                 CoordinatorEvents::NEW_BURN_BLOCK => {

--- a/src/chainstate/stacks/db/blocks.rs
+++ b/src/chainstate/stacks/db/blocks.rs
@@ -498,7 +498,9 @@ impl BlockStreamData {
                     num_written += num_sent;
                     test_debug!(
                         "Confirmed microblock stream for {}: sent {} bytes ({} total)",
-                        &self.microblock_hash, num_sent, num_written
+                        &self.microblock_hash,
+                        num_sent,
+                        num_written
                     );
                 }
                 StacksChainState::stream_microblocks_confirmed(&chainstate, fd, self, count)
@@ -2591,7 +2593,11 @@ impl StacksChainState {
         let num_bytes = StacksChainState::stream_data(fd, stream, &mut blob, count)?;
         test_debug!(
             "Stream microblock rowid={} hash={} offset={} total_bytes={}, num_bytes={}",
-            rowid, &stream.microblock_hash, stream.offset, stream.total_bytes, num_bytes
+            rowid,
+            &stream.microblock_hash,
+            stream.offset,
+            stream.total_bytes,
+            num_bytes
         );
         Ok(num_bytes)
     }

--- a/src/chainstate/stacks/db/blocks.rs
+++ b/src/chainstate/stacks/db/blocks.rs
@@ -463,13 +463,18 @@ impl BlockStreamData {
                 while self.num_mblocks_ptr < self.num_mblocks_buf.len() {
                     // stream length prefix
                     test_debug!(
-                        "Try to send length prefix {:?} (ptr={})",
+                        "Confirmed microblock stream for {}: try to send length prefix {:?} (ptr={})",
+                        &self.microblock_hash,
                         &self.num_mblocks_buf[self.num_mblocks_ptr..],
                         self.num_mblocks_ptr
                     );
                     let num_sent = match fd.write(&self.num_mblocks_buf[self.num_mblocks_ptr..]) {
                         Ok(0) => {
                             // done (disconnected)
+                            test_debug!(
+                                "Confirmed microblock stream for {}: wrote 0 bytes",
+                                &self.microblock_hash
+                            );
                             return Ok(num_written);
                         }
                         Ok(n) => {
@@ -491,6 +496,10 @@ impl BlockStreamData {
                         }
                     };
                     num_written += num_sent;
+                    test_debug!(
+                        "Confirmed microblock stream for {}: sent {} bytes ({} total)",
+                        &self.microblock_hash, num_sent, num_written
+                    );
                 }
                 StacksChainState::stream_microblocks_confirmed(&chainstate, fd, self, count)
                     .and_then(|bytes_sent| Ok(bytes_sent + num_written))
@@ -2579,7 +2588,12 @@ impl StacksChainState {
                 }
             })?;
 
-        StacksChainState::stream_data(fd, stream, &mut blob, count)
+        let num_bytes = StacksChainState::stream_data(fd, stream, &mut blob, count)?;
+        test_debug!(
+            "Stream microblock rowid={} hash={} offset={} total_bytes={}, num_bytes={}",
+            rowid, &stream.microblock_hash, stream.offset, stream.total_bytes, num_bytes
+        );
+        Ok(num_bytes)
     }
 
     /// Stream multiple microblocks from staging, moving in reverse order from the stream tail to the stream head.
@@ -2605,6 +2619,10 @@ impl StacksChainState {
                     Some(x) => x,
                     None => {
                         // out of mblocks
+                        debug!(
+                            "Out of microblocks to stream after confirmed microblock {}",
+                            &stream.microblock_hash
+                        );
                         break;
                     }
                 };
@@ -2617,6 +2635,10 @@ impl StacksChainState {
                     Some(rid) => rid,
                     None => {
                         // out of mblocks
+                        debug!(
+                            "No rowid found for confirmed stream microblock {}",
+                            &mblock_info.parent_hash
+                        );
                         break;
                     }
                 };
@@ -2629,12 +2651,21 @@ impl StacksChainState {
                     .checked_sub(nw)
                     .expect("BUG: wrote more data than called for");
             }
+            debug!(
+                "Streaming microblock={}: to_write={}, nw={}",
+                &stream.microblock_hash, to_write, nw
+            );
         }
+        debug!(
+            "Streamed confirmed microblocks: {} - {} = {}",
+            count,
+            to_write,
+            count - to_write
+        );
         Ok(count - to_write)
     }
 
     /// Stream block data from the chunk store.
-    /// Also works for a microblock stream.
     fn stream_data_from_chunk_store<W: Write>(
         blocks_path: &String,
         fd: &mut W,
@@ -2665,8 +2696,7 @@ impl StacksChainState {
         StacksChainState::stream_data(fd, stream, &mut file_fd, count)
     }
 
-    /// Stream block data from the chain state.  Pull from either staging or the chunk store,
-    /// wherever it happens to be located.
+    /// Stream block data from the chain state.
     /// Returns the number of bytes written, and updates `stream` to point to the next point to
     /// read.  Writes the bytes streamed to `fd`.
     pub fn stream_block<W: Write>(
@@ -5291,6 +5321,7 @@ pub mod test {
     use core::mempool::*;
     use net::test::*;
 
+    use rand::thread_rng;
     use rand::Rng;
 
     pub fn make_empty_coinbase_block(mblock_key: &StacksPrivateKey) -> StacksBlock {
@@ -5358,6 +5389,99 @@ pub mod test {
         block
     }
 
+    pub fn make_16k_block(mblock_key: &StacksPrivateKey) -> StacksBlock {
+        let privk = StacksPrivateKey::from_hex(
+            "59e4d5e18351d6027a37920efe53c2f1cbadc50dca7d77169b7291dff936ed6d01",
+        )
+        .unwrap();
+        let auth = TransactionAuth::from_p2pkh(&privk).unwrap();
+        let proof_bytes = hex_bytes("9275df67a68c8745c0ff97b48201ee6db447f7c93b23ae24cdc2400f52fdb08a1a6ac7ec71bf9c9c76e96ee4675ebff60625af28718501047bfd87b810c2d2139b73c23bd69de66360953a642c2a330a").unwrap();
+        let proof = VRFProof::from_bytes(&proof_bytes[..].to_vec()).unwrap();
+
+        let mut tx_coinbase = StacksTransaction::new(
+            TransactionVersion::Testnet,
+            auth.clone(),
+            TransactionPayload::Coinbase(CoinbasePayload([0u8; 32])),
+        );
+        tx_coinbase.anchor_mode = TransactionAnchorMode::OnChainOnly;
+        let mut tx_signer = StacksTransactionSigner::new(&tx_coinbase);
+
+        tx_signer.sign_origin(&privk).unwrap();
+
+        let tx_coinbase_signed = tx_signer.get_tx().unwrap();
+
+        // 16k + 8 contract
+        let contract_16k = {
+            let mut parts = vec![];
+            parts.push("(begin ".to_string());
+            for i in 0..1024 {
+                parts.push("(print \"abcdef\")".to_string()); // 16 bytes
+            }
+            parts.push(")".to_string());
+            parts.join("")
+        };
+
+        let mut tx_big_contract = StacksTransaction::new(
+            TransactionVersion::Testnet,
+            auth.clone(),
+            TransactionPayload::new_smart_contract(
+                &format!("hello-world-{}", &thread_rng().gen::<u32>()),
+                &contract_16k.to_string(),
+            )
+            .unwrap(),
+        );
+
+        tx_big_contract.anchor_mode = TransactionAnchorMode::OnChainOnly;
+        let mut tx_signer = StacksTransactionSigner::new(&tx_big_contract);
+        tx_signer.sign_origin(&privk).unwrap();
+
+        let tx_big_contract_signed = tx_signer.get_tx().unwrap();
+
+        let txs = vec![tx_coinbase_signed, tx_big_contract_signed];
+
+        let work_score = StacksWorkScore {
+            burn: 123,
+            work: 456,
+        };
+
+        let parent_header = StacksBlockHeader {
+            version: 0x01,
+            total_work: StacksWorkScore {
+                burn: 234,
+                work: 567,
+            },
+            proof: proof.clone(),
+            parent_block: BlockHeaderHash([5u8; 32]),
+            parent_microblock: BlockHeaderHash([6u8; 32]),
+            parent_microblock_sequence: 4,
+            tx_merkle_root: Sha512Trunc256Sum([7u8; 32]),
+            state_index_root: TrieHash([8u8; 32]),
+            microblock_pubkey_hash: Hash160([9u8; 20]),
+        };
+
+        let parent_microblock_header = StacksMicroblockHeader {
+            version: 0x12,
+            sequence: 0x34,
+            prev_block: BlockHeaderHash([0x0au8; 32]),
+            tx_merkle_root: Sha512Trunc256Sum([0x0bu8; 32]),
+            signature: MessageSignature([0x0cu8; 65]),
+        };
+
+        let mblock_pubkey_hash =
+            Hash160::from_node_public_key(&StacksPublicKey::from_private(mblock_key));
+        let mut block = StacksBlock::from_parent(
+            &parent_header,
+            &parent_microblock_header,
+            txs.clone(),
+            &work_score,
+            &proof,
+            &TrieHash([2u8; 32]),
+            &mblock_pubkey_hash,
+        );
+        block.header.version = 0x24;
+        block
+    }
+
     pub fn make_sample_microblock_stream_fork(
         privk: &StacksPrivateKey,
         base: &BlockHeaderHash,
@@ -5371,20 +5495,34 @@ pub mod test {
             let random_bytes = rng.gen::<[u8; 8]>();
             let random_bytes_str = to_hex(&random_bytes);
             let auth = TransactionAuth::from_p2pkh(&privk).unwrap();
-            let tx_smart_contract = StacksTransaction::new(
+
+            // 16k + 8 contract
+            let contract_16k = {
+                let mut parts = vec![];
+                parts.push("(begin ".to_string());
+                for i in 0..1024 {
+                    parts.push("(print \"abcdef\")".to_string()); // 16 bytes
+                }
+                parts.push(")".to_string());
+                parts.join("")
+            };
+
+            let mut tx_big_contract = StacksTransaction::new(
                 TransactionVersion::Testnet,
                 auth.clone(),
                 TransactionPayload::new_smart_contract(
-                    &format!("hello-microblock-{}", &random_bytes_str),
-                    &format!("(begin (+ 1 2))"),
+                    &format!("hello-world-{}", &thread_rng().gen::<u32>()),
+                    &contract_16k.to_string(),
                 )
                 .unwrap(),
             );
-            let mut tx_signer = StacksTransactionSigner::new(&tx_smart_contract);
+
+            tx_big_contract.anchor_mode = TransactionAnchorMode::OffChainOnly;
+            let mut tx_signer = StacksTransactionSigner::new(&tx_big_contract);
             tx_signer.sign_origin(&privk).unwrap();
 
-            let tx_signed = tx_signer.get_tx().unwrap();
-            all_txs.push(tx_signed);
+            let tx_big_contract_signed = tx_signer.get_tx().unwrap();
+            all_txs.push(tx_big_contract_signed);
         }
 
         // make microblocks with 3 transactions each (or fewer)
@@ -8090,7 +8228,7 @@ pub mod test {
         )
         .unwrap();
 
-        let block = make_empty_coinbase_block(&privk);
+        let block = make_16k_block(&privk);
 
         let consensus_hash = ConsensusHash([2u8; 20]);
         let parent_consensus_hash = ConsensusHash([1u8; 20]);

--- a/src/chainstate/stacks/db/mod.rs
+++ b/src/chainstate/stacks/db/mod.rs
@@ -1423,7 +1423,6 @@ impl StacksChainState {
         }
         let mut conn = self.begin_read_only_clarity_tx(burn_dbconn, parent_tip);
         let result = to_do(&mut conn);
-        conn.done();
         Some(result)
     }
 
@@ -1450,7 +1449,6 @@ impl StacksChainState {
                 burn_dbconn,
             );
             let result = to_do(&mut conn);
-            conn.done();
             Some(result)
         } else {
             None

--- a/src/chainstate/stacks/index/marf.rs
+++ b/src/chainstate/stacks/index/marf.rs
@@ -504,7 +504,7 @@ impl<'a, T: MarfTrieId> MarfTransaction<'a, T> {
             self.storage
                 .open_block(&T::sentinel())
                 .expect("BUG: should never fail to open the block sentinel");
-            self.storage.commit_tx()
+            self.storage.rollback()
         }
     }
 
@@ -516,7 +516,10 @@ impl<'a, T: MarfTrieId> MarfTransaction<'a, T> {
                 self.storage
                     .open_block(&T::sentinel())
                     .expect("BUG: should never fail to open the block sentinel");
-                self.storage.commit_tx();
+                // Dropping unconfirmed state cannot be done with a tx rollback,
+                //   because the unconfirmed state may already have been written
+                //   to the sqlite table before this transaction began
+                self.storage.commit_tx()
             }
         }
     }

--- a/src/chainstate/stacks/index/marf.rs
+++ b/src/chainstate/stacks/index/marf.rs
@@ -259,10 +259,8 @@ impl<'a, T: MarfTrieId> MarfTransaction<'a, T> {
         }
     }
 
-    ///  This function commits the current MARF sqlite transaction
-    ///    without flushing the in-memory Trie. This only used by
-    ///    Clarity MarfedKV and tests.
-    pub fn commit_tx(self) {
+    #[cfg(test)]
+    fn commit_tx(self) {
         self.storage.commit_tx()
     }
 

--- a/src/chainstate/stacks/index/marf.rs
+++ b/src/chainstate/stacks/index/marf.rs
@@ -88,6 +88,21 @@ pub trait MarfConnection<T: MarfTrieId> {
         self.with_conn(|c| MARF::get_by_key(c, block_hash, key))
     }
 
+    fn get_with_proof(
+        &mut self,
+        block_hash: &T,
+        key: &str,
+    ) -> Result<Option<(MARFValue, TrieMerkleProof<T>)>, Error> {
+        self.with_conn(|conn| {
+            let marf_value = match MARF::get_by_key(conn, block_hash, key)? {
+                None => return Ok(None),
+                Some(x) => x,
+            };
+            let proof = TrieMerkleProof::from_raw_entry(conn, key, &marf_value, block_hash)?;
+            Ok(Some((marf_value, proof)))
+        })
+    }
+
     fn get_block_at_height(&mut self, height: u32, tip: &T) -> Result<Option<T>, Error> {
         self.with_conn(|c| MARF::get_block_at_height(c, height, tip))
     }
@@ -104,6 +119,46 @@ pub trait MarfConnection<T: MarfTrieId> {
     /// Get the root trie hash at a particular block
     fn get_root_hash_at(&mut self, block_hash: &T) -> Result<TrieHash, Error> {
         self.with_conn(|c| c.get_root_hash_at(block_hash))
+    }
+
+    /// Check if a block can open successfully, i.e.,
+    ///   it's a known block, the storage system isn't issueing IOErrors, _and_ it's in the same fork
+    ///   as the current block
+    /// The MARF _must_ be open to a valid block for this check to be evaluated.
+    fn check_ancestor_block_hash(&mut self, bhh: &T) -> Result<(), Error> {
+        self.with_conn(|conn| {
+            let cur_block_hash = conn.get_cur_block();
+            if cur_block_hash == *bhh {
+                // a block is in its own fork
+                return Ok(());
+            }
+
+            let bhh_height =
+                MARF::get_block_height(conn, bhh, &cur_block_hash)?.ok_or_else(|| {
+                    Error::NonMatchingForks(bhh.clone().to_bytes(), cur_block_hash.clone().to_bytes())
+                })?;
+
+            let actual_block_at_height = MARF::get_block_at_height(conn, bhh_height, &cur_block_hash)?
+                .ok_or_else(|| Error::CorruptionError(format!(
+                    "ERROR: Could not find block for height {}, but it was returned by MARF::get_block_height()", bhh_height)))?;
+
+            if bhh != &actual_block_at_height {
+                test_debug!("non-matching forks: {} != {}", bhh, &actual_block_at_height);
+                return Err(Error::NonMatchingForks(
+                    bhh.clone().to_bytes(),
+                    cur_block_hash.to_bytes(),
+                ));
+            }
+
+            // test open
+            let result = conn.open_block(bhh);
+
+            // restore
+            conn.open_block(&cur_block_hash)
+                .map_err(|e| Error::RestoreMarfBlockError(Box::new(e)))?;
+
+            result
+        })
     }
 }
 
@@ -148,6 +203,60 @@ impl<'a, T: MarfTrieId> MarfTransaction<'a, T> {
         }
         self.storage.commit_tx();
         Ok(())
+    }
+
+    /// Finish writing the next trie in the MARF, but change the hash of the current Trie's
+    /// block hash to something other than what we opened it as.  This persists all changes.
+    pub fn commit_to(mut self, real_bhh: &T) -> Result<(), Error> {
+        if self.storage.readonly() {
+            return Err(Error::ReadOnlyError);
+        }
+        if self.storage.unconfirmed() {
+            return Err(Error::UnconfirmedError);
+        }
+        if let Some(_tip) = self.open_chain_tip.take() {
+            self.storage.flush_to(real_bhh)?;
+            self.storage.commit_tx();
+        }
+        Ok(())
+    }
+
+    /// Finish writing the next trie in the MARF -- this is used by miners
+    ///   to commit the mined block, but write it to the mined_block table,
+    ///   rather than out to the marf_data table (this prevents the
+    ///   miner's block from getting stepped on after the sortition).
+    pub fn commit_mined(mut self, bhh: &T) -> Result<(), Error> {
+        if self.storage.readonly() {
+            return Err(Error::ReadOnlyError);
+        }
+        if self.storage.unconfirmed() {
+            return Err(Error::UnconfirmedError);
+        }
+        if let Some(_tip) = self.open_chain_tip.take() {
+            self.storage.flush_mined(bhh)?;
+            self.storage.commit_tx();
+        }
+        Ok(())
+    }
+
+    pub fn get_open_chain_tip(&self) -> Option<&T> {
+        self.open_chain_tip.as_ref().map(|tip| &tip.block_hash)
+    }
+
+    pub fn get_open_chain_tip_height(&self) -> Option<u32> {
+        self.open_chain_tip.as_ref().map(|tip| tip.height)
+    }
+
+    pub fn get_block_height_of(
+        &mut self,
+        bhh: &T,
+        current_block_hash: &T,
+    ) -> Result<Option<u32>, Error> {
+        if Some(bhh) == self.get_open_chain_tip() {
+            return Ok(self.get_open_chain_tip_height());
+        } else {
+            MARF::get_block_height_miner_tip(&mut self.storage, bhh, current_block_hash)
+        }
     }
 
     ///  This function commits the current MARF sqlite transaction
@@ -396,6 +505,19 @@ impl<'a, T: MarfTrieId> MarfTransaction<'a, T> {
                 .open_block(&T::sentinel())
                 .expect("BUG: should never fail to open the block sentinel");
             self.storage.commit_tx()
+        }
+    }
+
+    /// Drop the current trie from the MARF, and roll back all unconfirmed state
+    pub fn drop_unconfirmed(mut self) {
+        if !self.storage.readonly() && self.storage.unconfirmed() {
+            if let Some(tip) = self.open_chain_tip.take() {
+                self.storage.drop_unconfirmed_trie(&tip.block_hash);
+                self.storage
+                    .open_block(&T::sentinel())
+                    .expect("BUG: should never fail to open the block sentinel");
+                self.storage.commit_tx();
+            }
         }
     }
 }
@@ -1275,45 +1397,6 @@ impl<T: MarfTrieId> MARF<T> {
     /// Get open chain tip
     pub fn get_open_chain_tip_height(&self) -> Option<u32> {
         self.open_chain_tip.as_ref().map(|x| x.height)
-    }
-
-    /// Check if a block can open successfully, i.e.,
-    ///   it's a known block, the storage system isn't issueing IOErrors, _and_ it's in the same fork
-    ///   as the current block
-    /// The MARF _must_ be open to a valid block for this check to be evaluated.
-    pub fn check_ancestor_block_hash(&mut self, bhh: &T) -> Result<(), Error> {
-        let mut conn = self.storage.connection();
-        let cur_block_hash = conn.get_cur_block();
-        if cur_block_hash == *bhh {
-            // a block is in its own fork
-            return Ok(());
-        }
-
-        let bhh_height =
-            MARF::get_block_height(&mut conn, bhh, &cur_block_hash)?.ok_or_else(|| {
-                Error::NonMatchingForks(bhh.clone().to_bytes(), cur_block_hash.clone().to_bytes())
-            })?;
-
-        let actual_block_at_height = MARF::get_block_at_height(&mut conn, bhh_height, &cur_block_hash)?
-            .ok_or_else(|| Error::CorruptionError(format!(
-                "ERROR: Could not find block for height {}, but it was returned by MARF::get_block_height()", bhh_height)))?;
-
-        if bhh != &actual_block_at_height {
-            test_debug!("non-matching forks: {} != {}", bhh, &actual_block_at_height);
-            return Err(Error::NonMatchingForks(
-                bhh.clone().to_bytes(),
-                cur_block_hash.to_bytes(),
-            ));
-        }
-
-        // test open
-        let result = conn.open_block(bhh);
-
-        // restore
-        conn.open_block(&cur_block_hash)
-            .map_err(|e| Error::RestoreMarfBlockError(Box::new(e)))?;
-
-        result
     }
 
     /// Access internal storage

--- a/src/chainstate/stacks/index/storage.rs
+++ b/src/chainstate/stacks/index/storage.rs
@@ -1165,6 +1165,19 @@ impl<'a, T: MarfTrieId> TrieStorageTransaction<'a, T> {
             }
         }
     }
+
+    pub fn rollback(self) {
+        match self.0.db {
+            SqliteConnection::Tx(tx) => {
+                tx.rollback().expect("CORRUPTION: Failed to commit MARF");
+            }
+            SqliteConnection::ConnRef(_) => {
+                unreachable!(
+                    "BUG: Constructed TrieStorageTransaction with a bare sqlite connection ref."
+                );
+            }
+        }
+    }
 }
 
 impl<'a, T: MarfTrieId> TrieStorageConnection<'a, T> {

--- a/src/clarity.rs
+++ b/src/clarity.rs
@@ -523,7 +523,7 @@ pub fn invoke_command(invoked_by: &str, args: &[String]) {
             let header_db = CLIHeadersDB::new(&db_name);
             in_block(db_name, marf_kv, |mut kv| {
                 {
-                    let mut db = kv.as_clarity_db(&header_db, &NULL_BURN_STATE_DB);
+                    let mut db = kv.as_foo_clarity_db(&header_db, &NULL_BURN_STATE_DB);
                     db.initialize();
                     db.begin();
                     for (principal, amount) in allocations.iter() {
@@ -727,7 +727,7 @@ pub fn invoke_command(invoked_by: &str, args: &[String]) {
             let header_db = CLIHeadersDB::new(&vm_filename);
             let result = in_block(vm_filename, marf_kv, |mut marf| {
                 let result = {
-                    let db = marf.as_clarity_db(&header_db, &NULL_BURN_STATE_DB);
+                    let db = marf.as_foo_clarity_db(&header_db, &NULL_BURN_STATE_DB);
                     let mut vm_env =
                         OwnedEnvironment::new_cost_limited(db, LimitedCostTracker::new_free());
                     vm_env
@@ -757,7 +757,7 @@ pub fn invoke_command(invoked_by: &str, args: &[String]) {
             let header_db = CLIHeadersDB::new(&vm_filename);
             let result = at_chaintip(vm_filename, marf_kv, |mut marf| {
                 let result = {
-                    let db = marf.as_clarity_db(&header_db, &NULL_BURN_STATE_DB);
+                    let db = marf.as_foo_clarity_db(&header_db, &NULL_BURN_STATE_DB);
                     let mut vm_env =
                         OwnedEnvironment::new_cost_limited(db, LimitedCostTracker::new_free());
                     vm_env
@@ -807,7 +807,7 @@ pub fn invoke_command(invoked_by: &str, args: &[String]) {
             let header_db = CLIHeadersDB::new(&vm_filename);
             let result = at_block(chain_tip, marf_kv, |mut marf| {
                 let result = {
-                    let db = marf.as_clarity_db(&header_db, &NULL_BURN_STATE_DB);
+                    let db = marf.as_foo_clarity_db(&header_db, &NULL_BURN_STATE_DB);
                     let mut vm_env =
                         OwnedEnvironment::new_cost_limited(db, LimitedCostTracker::new_free());
                     vm_env
@@ -867,7 +867,7 @@ pub fn invoke_command(invoked_by: &str, args: &[String]) {
                     Err(e) => (marf, Err(e)),
                     Ok(analysis) => {
                         let result = {
-                            let db = marf.as_clarity_db(&header_db, &NULL_BURN_STATE_DB);
+                            let db = marf.as_foo_clarity_db(&header_db, &NULL_BURN_STATE_DB);
                             let mut vm_env = OwnedEnvironment::new_cost_limited(
                                 db,
                                 LimitedCostTracker::new_free(),
@@ -947,7 +947,7 @@ pub fn invoke_command(invoked_by: &str, args: &[String]) {
 
             let result = in_block(vm_filename, marf_kv, |mut marf| {
                 let result = {
-                    let db = marf.as_clarity_db(&header_db, &NULL_BURN_STATE_DB);
+                    let db = marf.as_foo_clarity_db(&header_db, &NULL_BURN_STATE_DB);
                     let mut vm_env =
                         OwnedEnvironment::new_cost_limited(db, LimitedCostTracker::new_free());
                     vm_env.execute_transaction(

--- a/src/clarity.rs
+++ b/src/clarity.rs
@@ -271,11 +271,12 @@ where
         .to_string();
 
     // need to load the last block
-    let (from, to) = advance_cli_chain_tip(&cli_db_path);
-    marf_kv.begin(&from, &to);
-    let (mut marf_return, result) = f(marf_kv);
-    marf_return.commit_to(&to);
-    result
+    unimplemented!("")
+    //    let (from, to) = advance_cli_chain_tip(&cli_db_path);
+    //    marf_kv.begin(&from, &to);
+    //    let (mut marf_return, result) = f(marf_kv);
+    //    marf_return.commit_to(&to);
+    //    result
 }
 
 // like in_block, but does _not_ advance the chain tip.  Used for read-only queries against the
@@ -299,10 +300,11 @@ where
     let from = get_cli_chain_tip(&cli_db_conn);
     let to = StacksBlockId([2u8; 32]); // 0x0202020202 ... (pattern not used anywhere else)
 
-    marf_kv.begin(&from, &to);
-    let (mut marf_return, result) = f(marf_kv);
-    marf_return.rollback();
-    result
+    unimplemented!("")
+    //    marf_kv.begin(&from, &to);
+    //    let (mut marf_return, result) = f(marf_kv);
+    //    marf_return.rollback();
+    //    result
 }
 
 fn at_block<F, R>(blockhash: &str, mut marf_kv: MarfedKV, f: F) -> R
@@ -314,10 +316,12 @@ where
         .expect(&format!("FATAL: failed to parse inputted blockhash"));
     let to = StacksBlockId([2u8; 32]); // 0x0202020202 ... (pattern not used anywhere else)
 
-    marf_kv.begin(&from, &to);
-    let (mut marf_return, result) = f(marf_kv);
-    marf_return.rollback();
-    result
+    unimplemented!("")
+
+    //    marf_kv.begin(&from, &to);
+    //    let (mut marf_return, result) = f(marf_kv);
+    //    marf_return.rollback();
+    //    result
 }
 
 struct CLIHeadersDB {

--- a/src/net/chat.rs
+++ b/src/net/chat.rs
@@ -1811,6 +1811,13 @@ impl ConversationP2P {
                         break;
                     }
                 }
+                Err(net_error::PermanentlyDrained) => {
+                    trace!(
+                        "{:?}: failed to recv on P2P conversation: PermanentlyDrained",
+                        self
+                    );
+                    return Err(net_error::PermanentlyDrained);
+                }
                 Err(e) => {
                     info!("{:?}: failed to recv on P2P conversation: {:?}", self, &e);
                     return Err(e);

--- a/src/net/p2p.rs
+++ b/src/net/p2p.rs
@@ -4276,7 +4276,15 @@ impl PeerNetwork {
         }
 
         if let Err(e) = PeerNetwork::setup_unconfirmed_state(chainstate, sortdb) {
-            warn!("Failed to instantiate unconfirmed state: {:?}", &e);
+            if let net_error::ChainstateError(ref err_msg) = e {
+                if err_msg == "Stacks chainstate error: NoSuchBlockError" {
+                    trace!("Failed to instantiate unconfirmed state: {:?}", &e);
+                } else {
+                    warn!("Failed to instantiate unconfirmed state: {:?}", &e);
+                }
+            } else {
+                warn!("Failed to instantiate unconfirmed state: {:?}", &e);
+            }
         }
 
         debug!("<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< End Network Dispatch <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<");

--- a/src/net/server.rs
+++ b/src/net/server.rs
@@ -473,7 +473,7 @@ impl HttpPeer {
                                     Ok(_) => {}
                                     Err(e) => {
                                         debug!(
-                                            "Failed to flush HTP 400 to socket {:?}: {:?}",
+                                            "Failed to flush HTTP 400 to socket {:?}: {:?}",
                                             &client_sock, &e
                                         );
                                         convo_dead = true;
@@ -528,7 +528,7 @@ impl HttpPeer {
         if !convo_dead {
             // (continue) sending out data in this conversation, if the conversation is still
             // ongoing
-            match convo.send(client_sock, chainstate) {
+            match HttpPeer::saturate_http_socket(client_sock, convo, chainstate) {
                 Ok(_) => {}
                 Err(e) => {
                     debug!(

--- a/src/util/log.rs
+++ b/src/util/log.rs
@@ -121,11 +121,25 @@ fn make_json_logger() -> Logger {
     panic!("Tried to construct JSON logger, but stacks-blockchain built without slog_json feature enabled.")
 }
 
+#[cfg(not(test))]
 fn make_logger() -> Logger {
     if env::var("BLOCKSTACK_LOG_JSON") == Ok("1".into()) {
         make_json_logger()
     } else {
         let plain = slog_term::PlainSyncDecorator::new(std::io::stderr());
+        let drain = TermFormat::new(plain);
+
+        let logger = Logger::root(drain.fuse(), o!());
+        logger
+    }
+}
+
+#[cfg(test)]
+fn make_logger() -> Logger {
+    if env::var("BLOCKSTACK_LOG_JSON") == Ok("1".into()) {
+        make_json_logger()
+    } else {
+        let plain = slog_term::PlainSyncDecorator::new(slog_term::TestStdoutWriter);
         let drain = TermFormat::new(plain);
 
         let logger = Logger::root(drain.fuse(), o!());

--- a/src/vm/database/clarity_db.rs
+++ b/src/vm/database/clarity_db.rs
@@ -372,14 +372,17 @@ impl<'a> ClarityDatabase<'a> {
         self.store.depth() == 0
     }
 
+    /// Nest the key-value wrapper instance
     pub fn begin(&mut self) {
         self.store.nest();
     }
 
+    /// Commit current key-value wrapper layer
     pub fn commit(&mut self) {
         self.store.commit();
     }
 
+    /// Drop current key-value wrapper layer
     pub fn roll_back(&mut self) {
         self.store.rollback();
     }

--- a/src/vm/errors.rs
+++ b/src/vm/errors.rs
@@ -20,6 +20,7 @@ use rusqlite::Error as SqliteError;
 use serde_json::Error as SerdeJSONErr;
 use std::error;
 use std::fmt;
+use util::db::Error as DatabaseError;
 pub use vm::analysis::errors::CheckErrors;
 pub use vm::analysis::errors::{check_argument_count, check_arguments_at_least};
 use vm::ast::errors::ParseError;
@@ -61,6 +62,7 @@ pub enum InterpreterError {
     FailureConstructingListWithType,
     InsufficientBalance,
     CostContractLoadFailure,
+    DBError(IncomparableError<DatabaseError>),
 }
 
 /// RuntimeErrors are errors that smart contracts are expected

--- a/src/vm/tests/costs.rs
+++ b/src/vm/tests/costs.rs
@@ -327,11 +327,10 @@ fn test_cost_contract_short_circuits() {
         clarity_inst.destroy()
     };
 
-    marf_kv.begin(&StacksBlockId([1 as u8; 32]), &StacksBlockId([2 as u8; 32]));
-
     let without_interposing_5 = {
+        let mut store = marf_kv.begin(&StacksBlockId([1 as u8; 32]), &StacksBlockId([2 as u8; 32]));
         let mut owned_env = OwnedEnvironment::new_max_limit(
-            marf_kv.as_clarity_db(&NULL_HEADER_DB, &NULL_BURN_STATE_DB),
+            store.as_clarity_db(&NULL_HEADER_DB, &NULL_BURN_STATE_DB),
         );
 
         execute_transaction(
@@ -345,12 +344,14 @@ fn test_cost_contract_short_circuits() {
 
         let (_db, tracker) = owned_env.destruct().unwrap();
 
+        store.test_commit();
         tracker.get_total()
     };
 
     let without_interposing_10 = {
+        let mut store = marf_kv.begin(&StacksBlockId([2 as u8; 32]), &StacksBlockId([3 as u8; 32]));
         let mut owned_env = OwnedEnvironment::new_max_limit(
-            marf_kv.as_clarity_db(&NULL_HEADER_DB, &NULL_BURN_STATE_DB),
+            store.as_clarity_db(&NULL_HEADER_DB, &NULL_BURN_STATE_DB),
         );
 
         execute_transaction(
@@ -364,11 +365,13 @@ fn test_cost_contract_short_circuits() {
 
         let (_db, tracker) = owned_env.destruct().unwrap();
 
+        store.test_commit();
         tracker.get_total()
     };
 
     {
-        let mut db = marf_kv.as_clarity_db(&NULL_HEADER_DB, &NULL_BURN_STATE_DB);
+        let mut store = marf_kv.begin(&StacksBlockId([3 as u8; 32]), &StacksBlockId([4 as u8; 32]));
+        let mut db = store.as_clarity_db(&NULL_HEADER_DB, &NULL_BURN_STATE_DB);
         db.begin();
         db.set_variable(
             &STACKS_BOOT_COST_VOTE_CONTRACT,
@@ -392,14 +395,14 @@ fn test_cost_contract_short_circuits() {
         )
         .unwrap();
         db.commit();
+        store.test_commit();
     }
 
-    marf_kv.test_commit();
-    marf_kv.begin(&StacksBlockId([2 as u8; 32]), &StacksBlockId([3 as u8; 32]));
-
     let with_interposing_5 = {
+        let mut store = marf_kv.begin(&StacksBlockId([4 as u8; 32]), &StacksBlockId([5 as u8; 32]));
+
         let mut owned_env = OwnedEnvironment::new_max_limit(
-            marf_kv.as_clarity_db(&NULL_HEADER_DB, &NULL_BURN_STATE_DB),
+            store.as_clarity_db(&NULL_HEADER_DB, &NULL_BURN_STATE_DB),
         );
 
         execute_transaction(
@@ -413,12 +416,14 @@ fn test_cost_contract_short_circuits() {
 
         let (_db, tracker) = owned_env.destruct().unwrap();
 
+        store.test_commit();
         tracker.get_total()
     };
 
     let with_interposing_10 = {
+        let mut store = marf_kv.begin(&StacksBlockId([5 as u8; 32]), &StacksBlockId([6 as u8; 32]));
         let mut owned_env = OwnedEnvironment::new_max_limit(
-            marf_kv.as_clarity_db(&NULL_HEADER_DB, &NULL_BURN_STATE_DB),
+            store.as_clarity_db(&NULL_HEADER_DB, &NULL_BURN_STATE_DB),
         );
 
         execute_transaction(
@@ -563,8 +568,6 @@ fn test_cost_voting_integration() {
         clarity_inst.destroy()
     };
 
-    marf_kv.begin(&StacksBlockId([1 as u8; 32]), &StacksBlockId([2 as u8; 32]));
-
     let bad_cases = vec![
         // non existent "replacement target"
         (
@@ -643,7 +646,9 @@ fn test_cost_voting_integration() {
     let bad_proposals = bad_cases.len();
 
     {
-        let mut db = marf_kv.as_clarity_db(&NULL_HEADER_DB, &NULL_BURN_STATE_DB);
+        let mut store = marf_kv.begin(&StacksBlockId([1 as u8; 32]), &StacksBlockId([2 as u8; 32]));
+
+        let mut db = store.as_clarity_db(&NULL_HEADER_DB, &NULL_BURN_STATE_DB);
         db.begin();
 
         db.set_variable(
@@ -673,14 +678,13 @@ fn test_cost_voting_integration() {
             .unwrap();
         }
         db.commit();
+        store.test_commit();
     }
 
-    marf_kv.test_commit();
-    marf_kv.begin(&StacksBlockId([2 as u8; 32]), &StacksBlockId([3 as u8; 32]));
-
     let le_cost_without_interception = {
+        let mut store = marf_kv.begin(&StacksBlockId([2 as u8; 32]), &StacksBlockId([3 as u8; 32]));
         let mut owned_env = OwnedEnvironment::new_max_limit(
-            marf_kv.as_clarity_db(&NULL_HEADER_DB, &NULL_BURN_STATE_DB),
+            store.as_clarity_db(&NULL_HEADER_DB, &NULL_BURN_STATE_DB),
         );
 
         execute_transaction(
@@ -709,6 +713,7 @@ fn test_cost_voting_integration() {
                 "All cost functions should still point to the boot costs"
             );
         }
+        store.test_commit();
 
         tracker.get_total()
     };
@@ -734,11 +739,10 @@ fn test_cost_voting_integration() {
         ),
     ];
 
-    marf_kv.test_commit();
-    marf_kv.begin(&StacksBlockId([3 as u8; 32]), &StacksBlockId([4 as u8; 32]));
-
     {
-        let mut db = marf_kv.as_clarity_db(&NULL_HEADER_DB, &NULL_BURN_STATE_DB);
+        let mut store = marf_kv.begin(&StacksBlockId([3 as u8; 32]), &StacksBlockId([4 as u8; 32]));
+
+        let mut db = store.as_clarity_db(&NULL_HEADER_DB, &NULL_BURN_STATE_DB);
         db.begin();
 
         let good_proposals = good_cases.len() as u128;
@@ -769,14 +773,14 @@ fn test_cost_voting_integration() {
             .unwrap();
         }
         db.commit();
+
+        store.test_commit();
     }
 
-    marf_kv.test_commit();
-    marf_kv.begin(&StacksBlockId([4 as u8; 32]), &StacksBlockId([5 as u8; 32]));
-
     {
+        let mut store = marf_kv.begin(&StacksBlockId([4 as u8; 32]), &StacksBlockId([5 as u8; 32]));
         let mut owned_env = OwnedEnvironment::new_max_limit(
-            marf_kv.as_clarity_db(&NULL_HEADER_DB, &NULL_BURN_STATE_DB),
+            store.as_clarity_db(&NULL_HEADER_DB, &NULL_BURN_STATE_DB),
         );
 
         execute_transaction(
@@ -824,7 +828,6 @@ fn test_cost_voting_integration() {
                 );
             }
         }
+        store.test_commit();
     };
-
-    marf_kv.test_commit();
 }

--- a/src/vm/tests/costs.rs
+++ b/src/vm/tests/costs.rs
@@ -194,7 +194,7 @@ fn test_tracked_costs(prog: &str) -> ExecutionCost {
 
     let mut marf_kv = clarity_instance.destroy();
 
-    marf_kv.begin(
+    let mut store = marf_kv.begin(
         &StacksBlockHeader::make_index_block_hash(
             &FIRST_BURNCHAIN_CONSENSUS_HASH,
             &FIRST_STACKS_BLOCK_HASH,
@@ -202,9 +202,8 @@ fn test_tracked_costs(prog: &str) -> ExecutionCost {
         &StacksBlockId([1 as u8; 32]),
     );
 
-    let mut owned_env = OwnedEnvironment::new_max_limit(
-        marf_kv.as_clarity_db(&NULL_HEADER_DB, &NULL_BURN_STATE_DB),
-    );
+    let mut owned_env =
+        OwnedEnvironment::new_max_limit(store.as_clarity_db(&NULL_HEADER_DB, &NULL_BURN_STATE_DB));
 
     owned_env
         .initialize_contract(trait_contract_id.clone(), contract_trait)

--- a/src/vm/tests/forking.rs
+++ b/src/vm/tests/forking.rs
@@ -256,56 +256,48 @@ where
     F3: FnOnce(&mut OwnedEnvironment),
 {
     let mut marf_kv = MarfedKV::temporary();
-    marf_kv.begin(&StacksBlockId::sentinel(), &StacksBlockId([0 as u8; 32]));
 
     {
-        marf_kv
+        let mut store = marf_kv.begin(&StacksBlockId::sentinel(), &StacksBlockId([0 as u8; 32]));
+        store
             .as_clarity_db(&NULL_HEADER_DB, &NULL_BURN_STATE_DB)
             .initialize();
+        store.test_commit();
     }
-
-    marf_kv.test_commit();
-    marf_kv.begin(&StacksBlockId([0 as u8; 32]), &StacksBlockId([1 as u8; 32]));
 
     {
+        let mut store = marf_kv.begin(&StacksBlockId([0 as u8; 32]), &StacksBlockId([1 as u8; 32]));
         let mut owned_env =
-            OwnedEnvironment::new(marf_kv.as_clarity_db(&NULL_HEADER_DB, &NULL_BURN_STATE_DB));
-        f(&mut owned_env)
+            OwnedEnvironment::new(store.as_clarity_db(&NULL_HEADER_DB, &NULL_BURN_STATE_DB));
+        f(&mut owned_env);
+        store.test_commit();
     }
-
-    marf_kv.test_commit();
 
     // Now, we can do our forking.
 
-    marf_kv.begin(&StacksBlockId([1 as u8; 32]), &StacksBlockId([2 as u8; 32]));
-
     {
+        let mut store = marf_kv.begin(&StacksBlockId([1 as u8; 32]), &StacksBlockId([2 as u8; 32]));
         let mut owned_env =
-            OwnedEnvironment::new(marf_kv.as_clarity_db(&NULL_HEADER_DB, &NULL_BURN_STATE_DB));
-        a(&mut owned_env)
+            OwnedEnvironment::new(store.as_clarity_db(&NULL_HEADER_DB, &NULL_BURN_STATE_DB));
+        a(&mut owned_env);
+        store.test_commit();
     }
 
-    marf_kv.test_commit();
-
-    marf_kv.begin(&StacksBlockId([1 as u8; 32]), &StacksBlockId([3 as u8; 32]));
-
     {
+        let mut store = marf_kv.begin(&StacksBlockId([1 as u8; 32]), &StacksBlockId([3 as u8; 32]));
         let mut owned_env =
-            OwnedEnvironment::new(marf_kv.as_clarity_db(&NULL_HEADER_DB, &NULL_BURN_STATE_DB));
-        b(&mut owned_env)
+            OwnedEnvironment::new(store.as_clarity_db(&NULL_HEADER_DB, &NULL_BURN_STATE_DB));
+        b(&mut owned_env);
+        store.test_commit();
     }
 
-    marf_kv.test_commit();
-
-    marf_kv.begin(&StacksBlockId([2 as u8; 32]), &StacksBlockId([4 as u8; 32]));
-
     {
+        let mut store = marf_kv.begin(&StacksBlockId([2 as u8; 32]), &StacksBlockId([4 as u8; 32]));
         let mut owned_env =
-            OwnedEnvironment::new(marf_kv.as_clarity_db(&NULL_HEADER_DB, &NULL_BURN_STATE_DB));
-        z(&mut owned_env)
+            OwnedEnvironment::new(store.as_clarity_db(&NULL_HEADER_DB, &NULL_BURN_STATE_DB));
+        z(&mut owned_env);
+        store.test_commit();
     }
-
-    marf_kv.test_commit();
 }
 
 fn initialize_contract(owned_env: &mut OwnedEnvironment) {

--- a/src/vm/tests/mod.rs
+++ b/src/vm/tests/mod.rs
@@ -64,32 +64,33 @@ where
     F: FnOnce(&mut OwnedEnvironment) -> (),
 {
     let mut marf_kv = MarfedKV::temporary();
-    marf_kv.begin(
-        &StacksBlockId::sentinel(),
-        &StacksBlockHeader::make_index_block_hash(
-            &FIRST_BURNCHAIN_CONSENSUS_HASH,
-            &FIRST_STACKS_BLOCK_HASH,
-        ),
-    );
 
     {
-        marf_kv
+        let mut store = marf_kv.begin(
+            &StacksBlockId::sentinel(),
+            &StacksBlockHeader::make_index_block_hash(
+                &FIRST_BURNCHAIN_CONSENSUS_HASH,
+                &FIRST_STACKS_BLOCK_HASH,
+            ),
+        );
+
+        store
             .as_clarity_db(&NULL_HEADER_DB, &NULL_BURN_STATE_DB)
             .initialize();
+        store.test_commit();
     }
 
-    marf_kv.test_commit();
-    marf_kv.begin(
-        &StacksBlockHeader::make_index_block_hash(
-            &FIRST_BURNCHAIN_CONSENSUS_HASH,
-            &FIRST_STACKS_BLOCK_HASH,
-        ),
-        &StacksBlockId([1 as u8; 32]),
-    );
-
     {
+        let mut store = marf_kv.begin(
+            &StacksBlockHeader::make_index_block_hash(
+                &FIRST_BURNCHAIN_CONSENSUS_HASH,
+                &FIRST_STACKS_BLOCK_HASH,
+            ),
+            &StacksBlockId([1 as u8; 32]),
+        );
+
         let mut owned_env =
-            OwnedEnvironment::new(marf_kv.as_clarity_db(&NULL_HEADER_DB, &NULL_BURN_STATE_DB));
+            OwnedEnvironment::new(store.as_clarity_db(&NULL_HEADER_DB, &NULL_BURN_STATE_DB));
         // start an initial transaction.
         if !top_level {
             owned_env.begin();
@@ -103,8 +104,8 @@ pub fn execute(s: &str) -> Value {
     vm_execute(s).unwrap().unwrap()
 }
 
-pub fn symbols_from_values(mut vec: Vec<Value>) -> Vec<SymbolicExpression> {
-    vec.drain(..)
+pub fn symbols_from_values(vec: Vec<Value>) -> Vec<SymbolicExpression> {
+    vec.into_iter()
         .map(|value| SymbolicExpression::atom_value(value))
         .collect()
 }


### PR DESCRIPTION
This addresses #2045 -- removing the savepoints, and using the same DB transaction to build MARF tries as "side-store" writes.

The primary changes here are to `vm::database::marf` (which propagate to `vm::clarity`):

* In order to be used, a caller of the `MarfedKV` struct needs to create either a Writable or a ReadOnly db connection. The Writable connection wraps a `MarfTransaction` instance -- this is used to ensure that a ClarityBlockConnection always corresponds with one MarfTransaction (guaranteeing atomicity of side-store operations, importantly the _metadata_ side store operations).
* Unconfirmed state still requires the ability to "undo" metadata side store operations. This is because unconfirmed state may be "sqlite committed", and then later dropped. This is implemented by doing a SQL delete from during the unconfirmed block rollback.
