### PR TITLE
Update v1-v2-migration GH workflow to commit name_zonefile files

### DIFF
--- a/.github/workflows/v1-v2-migration.yml
+++ b/.github/workflows/v1-v2-migration.yml
@@ -10,11 +10,15 @@ env:
   COMMIT_USER: Hiro DevOps
   COMMIT_EMAIL: 45208873+blockstack-devops@users.noreply.github.com
   UPDATE_BRANCH: auto/v1-v2-migration
-  CHAINSTATE_DIR: stx-genesis
+  GENESIS_DIR: stx-genesis
   CHAINSTATE_URL: https://storage.googleapis.com/blockstack-v1-migration-data/chainstate.txt
   CHAINSTATE_METADATA_URL: https://storage.googleapis.com/storage/v1/b/blockstack-v1-migration-data/o/chainstate.txt
   CHAINSTATE_HASH_URL: https://storage.googleapis.com/blockstack-v1-migration-data/chainstate.txt.sha256
   CHAINSTATE_HASH_METADATA_URL: https://storage.googleapis.com/storage/v1/b/blockstack-v1-migration-data/o/chainstate.txt.sha256
+  NAME_ZONEFILES_URL: https://storage.googleapis.com/blockstack-v1-migration-data/name_zonefiles.txt
+  NAME_ZONEFILES_METADATA_URL: https://storage.googleapis.com/storage/v1/b/blockstack-v1-migration-data/o/name_zonefiles.txt
+  NAME_ZONEFILES_HASH_URL: https://storage.googleapis.com/blockstack-v1-migration-data/name_zonefiles.txt.sha256
+  NAME_ZONEFILES_HASH_METADATA_URL: https://storage.googleapis.com/storage/v1/b/blockstack-v1-migration-data/o/name_zonefiles.txt.sha256
   MD5_VERIFY_SCRIPT_URL: https://gist.github.com/wileyj/93b4222576cb702053ebfcd3cf9f570b
 on:
   repository_dispatch:
@@ -33,18 +37,30 @@ jobs:
 
       - name: Update files
         run: |
-          mkdir -p ${CHAINSTATE_DIR}
-          curl -s ${CHAINSTATE_URL} > ${CHAINSTATE_DIR}/chainstate.txt
+          mkdir -p ${GENESIS_DIR}
+          curl -s ${CHAINSTATE_URL} > ${GENESIS_DIR}/chainstate.txt
           echo "CHAINSTATE_TIME_CREATED=$(curl -s ${CHAINSTATE_METADATA_URL} | jq -r '.timeCreated')" >> $GITHUB_ENV
           echo "CHAINSTATE_SIZE=$(curl -s ${CHAINSTATE_METADATA_URL} | jq -r '.size')" >> $GITHUB_ENV
           echo "CHAINSTATE_MD5=$(curl -s ${CHAINSTATE_METADATA_URL} | jq -r '.md5Hash')" >> $GITHUB_ENV
           echo "CHAINSTATE_DOWNLOAD_LINK=$(curl -s ${CHAINSTATE_METADATA_URL} | jq -r '.mediaLink')" >> $GITHUB_ENV
 
-          curl -s ${CHAINSTATE_HASH_URL} > ${CHAINSTATE_DIR}/chainstate.txt.sha256
+          curl -s ${CHAINSTATE_HASH_URL} > ${GENESIS_DIR}/chainstate.txt.sha256
           echo "CHAINSTATE_HASH_TIME_CREATED=$(curl -s ${CHAINSTATE_HASH_METADATA_URL} | jq -r '.timeCreated')" >> $GITHUB_ENV
           echo "CHAINSTATE_HASH_SIZE=$(curl -s ${CHAINSTATE_HASH_METADATA_URL} | jq -r '.size')" >> $GITHUB_ENV
           echo "CHAINSTATE_HASH_MD5=$(curl -s ${CHAINSTATE_HASH_METADATA_URL} | jq -r '.md5Hash')" >> $GITHUB_ENV
           echo "CHAINSTATE_HASH_DOWNLOAD_LINK=$(curl -s ${CHAINSTATE_HASH_METADATA_URL} | jq -r '.mediaLink')" >> $GITHUB_ENV
