### PR TITLE
Fix/net slow lock

### DIFF
--- a/src/chainstate/stacks/db/blocks.rs
+++ b/src/chainstate/stacks/db/blocks.rs
@@ -5109,6 +5109,12 @@ impl StacksChainState {
                             tx_size,
                         )
                     })
+                    .map_err(|_| {
+                        MemPoolRejection::NoSuchChainTip(
+                            current_consensus_hash.clone(),
+                            current_block.clone(),
+                        )
+                    })?
                     .expect("BUG: do not have unconfirmed state, despite being Some(..)")
                 } else {
                     Err(MemPoolRejection::BadNonces(mismatch_error))

--- a/src/chainstate/stacks/db/mod.rs
+++ b/src/chainstate/stacks/db/mod.rs
@@ -1617,30 +1617,32 @@ impl StacksChainState {
         &mut self,
         burn_dbconn: &dyn BurnStateDB,
         to_do: F,
-    ) -> Option<R>
+    ) -> Result<Option<R>, Error>
     where
         F: FnOnce(&mut ClarityReadOnlyConnection) -> R,
     {
         if let Some(ref unconfirmed) = self.unconfirmed_state.as_ref() {
             if !unconfirmed.is_readable() {
-                return None;
+                return Ok(None);
             }
         }
 
         let mut unconfirmed_state_opt = self.unconfirmed_state.take();
         let res = if let Some(ref mut unconfirmed_state) = unconfirmed_state_opt {
-            let mut conn = unconfirmed_state.clarity_inst.read_only_connection(
-                &unconfirmed_state.unconfirmed_chain_tip,
-                self.db(),
-                burn_dbconn,
-            );
+            let mut conn = unconfirmed_state
+                .clarity_inst
+                .read_only_connection_checked(
+                    &unconfirmed_state.unconfirmed_chain_tip,
+                    self.db(),
+                    burn_dbconn,
+                )?;
             let result = to_do(&mut conn);
             Some(result)
         } else {
             None
         };
         self.unconfirmed_state = unconfirmed_state_opt;
-        res
+        Ok(res)
     }
 
     /// Run to_do on the unconfirmed Clarity VM state if the tip refers to the unconfirmed state;
