### PR TITLE
docs: fix simple typo, sytem -> system

### DIFF
--- a/sip/sip-008-analysis-cost-assessment.md
+++ b/sip/sip-008-analysis-cost-assessment.md
@@ -318,7 +318,7 @@ X := the total type size of the function signature
 
 ## let
 
-Let bindings require the static analysis sytem to iterate over
+Let bindings require the static analysis system to iterate over
 each let binding and ensure that they are syntactically correct.
 
 This imposes a runtime cost:


### PR DESCRIPTION
There is a small typo in sip/sip-008-analysis-cost-assessment.md.

Should read `system` rather than `sytem`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md