### PR TITLE
Fix: PoX Anchor Counting

### DIFF
--- a/src/chainstate/burn/db/sortdb.rs
+++ b/src/chainstate/burn/db/sortdb.rs
@@ -1788,6 +1788,7 @@ impl<'a> SortitionHandleConn<'a> {
         let winners = self.get_sortition_winners_in_fork(prepare_begin, prepare_end)?;
         for (winner_commit_txid, winner_block_height) in winners.into_iter() {
             let mut cursor = (winner_commit_txid, winner_block_height);
+            let mut found_ancestor = true;
 
             while cursor.1 > (prepare_begin as u64) {
                 // check if we've already discovered the candidate for this block
@@ -1798,6 +1799,15 @@ impl<'a> SortitionHandleConn<'a> {
                     let block_commit = self.get_block_commit_by_txid(&cursor.0)?.expect(
                         "CORRUPTED: Failed to fetch block commit for known sortition winner",
                     );
+                    // is this a height=1 block?
+                    if block_commit.is_parent_genesis() {
+                        debug!("First parent before prepare phase for block winner is the genesis block, dropping block's PoX anchor vote";
+                               "winner_txid" => %&cursor.0,
+                               "burn_block_height" => cursor.1);
+                        found_ancestor = false;
+                        break;
+                    }
+
                     // find the parent sortition
                     let sn = SortitionDB::get_ancestor_snapshot(
                         self,

--- a/src/chainstate/burn/db/sortdb.rs
+++ b/src/chainstate/burn/db/sortdb.rs
@@ -1822,6 +1822,9 @@ impl<'a> SortitionHandleConn<'a> {
                     cursor = (sn.winning_block_txid, sn.block_height);
                 }
             }
+            if !found_ancestor {
+                continue;
+            }
             // this is the burn block height of the sortition that chose the
             //   highest ancestor of winner_stacks_bh whose sortition occurred before prepare_begin
             //  the winner of that sortition is the PoX anchor block candidate that winner_stacks_bh is "voting for"

--- a/src/chainstate/burn/operations/leader_block_commit.rs
+++ b/src/chainstate/burn/operations/leader_block_commit.rs
@@ -223,6 +223,10 @@ impl LeaderBlockCommitOp {
         )
     }
 
+    pub fn is_parent_genesis(&self) -> bool {
+        self.parent_block_ptr == 0 && self.parent_vtxindex == 0
+    }
+
     /// parse a LeaderBlockCommitOp
     /// `pox_sunset_ht` is the height at which PoX *disables*
     pub fn parse_from_tx(

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -419,6 +419,16 @@ fn try_mine_microblock(
                                 // will need to relay this
                                 next_microblock = Some(microblock);
                             }
+                            Err(NetError::ChainstateError(err_str)) => {
+                                if err_str.contains("NoTransactionsToMine") {
+                                    trace!("Failed to mine microblock because there are no transactions to mine");
+                                } else {
+                                    warn!(
+                                        "Failed to mine one microblock: {:?}",
+                                        &NetError::ChainstateError(err_str)
+                                    );
+                                }
+                            }
                             Err(e) => {
                                 warn!("Failed to mine one microblock: {:?}", &e);
                             }


### PR DESCRIPTION
The PoX anchor selection logic assumes it can always find the parent of a sortition winner -- this is not true if the parent is the genesis block (this leads to a panic #2240)