### PR TITLE
Chore: use thread names in slog_json as well

### DIFF
--- a/src/util/log.rs
+++ b/src/util/log.rs
@@ -110,7 +110,10 @@ fn make_json_logger() -> Logger {
                           info.line()
                       }),
                       "thread" => FnValue(move |_| {
-                          format!("{:?}", thread::current().id())
+                          match thread::current().name() {
+                              None => format!("{:?}", thread::current().id()),
+                              Some(name) => name.to_string(),
+                          }
                       }),
     );
 


### PR DESCRIPTION
This uses the new thread names in our `slog_json` builds as well.