### PR TITLE
Remove redundant clones identified by Clippy.

### DIFF
--- a/src/address/c32.rs
+++ b/src/address/c32.rs
@@ -74,8 +74,7 @@ fn c32_normalize(input_str: &str) -> String {
         .to_uppercase()
         .replace("O", "0")
         .replace("L", "1")
-        .replace("I", "1")
-        .to_string();
+        .replace("I", "1");
     norm_str
 }
 

--- a/src/burnchains/bitcoin/blocks.rs
+++ b/src/burnchains/bitcoin/blocks.rs
@@ -214,7 +214,7 @@ impl BitcoinMessageHandler for BitcoinBlockDownloader {
                 block_hash = ipc_header.block_header.header.bitcoin_hash();
             }
             _ => {
-                return Err(btc_error::UnhandledMessage(msg.clone()));
+                return Err(btc_error::UnhandledMessage(msg));
             }
         }
 

--- a/src/burnchains/bitcoin/indexer.rs
+++ b/src/burnchains/bitcoin/indexer.rs
@@ -277,14 +277,14 @@ impl BitcoinIndexerConfig {
                 ]);
 
                 let cfg = BitcoinIndexerConfig {
-                    peer_host: peer_host.to_string(),
+                    peer_host: peer_host,
                     peer_port: peer_port,
                     rpc_port: rpc_port,
                     rpc_ssl: rpc_ssl,
                     username: username,
                     password: password,
                     timeout: timeout,
-                    spv_headers_path: spv_headers_path.to_string(),
+                    spv_headers_path: spv_headers_path,
                     first_block: first_block,
                     magic_bytes: blockstack_magic,
                 };
@@ -793,9 +793,10 @@ impl BurnchainIndexer for BitcoinIndexer {
         };
 
         if network_id_opt.is_none() {
-            return Err(burnchain_error::Bitcoin(btc_error::ConfigError(
-                format!("Unrecognized network name '{}'", network_name).to_string(),
-            )));
+            return Err(burnchain_error::Bitcoin(btc_error::ConfigError(format!(
+                "Unrecognized network name '{}'",
+                network_name
+            ))));
         }
         let bitcoin_network_id = network_id_opt.unwrap();
 

--- a/src/burnchains/bitcoin/network.rs
+++ b/src/burnchains/bitcoin/network.rs
@@ -144,8 +144,8 @@ impl BitcoinIndexer {
                 return self.handle_pong(message).and_then(|_r| Ok(true));
             }
             _ => match handler {
-                Some(custom_handler) => custom_handler.handle_message(self, message.clone()),
-                None => Err(btc_error::UnhandledMessage(message.clone())),
+                Some(custom_handler) => custom_handler.handle_message(self, message),
+                None => Err(btc_error::UnhandledMessage(message)),
             },
         }
     }

