### PR TITLE
increase the number of attempts to confrim BTC transaction from 10->20

### DIFF
--- a/net-test/bin/start.sh
+++ b/net-test/bin/start.sh
@@ -206,7 +206,7 @@ start_stacks_miner_node() {
 
    log "[$$]  Waiting for BTC to get confirmed..."
    TIMEOUT=2
-   for i in $(seq 1 10); do
+   for i in $(seq 1 20); do
        CONFIRMATIONS="$(curl -sf "$FAUCET_URL"/bitcoin/confirmations/"$TXID")"
        local RC=$?
        if [ $RC -ne 0 ]; then 


### PR DESCRIPTION

## Description
Running tests with testground, occasionally an instance or two would fail to confirm the BTC faucet transaction after 10 attempts. 
Increasing this int from `10`->`20` has helped in local testing, no more failures of this type have been caught. 

For details refer to issue #2046 

## Testing information
Due to this change, it may take longer to confirm BTC faucet tx in `./net-test`, but functionally nothing should be affected.


