### PR TITLE
Do not abort mining a block if the microblock stream failed to load

### DIFF
--- a/src/chainstate/stacks/db/blocks.rs
+++ b/src/chainstate/stacks/db/blocks.rs
@@ -1216,12 +1216,12 @@ impl StacksChainState {
                         &microblock.block_hash(),
                     ),
                 )? {
-                    test_debug!("Microblock {} is not processed", &microblock.block_hash());
+                    debug!("Microblock {} is not processed", &microblock.block_hash());
                     return Ok(None);
                 }
             }
 
-            test_debug!(
+            debug!(
                 "Loaded microblock {}/{}-{} (parent={}, expect_seq={})",
                 &parent_consensus_hash,
                 &parent_anchored_block_hash,


### PR DESCRIPTION
The miner should be able to continue mining an anchor block even if the parent microblock stream fails to load -- it should default to mining without confirming the parent microblock stream.