### PR TITLE
Update build metadata. don't trigger from pushed tags anymore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,6 +3,7 @@ target
 integration_tests/blockstack-consensus-data/
 integration_tests/test-out/
 api/data
+.git
 .venv
 .dockerignore
 testnet/index.html

--- a/.github/workflows/stacks-blockchain.yml
+++ b/.github/workflows/stacks-blockchain.yml
@@ -104,6 +104,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Set Vars
+        run: |
+          echo "GITHUB_SHA_SHORT=${GITHUB_SHA::7}" >> $GITHUB_ENV
+          echo "GITHUB_REF_SHORT=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+
       - name: Build/Tag/Push Image
         uses: docker/build-push-action@v1
         with:
@@ -113,7 +118,7 @@ jobs:
           tags: ${{ github.event.inputs.tag }}
           tag_with_ref: true
           add_git_labels: true
-          build_args: CARGO_PKG_VERSION=${{ github.event.inputs.tag || github.ref }}
+          build_args: STACKS_NODE_VERSION=${{ github.event.inputs.tag || env.GITHUB_SHA_SHORT }},GIT_BRANCH=${{ env.GITHUB_REF_SHORT }},GIT_COMMIT=${{ env.GITHUB_SHA_SHORT }}
           # Only push if (a tag was passed in) or (we're building a non-master branch which isn't a PR)
           push: ${{ github.event.inputs.tag != '' || (github.ref != 'refs/heads/master' && !contains(github.ref, 'refs/pull')) }}
 
@@ -142,6 +147,11 @@ jobs:
         env:
           TAG: ${{ github.event.inputs.tag }}
 
+      - name: Set Vars
+        run: |
+          echo "GITHUB_SHA_SHORT=${GITHUB_SHA::7}" >> $GITHUB_ENV
+          echo "GITHUB_REF_SHORT=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+
       - name: Build/Tag/Push Image
         uses: docker/build-push-action@v1
         with:
@@ -152,7 +162,7 @@ jobs:
           tags: ${{ env.STRETCH_TAG }}
           tag_with_ref: false
           add_git_labels: true
-          build_args: CARGO_PKG_VERSION=${{ github.event.inputs.tag || github.ref }}
+          build_args: STACKS_NODE_VERSION=${{ github.event.inputs.tag || env.GITHUB_SHA_SHORT }},GIT_BRANCH=${{ env.GITHUB_REF_SHORT }},GIT_COMMIT=${{ env.GITHUB_SHA_SHORT }}
           # Only push if (a tag was passed in) or (we're building a non-master branch which isn't a PR)
           push: ${{ github.event.inputs.tag != '' || (github.ref != 'refs/heads/master' && !contains(github.ref, 'refs/pull')) }}
 

--- a/.github/workflows/stacks-blockchain.yml
+++ b/.github/workflows/stacks-blockchain.yml
@@ -1,14 +1,10 @@
 name: stacks-blockchain
 
 # Only run when:
-#   - tags starting with "v" get pushed
 #   - PRs are opened against the master branch
 #   - the workflow is started from the UI (an optional tag can be passed in via parameter)
 #     - If the optional tag parameter is passed in, a new tag will be generated based off the selected branch
 on:
-  push:
-    tags:
-      - 'v*'
   pull_request:
   workflow_dispatch:
     inputs:
@@ -58,7 +54,6 @@ jobs:
   # Run net-tests
   nettest:
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
     steps:
       - uses: actions/checkout@v2
       - name: Run network relay tests
@@ -118,8 +113,9 @@ jobs:
           tags: ${{ github.event.inputs.tag }}
           tag_with_ref: true
           add_git_labels: true
