### PR TITLE
Nonblocking genesis tests

### DIFF
--- a/.github/workflows/stacks-blockchain.yml
+++ b/.github/workflows/stacks-blockchain.yml
@@ -166,8 +166,6 @@ jobs:
     outputs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}
     needs:
-      - sampled-genesis
-      - full-genesis
       - dist
       - build-publish
       - build-publish-stretch
@@ -219,8 +217,6 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - notify-start
-      - sampled-genesis
-      - full-genesis
       - dist
       - build-publish
       - build-publish-stretch


### PR DESCRIPTION
## Description

Changes the full and sample genesis tests to make them non-blocking for releases, since they could take over an hour and there's some inconsistent errors delaying releases.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [X] Other

## Does this introduce a breaking change?
No

## Are documentation updates required?
Nada