+
+          curl -s ${NAME_ZONEFILES_URL} > ${GENESIS_DIR}/name_zonefiles.txt
+          echo "NAME_ZONEFILES_TIME_CREATED=$(curl -s ${NAME_ZONEFILES_METADATA_URL} | jq -r '.timeCreated')" >> $GITHUB_ENV
+          echo "NAME_ZONEFILES_SIZE=$(curl -s ${NAME_ZONEFILES_METADATA_URL} | jq -r '.size')" >> $GITHUB_ENV
+          echo "NAME_ZONEFILES_MD5=$(curl -s ${NAME_ZONEFILES_METADATA_URL} | jq -r '.md5Hash')" >> $GITHUB_ENV
+          echo "NAME_ZONEFILES_DOWNLOAD_LINK=$(curl -s ${NAME_ZONEFILES_METADATA_URL} | jq -r '.mediaLink')" >> $GITHUB_ENV
+
+          curl -s ${NAME_ZONEFILES_HASH_URL} > ${GENESIS_DIR}/name_zonefiles.txt.sha256
+          echo "NAME_ZONEFILES_HASH_TIME_CREATED=$(curl -s ${NAME_ZONEFILES_HASH_METADATA_URL} | jq -r '.timeCreated')" >> $GITHUB_ENV
+          echo "NAME_ZONEFILES_HASH_SIZE=$(curl -s ${NAME_ZONEFILES_HASH_METADATA_URL} | jq -r '.size')" >> $GITHUB_ENV
+          echo "NAME_ZONEFILES_HASH_MD5=$(curl -s ${NAME_ZONEFILES_HASH_METADATA_URL} | jq -r '.md5Hash')" >> $GITHUB_ENV
+          echo "NAME_ZONEFILES_HASH_DOWNLOAD_LINK=$(curl -s ${NAME_ZONEFILES_HASH_METADATA_URL} | jq -r '.mediaLink')" >> $GITHUB_ENV
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
@@ -58,7 +74,7 @@ jobs:
           body: |
             :robot: This is an automated pull request created from reaching the threshold of BNS names registered under the `.miner` namespace.
 
-            This PR updates the chainstate and chainstate consensus hash files to be used in the creation of the genesis block in the Stacks V2 network:
+            This PR updates the chainstate file, chainstate consensus hash file, name_zonefile file, and name_zonefile consensus hash file to be used in the creation of the genesis block in the Stacks V2 network:
             * [chainstate.txt](${{ env.CHAINSTATE_URL }})
                 * Time created: `${{ env.CHAINSTATE_TIME_CREATED }}`
                 * File size: `${{ env.CHAINSTATE_SIZE }} bytes`
@@ -71,6 +87,18 @@ jobs:
                 * MD5 Hash: `${{ env.CHAINSTATE_HASH_MD5 }}`
                     * [Verify the MD5 hash with this script](${{ env.MD5_VERIFY_SCRIPT_URL }})
                 * [Download file](${{ env.CHAINSTATE_HASH_DOWNLOAD_LINK }})
+            * [name_zonefiles.txt](${{ env.NAME_ZONEFILES_URL }})
+                * Time created: `${{ env.NAME_ZONEFILES_TIME_CREATED }}`
+                * File size: `${{ env.NAME_ZONEFILES_SIZE }} bytes`
+                * MD5 Hash: `${{ env.NAME_ZONEFILES_MD5 }}`
+                    * [Verify the MD5 hash with this script](${{ env.MD5_VERIFY_SCRIPT_URL }})
+                * [Download file](${{ env.NAME_ZONEFILES_DOWNLOAD_LINK }})
+            * [name_zonefiles.txt.sha256](${{ env.NAME_ZONEFILES_HASH_URL }})
+                * Time created: `${{ env.NAME_ZONEFILES_HASH_TIME_CREATED }}`
+                * File size: `${{ env.NAME_ZONEFILES_HASH_SIZE }} bytes`
+                * MD5 Hash: `${{ env.NAME_ZONEFILES_HASH_MD5 }}`
+                    * [Verify the MD5 hash with this script](${{ env.MD5_VERIFY_SCRIPT_URL }})
+                * [Download file](${{ env.NAME_ZONEFILES_HASH_DOWNLOAD_LINK }})
 
             Once merged, a new tag will need to be created. This can be done one of two ways:
             * Trigger this [Github workflow](https://github.com/blockstack/stacks-blockchain/actions?query=workflow%3Astacks-blockchain) from the `master` branch by selecting "Run Workflow", passing in the desired tag to be created as an argument

--- a/.github/workflows/v1-v2-migration.yml
+++ b/.github/workflows/v1-v2-migration.yml
@@ -74,6 +74,8 @@ jobs:
           body: |
             :robot: This is an automated pull request created from reaching the threshold of BNS names registered under the `.miner` namespace.
 
+            **Export triggered at block height: `${{ github.event.client_payload.block_height }}`**
+
             This PR updates the chainstate file, chainstate consensus hash file, name_zonefile file, and name_zonefile consensus hash file to be used in the creation of the genesis block in the Stacks V2 network:
             * [chainstate.txt](${{ env.CHAINSTATE_URL }})
                 * Time created: `${{ env.CHAINSTATE_TIME_CREATED }}`


### PR DESCRIPTION
## Description

Updates the `v1-v2-migration` Github workflow to incorporate committing the `name_zonefiles` to the `stx-genesis` directory.

Also adds the block height to the PR description.

[Here's an example of what the PR will look like.](https://github.com/blockstack/gh-action-testing/pull/1)

Closes https://github.com/blockstackpbc/devops/issues/553
Closes https://github.com/blockstackpbc/devops/issues/555

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [X] Other

## Does this introduce a breaking change?
No.

## Are documentation updates required?
No.
