### PR TITLE
Remove "absurd comparisons" as identified by Clippy.

### DIFF
--- a/src/burnchains/bitcoin/indexer.rs
+++ b/src/burnchains/bitcoin/indexer.rs
@@ -193,7 +193,7 @@ impl BitcoinIndexerConfig {
                         btc_error::ConfigError("Invalid bitcoin:p2p_port value".to_string())
                     })?;
 
-                if peer_port <= 1024 || peer_port >= 65535 {
+                if peer_port <= 1024 || peer_port == 65535 {
                     return Err(btc_error::ConfigError("Invalid p2p_port".to_string()));
                 }
 
@@ -206,7 +206,7 @@ impl BitcoinIndexerConfig {
                         btc_error::ConfigError("Invalid bitcoin:port value".to_string())
                     })?;
 
-                if rpc_port <= 1024 || rpc_port >= 65535 {
+                if rpc_port <= 1024 || rpc_port == 65535 {
                     return Err(btc_error::ConfigError("Invalid rpc_port".to_string()));
                 }
 

--- a/src/vm/functions/assets.rs
+++ b/src/vm/functions/assets.rs
@@ -105,7 +105,7 @@ pub fn stx_transfer_consolidated(
     to: &PrincipalData,
     amount: u128,
 ) -> Result<Value> {
-    if amount <= 0 {
+    if amount == 0 {
         return clarity_ecode!(StxErrorCodes::NON_POSITIVE_AMOUNT);
     }
 
@@ -178,7 +178,7 @@ pub fn special_stx_burn(
     let from_val = eval(&args[1], env, context)?;
 
     if let (Value::Principal(ref from), Value::UInt(amount)) = (&from_val, amount_val) {
-        if amount <= 0 {
+        if amount == 0 {
             return clarity_ecode!(StxErrorCodes::NON_POSITIVE_AMOUNT);
         }
 
@@ -221,7 +221,7 @@ pub fn special_mint_token(
     let to = eval(&args[2], env, context)?;
 
     if let (Value::UInt(amount), Value::Principal(ref to_principal)) = (amount, to) {
-        if amount <= 0 {
+        if amount == 0 {
             return clarity_ecode!(MintTokenErrorCodes::NON_POSITIVE_AMOUNT);
         }
 
@@ -425,7 +425,7 @@ pub fn special_transfer_token(
         Value::Principal(ref to_principal),
     ) = (amount, from, to)
     {
-        if amount <= 0 {
+        if amount == 0 {
             return clarity_ecode!(TransferTokenErrorCodes::NON_POSITIVE_AMOUNT);
         }
 
@@ -594,7 +594,7 @@ pub fn special_burn_token(
     let from = eval(&args[2], env, context)?;
 
     if let (Value::UInt(amount), Value::Principal(ref burner)) = (amount, from) {
-        if amount <= 0 {
+        if amount == 0 {
             return clarity_ecode!(MintTokenErrorCodes::NON_POSITIVE_AMOUNT);
         }
 

--- a/src/vm/types/signatures.rs
+++ b/src/vm/types/signatures.rs
@@ -389,7 +389,7 @@ impl TypeSignature {
         match self {
             SequenceType(SequenceSubtype::ListType(ref my_list_type)) => {
                 if let SequenceType(SequenceSubtype::ListType(other_list_type)) = other {
-                    if other_list_type.max_len <= 0 {
+                    if other_list_type.max_len == 0 {
                         // if other is an empty list, a list type should always admit.
                         true
                     } else if my_list_type.max_len >= other_list_type.max_len {


### PR DESCRIPTION
Per
https://rust-lang.github.io/rust-clippy/rust-1.49.0/index.html#absurd_extreme_comparisons:

"Checks for comparisons where one side of the relation is either the
minimum or maximum value for its type and warns if it involves a case
that is always true or always false."

No functional changes.