--- a/src/chainstate/burn/operations/leader_key_register.rs
+++ b/src/chainstate/burn/operations/leader_key_register.rs
@@ -214,8 +214,8 @@ impl StacksMessageCodec for LeaderKeyRegisterOp {
             .map_err(net_error::WriteError)?;
 
         let memo = match self.memo.len() {
-            l if l <= 25 => self.memo[0..].to_vec().clone(),
-            _ => self.memo[0..25].to_vec().clone(),
+            l if l <= 25 => self.memo[0..].to_vec(),
+            _ => self.memo[0..25].to_vec(),
         };
         fd.write_all(&memo).map_err(net_error::WriteError)?;
         Ok(())

--- a/src/chainstate/stacks/db/blocks.rs
+++ b/src/chainstate/stacks/db/blocks.rs
@@ -1375,8 +1375,8 @@ impl StacksChainState {
                         &parent_index_block_hash, mblock.header.sequence
                     );
                     fork_poison = Some(TransactionPayload::PoisonMicroblock(
-                        mblock.header.clone(),
-                        tip_mblock.header.clone(),
+                        mblock.header,
+                        tip_mblock.header,
                     ));
                     ret.pop(); // last microblock pushed (i.e. the tip) conflicts with mblock
                     break;

--- a/src/chainstate/stacks/db/mod.rs
+++ b/src/chainstate/stacks/db/mod.rs
@@ -1172,7 +1172,7 @@ impl StacksChainState {
 
             let allocations_tx = StacksTransaction::new(
                 tx_version.clone(),
-                boot_code_auth.clone(),
+                boot_code_auth,
                 TransactionPayload::TokenTransfer(
                     PrincipalData::Standard(boot_code_address.into()),
                     0,
@@ -1314,7 +1314,7 @@ impl StacksChainState {
             .ok_or_else(|| Error::DBError(db_error::ParseError))?
             .to_string();
 
-        let mut state_path = path.clone();
+        let mut state_path = path;
 
         state_path.push("vm");
         StacksChainState::mkdirs(&state_path)?;

--- a/src/chainstate/stacks/db/transactions.rs
+++ b/src/chainstate/stacks/db/transactions.rs
@@ -730,7 +730,7 @@ impl StacksChainState {
                     &sender_principal,
                     mblock_header_1.sequence,
                 )?;
-                (sender_principal.clone(), mblock_header_1.sequence)
+                (sender_principal, mblock_header_1.sequence)
             } else {
                 // someone else beat the sender to this report
                 debug!("Sender {} reports an equal or worse poison-microblock record (at {}, but already have one for {}); dropping...", &sender_principal, mblock_header_1.sequence, seq;
@@ -752,7 +752,7 @@ impl StacksChainState {
                 &sender_principal,
                 mblock_header_1.sequence,
             )?;
-            (sender_principal.clone(), mblock_header_1.sequence)
+            (sender_principal, mblock_header_1.sequence)
         };
 
         let hash_data = BuffData {

--- a/src/chainstate/stacks/index/trie.rs
+++ b/src/chainstate/stacks/index/trie.rs
@@ -334,7 +334,7 @@ impl Trie {
         // update cursor to point to this node4 as the last-node-visited, and set the newly-created
         // ptr as the last ptr traversed (so the cursor still points to this leaf, but accurately
         // reflects the path taken to it).
-        cursor.repair_retarget(&node4.clone(), &ret, &storage.get_cur_block());
+        cursor.repair_retarget(&node4, &ret, &storage.get_cur_block());
 
         trace!(
             "Promoted {:?} to {:?}, {:?}, {:?}, new ptr = {:?}",
@@ -571,7 +571,7 @@ impl Trie {
             cur_node_cur_ptr.chr(),
             cur_node_cur_ptr.ptr(),
         );
-        cursor.repair_retarget(&new_node.clone(), &ret, &storage.get_cur_block());
+        cursor.repair_retarget(&new_node, &ret, &storage.get_cur_block());
 
         trace!("splice_leaf: node-X' at {:?}", &ret);
         Ok(ret)

--- a/src/chainstate/stacks/miner.rs
+++ b/src/chainstate/stacks/miner.rs
@@ -293,7 +293,7 @@ impl<'a> StacksMicroblockBuilder<'a> {
                         &cost_after,
                         &total_budget
                     );
-                    clarity_tx.reset_cost(cost_before.clone());
+                    clarity_tx.reset_cost(cost_before);
                 }
                 _ => {
                     warn!("Error processing TX {}: {}", tx.txid(), e);

--- a/src/clarity.rs
+++ b/src/clarity.rs
@@ -921,7 +921,7 @@ pub fn invoke_command(invoked_by: &str, args: &[String]) {
 
             let sender = {
                 if let Ok(sender) = PrincipalData::parse_standard_principal(sender_in) {
-                    PrincipalData::Standard(sender.clone())
+                    PrincipalData::Standard(sender)
                 } else {
                     eprintln!("Unexpected result parsing sender: {}", sender_in);
                     panic_test!();
@@ -939,7 +939,7 @@ pub fn invoke_command(invoked_by: &str, args: &[String]) {
                         argument_parsed,
                         &format!("Failed to parse a value from the argument: {}", argument),
                     );
-                    SymbolicExpression::atom_value(argument_value.clone())
+                    SymbolicExpression::atom_value(argument_value)
                 })
                 .collect();
 

--- a/src/core/mempool.rs
+++ b/src/core/mempool.rs
@@ -328,7 +328,7 @@ impl MemPoolDB {
         let (chainstate, _) = StacksChainState::open(mainnet, chain_id, chainstate_path)
             .map_err(|e| db_error::Other(format!("Failed to open chainstate: {:?}", &e)))?;
 
-        let mut path = PathBuf::from(chainstate.root_path.clone());
+        let mut path = PathBuf::from(chainstate.root_path);
 
         let admitter = MemPoolAdmitter::new(BlockHeaderHash([0u8; 32]), ConsensusHash([0u8; 20]));
 
@@ -360,7 +360,7 @@ impl MemPoolDB {
 
         Ok(MemPoolDB {
             db: conn,
-            path: db_path.to_string(),
+            path: db_path,
             admitter: admitter,
         })
     }

--- a/src/deps/bitcoin/network/message_blockdata.rs
+++ b/src/deps/bitcoin/network/message_blockdata.rs
@@ -80,7 +80,7 @@ impl GetBlocksMessage {
     pub fn new(locator_hashes: Vec<Sha256dHash>, stop_hash: Sha256dHash) -> GetBlocksMessage {
         GetBlocksMessage {
             version: constants::PROTOCOL_VERSION,
-            locator_hashes: locator_hashes.clone(),
+            locator_hashes: locator_hashes,
             stop_hash: stop_hash,
         }
     }

--- a/src/net/chat.rs
+++ b/src/net/chat.rs
@@ -420,8 +420,8 @@ impl Neighbor {
 
         let mut neighbor = match peer_opt {
             Some(neighbor) => {
-                let mut ret = neighbor.clone();
-                ret.addr = addr.clone();
+                let mut ret = neighbor;
+                ret.addr = addr;
                 ret
             }
             None => {

--- a/src/net/chat.rs
+++ b/src/net/chat.rs
@@ -421,7 +421,7 @@ impl Neighbor {
         let mut neighbor = match peer_opt {
             Some(neighbor) => {
                 let mut ret = neighbor;
-                ret.addr = addr;
+                ret.addr = addr.clone();
                 ret
             }
             None => {

--- a/src/net/db.rs
+++ b/src/net/db.rs
@@ -1313,7 +1313,7 @@ impl PeerDB {
 
         let qry = "SELECT * FROM asn4 WHERE prefix = (?1 & ~((1 << (32 - mask)) - 1)) ORDER BY prefix DESC LIMIT 1".to_string();
         let args = [&addr_u32 as &dyn ToSql];
-        let rows = query_rows::<ASEntry4, _>(conn, &qry.to_string(), &args)?;
+        let rows = query_rows::<ASEntry4, _>(conn, &qry, &args)?;
         match rows.len() {
             0 => Ok(None),
             _ => Ok(Some(rows[0].asn)),

--- a/src/net/inv.rs
+++ b/src/net/inv.rs
@@ -293,7 +293,7 @@ impl PeerBlocksInv {
                 highest_agreed_block_height,
                 num_bits,
                 zeros.clone(),
-                zeros.clone(),
+                zeros,
                 true,
             );
             self.num_sortitions = highest_agreed_block_height - self.first_block_height;
@@ -1084,7 +1084,7 @@ impl InvState {
     pub fn add_peer(&mut self, nk: NeighborKey) -> () {
         self.block_stats.insert(
             nk.clone(),
-            NeighborBlockStats::new(nk.clone(), self.first_block_height),
+            NeighborBlockStats::new(nk, self.first_block_height),
         );
     }
 

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -1561,12 +1561,12 @@ impl PartialEq for NeighborKey {
 impl fmt::Display for NeighborKey {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let peer_version_str = if self.peer_version > 0 {
-            format!("{:08x}", self.peer_version).to_string()
+            format!("{:08x}", self.peer_version)
         } else {
             "UNKNOWN".to_string()
         };
         let network_id_str = if self.network_id > 0 {
-            format!("{:08x}", self.network_id).to_string()
+            format!("{:08x}", self.network_id)
         } else {
             "UNKNOWN".to_string()
         };

--- a/src/net/neighbors.rs
+++ b/src/net/neighbors.rs
@@ -418,7 +418,7 @@ impl NeighborWalk {
         }
 
         self.prev_neighbor = Some(self.cur_neighbor.clone());
-        self.cur_neighbor = next_neighbor.clone();
+        self.cur_neighbor = next_neighbor;
         self.walk_outbound = next_neighbor_outbound;
         self.next_neighbor = None;
 
@@ -1421,7 +1421,7 @@ impl NeighborWalk {
             );
         }
 
-        self.next_neighbor = next_neighbor_opt.clone();
+        self.next_neighbor = next_neighbor_opt;
         if let Some(ref next_neighbor) = self.next_neighbor {
             if *next_neighbor == self.cur_neighbor {
                 self.next_walk_outbound = self.walk_outbound;

--- a/src/net/rpc.rs
+++ b/src/net/rpc.rs
@@ -593,7 +593,7 @@ impl ConversationHttp {
                 MAX_ATTACHMENT_INV_PAGES_PER_REQUEST
             );
             warn!("{}", msg);
-            let response = HttpResponseType::ServerError(response_metadata, msg.clone());
+            let response = HttpResponseType::ServerError(response_metadata, msg);
             response.send(http, fd)?;
             return Ok(());
         }
@@ -625,7 +625,7 @@ impl ConversationHttp {
             Err(e) => {
                 let msg = format!("Unable to read Atlas DB");
                 warn!("{}", msg);
-                let response = HttpResponseType::ServerError(response_metadata, msg.clone());
+                let response = HttpResponseType::ServerError(response_metadata, msg);
                 response.send(http, fd)?;
                 return Err(net_error::DBError(e));
             }
@@ -665,7 +665,7 @@ impl ConversationHttp {
             Err(e) => {
                 let msg = format!("Unable to read Atlas DB");
                 warn!("{}", msg);
-                let response = HttpResponseType::ServerError(response_metadata, msg.clone());
+                let response = HttpResponseType::ServerError(response_metadata, msg);
                 response.send(http, fd)?;
                 return Err(net_error::DBError(e));
             }
@@ -689,7 +689,7 @@ impl ConversationHttp {
             _ => {
                 let msg = format!("Unable to find attachment");
                 warn!("{}", msg);
-                let response = HttpResponseType::ServerError(response_metadata, msg.clone());
+                let response = HttpResponseType::ServerError(response_metadata, msg);
                 response.send(http, fd)
             }
         }

--- a/src/vm/analysis/type_checker/mod.rs
+++ b/src/vm/analysis/type_checker/mod.rs
@@ -268,11 +268,9 @@ impl FunctionType {
                 (expected_type, value) => {
                     if !expected_type.admits(&value) {
                         let actual_type = TypeSignature::type_of(&value);
-                        return Err(CheckErrors::TypeError(
-                            expected_type.clone(),
-                            actual_type.clone(),
-                        )
-                        .into());
+                        return Err(
+                            CheckErrors::TypeError(expected_type.clone(), actual_type).into()
+                        );
                     }
                 }
             }

--- a/src/vm/analysis/type_checker/natives/sequences.rs
+++ b/src/vm/analysis/type_checker/natives/sequences.rs
@@ -330,7 +330,7 @@ pub fn check_special_len(
 
     match collection_type {
         TypeSignature::SequenceType(_) => Ok(()),
-        _ => Err(CheckErrors::ExpectedSequence(collection_type.clone())),
+        _ => Err(CheckErrors::ExpectedSequence(collection_type)),
     }?;
 
     Ok(TypeSignature::UIntType)
@@ -382,7 +382,7 @@ pub fn check_special_index_of(
 
     let expected_input_type = match list_type {
         TypeSignature::SequenceType(ref sequence_type) => Ok(sequence_type.unit_type()),
-        _ => Err(CheckErrors::ExpectedSequence(list_type.clone())),
+        _ => Err(CheckErrors::ExpectedSequence(list_type)),
     }?;
 
     checker.type_check_expects(&args[1], context, &expected_input_type)?;

--- a/src/vm/analysis/types.rs
+++ b/src/vm/analysis/types.rs
@@ -198,7 +198,7 @@ impl ContractAnalysis {
                     let args_sig = func.args.iter().map(|a| a.signature.clone()).collect();
                     if !expected_sig.check_args_trait_compliance(args_sig) {
                         return Err(CheckErrors::BadTraitImplementation(
-                            trait_name.clone(),
+                            trait_name,
                             func_name.to_string(),
                         )
                         .into());

--- a/src/vm/ast/errors.rs
+++ b/src/vm/ast/errors.rs
@@ -93,7 +93,7 @@ impl ParseError {
 
     pub fn set_pre_expressions(&mut self, exprs: Vec<PreSymbolicExpression>) {
         self.diagnostic.spans = exprs.iter().map(|e| e.span.clone()).collect();
-        self.pre_expressions.replace(exprs.clone().to_vec());
+        self.pre_expressions.replace(exprs.to_vec());
     }
 }
 

--- a/src/vm/callables.rs
+++ b/src/vm/callables.rs
@@ -206,11 +206,9 @@ impl DefinedFunction {
 
         let args = self.arg_types.iter().map(|a| a.clone()).collect();
         if !expected_sig.check_args_trait_compliance(args) {
-            return Err(CheckErrors::BadTraitImplementation(
-                trait_name.clone(),
-                self.name.to_string(),
-            )
-            .into());
+            return Err(
+                CheckErrors::BadTraitImplementation(trait_name, self.name.to_string()).into(),
+            );
         }
 
         Ok(())

--- a/src/vm/functions/database.rs
+++ b/src/vm/functions/database.rs
@@ -141,10 +141,7 @@ pub fn special_contract_call(
                             .lookup_trait_definition(&trait_name)
                             .ok_or(CheckErrors::TraitReferenceUnknown(trait_name.clone()))?;
                         let expected_sig = constraining_trait.get(function_name).ok_or(
-                            CheckErrors::TraitMethodUnknown(
-                                trait_name.clone(),
-                                function_name.to_string(),
-                            ),
+                            CheckErrors::TraitMethodUnknown(trait_name, function_name.to_string()),
                         )?;
                         (contract_identifier, Some(expected_sig.returns.clone()))
                     }
@@ -159,7 +156,7 @@ pub fn special_contract_call(
         env.contract_context.contract_identifier.clone(),
     ));
 
-    let mut nested_env = env.nest_with_caller(contract_principal.clone());
+    let mut nested_env = env.nest_with_caller(contract_principal);
     let result = if nested_env.short_circuit_contract_call(
         &contract_identifier,
         function_name,
@@ -177,11 +174,9 @@ pub fn special_contract_call(
     if let Some(returns_type_signature) = type_returns_constraint {
         let actual_returns = TypeSignature::type_of(&result);
         if !returns_type_signature.admits_type(&actual_returns) {
-            return Err(CheckErrors::ReturnTypesMustMatch(
-                returns_type_signature.clone(),
-                actual_returns.clone(),
-            )
-            .into());
+            return Err(
+                CheckErrors::ReturnTypesMustMatch(returns_type_signature, actual_returns).into(),
+            );
         }
     }
 

--- a/src/vm/functions/mod.rs
+++ b/src/vm/functions/mod.rs
@@ -488,7 +488,7 @@ fn special_asserts(
                 Ok(conditional)
             } else {
                 let thrown = eval(&args[1], env, context)?;
-                Err(ShortReturnType::AssertionFailed(thrown.clone()).into())
+                Err(ShortReturnType::AssertionFailed(thrown).into())
             }
         }
         _ => Err(CheckErrors::TypeValueError(TypeSignature::BoolType, conditional).into()),

--- a/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
+++ b/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
@@ -182,7 +182,7 @@ impl BitcoinRegtestController {
 
     pub fn get_pox_constants(&self) -> PoxConstants {
         let burnchain = self.get_burnchain();
-        burnchain.pox_constants.clone()
+        burnchain.pox_constants
     }
 
     pub fn get_burnchain(&self) -> Burnchain {

--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -477,7 +477,7 @@ impl Config {
                     } else {
                         TESTNET_PEER_VERSION
                     },
-                    mode: burnchain_mode.clone(),
+                    mode: burnchain_mode,
                     burn_fee_cap: burnchain
                         .burn_fee_cap
                         .unwrap_or(default_burnchain_config.burn_fee_cap),

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -1037,7 +1037,7 @@ impl InitializedNeonNode {
             config.connection_options.private_key_lifetime.clone(),
             PeerAddress::from_socketaddr(&p2p_addr),
             p2p_sock.port(),
-            data_url.clone(),
+            data_url,
             &vec![],
             Some(&initial_neighbors),
         )
@@ -1097,7 +1097,7 @@ impl InitializedNeonNode {
             event_dispatcher,
             blocks_processed.clone(),
             burnchain,
-            coord_comms.clone(),
+            coord_comms,
             shared_unconfirmed_txs.clone(),
         )
         .expect("Failed to initialize mine/relay thread");
@@ -1112,7 +1112,7 @@ impl InitializedNeonNode {
             relay_send.clone(),
             sync_comms,
             attachments_rx,
-            shared_unconfirmed_txs.clone(),
+            shared_unconfirmed_txs,
         )
         .expect("Failed to initialize mine/relay thread");
 
@@ -1126,7 +1126,7 @@ impl InitializedNeonNode {
         let active_keys = vec![];
         let atlas_config = AtlasConfig::default();
         InitializedNeonNode {
-            config: config.clone(),
+            config: config,
             relay_channel: relay_send,
             last_burn_block,
             burnchain_signer,

--- a/testnet/stacks-node/src/node.rs
+++ b/testnet/stacks-node/src/node.rs
@@ -425,7 +425,7 @@ impl Node {
             self.config.connection_options.private_key_lifetime.clone(),
             PeerAddress::from_socketaddr(&p2p_addr),
             p2p_sock.port(),
-            data_url.clone(),
+            data_url,
             &vec![],
             Some(&initial_neighbors),
         )

--- a/testnet/stacks-node/src/run_loop/neon.rs
+++ b/testnet/stacks-node/src/run_loop/neon.rs
@@ -102,7 +102,7 @@ impl RunLoop {
         let mut burnchain = BitcoinRegtestController::with_burnchain(
             self.config.clone(),
             Some(coordinator_senders.clone()),
-            burnchain_opt.clone(),
+            burnchain_opt,
         );
         let pox_constants = burnchain.get_pox_constants();
 


### PR DESCRIPTION
Per
https://rust-lang.github.io/rust-clippy/rust-1.49.0/index.html#redundant_clone:

  Checks for a redundant clone() (and its relatives) which clones an
  owned value that is going to be dropped without further use.

  It is not always possible for the compiler to eliminate useless
  allocations and deallocations generated by redundant clone()s.

No functional changes.
