### PR TITLE
Fix: #2239 merge types on runtime merge

### DIFF
--- a/src/vm/tests/simple_apply_eval.rs
+++ b/src/vm/tests/simple_apply_eval.rs
@@ -930,6 +930,36 @@ fn test_lets() {
 }
 
 #[test]
+fn test_2239_merge() {
+    let tests = [
+        "(define-data-var a {p: uint} (merge {p: 2} {p: u2})) (var-get a)",
+        "(merge {p: 2} {p: u2})",
+        "(merge {p: 2} {q: 3})",
+        "(define-data-var c {p: uint} {p: u2}) (var-get c)",
+        "(define-data-var d {p: uint} (merge {p: u2} {p: u2})) (var-get d)",
+        "(define-data-var e {p: int, q: int} {p: 2, q: 3}) (var-get e)",
+        "(define-data-var f {p: int, q: int} (merge {q: 2, p: 3} {p: 4})) (var-get f)",
+    ];
+
+    let expectations = [
+        "(tuple (p u2))",
+        "(tuple (p u2))",
+        "(tuple (p 2) (q 3))",
+        "(tuple (p u2))",
+        "(tuple (p u2))",
+        "(tuple (p 2) (q 3))",
+        "(tuple (p 4) (q 2))",
+    ];
+
+    tests
+        .iter()
+        .zip(expectations.iter())
+        .for_each(|(program, expectation)| {
+            assert_eq!(expectation.to_string(), execute(program).to_string())
+        });
+}
+
+#[test]
 fn test_2053_stacked_user_funcs() {
     let test = "
 (define-read-only (identity (n int)) n)

--- a/src/vm/tests/simple_apply_eval.rs
+++ b/src/vm/tests/simple_apply_eval.rs
@@ -930,7 +930,10 @@ fn test_lets() {
 }
 
 #[test]
-fn test_2239_merge() {
+// tests that the type signature of the result of a merge tuple is updated.
+//  this is required to pass the type admission checks of, e.g., data store
+//  operations like `(define-data-var ...)`
+fn merge_update_type_signature_2239() {
     let tests = [
         "(define-data-var a {p: uint} (merge {p: 2} {p: u2})) (var-get a)",
         "(merge {p: 2} {p: u2})",

--- a/src/vm/types/mod.rs
+++ b/src/vm/types/mod.rs
@@ -1255,11 +1255,15 @@ impl TupleData {
         })
     }
 
-    pub fn shallow_merge(base: TupleData, updates: TupleData) -> Result<TupleData> {
-        let mut base = base;
-        for (name, value) in updates.data_map.into_iter() {
+    pub fn shallow_merge(mut base: TupleData, updates: TupleData) -> Result<TupleData> {
+        let TupleData {
+            data_map,
+            mut type_signature,
+        } = updates;
+        for (name, value) in data_map.into_iter() {
             base.data_map.insert(name, value);
         }
+        base.type_signature.shallow_merge(&mut type_signature);
         Ok(base)
     }
 }


### PR DESCRIPTION
This fixes #2239, and provides a witnessing test. 