@@ -1651,7 +1653,7 @@ impl StacksChainState {
         burn_dbconn: &dyn BurnStateDB,
         parent_tip: &StacksBlockId,
         to_do: F,
-    ) -> Option<R>
+    ) -> Result<Option<R>, Error>
     where
         F: FnOnce(&mut ClarityReadOnlyConnection) -> R,
     {
@@ -1665,7 +1667,7 @@ impl StacksChainState {
         if unconfirmed {
             self.with_read_only_unconfirmed_clarity_tx(burn_dbconn, to_do)
         } else {
-            self.with_read_only_clarity_tx(burn_dbconn, parent_tip, to_do)
+            Ok(self.with_read_only_clarity_tx(burn_dbconn, parent_tip, to_do))
         }
     }
 
@@ -1704,8 +1706,6 @@ impl StacksChainState {
     }
 
     /// Open a Clarity transaction against this chainstate's unconfirmed state, if it exists.
-    /// This marks the unconfirmed chainstate as "dirty" so that no future queries against it can
-    /// happen.
     pub fn begin_unconfirmed<'a>(
         &'a mut self,
         burn_dbconn: &'a dyn BurnStateDB,
@@ -1716,8 +1716,6 @@ impl StacksChainState {
                 debug!("Unconfirmed state is not writable; cannot begin unconfirmed Clarity Tx");
                 return None;
             }
-
-            unconfirmed.set_dirty(true);
 
             Some(StacksChainState::chainstate_begin_unconfirmed(
                 conf,

--- a/src/chainstate/stacks/index/marf.rs
+++ b/src/chainstate/stacks/index/marf.rs
@@ -2653,7 +2653,7 @@ mod test {
             m.commit().unwrap();
             let flush_end_time = get_epoch_time_ms();
 
-            debug!(
+            eprintln!(
                 "Inserted {} in {} (1 insert = {} ms).  Processed {} keys in {} ms (flush = {} ms)",
                 i,
                 end_time - start_time,
@@ -2703,7 +2703,7 @@ mod test {
 
             end_time = get_epoch_time_ms();
 
-            debug!(
+            eprintln!(
                 "Got {} in {} (1 get = {} ms)",
                 i,
                 end_time - start_time,

--- a/src/vm/clarity.rs
+++ b/src/vm/clarity.rs
@@ -383,6 +383,21 @@ impl ClarityInstance {
         }
     }
 
+    pub fn read_only_connection_checked<'a>(
+        &'a mut self,
+        at_block: &StacksBlockId,
+        header_db: &'a dyn HeadersDB,
+        burn_state_db: &'a dyn BurnStateDB,
+    ) -> Result<ClarityReadOnlyConnection<'a>, Error> {
+        let datastore = self.datastore.begin_read_only_checked(Some(at_block))?;
+
+        Ok(ClarityReadOnlyConnection {
+            datastore,
+            header_db,
+            burn_state_db,
+        })
+    }
+
     pub fn eval_read_only(
         &mut self,
         at_block: &StacksBlockId,

--- a/src/vm/clarity.rs
+++ b/src/vm/clarity.rs
@@ -374,13 +374,8 @@ impl ClarityInstance {
         header_db: &'a dyn HeadersDB,
         burn_state_db: &'a dyn BurnStateDB,
     ) -> ClarityReadOnlyConnection<'a> {
-        let datastore = self.datastore.begin_read_only(Some(at_block));
-
-        ClarityReadOnlyConnection {
-            datastore,
-            header_db,
-            burn_state_db,
-        }
+        self.read_only_connection_checked(at_block, header_db, burn_state_db)
+            .expect(&format!("BUG: failed to open block {}", at_block))
     }
 
     pub fn read_only_connection_checked<'a>(

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -649,7 +649,8 @@ fn spawn_peer(
 
                 if mblock_deadline < get_epoch_time_ms() {
                     results_with_data.push_back(RelayerDirective::RunMicroblockTenure);
-                    mblock_deadline = get_epoch_time_ms() + (config.node.microblock_frequency as u128);
+                    mblock_deadline =
+                        get_epoch_time_ms() + (config.node.microblock_frequency as u128);
                 }
 
                 while let Some(next_result) = results_with_data.pop_front() {

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -844,15 +844,21 @@ fn microblock_integration_test() {
     let tx = make_stacks_transfer_mblock_only(&spender_sk, 0, 1000, &recipient.into(), 1000);
     submit_tx(&http_origin, &tx);
 
+    info!("Try to mine a microblock-only tx");
+
     // now let's mine a couple blocks, and then check the sender's nonce.
     // this one wakes up our node, so that it'll mine a microblock _and_ an anchor block.
     next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
     // this one will contain the sortition from above anchor block,
     //    which *should* have also confirmed the microblock.
+    info!("Wait for second block");
     next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
 
     // I guess let's push another block for good measure?
+    info!("Wait for third block");
     next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+
+    info!("Test microblock");
 
     // microblock must have bumped our nonce
     // and our spender
@@ -999,13 +1005,14 @@ fn microblock_integration_test() {
         "{}/v2/accounts/{}?proof=0&tip={}",
         &http_origin, &spender_addr, &tip_info.unanchored_tip
     );
+    eprintln!("{:?}", &path);
+
     let res = client
         .get(&path)
         .send()
         .unwrap()
         .json::<AccountEntryResponse>()
         .unwrap();
-    eprintln!("{:?}", &path);
     eprintln!("{:#?}", res);
     assert_eq!(res.nonce, 2);
     assert_eq!(u128::from_str_radix(&res.balance[2..], 16).unwrap(), 96300);


### PR DESCRIPTION
This PR addresses #2258 by moving management of unconfirmed state and microblock mining back into the relayer thread (now that it's safe to do this).

The p2p thread will drive microblock mining using a `RunMicroblockTenure` relayer directive, which will be sent to wake up the relayer every so often to mine the next microblock (according to the microblock interval from the config file).

The p2p thread can no longer manage the unconfirmed state trie on its own, so I modified the `UnconfirmedState` struct to have a "read-only" mode that will allow it to be used to query an existing trie in the underlying MARF.  To make this happen safely, I also added a new Clarity API method `begin_read_only_checked()`, which unlike `begin_read_only()` can fail if, for example, the given trie doesn't exist.  This is necessary because the relayer thread can delete the unconfirmed trie while the p2p thread is using it to service requests; these requests should fail gracefully if this happens.

Because the p2p thread needs to know which transactions went into the unconfirmed state trie (so it can handle `/v2/transactions/unconfirmed/{:txid}`), I took the path of least resistance and made it so that the relay thread will share a copy of its unconfirmed state's mined transaction list with the p2p thread via a mutex guard.  It's not the prettiest solution, but it requires fewer lines of code an introduces fewer failure modes than the alternatives I could think of.