-          # Only push if (a tag was passed in) or (we're building a tag) or (we're building a non-master branch which isn't a PR)
-          push: ${{ github.event.inputs.tag != '' || contains(github.ref, 'refs/tags') || (github.ref != 'refs/heads/master' && !contains(github.ref, 'refs/pull')) }}
+          build_args: CARGO_PKG_VERSION=${{ github.event.inputs.tag || github.ref }}
+          # Only push if (a tag was passed in) or (we're building a non-master branch which isn't a PR)
+          push: ${{ github.event.inputs.tag != '' || (github.ref != 'refs/heads/master' && !contains(github.ref, 'refs/pull')) }}
 
   # Build docker image, tag it with the git tag and `latest` if running on master branch, and publish under the following conditions
   # Will publish if:
@@ -156,13 +152,14 @@ jobs:
           tags: ${{ env.STRETCH_TAG }}
           tag_with_ref: false
           add_git_labels: true
-          # Only push if (a tag was passed in) or (we're building a tag) or (we're building a non-master branch which isn't a PR)
-          push: ${{ github.event.inputs.tag != '' || contains(github.ref, 'refs/tags') || (github.ref != 'refs/heads/master' && !contains(github.ref, 'refs/pull')) }}
+          build_args: CARGO_PKG_VERSION=${{ github.event.inputs.tag || github.ref }}
+          # Only push if (a tag was passed in) or (we're building a non-master branch which isn't a PR)
+          push: ${{ github.event.inputs.tag != '' || (github.ref != 'refs/heads/master' && !contains(github.ref, 'refs/pull')) }}
 
-  # Create a new release if we're building a tag or a tag was passed in
+  # Create a new release if we're building a tag
   create-release:
     runs-on: ubuntu-latest
-    if: ${{ github.event.inputs.tag != '' || contains(github.ref, 'refs/tags') }}
+    if: ${{ github.event.inputs.tag != '' }}
     outputs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}
     needs:
@@ -187,7 +184,7 @@ jobs:
   # Upload distributables to a new release if we're building a tag or a tag was passed in
   upload-dist:
     runs-on: ubuntu-latest
-    if: ${{ github.event.inputs.tag != '' || contains(github.ref, 'refs/tags') }}
+    if: ${{ github.event.inputs.tag != '' }}
     needs:
       - create-release
     strategy:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,8 @@
 FROM rust:alpine as build
 
-ARG CARGO_PKG_VERSION
-
-ENV CARGO_PKG_NAME=stacks-blockchain \
-    CARGO_PKG_VERSION=${CARGO_PKG_VERSION}
+ARG STACKS_NODE_VERSION="No Version Info"
+ARG GIT_BRANCH='No Branch Info'
+ARG GIT_COMMIT='No Commit Info'
 
 WORKDIR /src
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
 FROM rust:alpine as build
 
+ARG CARGO_PKG_VERSION
+
+ENV CARGO_PKG_NAME=stacks-blockchain \
+    CARGO_PKG_VERSION=${CARGO_PKG_VERSION}
+
 WORKDIR /src
 
 COPY . .
@@ -18,4 +23,4 @@ FROM alpine
 
 COPY --from=build /out/ /bin/
 
-CMD ["stacks-node", "argon"]
+CMD ["stacks-node", "xenon"]

--- a/Dockerfile.stretch
+++ b/Dockerfile.stretch
@@ -1,9 +1,8 @@
 FROM rust:stretch as build
 
-ARG CARGO_PKG_VERSION
-
-ENV CARGO_PKG_NAME=stacks-blockchain \
-    CARGO_PKG_VERSION=${CARGO_PKG_VERSION}
+ARG STACKS_NODE_VERSION="No Version Info"
+ARG GIT_BRANCH='No Branch Info'
+ARG GIT_COMMIT='No Commit Info'
 
 WORKDIR /src
 

--- a/Dockerfile.stretch
+++ b/Dockerfile.stretch
@@ -1,5 +1,10 @@
 FROM rust:stretch as build
 
+ARG CARGO_PKG_VERSION
+
+ENV CARGO_PKG_NAME=stacks-blockchain \
+    CARGO_PKG_VERSION=${CARGO_PKG_VERSION}
+
 WORKDIR /src
 
 COPY . .
