### PR TITLE
Immediate updates of `total-liquid-ustx`

### DIFF
--- a/.github/actions/bitcoin-int-tests/Dockerfile.atlas-test
+++ b/.github/actions/bitcoin-int-tests/Dockerfile.atlas-test
@@ -1,0 +1,16 @@
+FROM rust:buster
+
+WORKDIR /src
+
+COPY . .
+
+RUN cargo test --no-run --workspace
+
+RUN cd / && wget https://bitcoin.org/bin/bitcoin-core-0.20.0/bitcoin-0.20.0-x86_64-linux-gnu.tar.gz
+RUN cd / && tar -xvzf bitcoin-0.20.0-x86_64-linux-gnu.tar.gz
+
+RUN ln -s /bitcoin-0.20.0/bin/bitcoind /bin/
+
+ENV BITCOIND_TEST 1
+WORKDIR /src/testnet/stacks-node
+RUN cargo test -- --test-threads 1 --ignored tests::neon_integrations::atlas_integration_test

--- a/.github/actions/bitcoin-int-tests/Dockerfile.bitcoin-tests
+++ b/.github/actions/bitcoin-int-tests/Dockerfile.bitcoin-tests
@@ -16,7 +16,6 @@ WORKDIR /src/testnet/stacks-node
 RUN cargo test -- --test-threads 1 --ignored tests::integrations::integration_test_get_info
 RUN cargo test -- --test-threads 1 --ignored tests::neon_integrations::bitcoind_integration_test
 RUN cargo test -- --test-threads 1 --ignored tests::neon_integrations::size_check_integration_test
-RUN cargo test -- --test-threads 1 --ignored tests::neon_integrations::atlas_integration_test
 RUN cargo test -- --test-threads 1 --ignored tests::neon_integrations::liquid_ustx_integration
 RUN cargo test -- --test-threads 1 --ignored tests::neon_integrations::stx_transfer_btc_integration_test
 RUN cargo test -- --test-threads 1 --ignored tests::neon_integrations::bitcoind_forking_test

--- a/.github/actions/bitcoin-int-tests/Dockerfile.bitcoin-tests
+++ b/.github/actions/bitcoin-int-tests/Dockerfile.bitcoin-tests
@@ -12,4 +12,15 @@ RUN cd / && tar -xvzf bitcoin-0.20.0-x86_64-linux-gnu.tar.gz
 RUN ln -s /bitcoin-0.20.0/bin/bitcoind /bin/
 
 ENV BITCOIND_TEST 1
-RUN cd testnet/stacks-node && cargo test -- --test-threads 1 --ignored
+WORKDIR /src/testnet/stacks-node
+RUN cargo test -- --test-threads 1 --ignored tests::integrations::integration_test_get_info
+RUN cargo test -- --test-threads 1 --ignored tests::neon_integrations::bitcoind_integration_test
+RUN cargo test -- --test-threads 1 --ignored tests::neon_integrations::size_check_integration_test
+RUN cargo test -- --test-threads 1 --ignored tests::neon_integrations::atlas_integration_test
+RUN cargo test -- --test-threads 1 --ignored tests::neon_integrations::liquid_ustx_integration
+RUN cargo test -- --test-threads 1 --ignored tests::neon_integrations::stx_transfer_btc_integration_test
+RUN cargo test -- --test-threads 1 --ignored tests::neon_integrations::bitcoind_forking_test
+RUN cargo test -- --test-threads 1 --ignored tests::neon_integrations::microblock_integration_test
+RUN cargo test -- --test-threads 1 --ignored tests::neon_integrations::pox_integration_test
+RUN cargo test -- --test-threads 1 --ignored tests::bitcoin_regtest::bitcoind_integration_test
+RUN cargo test -- --test-threads 1 --ignored tests::should_succeed_handling_malformed_and_valid_txs

--- a/.github/workflows/bitcoin-tests.yml
+++ b/.github/workflows/bitcoin-tests.yml
@@ -1,0 +1,28 @@
+name: stacks-bitcoin-integration-tests
+
+# Only run when:
+#   - tags starting with "v" get pushed
+#   - PRs are opened against the master branch
+#   - the workflow is started from the UI (an optional tag can be passed in via parameter)
+#     - If the optional tag parameter is passed in, a new tag will be generated based off the selected branch
+on:
+  pull_request:
+
+jobs:
+  # Run sampled genesis tests
+  sampled-genesis:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: All integration tests with sampled genesis
+        env:
+          DOCKER_BUILDKIT: 1
+        run: docker build -f ./.github/actions/bitcoin-int-tests/Dockerfile.bitcoin-tests .
+  atlas-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: All integration tests with sampled genesis
+        env:
+          DOCKER_BUILDKIT: 1
+        run: docker build -f ./.github/actions/bitcoin-int-tests/Dockerfile.atlas-test .

