### PR TITLE
Use thread-names instead of thread-ids in logs.

### DIFF
--- a/src/util/log.rs
+++ b/src/util/log.rs
@@ -50,7 +50,10 @@ fn print_msg_header(mut rd: &mut dyn RecordDecorator, record: &Record) -> io::Re
     write!(rd, " ")?;
     write!(rd, "[{}:{}]", record.file(), record.line())?;
     write!(rd, " ")?;
-    write!(rd, "[{:?}]", thread::current().id())?;
+    match thread::current().name() {
+        None => write!(rd, "[{:?}]", thread::current().id())?,
+        Some(name) => write!(rd, "[{}]", name)?,
+    }
 
     rd.start_whitespace()?;
     write!(rd, " ")?;


### PR DESCRIPTION
Actual lines changed is < 20, most of the diff is whitespace adjustment by `cargo fmt`.