### PR TITLE
Update cost-voting to use block-height over burn-block-height

### DIFF
--- a/src/vm/database/clarity_db.rs
+++ b/src/vm/database/clarity_db.rs
@@ -691,9 +691,16 @@ impl<'a> ClarityDatabase<'a> {
             .into()
     }
 
+    /// Returns the total liquid ustx of the parent block
+    ///   if we'd rather expose `total-liquid-ustx` as the _current_ block's
+    ///   total liquid supply, then it needs to be tracked as a variable in the
+    ///   clarity marf proper (rather than the headers db)
     pub fn get_total_liquid_ustx(&mut self) -> u128 {
         let cur_height = self.get_current_block_height();
-        let cur_id_bhh = self.get_index_block_header_hash(cur_height);
+        if cur_height == 0 {
+            return 0;
+        }
+        let cur_id_bhh = self.get_index_block_header_hash(cur_height - 1);
         self.headers_db.get_total_liquid_ustx(&cur_id_bhh)
     }
 

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -215,6 +215,31 @@ fn wait_for_runloop(blocks_processed: &Arc<AtomicU64>) {
     }
 }
 
+fn submit_tx(http_origin: &str, tx: &Vec<u8>) {
+    let client = reqwest::blocking::Client::new();
+    let path = format!("{}/v2/transactions", http_origin);
+    let res = client
+        .post(&path)
+        .header("Content-Type", "application/octet-stream")
+        .body(tx.clone())
+        .send()
+        .unwrap();
+    eprintln!("{:#?}", res);
+    if res.status().is_success() {
+        let res: String = res.json().unwrap();
+        assert_eq!(
+            res,
+            StacksTransaction::consensus_deserialize(&mut &tx[..])
+                .unwrap()
+                .txid()
+                .to_string()
+        );
+    } else {
+        eprintln!("{}", res.text().unwrap());
+        panic!("");
+    }
+}
+
 fn get_tip_anchored_block(conf: &Config) -> (ConsensusHash, StacksBlock) {
     let http_origin = format!("http://{}", &conf.node.rpc_bind);
     let client = reqwest::blocking::Client::new();
@@ -334,6 +359,135 @@ fn get_balance<F: std::fmt::Display>(
         .unwrap();
     eprintln!("Response: {:#?}", res);
     u128::from_str_radix(&res.balance[2..], 16).unwrap()
+}
+
+#[test]
+#[ignore]
+fn liquid_ustx_integration() {
+    if env::var("BITCOIND_TEST") != Ok("1".into()) {
+        return;
+    }
+
+    // the contract that we'll test the costs of
+    let caller_src = "
+    (define-public (execute)
+       (ok stx-liquid-supply))
+    ";
+
+    let spender_sk = StacksPrivateKey::new();
+    let spender_addr = to_addr(&spender_sk);
+    let spender_princ: PrincipalData = spender_addr.into();
+
+    let (mut conf, miner_account) = neon_integration_test_conf();
+
+    test_observer::spawn();
+
+    conf.events_observers.push(EventObserverConfig {
+        endpoint: format!("localhost:{}", test_observer::EVENT_OBSERVER_PORT),
+        events_keys: vec![EventKeyType::AnyEvent],
+    });
+
+    let spender_bal = 10_000_000_000 * (core::MICROSTACKS_PER_STACKS as u64);
+
+    conf.initial_balances.push(InitialBalance {
+        address: spender_princ.clone(),
+        amount: spender_bal,
+    });
+
+    let mut btcd_controller = BitcoinCoreController::new(conf.clone());
+    btcd_controller
+        .start_bitcoind()
+        .map_err(|_e| ())
+        .expect("Failed starting bitcoind");
+
+    let burnchain_config = Burnchain::regtest(&conf.get_burn_db_path());
+
+    let mut btc_regtest_controller = BitcoinRegtestController::with_burnchain(
+        conf.clone(),
+        None,
+        Some(burnchain_config.clone()),
+    );
+    let http_origin = format!("http://{}", &conf.node.rpc_bind);
+
+    btc_regtest_controller.bootstrap_chain(201);
+
+    eprintln!("Chain bootstrapped...");
+
+    let mut run_loop = neon::RunLoop::new(conf.clone());
+    let blocks_processed = run_loop.get_blocks_processed_arc();
+    let client = reqwest::blocking::Client::new();
+    let channel = run_loop.get_coordinator_channel().unwrap();
+
+    thread::spawn(move || run_loop.start(0, Some(burnchain_config)));
+
+    // give the run loop some time to start up!
+    wait_for_runloop(&blocks_processed);
+
+    // first block wakes up the run loop
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+
+    // first block will hold our VRF registration
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+
+    // second block will be the first mined Stacks block
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+
+    let sort_height = channel.get_sortitions_processed();
+
+    let publish = make_contract_publish(&spender_sk, 0, 1000, "caller", caller_src);
+
+    submit_tx(&http_origin, &publish);
+
+    // mine 1 burn block for the miner to issue the next block
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+    // mine next burn block for the miner to win
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+
+    let call_tx = make_contract_call(
+        &spender_sk,
+        1,
+        1000,
+        &spender_addr,
+        "caller",
+        "execute",
+        &[],
+    );
+
+    submit_tx(&http_origin, &call_tx);
+
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+
+    // clear and mine another burnchain block, so that the new winner is seen by the observer
+    //   (the observer is logically "one block behind" the miner
+    test_observer::clear();
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+
+    let mut blocks = test_observer::get_blocks();
+    // should have produced 1 new block
+    assert_eq!(blocks.len(), 1);
+    let block = blocks.pop().unwrap();
+    let transactions = block.get("transactions").unwrap().as_array().unwrap();
+    eprintln!("{}", transactions.len());
+    let mut tested = false;
+    for tx in transactions.iter() {
+        let raw_tx = tx.get("raw_tx").unwrap().as_str().unwrap();
+        if raw_tx == "0x00" {
+            continue;
+        }
+        let tx_bytes = hex_bytes(&raw_tx[2..]).unwrap();
+        let parsed = StacksTransaction::consensus_deserialize(&mut &tx_bytes[..]).unwrap();
+        if let TransactionPayload::ContractCall(contract_call) = parsed.payload {
+            eprintln!("{}", contract_call.function_name.as_str());
+            if contract_call.function_name.as_str() == "execute" {
+                let raw_result = tx.get("raw_result").unwrap().as_str().unwrap();
+                let parsed = <Value as ClarityDeserializable<Value>>::deserialize(&raw_result[2..]);
+                let liquid_ustx = parsed.expect_result_ok().expect_u128();
+                assert!(liquid_ustx > 0, "Should be more liquid ustx than 0");
+                tested = true;
+            }
+        }
+    }
+    assert!(tested, "Should have found a contract call tx");
 }
 
 #[test]


### PR DESCRIPTION
This PR addresses #2223 by using `block-height` rather than `burn-block-height`.