### PR TITLE
Fix #2262 deadlocking behavior by converting tx usage to conn

### DIFF
--- a/src/chainstate/stacks/db/headers.rs
+++ b/src/chainstate/stacks/db/headers.rs
@@ -256,14 +256,23 @@ impl StacksChainState {
     }
 
     /// Get an ancestor block header
-    pub fn get_tip_ancestor<'a>(
-        tx: &mut StacksDBTx<'a>,
+    pub fn get_tip_ancestor(
+        tx: &mut StacksDBTx,
         tip: &StacksHeaderInfo,
         height: u64,
     ) -> Result<Option<StacksHeaderInfo>, Error> {
         assert!(tip.block_height >= height);
+        StacksChainState::get_index_tip_ancestor(tx, &tip.index_block_hash(), height)
+    }
+
+    /// Get an ancestor block header given an index hash
+    pub fn get_index_tip_ancestor(
+        tx: &mut StacksDBTx,
+        tip_index_hash: &StacksBlockId,
+        height: u64,
+    ) -> Result<Option<StacksHeaderInfo>, Error> {
         match tx
-            .get_ancestor_block_hash(height, &tip.index_block_hash())
+            .get_ancestor_block_hash(height, tip_index_hash)
             .map_err(Error::DBError)?
         {
             Some(bhh) => {
@@ -274,17 +283,17 @@ impl StacksChainState {
     }
 
     /// Get an ancestor block header given an index hash
-    pub fn get_index_tip_ancestor<'a>(
-        tx: &mut StacksDBTx<'a>,
+    pub fn get_index_tip_ancestor_conn(
+        conn: &StacksDBConn,
         tip_index_hash: &StacksBlockId,
         height: u64,
     ) -> Result<Option<StacksHeaderInfo>, Error> {
-        match tx
+        match conn
             .get_ancestor_block_hash(height, tip_index_hash)
             .map_err(Error::DBError)?
         {
             Some(bhh) => {
-                StacksChainState::get_stacks_block_header_info_by_index_block_hash(tx, &bhh)
+                StacksChainState::get_stacks_block_header_info_by_index_block_hash(conn, &bhh)
             }
             None => Ok(None),
         }

--- a/src/chainstate/stacks/db/mod.rs
+++ b/src/chainstate/stacks/db/mod.rs
@@ -1403,6 +1403,10 @@ impl StacksChainState {
         Ok(StacksDBTx::new(&mut self.state_index, ()))
     }
 
+    pub fn index_conn<'a>(&'a self) -> Result<StacksDBConn<'a>, Error> {
+        Ok(StacksDBConn::new(&self.state_index, ()))
+    }
+
     /// Begin a transaction against the underlying DB
     /// Does not create a Clarity instance, and does not affect the MARF.
     pub fn db_tx_begin<'a>(&'a mut self) -> Result<DBTx<'a>, Error> {

--- a/src/core/mempool.rs
+++ b/src/core/mempool.rs
@@ -392,11 +392,11 @@ impl MemPoolDB {
         }
 
         let ancestor_tip = {
-            let mut headers_tx = chainstate.index_tx_begin()?;
+            let headers_conn = chainstate.index_conn()?;
             let index_block =
                 StacksBlockHeader::make_index_block_hash(tip_consensus_hash, tip_block_hash);
-            match StacksChainState::get_index_tip_ancestor(
-                &mut headers_tx,
+            match StacksChainState::get_index_tip_ancestor_conn(
+                &headers_conn,
                 &index_block,
                 next_height,
             )? {


### PR DESCRIPTION
This addresses #2262 by changing the reads required by the mempool walker into using a `conn` rather than a `tx`.