--- a/.github/workflows/stacks-blockchain.yml
+++ b/.github/workflows/stacks-blockchain.yml
@@ -45,16 +45,6 @@ jobs:
           DOCKER_BUILDKIT: 1
         run: docker build -f ./.github/actions/bitcoin-int-tests/Dockerfile.large-genesis .
 
-  # Run sampled genesis tests
-  sampled-genesis:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: All integration tests with sampled genesis
-        env:
-          DOCKER_BUILDKIT: 1
-        run: docker build -f ./.github/actions/bitcoin-int-tests/Dockerfile.bitcoin-tests .
-  
   # Run net-tests
   nettest:
     runs-on: ubuntu-latest

--- a/src/chainstate/coordinator/mod.rs
+++ b/src/chainstate/coordinator/mod.rs
@@ -219,15 +219,23 @@ impl RewardSetProvider for OnChainRewardSetProvider {
             liquid_ustx,
         );
 
-        info!("PoX reward cycle threshold: {}, participation: {}, liquid_ustx: {}, num registered addrs: {}", threshold, participation, liquid_ustx, registered_addrs.len());
-
         if !burnchain
             .pox_constants
             .enough_participation(participation, liquid_ustx)
         {
-            info!("PoX reward cycle did not have enough participation. Defaulting to burn. participation={}, liquid_ustx={}, burn_height={}",
-                  participation, liquid_ustx, current_burn_height);
+            info!("PoX reward cycle did not have enough participation. Defaulting to burn";
+                  "burn_height" => current_burn_height,
+                  "participation" => participation,
+                  "liquid_ustx" => liquid_ustx,
+                  "registered_addrs" => registered_addrs.len());
             return Ok(vec![]);
+        } else {
+            info!("PoX reward cycle threshold computed";
+                  "burn_height" => current_burn_height,
+                  "threshold" => threshold,
+                  "participation" => participation,
+                  "liquid_ustx" => liquid_ustx,
+                  "registered_addrs" => registered_addrs.len());
         }
 
         Ok(StacksChainState::make_reward_set(

--- a/src/chainstate/coordinator/mod.rs
+++ b/src/chainstate/coordinator/mod.rs
@@ -211,12 +211,7 @@ impl RewardSetProvider for OnChainRewardSetProvider {
         let registered_addrs =
             chainstate.get_reward_addresses(burnchain, sortdb, current_burn_height, block_id)?;
 
-        let liquid_ustx = StacksChainState::get_stacks_block_header_info_by_index_block_hash(
-            chainstate.db(),
-            block_id,
-        )?
-        .expect("CORRUPTION: Failed to look up block header info for PoX anchor block")
-        .total_liquid_ustx;
+        let liquid_ustx = chainstate.get_liquid_ustx(block_id);
 
         let (threshold, participation) = StacksChainState::get_reward_threshold_and_participation(
             &burnchain.pox_constants,
@@ -224,7 +219,7 @@ impl RewardSetProvider for OnChainRewardSetProvider {
             liquid_ustx,
         );
 
-        test_debug!("PoX reward cycle threshold: {}, participation: {}, liquid_ustx: {}, num registered addrs: {}", threshold, participation, liquid_ustx, registered_addrs.len());
+        info!("PoX reward cycle threshold: {}, participation: {}, liquid_ustx: {}, num registered addrs: {}", threshold, participation, liquid_ustx, registered_addrs.len());
 
         if !burnchain
             .pox_constants

--- a/src/chainstate/coordinator/tests.rs
+++ b/src/chainstate/coordinator/tests.rs
@@ -442,7 +442,7 @@ fn make_genesis_block_with_recipients(
 
     let sortition_tip = SortitionDB::get_canonical_burn_chain_tip(sort_db.conn()).unwrap();
 
-    let parent_stacks_header = StacksHeaderInfo::regtest_genesis(0);
+    let parent_stacks_header = StacksHeaderInfo::regtest_genesis();
 
     let proof = VRF::prove(vrf_key, sortition_tip.sortition_hash.as_bytes());
 

--- a/src/chainstate/stacks/boot/contract_tests.rs
+++ b/src/chainstate/stacks/boot/contract_tests.rs
@@ -277,9 +277,6 @@ impl HeadersDB for TestSimHeadersDB {
     fn get_miner_address(&self, _id_bhh: &StacksBlockId) -> Option<StacksAddress> {
         Some(MINER_ADDR.clone())
     }
-    fn get_total_liquid_ustx(&self, _id_bhh: &StacksBlockId) -> u128 {
-        *LIQUID_SUPPLY
-    }
 }
 
 #[test]

--- a/src/chainstate/stacks/boot/mod.rs
+++ b/src/chainstate/stacks/boot/mod.rs
@@ -166,6 +166,17 @@ impl StacksChainState {
             .map_err(Error::ClarityError)
     }
 
+    pub fn get_liquid_ustx(&mut self, stacks_block_id: &StacksBlockId) -> u128 {
+        let mut connection = self.clarity_state.read_only_connection(
+            stacks_block_id,
+            &NULL_HEADER_DB,
+            &NULL_BURN_STATE_DB,
+        );
+        connection.with_clarity_db_readonly_owned(|mut clarity_db| {
+            (clarity_db.get_total_liquid_ustx(), clarity_db)
+        })
+    }
+
     /// Determine the minimum amount of STX per reward address required to stack in the _next_
     /// reward cycle
     #[cfg(test)]

--- a/src/chainstate/stacks/boot/mod.rs
+++ b/src/chainstate/stacks/boot/mod.rs
@@ -1030,7 +1030,6 @@ pub mod test {
 
         let num_blocks = 10;
         let mut expected_liquid_ustx = 1024 * POX_THRESHOLD_STEPS_USTX * (keys.len() as u128);
-        let mut prior_liquid_ustx = expected_liquid_ustx;
         let mut missed_initial_blocks = 0;
 
         for tenure_id in 0..num_blocks {
@@ -1082,15 +1081,13 @@ pub mod test {
             peer.process_stacks_epoch_at_tip(&stacks_block, &microblocks);
 
             let liquid_ustx = get_liquid_ustx(&mut peer);
-            // get_liquid_ustx is "off by one", i.e., it loads the parents liquid ustx
-            assert_eq!(liquid_ustx, prior_liquid_ustx);
+            assert_eq!(liquid_ustx, expected_liquid_ustx);
 
             if tenure_id >= MINER_REWARD_MATURITY as usize {
                 let block_reward = 1_000 * MICROSTACKS_PER_STACKS as u128;
                 let expected_bonus = (missed_initial_blocks as u128 * block_reward)
                     / (INITIAL_MINING_BONUS_WINDOW as u128);
                 // add mature coinbases
-                prior_liquid_ustx = expected_liquid_ustx;
                 expected_liquid_ustx += block_reward + expected_bonus;
             }
         }
@@ -1331,7 +1328,6 @@ pub mod test {
 
         let num_blocks = 10;
         let mut expected_liquid_ustx = 1024 * POX_THRESHOLD_STEPS_USTX * (keys.len() as u128);
-        let mut prior_liquid_ustx = expected_liquid_ustx;
         let mut missed_initial_blocks = 0;
 
         let alice = keys.pop().unwrap();
@@ -1393,11 +1389,9 @@ pub mod test {
             peer.process_stacks_epoch_at_tip(&stacks_block, &microblocks);
 
             let liquid_ustx = get_liquid_ustx(&mut peer);
-            // get_liquid_ustx is "off by one", i.e., it loads the parents liquid ustx
-            assert_eq!(liquid_ustx, prior_liquid_ustx);
 
             expected_liquid_ustx -= 1;
-            prior_liquid_ustx = expected_liquid_ustx;
+            assert_eq!(liquid_ustx, expected_liquid_ustx);
 
             if tenure_id >= MINER_REWARD_MATURITY as usize {
                 let block_reward = 1_000 * MICROSTACKS_PER_STACKS as u128;
@@ -1832,7 +1826,7 @@ pub mod test {
 
                 if cur_reward_cycle >= lockup_reward_cycle {
                     // this will grow as more miner rewards are unlocked, so be wary
-                    if tenure_id >= (MINER_REWARD_MATURITY + 2) as usize {
+                    if tenure_id >= (MINER_REWARD_MATURITY + 1) as usize {
                         // miner rewards increased liquid supply, so less than 25% is locked.
                         // minimum participation decreases.
                         assert!(total_liquid_ustx > 4 * 1024 * POX_THRESHOLD_STEPS_USTX);
@@ -2720,7 +2714,7 @@ pub mod test {
 
                 if cur_reward_cycle >= alice_reward_cycle {
                     // this will grow as more miner rewards are unlocked, so be wary
-                    if tenure_id >= (MINER_REWARD_MATURITY + 2) as usize {
+                    if tenure_id >= (MINER_REWARD_MATURITY + 1) as usize {
                         // miner rewards increased liquid supply, so less than 25% is locked.
                         // minimum participation decreases.
                         assert!(total_liquid_ustx > 4 * 1024 * POX_THRESHOLD_STEPS_USTX);
@@ -3034,7 +3028,7 @@ pub mod test {
             eprintln!("\ntenure: {}\nreward cycle: {}\nmin-uSTX: {}\naddrs: {:?}\ntotal_liquid_ustx: {}\ntotal-stacked: {}\n", tenure_id, cur_reward_cycle, min_ustx, &reward_addrs, total_liquid_ustx, total_stacked);
 
             // this will grow as more miner rewards are unlocked, so be wary
-            if tenure_id >= (MINER_REWARD_MATURITY + 2) as usize {
+            if tenure_id >= (MINER_REWARD_MATURITY + 1) as usize {
                 // miner rewards increased liquid supply, so less than 25% is locked.
                 // minimum participation decreases.
                 assert!(total_liquid_ustx > 4 * 1024 * POX_THRESHOLD_STEPS_USTX);
@@ -3978,7 +3972,7 @@ pub mod test {
 
                 if cur_reward_cycle >= alice_reward_cycle {
                     // this will grow as more miner rewards are unlocked, so be wary
-                    if tenure_id >= (MINER_REWARD_MATURITY + 2) as usize {
+                    if tenure_id >= (MINER_REWARD_MATURITY + 1) as usize {
                         // miner rewards increased liquid supply, so less than 25% is locked.
                         // minimum participation decreases.
                         assert!(total_liquid_ustx > 4 * 1024 * POX_THRESHOLD_STEPS_USTX);

--- a/src/chainstate/stacks/db/accounts.rs
+++ b/src/chainstate/stacks/db/accounts.rs
@@ -835,7 +835,6 @@ mod test {
             Sha512Trunc256Sum::from_data(&parent_header_info.consensus_hash.0).0,
         );
         new_tip.burn_header_height = parent_header_info.burn_header_height + 1;
-        new_tip.total_liquid_ustx = parent_header_info.total_liquid_ustx + block_reward.coinbase;
 
         block_reward.parent_consensus_hash = parent_header_info.consensus_hash.clone();
         block_reward.parent_block_hash = parent_header_info.anchored_header.block_hash().clone();
@@ -860,7 +859,6 @@ mod test {
             new_tip.microblock_tail.clone(),
             &block_reward,
             &user_burns,
-            new_tip.total_liquid_ustx,
             &ExecutionCost::zero(),
             123,
         )
@@ -901,7 +899,7 @@ mod test {
             let mut tx = chainstate.index_tx_begin().unwrap();
             let ancestor_0 = StacksChainState::get_tip_ancestor(
                 &mut tx,
-                &StacksHeaderInfo::regtest_genesis(0),
+                &StacksHeaderInfo::regtest_genesis(),
                 0,
             )
             .unwrap();
@@ -910,7 +908,7 @@ mod test {
 
         let parent_tip = advance_tip(
             &mut chainstate,
-            &StacksHeaderInfo::regtest_genesis(0),
+            &StacksHeaderInfo::regtest_genesis(),
             &mut miner_reward,
             &mut user_supports,
         );
@@ -957,14 +955,14 @@ mod test {
         let mut miner_reward = make_dummy_miner_payment_schedule(&miner_1, 500, 0, 0, 1000, 1000);
         let user_reward = make_dummy_user_payment_schedule(&user_1, 500, 0, 0, 750, 1000, 1);
 
-        let initial_tip = StacksHeaderInfo::regtest_genesis(0);
+        let initial_tip = StacksHeaderInfo::regtest_genesis();
 
         let user_support = StagingUserBurnSupport::from_miner_payment_schedule(&user_reward);
         let mut user_supports = vec![user_support];
 
         let parent_tip = advance_tip(
             &mut chainstate,
-            &StacksHeaderInfo::regtest_genesis(0),
+            &StacksHeaderInfo::regtest_genesis(),
             &mut miner_reward,
             &mut user_supports,
         );

--- a/src/chainstate/stacks/db/blocks.rs
+++ b/src/chainstate/stacks/db/blocks.rs
@@ -4333,15 +4333,7 @@ impl StacksChainState {
                     0
                 };
 
-            clarity_tx
-                .connection()
-                .as_transaction(|tx| {
-                    tx.with_clarity_db(|db| {
-                        db.increment_ustx_liquid_supply(new_liquid_miner_ustx)
-                            .map_err(|e| e.into())
-                    })
-                })
-                .expect("FATAL: `ust-liquid-supply` overflowed");
+            clarity_tx.increment_ustx_liquid_supply(new_liquid_miner_ustx);
 
             // obtain reward info for receipt
             let (matured_rewards, matured_rewards_info) =
@@ -4366,15 +4358,7 @@ impl StacksChainState {
             let (new_unlocked_ustx, _unlocked_events) =
                 StacksChainState::process_stx_unlocks(&mut clarity_tx)?;
 
-            clarity_tx
-                .connection()
-                .as_transaction(|tx| {
-                    tx.with_clarity_db(|db| {
-                        db.increment_ustx_liquid_supply(new_unlocked_ustx)
-                            .map_err(|e| e.into())
-                    })
-                })
-                .expect("FATAL: `ust-liquid-supply` overflowed");
+            clarity_tx.increment_ustx_liquid_supply(new_unlocked_ustx);
 
             // record that this microblock public key hash was used at this height
             match StacksChainState::insert_microblock_pubkey_hash(

--- a/src/chainstate/stacks/db/blocks.rs
+++ b/src/chainstate/stacks/db/blocks.rs
@@ -4109,7 +4109,6 @@ impl StacksChainState {
             tx_receipts,
             microblock_execution_cost,
             block_execution_cost,
-            total_liquid_ustx,
             matured_rewards,
             matured_rewards_info,
         ) = {
@@ -4334,6 +4333,16 @@ impl StacksChainState {
                     0
                 };
 
+            clarity_tx
+                .connection()
+                .as_transaction(|tx| {
+                    tx.with_clarity_db(|db| {
+                        db.increment_ustx_liquid_supply(new_liquid_miner_ustx)
+                            .map_err(|e| e.into())
+                    })
+                })
+                .expect("FATAL: `ust-liquid-supply` overflowed");
+
             // obtain reward info for receipt
             let (matured_rewards, matured_rewards_info) =
                 if let Some((miner_reward, mut user_rewards, parent_reward, reward_ptr)) =
@@ -4357,15 +4366,15 @@ impl StacksChainState {
             let (new_unlocked_ustx, _unlocked_events) =
                 StacksChainState::process_stx_unlocks(&mut clarity_tx)?;
 
-            // calculate total liquid uSTX
-            let total_liquid_ustx = parent_chain_tip
-                .total_liquid_ustx
-                .checked_add(new_liquid_miner_ustx)
-                .expect("FATAL: uSTX overflow")
-                .checked_add(new_unlocked_ustx)
-                .expect("FATAL: uSTX overflow")
-                .checked_sub(total_burnt)
-                .expect("FATAL: uSTX underflow");
+            clarity_tx
+                .connection()
+                .as_transaction(|tx| {
+                    tx.with_clarity_db(|db| {
+                        db.increment_ustx_liquid_supply(new_unlocked_ustx)
+                            .map_err(|e| e.into())
+                    })
+                })
+                .expect("FATAL: `ust-liquid-supply` overflowed");
 
             // record that this microblock public key hash was used at this height
             match StacksChainState::insert_microblock_pubkey_hash(
@@ -4450,7 +4459,6 @@ impl StacksChainState {
                 receipts,
                 microblock_cost,
                 block_cost,
-                total_liquid_ustx,
                 matured_rewards,
                 matured_rewards_info,
             )
@@ -4473,7 +4481,6 @@ impl StacksChainState {
             microblock_tail_opt,
             &scheduled_miner_reward,
             user_burns,
-            total_liquid_ustx,
             &block_execution_cost,
             block_size,
         )

--- a/src/chainstate/stacks/db/headers.rs
+++ b/src/chainstate/stacks/db/headers.rs
@@ -135,7 +135,6 @@ impl StacksChainState {
 
         let total_work_str = format!("{}", header.total_work.work);
         let total_burn_str = format!("{}", header.total_work.burn);
-        let total_liquid_stx_str = format!("{}", tip_info.total_liquid_ustx);
         let block_size_str = format!("{}", tip_info.anchored_block_size);
 
         let block_hash = header.block_hash();
@@ -162,7 +161,6 @@ impl StacksChainState {
             &burn_header_hash,
             &(burn_header_height as i64),
             &(burn_header_timestamp as i64),
-            &total_liquid_stx_str,
             &(block_height as i64),
             &index_root,
             anchored_block_cost,
@@ -187,13 +185,12 @@ impl StacksChainState {
                     burn_header_hash, \
                     burn_header_height, \
                     burn_header_timestamp, \
-                    total_liquid_ustx, \
                     block_height, \
                     index_root,
                     cost,
                     block_size,
                     parent_block_id) \
-                    VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22)", args)
+                    VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21)", args)
             .map_err(|e| Error::DBError(db_error::SqliteError(e)))?;
 
         Ok(())

--- a/src/chainstate/stacks/db/mod.rs
+++ b/src/chainstate/stacks/db/mod.rs
@@ -2088,8 +2088,8 @@ pub mod test {
         // If the genesis data changed, then this test will fail.
         // Just update the expected value
         assert_eq!(
-            format!("{}", genesis_root_hash),
-            "dd2213e2a0f506ec519672752f033ce2070fa279a579d983bcf2edefb35ce131"
+            genesis_root_hash.to_string(),
+            "96b7696b43c286fd9b824d111e1662bd748400257b27467908088bc37d048d8e"
         );
     }
 

--- a/src/chainstate/stacks/db/mod.rs
+++ b/src/chainstate/stacks/db/mod.rs
@@ -145,7 +145,6 @@ pub struct StacksHeaderInfo {
     pub burn_header_hash: BurnchainHeaderHash,
     pub burn_header_height: u32,
     pub burn_header_timestamp: u64,
-    pub total_liquid_ustx: u128,
     pub anchored_block_size: u64,
 }
 
@@ -177,7 +176,7 @@ impl StacksHeaderInfo {
         self.anchored_header.index_block_hash(&self.consensus_hash)
     }
 
-    pub fn regtest_genesis(total_liquid_ustx: u128) -> StacksHeaderInfo {
+    pub fn regtest_genesis() -> StacksHeaderInfo {
         let burnchain_params = BurnchainParameters::bitcoin_regtest();
         StacksHeaderInfo {
             anchored_header: StacksBlockHeader::genesis_block_header(),
@@ -188,14 +187,12 @@ impl StacksHeaderInfo {
             burn_header_height: burnchain_params.first_block_height as u32,
             consensus_hash: ConsensusHash::empty(),
             burn_header_timestamp: 0,
-            total_liquid_ustx,
             anchored_block_size: 0,
         }
     }
 
     pub fn genesis(
         root_hash: TrieHash,
-        initial_liquid_ustx: u128,
         first_burnchain_block_hash: &BurnchainHeaderHash,
         first_burnchain_block_height: u32,
         first_burnchain_block_timestamp: u64,
@@ -209,7 +206,6 @@ impl StacksHeaderInfo {
             burn_header_height: first_burnchain_block_height,
             consensus_hash: FIRST_BURNCHAIN_CONSENSUS_HASH.clone(),
             burn_header_timestamp: first_burnchain_block_timestamp,
-            total_liquid_ustx: initial_liquid_ustx,
             anchored_block_size: 0,
         }
     }
@@ -245,10 +241,6 @@ impl FromRow<StacksHeaderInfo> for StacksHeaderInfo {
         let burn_header_height = u64::from_column(row, "burn_header_height")? as u32;
         let burn_header_timestamp = u64::from_column(row, "burn_header_timestamp")?;
         let stacks_header = StacksBlockHeader::from_row(row)?;
-        let total_liquid_ustx_str: String = row.get("total_liquid_ustx");
-        let total_liquid_ustx = total_liquid_ustx_str
-            .parse::<u128>()
-            .map_err(|_| db_error::ParseError)?;
         let anchored_block_size_str: String = row.get("block_size");
         let anchored_block_size = anchored_block_size_str
             .parse::<u64>()
@@ -267,7 +259,6 @@ impl FromRow<StacksHeaderInfo> for StacksHeaderInfo {
             burn_header_hash: burn_header_hash,
             burn_header_height: burn_header_height,
             burn_header_timestamp: burn_header_timestamp,
-            total_liquid_ustx: total_liquid_ustx,
             anchored_block_size: anchored_block_size,
         })
     }
@@ -481,7 +472,6 @@ const STACKS_CHAIN_STATE_SQL: &'static [&'static str] = &[
         burn_header_hash TEXT NOT NULL,              -- burn header hash corresponding to the consensus hash (NOT guaranteed to be unique, since we can have 2+ blocks per burn block if there's a PoX fork)
         burn_header_height INT NOT NULL,             -- height of the burnchain block header that generated this consensus hash
         burn_header_timestamp INT NOT NULL,          -- timestamp from burnchain block header that generated this consensus hash
-        total_liquid_ustx TEXT NOT NULL,             -- string representation of the u128 that encodes the total number of liquid uSTX (i.e. that exist and aren't locked in the .lockup contract)
         parent_block_id TEXT NOT NULL,               -- NOTE: this is the parent index_block_hash
 
         cost TEXT NOT NULL,
@@ -1191,6 +1181,16 @@ impl StacksChainState {
                 callback(&mut clarity_tx);
             }
 
+            clarity_tx
+                .connection()
+                .as_transaction(|tx| {
+                    tx.with_clarity_db(|db| {
+                        db.increment_ustx_liquid_supply(initial_liquid_ustx)
+                            .map_err(|e| e.into())
+                    })
+                })
+                .expect("FATAL: `ust-liquid-supply` overflowed");
+
             clarity_tx.commit_to_block(&FIRST_BURNCHAIN_CONSENSUS_HASH, &FIRST_STACKS_BLOCK_HASH);
         }
 
@@ -1220,7 +1220,6 @@ impl StacksChainState {
 
             let first_tip_info = StacksHeaderInfo::genesis(
                 first_root_hash,
-                initial_liquid_ustx,
                 &boot_data.first_burnchain_block_hash,
                 boot_data.first_burnchain_block_height,
                 boot_data.first_burnchain_block_timestamp as u64,
@@ -1846,7 +1845,6 @@ impl StacksChainState {
         microblock_tail_opt: Option<StacksMicroblockHeader>,
         block_reward: &MinerPaymentSchedule,
         user_burns: &Vec<StagingUserBurnSupport>,
-        total_liquid_ustx: u128,
         anchor_block_cost: &ExecutionCost,
         anchor_block_size: u64,
     ) -> Result<StacksHeaderInfo, Error> {
@@ -1890,7 +1888,6 @@ impl StacksChainState {
             burn_header_hash: new_burn_header_hash.clone(),
             burn_header_height: new_burnchain_height,
             burn_header_timestamp: new_burnchain_timestamp,
-            total_liquid_ustx,
             anchored_block_size: anchor_block_size,
         };
 

--- a/src/chainstate/stacks/db/mod.rs
+++ b/src/chainstate/stacks/db/mod.rs
@@ -356,6 +356,17 @@ impl<'a> ClarityTx<'a> {
     pub fn connection(&mut self) -> &mut ClarityBlockConnection<'a> {
         &mut self.block
     }
+
+    pub fn increment_ustx_liquid_supply(&mut self, incr_by: u128) {
+        self.connection()
+            .as_transaction(|tx| {
+                tx.with_clarity_db(|db| {
+                    db.increment_ustx_liquid_supply(incr_by)
+                        .map_err(|e| e.into())
+                })
+            })
+            .expect("FATAL: `ust-liquid-supply` overflowed");
+    }
 }
 
 pub struct ChainstateTx<'a> {

--- a/src/chainstate/stacks/miner.rs
+++ b/src/chainstate/stacks/miner.rs
@@ -539,7 +539,6 @@ impl StacksBlockBuilder {
             burn_header_hash: genesis_burn_header_hash.clone(),
             burn_header_timestamp: genesis_burn_header_timestamp,
             burn_header_height: genesis_burn_header_height,
-            total_liquid_ustx: 0,
             anchored_block_size: 0,
         };
 

--- a/src/chainstate/stacks/miner.rs
+++ b/src/chainstate/stacks/miner.rs
@@ -774,30 +774,14 @@ impl StacksBlockBuilder {
             )
             .expect("FATAL: failed to process miner rewards");
 
-            clarity_tx
-                .connection()
-                .as_transaction(|tx| {
-                    tx.with_clarity_db(|db| {
-                        db.increment_ustx_liquid_supply(matured_ustx)
-                            .map_err(|e| e.into())
-                    })
-                })
-                .expect("FATAL: `ust-liquid-supply` overflowed");
+            clarity_tx.increment_ustx_liquid_supply(matured_ustx);
         }
 
         // process unlocks
         let (new_unlocked_ustx, _) =
             StacksChainState::process_stx_unlocks(clarity_tx).expect("FATAL: failed to unlock STX");
 
-        clarity_tx
-            .connection()
-            .as_transaction(|tx| {
-                tx.with_clarity_db(|db| {
-                    db.increment_ustx_liquid_supply(new_unlocked_ustx)
-                        .map_err(|e| e.into())
-                })
-            })
-            .expect("FATAL: `ust-liquid-supply` overflowed");
+        clarity_tx.increment_ustx_liquid_supply(new_unlocked_ustx);
 
         // mark microblock public key as used
         StacksChainState::insert_microblock_pubkey_hash(

--- a/src/clarity.rs
+++ b/src/clarity.rs
@@ -410,9 +410,6 @@ impl HeadersDB for CLIHeadersDB {
     fn get_miner_address(&self, _id_bhh: &StacksBlockId) -> Option<StacksAddress> {
         None
     }
-    fn get_total_liquid_ustx(&self, _id_bhh: &StacksBlockId) -> u128 {
-        0
-    }
 }
 
 fn get_eval_input(invoked_by: &str, args: &[String]) -> EvalInput {

--- a/src/vm/contexts.rs
+++ b/src/vm/contexts.rs
@@ -587,6 +587,11 @@ impl<'a> OwnedEnvironment<'a> {
             balance.amount_unlocked += amount;
             snapshot.set_balance(balance);
             snapshot.save();
+
+            env.global_context
+                .database
+                .increment_ustx_liquid_supply(amount)
+                .unwrap();
             Ok(())
         })
         .unwrap();

--- a/src/vm/docs/mod.rs
+++ b/src/vm/docs/mod.rs
@@ -1790,9 +1790,6 @@ mod test {
         fn get_miner_address(&self, _id_bhh: &StacksBlockId) -> Option<StacksAddress> {
             None
         }
-        fn get_total_liquid_ustx(&self, _id_bhh: &StacksBlockId) -> u128 {
-            1592653589333333u128
-        }
     }
 
     struct DocBurnStateDB {}

--- a/src/vm/docs/mod.rs
+++ b/src/vm/docs/mod.rs
@@ -1900,6 +1900,10 @@ mod test {
                         .get_stx_balance_snapshot_genesis(&docs_principal_id);
                     snapshot.set_balance(balance);
                     snapshot.save();
+                    e.global_context
+                        .database
+                        .increment_ustx_liquid_supply(100000)
+                        .unwrap();
                     Ok(())
                 },
             )

--- a/src/vm/functions/assets.rs
+++ b/src/vm/functions/assets.rs
@@ -197,6 +197,10 @@ pub fn special_stx_burn(
         burner_snapshot.debit(amount);
         burner_snapshot.save();
 
+        env.global_context
+            .database
+            .decrement_ustx_liquid_supply(amount)?;
+
         env.global_context.log_stx_burn(&from, amount)?;
         env.register_stx_burn_event(from.clone(), amount)?;
 

--- a/src/vm/tests/assets.rs
+++ b/src/vm/tests/assets.rs
@@ -177,7 +177,7 @@ fn test_native_stx_ops(owned_env: &mut OwnedEnvironment) {
         .initialize_contract(second_contract_id.clone(), contract_second)
         .unwrap();
 
-    owned_env.stx_faucet(&(p1_principal.clone().into()), u128::max_value() - 1);
+    owned_env.stx_faucet(&(p1_principal.clone().into()), u128::max_value() - 1500);
     owned_env.stx_faucet(&p2_principal, 1000);
 
     // test 1: send 0
@@ -273,18 +273,19 @@ fn test_native_stx_ops(owned_env: &mut OwnedEnvironment) {
     assert_eq!(asset_map.to_table().len(), 0);
 
     // test 5: overflow
-
-    assert_eq!(
-        execute_transaction(
-            owned_env,
-            p2.clone(),
-            &token_contract_id,
-            "xfer-stx",
-            &symbols_from_values(vec![Value::UInt(2), p2.clone(), p1.clone()])
-        )
-        .unwrap_err(),
-        RuntimeErrorType::ArithmeticOverflow.into()
-    );
+    //  NOTE: this tested behavior is no longer reachable: the total liquid ustx supply
+    //    will overflow before such an overflowing transfer is allowed.
+    // assert_eq!(
+    //     execute_transaction(
+    //         owned_env,
+    //         p2.clone(),
+    //         &token_contract_id,
+    //         "xfer-stx",
+    //         &symbols_from_values(vec![Value::UInt(2), p2.clone(), p1.clone()])
+    //     )
+    //     .unwrap_err(),
+    //     RuntimeErrorType::ArithmeticOverflow.into()
+    // );
 
     // test 6: check balance
 

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -1257,7 +1257,6 @@ impl InitializedNeonNode {
                     .expect("Bitcoin network unsupported");
 
             let chain_tip = ChainTip::genesis(
-                config.get_initial_liquid_ustx(),
                 &burnchain_params.first_block_hash,
                 burnchain_params.first_block_height.into(),
                 burnchain_params.first_block_timestamp.into(),

--- a/testnet/stacks-node/src/node.rs
+++ b/testnet/stacks-node/src/node.rs
@@ -54,7 +54,6 @@ pub struct ChainTip {
 
 impl ChainTip {
     pub fn genesis(
-        initial_liquid_ustx: u128,
         first_burnchain_block_hash: &BurnchainHeaderHash,
         first_burnchain_block_height: u64,
         first_burnchain_block_timestamp: u64,
@@ -62,7 +61,6 @@ impl ChainTip {
         ChainTip {
             metadata: StacksHeaderInfo::genesis(
                 TrieHash([0u8; 32]),
-                initial_liquid_ustx,
                 first_burnchain_block_hash,
                 first_burnchain_block_height as u32,
                 first_burnchain_block_timestamp,
@@ -605,12 +603,7 @@ impl Node {
 
         // Get the stack's chain tip
         let chain_tip = match self.bootstraping_chain {
-            true => ChainTip::genesis(
-                self.config.get_initial_liquid_ustx(),
-                &BurnchainHeaderHash::zero(),
-                0,
-                0,
-            ),
+            true => ChainTip::genesis(&BurnchainHeaderHash::zero(), 0, 0),
             false => match &self.chain_tip {
                 Some(chain_tip) => chain_tip.clone(),
                 None => unreachable!(),

--- a/testnet/stacks-node/src/run_loop/helium.rs
+++ b/testnet/stacks-node/src/run_loop/helium.rs
@@ -65,12 +65,7 @@ impl RunLoop {
         // Sync and update node with this new block.
         let (burnchain_tip, _) = burnchain.sync(None)?;
         self.node.process_burnchain_state(&burnchain_tip); // todo(ludo): should return genesis?
-        let mut chain_tip = ChainTip::genesis(
-            self.config.get_initial_liquid_ustx(),
-            &BurnchainHeaderHash::zero(),
-            0,
-            0,
-        );
+        let mut chain_tip = ChainTip::genesis(&BurnchainHeaderHash::zero(), 0, 0);
 
         self.node.spawn_peer_server();
 


### PR DESCRIPTION
This fixes #2232 by using the clarity_db MARF to store the current liquid supply of STX.

This PR also tries to play some tricks with our current integration tests workflows:
1. It creates a separate workflow for the integration tests, which allows them to be re-run without re-running the other jobs (the dist and build-release jobs are non-trivial executions).
2. It runs the tests in separate `cargo test` commands. This solves any issues that may be caused by using lazy_statics to track test state _and_ it makes the tests "fail fast".
3. It separates the atlas integration test into its own test runner.