@@ -17,4 +22,4 @@ FROM debian:stretch-slim
 RUN apt update && apt install -y netcat
 COPY --from=build /out/ /bin/
 
-CMD ["stacks-node", "argon"]
+CMD ["stacks-node", "xenon"]

--- a/build.rs
+++ b/build.rs
@@ -8,13 +8,12 @@ fn current_git_hash() -> Option<String> {
             .arg("--pretty=format:%h") // Abbreviated commit hash
             .current_dir(env!("CARGO_MANIFEST_DIR"))
             .output();
-    
+
         if let Ok(commit) = commit {
             if let Ok(commit) = String::from_utf8(commit.stdout) {
                 return Some(commit);
             }
         }
-
     } else {
         return option_env!("GIT_COMMIT").map(String::from);
     }

--- a/build.rs
+++ b/build.rs
@@ -1,32 +1,43 @@
 use std::process::Command;
 
 fn current_git_hash() -> Option<String> {
-    let commit = Command::new("git")
-        .arg("log")
-        .arg("-1")
-        .arg("--pretty=format:%h") // Abbreviated commit hash
-        .current_dir(env!("CARGO_MANIFEST_DIR"))
-        .output();
-
-    if let Ok(commit) = commit {
-        if let Ok(commit) = String::from_utf8(commit.stdout) {
-            return Some(commit);
+    if option_env!("GIT_COMMIT") == None {
+        let commit = Command::new("git")
+            .arg("log")
+            .arg("-1")
+            .arg("--pretty=format:%h") // Abbreviated commit hash
+            .current_dir(env!("CARGO_MANIFEST_DIR"))
+            .output();
+    
+        if let Ok(commit) = commit {
+            if let Ok(commit) = String::from_utf8(commit.stdout) {
+                return Some(commit);
+            }
         }
+
+    } else {
+        return option_env!("GIT_COMMIT").map(String::from);
     }
+
     None
 }
 
 fn current_git_branch() -> Option<String> {
-    let commit = Command::new("git")
-        .arg("rev-parse")
-        .arg("--abbrev-ref")
-        .arg("HEAD")
-        .output();
-    if let Ok(commit) = commit {
-        if let Ok(commit) = String::from_utf8(commit.stdout) {
-            return Some(commit);
+    if option_env!("GIT_BRANCH") == None {
+        let commit = Command::new("git")
+            .arg("rev-parse")
+            .arg("--abbrev-ref")
+            .arg("HEAD")
+            .output();
+        if let Ok(commit) = commit {
+            if let Ok(commit) = String::from_utf8(commit.stdout) {
+                return Some(commit);
+            }
         }
+    } else {
+        return option_env!("GIT_BRANCH").map(String::from);
     }
+
     None
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,16 +96,15 @@ const BUILD_TYPE: &'static str = "release";
 
 pub fn version_string(pkg_name: &str, pkg_version: &str) -> String {
     let git_branch = GIT_BRANCH
-        .map(|x| format!("{}:", x))
+        .map(|x| format!("{}", x))
         .unwrap_or("".to_string());
     let git_commit = GIT_COMMIT.unwrap_or("");
     let git_tree_clean = GIT_TREE_CLEAN.unwrap_or("");
 
     format!(
-        "{} {} => {} ({}{}{}, {} build, {} [{}])",
+        "{} {} ({}:{}{}, {} build, {} [{}])",
         pkg_name,
         pkg_version,
-        core::CHAINSTATE_VERSION,
         &git_branch,
         git_commit,
         git_tree_clean,

--- a/src/net/rpc.rs
+++ b/src/net/rpc.rs
@@ -189,8 +189,8 @@ impl RPCPeerInfoData {
         let server_version = version_string(
             "stacks-node",
             option_env!("STACKS_NODE_VERSION")
-                        .or(option_env!("CARGO_PKG_VERSION"))
-                        .unwrap_or("0.0.0.0"),
+                .or(option_env!("CARGO_PKG_VERSION"))
+                .unwrap_or("0.0.0.0"),
         );
         let stacks_tip_consensus_hash = burnchain_tip.canonical_stacks_tip_consensus_hash;
         let stacks_tip = burnchain_tip.canonical_stacks_tip_hash;

--- a/src/net/rpc.rs
+++ b/src/net/rpc.rs
@@ -187,8 +187,10 @@ impl RPCPeerInfoData {
         };
 
         let server_version = version_string(
-            option_env!("CARGO_PKG_NAME").unwrap_or("stacks-node"),
-            option_env!("CARGO_PKG_VERSION").unwrap_or("0.0.0.0"),
+            "stacks-node",
+            option_env!("STACKS_NODE_VERSION")
+                        .or(option_env!("CARGO_PKG_VERSION"))
+                        .unwrap_or("0.0.0.0"),
         );
         let stacks_tip_consensus_hash = burnchain_tip.canonical_stacks_tip_consensus_hash;
         let stacks_tip = burnchain_tip.canonical_stacks_tip_hash;

--- a/testnet/stacks-node/src/main.rs
+++ b/testnet/stacks-node/src/main.rs
@@ -116,8 +116,10 @@ fn main() {
             println!(
                 "{}",
                 &stacks::version_string(
-                    option_env!("CARGO_PKG_NAME").unwrap_or("stacks-node"),
-                    option_env!("CARGO_PKG_VERSION").unwrap_or("0.0.0.0")
+                    "stacks-node",
+                    option_env!("STACKS_NODE_VERSION")
+                        .or(option_env!("CARGO_PKG_VERSION"))
+                        .unwrap_or("0.0.0.0")
                 )
             );
             return;


### PR DESCRIPTION
* Updates the package name and version displayed in the `/v2/info` endpoint.
    * The `server_version` at `/v2/info` and `stacks-node version` command should now read something similar to:
    ```bash
    "stacks-node v24.3.2.0-xenon (build-metadata:0087561+, release build, linux [x86_64])"
    ```

    ```bash
    docker run --rm build-metadata-stretch stacks-node version
    stacks-node v24.3.2.0-xenon (build-metadata:0087561+, release build, linux [x86_64])
    ```

![Screen Shot 2021-01-06 at 10 59 15 PM](https://user-images.githubusercontent.com/2747302/103849500-d54cb500-5072-11eb-90a5-ca09a7e16790.png)


* Disables triggering a release when a tag is pushed up. cc @kantai 
    * I disabled this because since we added a GH workflow which creates a new `clarity-js-sdk` PR upon each `stacks-blockchain` release, a new tag that gets created by the standard release workflow will create a loop, causing the release workflow to run again and attempt re-releasing the version.
    * With this disabled, we will no longer be able to push up a Git tag created locally to trigger a new release. [This GH workflow will need to be invoked manually](https://github.com/blockstack/stacks-blockchain/actions?query=workflow%3Astacks-blockchain), with a new tag passed into the textbox.
    * @kantai if you want this to remain enabled, an alternative solution is possible but will require more testing to ensure it doesn't break the clarity-js-sdk-pr workflow.

Closes https://github.com/blockstack/stacks-blockchain/issues/2275
Closes https://github.com/blockstackpbc/devops/issues/554

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [X] API reference/documentation update
- [X] Other

## Does this introduce a breaking change?
No

## Are documentation updates required?
No

## Testing information

1. Run a new node via `docker run -p 20443:20443 --rm blockstack/stacks-blockchain:build-metadata-stretch`
2. Open `localhost:20443/v2/info` in a browser once to initial boot finishes.

## Checklist
- [ ] Code is commented where needed
- [ ] Unit test coverage for new or modified code paths
- [ ] `npm run test` passes
- [ ] Changelog is updated
- [ ] Tag 1 of @person1 or @person2
