### PR TITLE
Test fixes

### DIFF
--- a/src/util/pipe.rs
+++ b/src/util/pipe.rs
@@ -412,7 +412,8 @@ mod test {
 
     #[test]
     fn test_connection_pipe_producer_consumer() {
-        let mut buf = vec![0u8; 1048576]; // 1 MB
+        let mut buf = Vec::new();
+        buf.resize(1048576, 0);
 
         let mut rng = rand::thread_rng();
         rng.fill_bytes(&mut *buf);

--- a/src/util/pipe.rs
+++ b/src/util/pipe.rs
@@ -412,7 +412,8 @@ mod test {
 
     #[test]
     fn test_connection_pipe_producer_consumer() {
-        let mut buf = Box::new([0u8; 1048576]); // 1 MB
+        let mut buf = vec![0u8; 1048576]; // 1 MB
+
         let mut rng = rand::thread_rng();
         rng.fill_bytes(&mut *buf);
 


### PR DESCRIPTION
Opening this PR to try and fix some of the current test errors we're seeing. So far:

1. Fix the stack overflow caused by one of the pipe util tests.
2. DRY `neon_integrations` and `clear()` the event observer between runs.