### PR TITLE
Pessimistic block limits

### DIFF
--- a/benches/block_limits.rs
+++ b/benches/block_limits.rs
@@ -1,149 +1,530 @@
 extern crate blockstack_lib;
+extern crate rand;
 extern crate serde_json;
 
 use blockstack_lib::{
-    chainstate::burn::BlockHeaderHash,
-    chainstate::stacks::index::storage::TrieFileStorage,
+    burnchains::BurnchainHeaderHash,
+    chainstate::{
+        self,
+        burn::BlockHeaderHash,
+        stacks::boot::STACKS_BOOT_POX_CONTRACT,
+        stacks::{index::MarfTrieId, StacksBlockId},
+    },
     vm::clarity::ClarityInstance,
     vm::costs::ExecutionCost,
-    vm::database::{MarfedKV, NULL_HEADER_DB},
-    vm::types::QualifiedContractIdentifier,
+    vm::database::MarfedKV,
+    vm::{
+        database::{HeadersDB, NULL_BURN_STATE_DB},
+        types::{PrincipalData, QualifiedContractIdentifier, StandardPrincipalData},
+        Value,
+    },
 };
+use chainstate::{burn::VRFSeed, stacks::StacksAddress};
 
-use std::env;
-use std::fmt::Write;
+use std::fs;
 use std::process;
+use std::{env, time::Instant};
 
-fn test_via_tx(scaling: u32, inner_loop: &str, other_decl: &str) -> ExecutionCost {
-    let marf = MarfedKV::temporary();
+use rand::Rng;
+
+struct TestHeadersDB;
+
+impl HeadersDB for TestHeadersDB {
+    fn get_stacks_block_header_hash_for_block(
+        &self,
+        id_bhh: &StacksBlockId,
+    ) -> Option<BlockHeaderHash> {
+        Some(BlockHeaderHash(id_bhh.0.clone()))
+    }
+
+    fn get_burn_header_hash_for_block(
+        &self,
+        id_bhh: &StacksBlockId,
+    ) -> Option<BurnchainHeaderHash> {
+        Some(BurnchainHeaderHash(id_bhh.0.clone()))
+    }
+
+    fn get_vrf_seed_for_block(&self, _id_bhh: &StacksBlockId) -> Option<VRFSeed> {
+        Some(VRFSeed([0; 32]))
+    }
+
+    fn get_burn_block_time_for_block(&self, _id_bhh: &StacksBlockId) -> Option<u64> {
+        Some(1)
+    }
+
+    fn get_burn_block_height_for_block(&self, id_bhh: &StacksBlockId) -> Option<u32> {
+        if id_bhh == &StacksBlockId::sentinel() {
+            Some(0)
+        } else {
+            let mut bytes = [0; 4];
+            bytes.copy_from_slice(&id_bhh.0[0..4]);
+            let height = u32::from_le_bytes(bytes);
+            Some(height)
+        }
+    }
+
+    fn get_miner_address(&self, _id_bhh: &StacksBlockId) -> Option<StacksAddress> {
+        None
+    }
+}
+
+fn as_hash160(inp: u32) -> [u8; 20] {
+    let mut out = [0; 20];
+    out[0..4].copy_from_slice(&inp.to_le_bytes());
+    out
+}
+
+fn as_hash(inp: u32) -> [u8; 32] {
+    let mut out = [0; 32];
+    out[0..4].copy_from_slice(&inp.to_le_bytes());
+    out
+}
+
+fn transfer_test(buildup_count: u32, scaling: u32, genesis_size: u32) -> ExecutionCost {
+    let start = Instant::now();
+
+    let marf = setup_chain_state(genesis_size);
     let mut clarity_instance = ClarityInstance::new(marf, ExecutionCost::max_value());
+    let blocks: Vec<_> = (0..(buildup_count + 1))
+        .into_iter()
+        .map(|i| StacksBlockId(as_hash(i)))
+        .collect();
 
-    let contract_identifier = QualifiedContractIdentifier::local("foo").unwrap();
+    let principals: Vec<PrincipalData> = (0..(buildup_count - 1))
+        .into_iter()
+        .map(|i| StandardPrincipalData(0, as_hash160(i)).into())
+        .collect();
 
-    let blocks = [
-        TrieFileStorage::block_sentinel(),
-        BlockHeaderHash::from_bytes(&[1 as u8; 32]).unwrap(),
-        BlockHeaderHash::from_bytes(&[2 as u8; 32]).unwrap(),
-    ];
+    let last_mint_block = blocks.len() - 2;
+    let last_block = blocks.len() - 1;
 
-    {
-        let mut conn = clarity_instance.begin_block(&blocks[0], &blocks[1], &NULL_HEADER_DB);
+    for ix in 1..(last_mint_block + 1) {
+        let parent_block = &blocks[ix - 1];
+        let current_block = &blocks[ix];
 
-        let mut contract = "(define-constant list-0 (list 0))".to_string();
+        let mut conn = clarity_instance.begin_block(
+            parent_block,
+            current_block,
+            &TestHeadersDB,
+            &NULL_BURN_STATE_DB,
+        );
 
-        for i in 0..15 {
-            contract.push_str("\n");
-            contract.push_str(&format!(
-                "(define-constant list-{} (concat list-{} list-{}))",
-                i + 1,
-                i,
-                i
-            ));
-        }
+        // minting phase
+        conn.as_transaction(|tx| {
+            tx.with_clarity_db(|db| {
+                let mut stx_account_0 = db.get_stx_balance_snapshot_genesis(&principals[ix - 1]);
+                stx_account_0.credit(1_000_000);
+                stx_account_0.save();
+                Ok(())
+            })
+            .unwrap()
+        });
 
-        contract.push_str("\n");
-        contract.push_str(other_decl);
-        contract.push_str("\n");
-        contract.push_str(inner_loop);
+        conn.commit_to_block(current_block);
+    }
 
-        write!(
-            contract,
-            "\n(define-private (outer-loop) (map inner-loop list-10))\n"
-        )
-        .unwrap();
-        write!(contract, "(define-public (do-it) (begin \n").unwrap();
-        for _i in 0..scaling {
-            write!(contract, "(outer-loop)\n").unwrap();
-        }
-        write!(contract, " (ok 1)))\n").unwrap();
+    eprintln!("Finished buildup in {}ms", start.elapsed().as_millis());
 
-        let (ct_ast, _ct_analysis) = conn
-            .analyze_smart_contract(&contract_identifier, &contract)
+    // transfer phase
+    let mut conn = clarity_instance.begin_block(
+        &blocks[last_mint_block],
+        &blocks[last_block],
+        &TestHeadersDB,
+        &NULL_BURN_STATE_DB,
+    );
+
+    let begin = Instant::now();
+
+    let mut rng = rand::thread_rng();
+    for _i in 0..scaling {
+        let from = rng.gen_range(0, principals.len());
+        let to = (from + rng.gen_range(1, principals.len())) % principals.len();
+
+        conn.as_transaction(|tx| {
+            tx.run_stx_transfer(&principals[from], &principals[to], 10)
+                .unwrap()
+        });
+    }
+
+    let this_cost = conn.commit_to_block(&blocks[last_block]).get_total();
+    let elapsed = begin.elapsed();
+
+    println!(
+        "{} transfers in {} ms, after {} block buildup with a {} account genesis",
+        scaling,
+        elapsed.as_millis(),
+        buildup_count,
+        genesis_size,
+    );
+
+    this_cost
+}
+
+fn setup_chain_state(scaling: u32) -> MarfedKV {
+    let pre_initialized_path = format!("/tmp/block_limit_bench_{}.marf", scaling);
+    let out_path = "/tmp/block_limit_bench_last.marf";
+
+    if fs::metadata(&pre_initialized_path).is_err() {
+        let marf = MarfedKV::open(&pre_initialized_path, None).unwrap();
+        let mut clarity_instance = ClarityInstance::new(marf, ExecutionCost::max_value());
+        let mut conn = clarity_instance.begin_test_genesis_block(
+            &StacksBlockId::sentinel(),
+            &StacksBlockId(as_hash(0)),
+            &TestHeadersDB,
+            &NULL_BURN_STATE_DB,
+        );
+
+        conn.as_transaction(|tx| {
+            for j in 0..scaling {
+                tx.with_clarity_db(|db| {
+                    let addr = StandardPrincipalData(0, as_hash160(j + 1)).into();
+                    let mut stx_account_0 = db.get_stx_balance_snapshot_genesis(&addr);
+                    stx_account_0.credit(1);
+                    stx_account_0.save();
+                    db.increment_ustx_liquid_supply(1).unwrap();
+                    Ok(())
+                })
+                .unwrap();
+            }
+        });
+
+        conn.commit_to_block(&StacksBlockId(as_hash(0)));
+    };
+
+    fs::copy(
+        &format!("{}/marf", pre_initialized_path),
+        &format!("{}/marf", out_path),
+    )
+    .unwrap();
+    return MarfedKV::open(out_path, None).unwrap();
+}
+
+fn test_via_raw_contract(
+    eval: &str,
+    scaling: u32,
+    buildup_count: u32,
+    genesis_size: u32,
+) -> ExecutionCost {
+    let start = Instant::now();
+
+    let marf = setup_chain_state(genesis_size);
+
+    let mut clarity_instance = ClarityInstance::new(marf, ExecutionCost::max_value());
+    let blocks: Vec<_> = (0..(buildup_count + 1))
+        .into_iter()
+        .map(|i| StacksBlockId(as_hash(i)))
+        .collect();
+
+    let stacker: PrincipalData = StandardPrincipalData(0, as_hash160(0)).into();
+
+    let contract_id =
+        QualifiedContractIdentifier::new(StandardPrincipalData(0, as_hash160(0)), "test".into());
+
+    let mut smart_contract = "".to_string();
+    for _i in 0..scaling {
+        smart_contract.push_str(&format!("{}\n", eval));
+    }
+
+    let last_mint_block = blocks.len() - 2;
+    let last_block = blocks.len() - 1;
+
+    for ix in 1..(last_mint_block + 1) {
+        let parent_block = &blocks[ix - 1];
+        let current_block = &blocks[ix];
+
+        let mut conn = clarity_instance.begin_block(
+            parent_block,
+            current_block,
+            &TestHeadersDB,
+            &NULL_BURN_STATE_DB,
+        );
+
+        // minting phase
+        conn.as_transaction(|tx| {
+            tx.with_clarity_db(|db| {
+                let mut stx_account_0 = db.get_stx_balance_snapshot_genesis(&stacker);
+                stx_account_0.credit(1_000_000);
+                stx_account_0.save();
+                db.increment_ustx_liquid_supply(1_000_000).unwrap();
+                Ok(())
+            })
             .unwrap();
-        conn.initialize_smart_contract(
-            // initialize the ok contract without errs, but still abort.
-            &contract_identifier,
-            &ct_ast,
-            &contract,
-            |_, _| false,
-        )
-        .unwrap();
+        });
 
-        conn.commit_to_block(&blocks[1]);
+        conn.commit_to_block(current_block);
     }
 
-    {
-        let mut conn = clarity_instance.begin_block(&blocks[1], &blocks[2], &NULL_HEADER_DB);
-        conn.run_contract_call(
-            &contract_identifier.clone().into(),
-            &contract_identifier,
-            "do-it",
-            &[],
-            |_, _| false,
-        )
-        .unwrap();
-        conn.commit_to_block(&blocks[2]).get_total()
+    eprintln!("Finished buildup in {}ms", start.elapsed().as_millis());
+
+    // execute the block
+    let mut conn = clarity_instance.begin_block(
+        &blocks[last_mint_block],
+        &blocks[last_block],
+        &TestHeadersDB,
+        &NULL_BURN_STATE_DB,
+    );
+
+    let begin = Instant::now();
+
+    let exec_cost = conn.as_transaction(|tx| {
+        let analysis_cost = tx.cost_so_far();
+        let (contract_ast, contract_analysis) = tx
+            .analyze_smart_contract(&contract_id, &smart_contract)
+            .unwrap();
+        tx.initialize_smart_contract(&contract_id, &contract_ast, &smart_contract, |_, _| false)
+            .unwrap();
+
+        let mut initialize_cost = tx.cost_so_far();
+        initialize_cost.sub(&analysis_cost).unwrap();
+
+        tx.save_analysis(&contract_id, &contract_analysis)
+            .expect("FATAL: failed to store contract analysis");
+
+        initialize_cost
+    });
+
+    let _this_cost = conn.commit_to_block(&blocks[last_block]).get_total();
+    let elapsed = begin.elapsed();
+
+    println!(
+        "Completed raw execution scaled at {} in {} ms, after {} block buildup with a {} account genesis",
+        scaling,
+        elapsed.as_millis(),
+        buildup_count,
+        genesis_size,
+    );
+
+    exec_cost
+}
+
+fn smart_contract_test(scaling: u32, buildup_count: u32, genesis_size: u32) -> ExecutionCost {
+    let start = Instant::now();
+
+    let marf = setup_chain_state(genesis_size);
+
+    let mut clarity_instance = ClarityInstance::new(marf, ExecutionCost::max_value());
+    let blocks: Vec<_> = (0..(buildup_count + 1))
+        .into_iter()
+        .map(|i| StacksBlockId(as_hash(i)))
+        .collect();
+
+    let stacker: PrincipalData = StandardPrincipalData(0, as_hash160(0)).into();
+
+    let contract_id =
+        QualifiedContractIdentifier::new(StandardPrincipalData(0, as_hash160(0)), "test".into());
+
+    let mut smart_contract = "".to_string();
+    for i in 0..scaling {
+        smart_contract.push_str(&format!("(define-public (foo-{}) (ok (+ u2 u3)))\n", i));
     }
+
+    let last_mint_block = blocks.len() - 2;
+    let last_block = blocks.len() - 1;
+
+    for ix in 1..(last_mint_block + 1) {
+        let parent_block = &blocks[ix - 1];
+        let current_block = &blocks[ix];
+
+        let mut conn = clarity_instance.begin_block(
+            parent_block,
+            current_block,
+            &TestHeadersDB,
+            &NULL_BURN_STATE_DB,
+        );
+
+        // minting phase
+        conn.as_transaction(|tx| {
+            tx.with_clarity_db(|db| {
+                let mut stx_account_0 = db.get_stx_balance_snapshot_genesis(&stacker);
+                stx_account_0.credit(1_000_000);
+                stx_account_0.save();
+                db.increment_ustx_liquid_supply(1_000_000).unwrap();
+                Ok(())
+            })
+            .unwrap();
+        });
+
+        conn.commit_to_block(current_block);
+    }
+
+    eprintln!("Finished buildup in {}ms", start.elapsed().as_millis());
+
+    // execute the block
+    let mut conn = clarity_instance.begin_block(
+        &blocks[last_mint_block],
+        &blocks[last_block],
+        &TestHeadersDB,
+        &NULL_BURN_STATE_DB,
+    );
+
+    let begin = Instant::now();
+
+    conn.as_transaction(|tx| {
+        let (contract_ast, contract_analysis) = tx
+            .analyze_smart_contract(&contract_id, &smart_contract)
+            .unwrap();
+        tx.initialize_smart_contract(&contract_id, &contract_ast, &smart_contract, |_, _| false)
+            .unwrap();
+
+        tx.save_analysis(&contract_id, &contract_analysis)
+            .expect("FATAL: failed to store contract analysis");
+    });
+
+    let this_cost = conn.commit_to_block(&blocks[last_block]).get_total();
+    let elapsed = begin.elapsed();
+
+    println!(
+        "Completed smart-contract scaled at {} in {} ms, after {} block buildup with a {} account genesis",
+        scaling,
+        elapsed.as_millis(),
+        buildup_count,
+        genesis_size,
+    );
+
+    this_cost
 }
 
-// on a fairly underpowered laptop:
-// read-length of ~1e9 corresponds to 10 seconds. (scaling => 2)
-fn read_length_test(scaling: u32) -> ExecutionCost {
-    let other_decl = "(define-data-var var-to-read (list 33000 int) list-15)";
-    let inner_loop = "(define-private (inner-loop (x int)) (len (var-get var-to-read)))";
-    test_via_tx(scaling, inner_loop, other_decl)
-}
+fn stack_stx_test(buildup_count: u32, genesis_size: u32, scaling: u32) -> ExecutionCost {
+    let start = Instant::now();
+    let marf = setup_chain_state(genesis_size);
 
-// on a fairly underpowered laptop:
-// read-count of ~50k corresponds to 10 seconds. (scaling => 50)
-fn read_count_test(scaling: u32) -> ExecutionCost {
-    let other_decl = "(define-data-var var-to-read int 0)";
-    let inner_loop = "(define-private (inner-loop (x int)) (var-get var-to-read))";
-    test_via_tx(scaling, inner_loop, other_decl)
-}
+    let mut clarity_instance = ClarityInstance::new(marf, ExecutionCost::max_value());
+    let blocks: Vec<_> = (0..(buildup_count + 1))
+        .into_iter()
+        .map(|i| StacksBlockId(as_hash(i)))
+        .collect();
 
-// on a fairly underpowered laptop:
-// write-length of ~1e8 corresponds to 10 seconds. (scaling => 10)
-//   at scaling = 5, the tx takes about 5 seconds => write-length of ~8e7,
-//   so for ~10s, max write-len should be 1.5e8
-fn write_length_test(scaling: u32) -> ExecutionCost {
-    let other_decl = "(define-data-var var-to-read (list 1024 int) list-10)";
-    let inner_loop = "(define-private (inner-loop (x int)) (var-set var-to-read list-10))";
-    test_via_tx(scaling, inner_loop, other_decl)
-}
+    let stackers: Vec<PrincipalData> = (0..scaling)
+        .into_iter()
+        .map(|i| StandardPrincipalData(0, as_hash160(i)).into())
+        .collect();
 
-// on a fairly underpowered laptop:
-// write-count of ~50k corresponds to 10 seconds. (scaling => 50)
-fn write_count_test(scaling: u32) -> ExecutionCost {
-    let other_decl = "(define-data-var var-to-read int 0)";
-    let inner_loop = "(define-private (inner-loop (x int)) (var-set var-to-read 0))";
-    test_via_tx(scaling, inner_loop, other_decl)
-}
+    let stacker_balance = (buildup_count as u128 - 1) * 1_000_000;
 
-// on a fairly underpowered laptop:
-// runtime count of ~1e8 corresponds to 10 seconds. (scaling => 6)
-fn runtime_hash_test(scaling: u32) -> ExecutionCost {
-    let other_decl = "";
-    let inner_loop = "(define-private (inner-loop (x int)) (begin (map sha512 list-10) 0))";
-    test_via_tx(scaling, inner_loop, other_decl)
+    let pox_addrs: Vec<Value> = (0..50u64)
+        .map(|ix| {
+            blockstack_lib::vm::execute(&format!(
+                "{{ version: 0x00, hashbytes: 0x000000000000000000000000{} }}",
+                &blockstack_lib::util::hash::to_hex(&ix.to_le_bytes())
+            ))
+            .unwrap()
+            .unwrap()
+        })
+        .collect();
+
+    let last_mint_block = blocks.len() - 2;
+    let last_block = blocks.len() - 1;
+
+    for ix in 1..(last_mint_block + 1) {
+        let parent_block = &blocks[ix - 1];
+        let current_block = &blocks[ix];
+
+        let mut conn = clarity_instance.begin_block(
+            parent_block,
+            current_block,
+            &TestHeadersDB,
+            &NULL_BURN_STATE_DB,
+        );
+
+        // minting phase
+        conn.as_transaction(|tx| {
+            tx.with_clarity_db(|db| {
+                for stacker in stackers.iter() {
+                    let mut stx_account_0 = db.get_stx_balance_snapshot_genesis(stacker);
+                    stx_account_0.credit(1_000_000);
+                    stx_account_0.save();
+                    db.increment_ustx_liquid_supply(1_000_000).unwrap();
+                }
+                Ok(())
+            })
+            .unwrap();
+        });
+
+        conn.commit_to_block(current_block);
+    }
+
+    eprintln!("Finished buildup in {}ms", start.elapsed().as_millis());
+
+    // do the stack-stx block
+    let mut conn = clarity_instance.begin_block(
+        &blocks[last_mint_block],
+        &blocks[last_block],
+        &TestHeadersDB,
+        &NULL_BURN_STATE_DB,
+    );
+
+    let begin = Instant::now();
+
+    conn.as_transaction(|tx| {
+        for stacker in stackers.iter() {
+            let result = tx
+                .run_contract_call(
+                    stacker,
+                    &*STACKS_BOOT_POX_CONTRACT,
+                    "stack-stx",
+                    &[
+                        Value::UInt(stacker_balance),
+                        pox_addrs[0].clone(),
+                        Value::UInt(buildup_count as u128 + 2),
+                        Value::UInt(12),
+                    ],
+                    |_, _| false,
+                )
+                .unwrap()
+                .0;
+            if let Err(v) = result.expect_result() {
+                panic!("Stacking failed: {}", v);
+            }
+        }
+    });
+
+    let this_cost = conn.commit_to_block(&blocks[last_block]).get_total();
+    let elapsed = begin.elapsed();
+
+    println!(
+        "Completed {} stack-stx ops in {} ms, after {} block buildup with a {} account genesis",
+        scaling,
+        elapsed.as_millis(),
+        buildup_count,
+        genesis_size,
+    );
+
+    this_cost
 }
 
 fn main() {
     let argv: Vec<_> = env::args().collect();
 
     if argv.len() < 3 {
-        eprintln!("Usage: {} [test-name] [scalar]", argv[0]);
+        eprintln!(
+            "Usage: {} [test-name] [scalar-0] ... [scalar-n]
+
+transfer <block_build_up> <genesis_size> <number_of_ops>
+smart-contract <block_build_up> <genesis_size> <number_of_ops>
+stack-stx <block_build_up> <genesis_size> <number_of_ops>
+clarity-transfer <block_build_up> <genesis_size> <number_of_ops>
+clarity-verify <block_build_up> <genesis_size> <number_of_ops>
+clarity-raw  <block_build_up> <genesis_size> <number_of_ops> <eval-block>
+",
+            argv[0]
+        );
         process::exit(1);
     }
 
-    let scalar = argv[2].parse().expect("Invalid scalar");
+    let block_build_up = argv[2].parse().expect("Invalid scalar");
+    let genesis_size = argv[3].parse().expect("Invalid scalar");
+    let scaling = argv[4].parse().expect("Invalid scalar");
 
     let result = match argv[1].as_str() {
-        "runtime" => runtime_hash_test(scalar),
-        "read-length" => read_length_test(scalar),
-        "read-count" => read_count_test(scalar),
-        "write-count" => write_count_test(scalar),
-        "write-length" => write_length_test(scalar),
+        "transfer" => transfer_test(block_build_up, scaling, genesis_size),
+        "smart-contract" => smart_contract_test(scaling, block_build_up, genesis_size),
+        "clarity-transfer" => test_via_raw_contract("(stx-transfer? u1 tx-sender 'SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR)",
+                                                    scaling, block_build_up, genesis_size),
+        "clarity-verify" => test_via_raw_contract("(secp256k1-verify 0xde5b9eb9e7c5592930eb2e30a01369c36586d872082ed8181ee83d2a0ec20f04
+ 0x8738487ebe69b93d8e51583be8eee50bb4213fc49c767d329632730cc193b873554428fc936ca3569afc15f1c9365f6591d6251a89fee9c9ac661116824d3a1301
+ 0x03adb8de4bfb65db2cfd6120d55c6526ae9c52e675db7e47308636534ba7786110)",
+                                                  scaling, block_build_up, genesis_size),
+        "stack-stx" => stack_stx_test(block_build_up, genesis_size, scaling),
         _ => {
             eprintln!("bad test name");
             process::exit(1);

--- a/src/chainstate/stacks/boot/costs.clar
+++ b/src/chainstate/stacks/boot/costs.clar
@@ -26,70 +26,74 @@
 
 
 ;; Cost Functions
-
 (define-read-only (cost_analysis_type_annotate (n uint))
-    (runtime (linear n u1 u1)))
+    (runtime (linear n u1000 u1000)))
 
 (define-read-only (cost_analysis_type_check (n uint))
-    (runtime (linear n u1 u1)))
+    (runtime (linear n u1000 u1000)))
 
 (define-read-only (cost_analysis_type_lookup (n uint))
-    (runtime (linear n u1 u1)))
+    (runtime (linear n u1000 u1000)))
 
 (define-read-only (cost_analysis_visit (n uint))
-    (runtime u1))
+    (runtime u1000))
 
 (define-read-only (cost_analysis_iterable_func (n uint))
-    (runtime (linear n u1 u1)))
+    (runtime (linear n u1000 u1000)))
 
 (define-read-only (cost_analysis_option_cons (n uint))
-    (runtime u1))
+    (runtime u1000))
 
 (define-read-only (cost_analysis_option_check (n uint))
-    (runtime u1))
+    (runtime u1000))
 
 (define-read-only (cost_analysis_bind_name (n uint))
-    (runtime (linear n u1 u1)))
+    (runtime (linear n u1000 u1000)))
 
 (define-read-only (cost_analysis_list_items_check (n uint))
-    (runtime (linear n u1 u1)))
+    (runtime (linear n u1000 u1000)))
 
 (define-read-only (cost_analysis_check_tuple_get (n uint))
-    (runtime (logn n u1 u1)))
+    (runtime (logn n u1000 u1000)))
 
 (define-read-only (cost_analysis_check_tuple_merge (n uint)) 
-    (runtime (linear n u1 u1)))
+    (runtime (linear n u1000 u1000)))
 
 (define-read-only (cost_analysis_check_tuple_cons (n uint))
-    (runtime (nlogn n u1 u1)))
+    (runtime (nlogn n u1000 u1000)))
 
 (define-read-only (cost_analysis_tuple_items_check (n uint))
-    (runtime (linear n u1 u1)))
+    (runtime (linear n u1000 u1000)))
 
 (define-read-only (cost_analysis_check_let (n uint))
-    (runtime (linear n u1 u1)))
+    (runtime (linear n u1000 u1000)))
 
 (define-read-only (cost_analysis_lookup_function (n uint))
-    (runtime u1))
+    (runtime u1000))
 
 (define-read-only (cost_analysis_lookup_function_types (n uint))
-    (runtime (linear n u1 u1)))
+    (runtime (linear n u1000 u1000)))
 
 (define-read-only (cost_analysis_lookup_variable_const (n uint))
-    (runtime u1))
+    (runtime u1000))
 
 (define-read-only (cost_analysis_lookup_variable_depth (n uint))
-    (runtime (nlogn n u1 u1)))
+    (runtime (nlogn n u1000 u1000)))
 
+;; ast-parse is a very expensive linear operation, 
+;;   primarily because it does the work of capturing
+;;   most of the analysis phase's linear cost, but also
+;;   because the most expensive part of the analysis phase 
+;;   is the ast
 (define-read-only (cost_ast_parse (n uint))
-    (runtime (linear n u1 u1)))
+    (runtime (linear n u10000 u1000)))
 
 (define-read-only (cost_ast_cycle_detection (n uint))
-    (runtime (linear n u1 u1)))
+    (runtime (linear n u1000 u1000)))
 
 (define-read-only (cost_analysis_storage (n uint))
     {
-        runtime: (linear n u1 u1),
+        runtime: (linear n u1000 u1000),
         write_length: (linear n u1 u1),
         write_count: u1,
         read_count: u1,
@@ -98,7 +102,7 @@
 
 (define-read-only (cost_analysis_use_trait_entry (n uint))
     {
-        runtime: (linear n u1 u1),
+        runtime: (linear n u1000 u1000),
         write_length: (linear n u1 u1),
         write_count: u0,
         read_count: u1,
@@ -107,7 +111,7 @@
 
 (define-read-only (cost_analysis_get_function_entry (n uint))
     {
-        runtime: (linear n u1 u1),
+        runtime: (linear n u1000 u1000),
         write_length: u0,
         write_count: u0,
         read_count: u1,
@@ -116,7 +120,7 @@
 
 (define-read-only (cost_analysis_fetch_contract_entry (n uint))
     {
-        runtime: (linear n u1 u1),
+        runtime: (linear n u1000 u1000),
         write_length: u0,
         write_count: u0,
         read_count: u1,
@@ -124,212 +128,212 @@
     })
 
 (define-read-only (cost_lookup_variable_depth (n uint))
-    (runtime (linear n u1 u1)))
+    (runtime (linear n u1000 u1000)))
 
 (define-read-only (cost_lookup_variable_size (n uint))
-    (runtime (linear n u1 u0)))
+    (runtime (linear n u1000 u0)))
 
 (define-read-only (cost_lookup_function (n uint))
-    (runtime u1))
+    (runtime u1000))
 
 (define-read-only (cost_bind_name (n uint))
-    (runtime u1))
+    (runtime u1000))
 
 (define-read-only (cost_inner_type_check_cost (n uint))
-    (runtime (linear n u1 u1)))
+    (runtime (linear n u1000 u1000)))
 
 (define-read-only (cost_user_function_application (n uint))
-    (runtime (linear n u1 u1)))
+    (runtime (linear n u1000 u1000)))
 
 (define-read-only (cost_let (n uint))
-    (runtime (linear n u1 u1)))
+    (runtime (linear n u1000 u1000)))
 
 (define-read-only (cost_if (n uint))
-    (runtime u1))
+    (runtime u1000))
 
 (define-read-only (cost_asserts (n uint))
-    (runtime u1))
+    (runtime u1000))
 
 (define-read-only (cost_map (n uint))
-    (runtime (linear n u1 u1)))
+    (runtime (linear n u1000 u1000)))
 
 (define-read-only (cost_filter (n uint))
-    (runtime u1))
+    (runtime u1000))
 
 (define-read-only (cost_len (n uint))
-    (runtime u1))
+    (runtime u1000))
 
 (define-read-only (cost_element_at (n uint))
-    (runtime u1))
+    (runtime u1000))
 
 (define-read-only (cost_index_of (n uint))
-    (runtime (linear n u1 u1)))
+    (runtime (linear n u1000 u1000)))
 
 (define-read-only (cost_fold (n uint))
-    (runtime u1))
+    (runtime u1000))
 
 (define-read-only (cost_list_cons (n uint))
-    (runtime (linear n u1 u1)))
+    (runtime (linear n u1000 u1000)))
 
 (define-read-only (cost_type_parse_step (n uint))
-    (runtime u1))
+    (runtime u1000))
 
 (define-read-only (cost_data_hash_cost (n uint))
-    (runtime (linear n u1 u1)))
+    (runtime (linear n u1000 u1000)))
 
 (define-read-only (cost_tuple_get (n uint))
-    (runtime (nlogn n u1 u1)))
+    (runtime (nlogn n u1000 u1000)))
 
 (define-read-only (cost_tuple_merge (n uint))
-    (runtime (linear n u1 u1)))
+    (runtime (linear n u1000 u1000)))
 
 (define-read-only (cost_tuple_cons (n uint))
-    (runtime (nlogn n u1 u1)))
+    (runtime (nlogn n u1000 u1000)))
 
 (define-read-only (cost_add (n uint))
-    (runtime (linear n u1 u1)))
+    (runtime (linear n u1000 u1000)))
 
 (define-read-only (cost_sub (n uint))
-    (runtime (linear n u1 u1)))
+    (runtime (linear n u1000 u1000)))
 
 (define-read-only (cost_mul (n uint))
-    (runtime (linear n u1 u1)))
+    (runtime (linear n u1000 u1000)))
 
 (define-read-only (cost_div (n uint))
-    (runtime (linear n u1 u1)))
+    (runtime (linear n u1000 u1000)))
 
 (define-read-only (cost_geq (n uint))
-    (runtime u1))
+    (runtime u1000))
 
 (define-read-only (cost_leq (n uint))
-    (runtime u1))
+    (runtime u1000))
 
 (define-read-only (cost_le (n uint))
-    (runtime u1))
+    (runtime u1000))
 
 (define-read-only (cost_ge  (n uint))
-    (runtime u1))
+    (runtime u1000))
 
 (define-read-only (cost_int_cast (n uint))
-    (runtime u1))
+    (runtime u1000))
 
 (define-read-only (cost_mod (n uint))
-    (runtime u1))
+    (runtime u1000))
 
 (define-read-only (cost_pow (n uint))
-    (runtime u1))
+    (runtime u1000))
 
 (define-read-only (cost_sqrti (n uint))
-    (runtime u1))
+    (runtime u1000))
 
 (define-read-only (cost_log2 (n uint))
-    (runtime u1))
+    (runtime u1000))
 
 (define-read-only (cost_xor (n uint))
-    (runtime u1))
+    (runtime u1000))
 
 (define-read-only (cost_not (n uint))
-    (runtime u1))
+    (runtime u1000))
 
 (define-read-only (cost_eq (n uint))
-    (runtime (linear n u1 u1)))
+    (runtime (linear n u1000 u1000)))
 
 (define-read-only (cost_begin (n uint))
-    (runtime u1))
+    (runtime u1000))
 
 (define-read-only (cost_hash160 (n uint))
-    (runtime (linear n u1 u1)))
+    (runtime (linear n u1000 u1000)))
 
 (define-read-only (cost_sha256 (n uint))
-    (runtime (linear n u1 u1)))
+    (runtime (linear n u1000 u1000)))
 
 (define-read-only (cost_sha512 (n uint))
-    (runtime (linear n u1 u1)))
+    (runtime (linear n u1000 u1000)))
 
 (define-read-only (cost_sha512t256 (n uint))
-    (runtime (linear n u1 u1)))
+    (runtime (linear n u1000 u1000)))
 
 (define-read-only (cost_keccak256 (n uint))
-    (runtime (linear n u1 u1)))
+    (runtime (linear n u1000 u1000)))
 
 (define-read-only (cost_secp256k1recover (n uint))
-    (runtime u1))
+    (runtime u1000))
 
 (define-read-only (cost_secp256k1verify (n uint))
-    (runtime u1))
+    (runtime u1000))
 
 (define-read-only (cost_print (n uint))
-    (runtime (linear n u1 u1)))
+    (runtime (linear n u1000 u1000)))
 
 (define-read-only (cost_some_cons (n uint))
-    (runtime u1))
+    (runtime u1000))
 
 (define-read-only (cost_ok_cons (n uint))
-    (runtime u1))
+    (runtime u1000))
 
 (define-read-only (cost_err_cons (n uint))
-    (runtime u1))
+    (runtime u1000))
 
 (define-read-only (cost_default_to (n uint))
-    (runtime u1))
+    (runtime u1000))
 
 (define-read-only (cost_unwrap_ret (n uint))
-    (runtime u1))
+    (runtime u1000))
 
 (define-read-only (cost_unwrap_err_or_ret (n uint))
-    (runtime u1))
+    (runtime u1000))
 
 (define-read-only (cost_is_okay (n uint))
-    (runtime u1))
+    (runtime u1000))
 
 (define-read-only (cost_is_none (n uint))
-    (runtime u1))
+    (runtime u1000))
 
 (define-read-only (cost_is_err (n uint))
-    (runtime u1))
+    (runtime u1000))
 
 (define-read-only (cost_is_some (n uint))
-    (runtime u1))
+    (runtime u1000))
 
 (define-read-only (cost_unwrap (n uint))
-    (runtime u1))
+    (runtime u1000))
 
 (define-read-only (cost_unwrap_err (n uint))
-    (runtime u1))
+    (runtime u1000))
 
 (define-read-only (cost_try_ret (n uint))
-    (runtime u1))
+    (runtime u1000))
 
 (define-read-only (cost_match (n uint))
-    (runtime u1))
+    (runtime u1000))
 
 (define-read-only (cost_or (n uint))
-    (runtime (linear n u1 u1)))
+    (runtime (linear n u1000 u1000)))
 
 (define-read-only (cost_and (n uint))
-    (runtime (linear n u1 u1)))
+    (runtime (linear n u1000 u1000)))
 
 (define-read-only (cost_append (n uint))
-    (runtime (linear n u1 u1)))
+    (runtime (linear n u1000 u1000)))
 
 (define-read-only (cost_concat (n uint))
-    (runtime (linear n u1 u1)))
+    (runtime (linear n u1000 u1000)))
 
 (define-read-only (cost_as_max_len (n uint))
-    (runtime u1))
+    (runtime u1000))
 
 (define-read-only (cost_contract_call (n uint))
-    (runtime u1))
+    (runtime u1000))
 
 (define-read-only (cost_contract_of (n uint))
-    (runtime u1))
+    (runtime u1000))
 
 (define-read-only (cost_principal_of (n uint))
-    (runtime u1))
+    (runtime u1000))
 
 (define-read-only (cost_at_block (n uint))
     {
-        runtime: u1,
+        runtime: u1000,
         write_length: u0,
         write_count: u0,
         read_count: u1,
@@ -338,7 +342,7 @@
 
 (define-read-only (cost_load_contract (n uint))
     {
-        runtime: (linear n u1 u1),
+        runtime: (linear n u1000 u1000),
         write_length: u0,
         write_count: u0,
         read_count: u1,
@@ -347,7 +351,7 @@
 
 (define-read-only (cost_create_map (n uint))
     {
-        runtime: (linear n u1 u1),
+        runtime: (linear n u1000 u1000),
         write_length: (linear n u1 u1),
         write_count: u1,
         read_count: u0,
@@ -356,7 +360,7 @@
 
 (define-read-only (cost_create_var (n uint))
     {
-        runtime: (linear n u1 u1),
+        runtime: (linear n u1000 u1000),
         write_length: (linear n u1 u1),
         write_count: u2,
         read_count: u0,
@@ -365,7 +369,7 @@
 
 (define-read-only (cost_create_nft (n uint))
     {
-        runtime: (linear n u1 u1),
+        runtime: (linear n u1000 u1000),
         write_length: (linear n u1 u1),
         write_count: u1,
         read_count: u0,
@@ -374,7 +378,7 @@
 
 (define-read-only (cost_create_ft (n uint))
     {
-        runtime: u1,
+        runtime: u1000,
         write_length: u1,
         write_count: u2,
         read_count: u0,
@@ -383,7 +387,7 @@
 
 (define-read-only (cost_fetch_entry (n uint))
     {
-        runtime: (linear n u1 u1),
+        runtime: (linear n u1000 u1000),
         write_length: u0,
         write_count: u0,
         read_count: u1,
@@ -392,7 +396,7 @@
 
 (define-read-only (cost_set_entry (n uint))
     {
-        runtime: (linear n u1 u1),
+        runtime: (linear n u1000 u1000),
         write_length: (linear n u1 u1),
         write_count: u1,
         read_count: u1,
@@ -401,7 +405,7 @@
 
 (define-read-only (cost_fetch_var (n uint))
     {
-        runtime: (linear n u1 u1),
+        runtime: (linear n u1000 u1000),
         write_length: u0,
         write_count: u0,
         read_count: u1,
@@ -410,7 +414,7 @@
 
 (define-read-only (cost_set_var (n uint))
     {
-        runtime: (linear n u1 u1),
+        runtime: (linear n u1000 u1000),
         write_length: (linear n u1 u1),
         write_count: u1,
         read_count: u1,
@@ -419,7 +423,7 @@
 
 (define-read-only (cost_contract_storage (n uint))
     {
-        runtime: (linear n u1 u1),
+        runtime: (linear n u1000 u1000),
         write_length: (linear n u1 u1),
         write_count: u1,
         read_count: u0,
@@ -428,7 +432,7 @@
 
 (define-read-only (cost_block_info (n uint))
     {
-        runtime: u1,
+        runtime: u1000,
         write_length: u0,
         write_count: u0,
         read_count: u1,
@@ -437,7 +441,7 @@
 
 (define-read-only (cost_stx_balance (n uint))
     {
-        runtime: u1,
+        runtime: u1000,
         write_length: u0,
         write_count: u0,
         read_count: u1,
@@ -446,7 +450,7 @@
 
 (define-read-only (cost_stx_transfer (n uint))
     {
-        runtime: u1,
+        runtime: u1000,
         write_length: u1,
         write_count: u1,
         read_count: u1,
@@ -455,7 +459,7 @@
 
 (define-read-only (cost_ft_mint (n uint))
     {
-        runtime: u1,
+        runtime: u1000,
         write_length: u1,
         write_count: u2,
         read_count: u2,
@@ -464,7 +468,7 @@
 
 (define-read-only (cost_ft_transfer (n uint))
     {
-        runtime: u1,
+        runtime: u1000,
         write_length: u1,
         write_count: u2,
         read_count: u2,
@@ -473,7 +477,7 @@
 
 (define-read-only (cost_ft_balance (n uint))
     {
-        runtime: u1,
+        runtime: u1000,
         write_length: u0,
         write_count: u0,
         read_count: u1,
@@ -482,7 +486,7 @@
 
 (define-read-only (cost_nft_mint (n uint))
     {
-        runtime: (linear n u1 u1),
+        runtime: (linear n u1000 u1000),
         write_length: u1,
         write_count: u1,
         read_count: u1,
@@ -491,7 +495,7 @@
 
 (define-read-only (cost_nft_transfer (n uint))
     {
-        runtime: (linear n u1 u1),
+        runtime: (linear n u1000 u1000),
         write_length: u1,
         write_count: u1,
         read_count: u1,
@@ -500,7 +504,7 @@
 
 (define-read-only (cost_nft_owner (n uint))
     {
-        runtime: (linear n u1 u1),
+        runtime: (linear n u1000 u1000),
         write_length: u0,
         write_count: u0,
         read_count: u1,
@@ -509,7 +513,7 @@
 
 (define-read-only (cost_ft_get_supply (n uint))
     {
-        runtime: u1,
+        runtime: u1000,
         write_length: u0,
         write_count: u0,
         read_count: u1,
@@ -518,7 +522,7 @@
 
 (define-read-only (cost_ft_burn (n uint))
     {
-        runtime: u1,
+        runtime: u1000,
         write_length: u1,
         write_count: u2,
         read_count: u2,
@@ -527,7 +531,7 @@
 
 (define-read-only (cost_nft_burn (n uint))
     {
-        runtime: (linear n u1 u1),
+        runtime: (linear n u1000 u1000),
         write_length: u1,
         write_count: u1,
         read_count: u1,
@@ -536,7 +540,7 @@
 
 (define-read-only (poison_microblock (n uint))
     {
-        runtime: u1,
+        runtime: u1000,
         write_length: u1,
         write_count: u1,
         read_count: u1, 

--- a/src/chainstate/stacks/boot/costs.clar
+++ b/src/chainstate/stacks/boot/costs.clar
@@ -345,7 +345,8 @@
         runtime: (linear n u1000 u1000),
         write_length: u0,
         write_count: u0,
-        read_count: u1,
+        ;; set to 3 because of the associated metadata loads
+        read_count: u3,
         read_length: (linear n u1 u1)
     })
 

--- a/src/chainstate/stacks/boot/mod.rs
+++ b/src/chainstate/stacks/boot/mod.rs
@@ -68,7 +68,7 @@ lazy_static! {
         StacksAddress::from_string(STACKS_BOOT_CODE_CONTRACT_ADDRESS_STR).unwrap();
     static ref BOOT_CODE_POX_MAINNET: String =
         format!("{}\n{}", BOOT_CODE_POX_MAINNET_CONSTS, BOOT_CODE_POX_BODY);
-    static ref BOOT_CODE_POX_TESTNET: String =
+    pub static ref BOOT_CODE_POX_TESTNET: String =
         format!("{}\n{}", BOOT_CODE_POX_TESTNET_CONSTS, BOOT_CODE_POX_BODY);
     pub static ref STACKS_BOOT_CODE_MAINNET: [(&'static str, &'static str); 5] = [
         ("pox", &BOOT_CODE_POX_MAINNET),
@@ -84,6 +84,7 @@ lazy_static! {
         ("cost-voting", BOOT_CODE_COST_VOTING),
         ("bns", &BOOT_CODE_BNS),
     ];
+    pub static ref STACKS_BOOT_POX_CONTRACT: QualifiedContractIdentifier = boot_code_id("pox");
     pub static ref STACKS_BOOT_COST_CONTRACT: QualifiedContractIdentifier = boot_code_id("costs");
     pub static ref STACKS_BOOT_COST_VOTE_CONTRACT: QualifiedContractIdentifier =
         boot_code_id("cost-voting");

--- a/src/chainstate/stacks/db/accounts.rs
+++ b/src/chainstate/stacks/db/accounts.rs
@@ -162,7 +162,7 @@ impl StacksChainState {
         clarity_tx
             .connection()
             .with_clarity_db_readonly(|ref mut db| {
-                let ft_balance = db.get_ft_balance(contract_id, token_name, principal)?;
+                let ft_balance = db.get_ft_balance(contract_id, token_name, principal, None)?;
                 Ok(ft_balance)
             })
             .map_err(Error::ClarityError)

--- a/src/chainstate/stacks/db/accounts.rs
+++ b/src/chainstate/stacks/db/accounts.rs
@@ -177,7 +177,7 @@ impl StacksChainState {
         clarity_tx
             .connection()
             .with_clarity_db_readonly(|ref mut db| {
-                let nft_owner = db.get_nft_owner(contract_id, token_name, token_value)?;
+                let nft_owner = db.get_nft_owner(contract_id, token_name, token_value, None)?;
                 Ok(nft_owner)
             })
             .map_err(Error::ClarityError)

--- a/src/chainstate/stacks/db/accounts.rs
+++ b/src/chainstate/stacks/db/accounts.rs
@@ -177,7 +177,9 @@ impl StacksChainState {
         clarity_tx
             .connection()
             .with_clarity_db_readonly(|ref mut db| {
-                let nft_owner = db.get_nft_owner(contract_id, token_name, token_value, None)?;
+                let expected_asset_type = db.get_nft_key_type(contract_id, token_name)?;
+                let nft_owner =
+                    db.get_nft_owner(contract_id, token_name, token_value, &expected_asset_type)?;
                 Ok(nft_owner)
             })
             .map_err(Error::ClarityError)

--- a/src/chainstate/stacks/db/blocks.rs
+++ b/src/chainstate/stacks/db/blocks.rs
@@ -3984,7 +3984,8 @@ impl StacksChainState {
             .as_transaction(|tx_connection| {
                 let result = tx_connection.with_clarity_db(|db| {
                     let block_height = Value::UInt(db.get_current_block_height().into());
-                    let res = db.fetch_entry(&lockup_contract_id, "lockups", &block_height)?;
+                    let res =
+                        db.fetch_entry(&lockup_contract_id, "lockups", &block_height, None)?;
                     Ok(res)
                 })?;
 

--- a/src/chainstate/stacks/db/blocks.rs
+++ b/src/chainstate/stacks/db/blocks.rs
@@ -3984,8 +3984,11 @@ impl StacksChainState {
             .as_transaction(|tx_connection| {
                 let result = tx_connection.with_clarity_db(|db| {
                     let block_height = Value::UInt(db.get_current_block_height().into());
-                    let res =
-                        db.fetch_entry(&lockup_contract_id, "lockups", &block_height, None)?;
+                    let res = db.fetch_entry_unknown_descriptor(
+                        &lockup_contract_id,
+                        "lockups",
+                        &block_height,
+                    )?;
                     Ok(res)
                 })?;
 

--- a/src/chainstate/stacks/db/contracts.rs
+++ b/src/chainstate/stacks/db/contracts.rs
@@ -75,7 +75,7 @@ impl StacksChainState {
     ) -> Result<Option<Value>, Error> {
         clarity_tx
             .with_clarity_db_readonly(|ref mut db| {
-                match db.lookup_variable(contract_id, data_var) {
+                match db.lookup_variable(contract_id, data_var, None) {
                     Ok(c) => Ok(Some(c)),
                     Err(clarity_vm_error::Unchecked(CheckErrors::NoSuchDataVariable(_))) => {
                         Ok(None)

--- a/src/chainstate/stacks/db/contracts.rs
+++ b/src/chainstate/stacks/db/contracts.rs
@@ -75,7 +75,7 @@ impl StacksChainState {
     ) -> Result<Option<Value>, Error> {
         clarity_tx
             .with_clarity_db_readonly(|ref mut db| {
-                match db.lookup_variable(contract_id, data_var, None) {
+                match db.lookup_variable_unknown_descriptor(contract_id, data_var) {
                     Ok(c) => Ok(Some(c)),
                     Err(clarity_vm_error::Unchecked(CheckErrors::NoSuchDataVariable(_))) => {
                         Ok(None)

--- a/src/chainstate/stacks/db/mod.rs
+++ b/src/chainstate/stacks/db/mod.rs
@@ -2111,7 +2111,7 @@ pub mod test {
         // Just update the expected value
         assert_eq!(
             genesis_root_hash.to_string(),
-            "3c2ba491ed8c963a9f83fe09871c6a73780f6bf4325abea3d04008154839ff41",
+            "ac363507627a6dd5cf3da0b9e3a7c3f85d064e7f7a3d50248b78e4721584f558",
         );
     }
 

--- a/src/chainstate/stacks/db/mod.rs
+++ b/src/chainstate/stacks/db/mod.rs
@@ -1004,7 +1004,7 @@ impl StacksChainState {
                             for (block_height, schedule) in lockups_per_block.into_iter() {
                                 let key = Value::UInt(block_height.into());
                                 let value = Value::list_from(schedule).unwrap();
-                                db.insert_entry(&lockup_contract_id, "lockups", key, value)?;
+                                db.insert_entry(&lockup_contract_id, "lockups", key, value, None)?;
                             }
                             Ok(())
                         })
@@ -1078,6 +1078,7 @@ impl StacksChainState {
                                     "namespaces",
                                     namespace,
                                     namespace_props,
+                                    None,
                                 )?;
                             }
                             Ok(())
@@ -1135,7 +1136,13 @@ impl StacksChainState {
                                     }
                                 };
 
-                                db.set_nft_owner(&bns_contract_id, "names", &fqn, &owner_address)?;
+                                db.set_nft_owner(
+                                    &bns_contract_id,
+                                    "names",
+                                    &fqn,
+                                    &owner_address,
+                                    None,
+                                )?;
 
                                 let registered_at = Value::UInt(entry.registered_at.into());
                                 let name_props = Value::Tuple(
@@ -1156,6 +1163,7 @@ impl StacksChainState {
                                     "name-properties",
                                     fqn.clone(),
                                     name_props,
+                                    None,
                                 )?;
 
                                 db.insert_entry(
@@ -1163,6 +1171,7 @@ impl StacksChainState {
                                     "owner-name",
                                     Value::Principal(owner_address),
                                     fqn,
+                                    None,
                                 )?;
                             }
                             Ok(())

--- a/src/chainstate/stacks/db/mod.rs
+++ b/src/chainstate/stacks/db/mod.rs
@@ -2102,7 +2102,7 @@ pub mod test {
         // Just update the expected value
         assert_eq!(
             genesis_root_hash.to_string(),
-            "96b7696b43c286fd9b824d111e1662bd748400257b27467908088bc37d048d8e"
+            "3c2ba491ed8c963a9f83fe09871c6a73780f6bf4325abea3d04008154839ff41",
         );
     }
 

--- a/src/chainstate/stacks/db/mod.rs
+++ b/src/chainstate/stacks/db/mod.rs
@@ -1004,7 +1004,12 @@ impl StacksChainState {
                             for (block_height, schedule) in lockups_per_block.into_iter() {
                                 let key = Value::UInt(block_height.into());
                                 let value = Value::list_from(schedule).unwrap();
-                                db.insert_entry(&lockup_contract_id, "lockups", key, value, None)?;
+                                db.insert_entry_unknown_descriptor(
+                                    &lockup_contract_id,
+                                    "lockups",
+                                    key,
+                                    value,
+                                )?;
                             }
                             Ok(())
                         })
@@ -1074,12 +1079,11 @@ impl StacksChainState {
                                     .unwrap(),
                                 );
 
-                                db.insert_entry(
+                                db.insert_entry_unknown_descriptor(
                                     &bns_contract_id,
                                     "namespaces",
                                     namespace,
                                     namespace_props,
-                                    None,
                                 )?;
                             }
                             Ok(())
@@ -1137,12 +1141,14 @@ impl StacksChainState {
                                     }
                                 };
 
+                                let expected_asset_type =
+                                    db.get_nft_key_type(&bns_contract_id, "names")?;
                                 db.set_nft_owner(
                                     &bns_contract_id,
                                     "names",
                                     &fqn,
                                     &owner_address,
-                                    None,
+                                    &expected_asset_type,
                                 )?;
 
                                 let registered_at = Value::UInt(entry.registered_at.into());
@@ -1159,20 +1165,18 @@ impl StacksChainState {
                                     .unwrap(),
                                 );
 
-                                db.insert_entry(
+                                db.insert_entry_unknown_descriptor(
                                     &bns_contract_id,
                                     "name-properties",
                                     fqn.clone(),
                                     name_props,
-                                    None,
                                 )?;
 
-                                db.insert_entry(
+                                db.insert_entry_unknown_descriptor(
                                     &bns_contract_id,
                                     "owner-name",
                                     Value::Principal(owner_address),
                                     fqn,
-                                    None,
                                 )?;
                             }
                             Ok(())

--- a/src/chainstate/stacks/db/mod.rs
+++ b/src/chainstate/stacks/db/mod.rs
@@ -2116,7 +2116,7 @@ pub mod test {
         // Just update the expected value
         assert_eq!(
             genesis_root_hash.to_string(),
-            "ac363507627a6dd5cf3da0b9e3a7c3f85d064e7f7a3d50248b78e4721584f558",
+            "146bb2f3c11d543c126067a4fb39091c0596b3257a3c0b6ef4b9861546ae56e9",
         );
     }
 

--- a/src/vm/clarity.rs
+++ b/src/vm/clarity.rs
@@ -39,10 +39,9 @@ use chainstate::stacks::Error as ChainstateError;
 use chainstate::stacks::StacksBlockId;
 use chainstate::stacks::StacksMicroblockHeader;
 
-#[cfg(test)]
 use chainstate::stacks::boot::{
-    BOOT_CODE_COSTS, BOOT_CODE_COST_VOTING, STACKS_BOOT_COST_CONTRACT,
-    STACKS_BOOT_COST_VOTE_CONTRACT,
+    BOOT_CODE_COSTS, BOOT_CODE_COST_VOTING, BOOT_CODE_POX_TESTNET, STACKS_BOOT_COST_CONTRACT,
+    STACKS_BOOT_COST_VOTE_CONTRACT, STACKS_BOOT_POX_CONTRACT,
 };
 
 use std::error;
@@ -293,8 +292,7 @@ impl ClarityInstance {
     }
 
     /// begin a genesis block with the default cost contract
-    ///  used in testing.
-    #[cfg(test)]
+    ///  used in testing + benchmarking
     pub fn begin_test_genesis_block<'a>(
         &'a mut self,
         current: &StacksBlockId,
@@ -336,6 +334,20 @@ impl ClarityInstance {
                     &*STACKS_BOOT_COST_VOTE_CONTRACT,
                     &ast,
                     BOOT_CODE_COST_VOTING,
+                    |_, _| false,
+                )
+                .unwrap();
+        });
+
+        conn.as_transaction(|clarity_db| {
+            let (ast, _) = clarity_db
+                .analyze_smart_contract(&*STACKS_BOOT_POX_CONTRACT, &*BOOT_CODE_POX_TESTNET)
+                .unwrap();
+            clarity_db
+                .initialize_smart_contract(
+                    &*STACKS_BOOT_POX_CONTRACT,
+                    &ast,
+                    &*BOOT_CODE_POX_TESTNET,
                     |_, _| false,
                 )
                 .unwrap();

--- a/src/vm/contexts.rs
+++ b/src/vm/contexts.rs
@@ -27,7 +27,10 @@ use vm::costs::{
     cost_functions, runtime_cost, ClarityCostFunctionReference, CostErrors, CostTracker,
     ExecutionCost, LimitedCostTracker,
 };
-use vm::database::ClarityDatabase;
+use vm::database::{
+    ClarityDatabase, DataMapMetadata, DataVariableMetadata, FungibleTokenMetadata,
+    NonFungibleTokenMetadata,
+};
 use vm::errors::{CheckErrors, InterpreterError, InterpreterResult as Result, RuntimeErrorType};
 use vm::functions::handle_contract_call_special_cases;
 use vm::representations::{ClarityName, ContractName, SymbolicExpression};
@@ -117,6 +120,11 @@ pub struct ContractContext {
     // tracks the names of NFTs, FTs, Maps, and Data Vars.
     //  used for ensuring that they never are defined twice.
     pub persisted_names: HashSet<ClarityName>,
+    // track metadata for contract defined storage
+    pub meta_data_map: HashMap<ClarityName, DataMapMetadata>,
+    pub meta_data_var: HashMap<ClarityName, DataVariableMetadata>,
+    pub meta_nft: HashMap<ClarityName, NonFungibleTokenMetadata>,
+    pub meta_ft: HashMap<ClarityName, FungibleTokenMetadata>,
     pub data_size: u64,
 }
 
@@ -1436,6 +1444,10 @@ impl ContractContext {
             implemented_traits: HashSet::new(),
             persisted_names: HashSet::new(),
             data_size: 0,
+            meta_data_map: HashMap::new(),
+            meta_data_var: HashMap::new(),
+            meta_nft: HashMap::new(),
+            meta_ft: HashMap::new(),
         }
     }
 

--- a/src/vm/costs/mod.rs
+++ b/src/vm/costs/mod.rs
@@ -344,7 +344,7 @@ fn load_cost_functions(
         .expect_u128();
     let cost_voting_contract = &STACKS_BOOT_COST_VOTE_CONTRACT;
     let confirmed_proposals_count = clarity_db
-        .lookup_variable(&cost_voting_contract, "confirmed-proposal-count")
+        .lookup_variable(&cost_voting_contract, "confirmed-proposal-count", None)
         .map_err(|e| CostErrors::CostComputationFailed(e.to_string()))?
         .expect_u128();
     debug!("Check cost voting contract";
@@ -371,6 +371,7 @@ fn load_cost_functions(
                     )])
                     .expect("BUG: failed to construct simple tuple"),
                 ),
+                None,
             )
             .expect("BUG: Failed querying confirmed-proposals")
             .expect_optional()

--- a/src/vm/costs/mod.rs
+++ b/src/vm/costs/mod.rs
@@ -344,7 +344,7 @@ fn load_cost_functions(
         .expect_u128();
     let cost_voting_contract = &STACKS_BOOT_COST_VOTE_CONTRACT;
     let confirmed_proposals_count = clarity_db
-        .lookup_variable(&cost_voting_contract, "confirmed-proposal-count", None)
+        .lookup_variable_unknown_descriptor(&cost_voting_contract, "confirmed-proposal-count")
         .map_err(|e| CostErrors::CostComputationFailed(e.to_string()))?
         .expect_u128();
     debug!("Check cost voting contract";
@@ -361,7 +361,7 @@ fn load_cost_functions(
     for confirmed_proposal in fetch_start..fetch_end {
         // fetch the proposal data
         let entry = clarity_db
-            .fetch_entry(
+            .fetch_entry_unknown_descriptor(
                 &cost_voting_contract,
                 "confirmed-proposals",
                 &Value::from(
@@ -371,7 +371,6 @@ fn load_cost_functions(
                     )])
                     .expect("BUG: failed to construct simple tuple"),
                 ),
-                None,
             )
             .expect("BUG: Failed querying confirmed-proposals")
             .expect_optional()

--- a/src/vm/database/clarity_db.rs
+++ b/src/vm/database/clarity_db.rs
@@ -1117,7 +1117,7 @@ impl<'a> ClarityDatabase<'a> {
         self.put(&supply_key, &(0 as u128));
     }
 
-    fn load_ft(
+    pub fn load_ft(
         &mut self,
         contract_identifier: &QualifiedContractIdentifier,
         token_name: &str,
@@ -1157,8 +1157,12 @@ impl<'a> ClarityDatabase<'a> {
         contract_identifier: &QualifiedContractIdentifier,
         token_name: &str,
         amount: u128,
+        descriptor: Option<FungibleTokenMetadata>,
     ) -> Result<()> {
-        let descriptor = self.load_ft(contract_identifier, token_name)?;
+        let descriptor = match descriptor {
+            Some(x) => x,
+            None => self.load_ft(contract_identifier, token_name)?,
+        };
 
         let key = ClarityDatabase::make_key_for_trip(
             contract_identifier,
@@ -1213,8 +1217,11 @@ impl<'a> ClarityDatabase<'a> {
         contract_identifier: &QualifiedContractIdentifier,
         token_name: &str,
         principal: &PrincipalData,
+        descriptor: Option<FungibleTokenMetadata>,
     ) -> Result<u128> {
-        self.load_ft(contract_identifier, token_name)?;
+        if descriptor.is_none() {
+            self.load_ft(contract_identifier, token_name)?;
+        }
 
         let key = ClarityDatabase::make_key_for_quad(
             contract_identifier,

--- a/src/vm/database/clarity_db.rs
+++ b/src/vm/database/clarity_db.rs
@@ -857,19 +857,27 @@ impl<'a> ClarityDatabase<'a> {
             .ok_or(CheckErrors::NoSuchDataVariable(variable_name.to_string()).into())
     }
 
+    pub fn set_variable_unknown_descriptor(
+        &mut self,
+        contract_identifier: &QualifiedContractIdentifier,
+        variable_name: &str,
+        value: Value,
+    ) -> Result<Value> {
+        let descriptor = self.load_variable(contract_identifier, variable_name)?;
+        self.set_variable(contract_identifier, variable_name, value, &descriptor)
+    }
+
     pub fn set_variable(
         &mut self,
         contract_identifier: &QualifiedContractIdentifier,
         variable_name: &str,
         value: Value,
-        variable_descriptor: Option<DataVariableMetadata>,
+        variable_descriptor: &DataVariableMetadata,
     ) -> Result<Value> {
-        let variable_descriptor = match variable_descriptor {
-            Some(x) => x,
-            None => self.load_variable(contract_identifier, variable_name)?,
-        };
         if !variable_descriptor.value_type.admits(&value) {
-            return Err(CheckErrors::TypeValueError(variable_descriptor.value_type, value).into());
+            return Err(
+                CheckErrors::TypeValueError(variable_descriptor.value_type.clone(), value).into(),
+            );
         }
 
         let key = ClarityDatabase::make_key_for_trip(
@@ -883,17 +891,21 @@ impl<'a> ClarityDatabase<'a> {
         return Ok(Value::Bool(true));
     }
 
+    pub fn lookup_variable_unknown_descriptor(
+        &mut self,
+        contract_identifier: &QualifiedContractIdentifier,
+        variable_name: &str,
+    ) -> Result<Value> {
+        let descriptor = self.load_variable(contract_identifier, variable_name)?;
+        self.lookup_variable(contract_identifier, variable_name, &descriptor)
+    }
+
     pub fn lookup_variable(
         &mut self,
         contract_identifier: &QualifiedContractIdentifier,
         variable_name: &str,
-        variable_descriptor: Option<DataVariableMetadata>,
+        variable_descriptor: &DataVariableMetadata,
     ) -> Result<Value> {
-        let variable_descriptor = match variable_descriptor {
-            Some(x) => x,
-            None => self.load_variable(contract_identifier, variable_name)?,
-        };
-
         let key = ClarityDatabase::make_key_for_trip(
             contract_identifier,
             StoreType::Variable,
@@ -917,14 +929,16 @@ impl<'a> ClarityDatabase<'a> {
         map_name: &str,
         key_type: TypeSignature,
         value_type: TypeSignature,
-    ) {
+    ) -> DataMapMetadata {
         let data = DataMapMetadata {
             key_type,
             value_type,
         };
 
         let key = ClarityDatabase::make_metadata_key(StoreType::DataMapMeta, map_name);
-        self.insert_metadata(contract_identifier, &key, &data)
+        self.insert_metadata(contract_identifier, &key, &data);
+
+        data
     }
 
     pub fn load_map(
@@ -951,27 +965,35 @@ impl<'a> ClarityDatabase<'a> {
         )
     }
 
+    pub fn fetch_entry_unknown_descriptor(
+        &mut self,
+        contract_identifier: &QualifiedContractIdentifier,
+        map_name: &str,
+        key_value: &Value,
+    ) -> Result<Value> {
+        let descriptor = self.load_map(contract_identifier, map_name)?;
+        self.fetch_entry(contract_identifier, map_name, key_value, &descriptor)
+    }
+
     pub fn fetch_entry(
         &mut self,
         contract_identifier: &QualifiedContractIdentifier,
         map_name: &str,
         key_value: &Value,
-        map_descriptor: Option<DataMapMetadata>,
+        map_descriptor: &DataMapMetadata,
     ) -> Result<Value> {
-        let map_descriptor = match map_descriptor {
-            Some(x) => x,
-            None => self.load_map(contract_identifier, map_name)?,
-        };
         if !map_descriptor.key_type.admits(key_value) {
-            return Err(
-                CheckErrors::TypeValueError(map_descriptor.key_type, (*key_value).clone()).into(),
-            );
+            return Err(CheckErrors::TypeValueError(
+                map_descriptor.key_type.clone(),
+                (*key_value).clone(),
+            )
+            .into());
         }
 
         let key =
             ClarityDatabase::make_key_for_data_map_entry(contract_identifier, map_name, key_value);
 
-        let stored_type = TypeSignature::new_option(map_descriptor.value_type)?;
+        let stored_type = TypeSignature::new_option(map_descriptor.value_type.clone())?;
         let result = self.get_value(&key, &stored_type);
 
         match result {
@@ -986,7 +1008,7 @@ impl<'a> ClarityDatabase<'a> {
         map_name: &str,
         key: Value,
         value: Value,
-        map_descriptor: Option<DataMapMetadata>,
+        map_descriptor: &DataMapMetadata,
     ) -> Result<Value> {
         self.inner_set_entry(
             contract_identifier,
@@ -998,13 +1020,35 @@ impl<'a> ClarityDatabase<'a> {
         )
     }
 
+    pub fn set_entry_unknown_descriptor(
+        &mut self,
+        contract_identifier: &QualifiedContractIdentifier,
+        map_name: &str,
+        key: Value,
+        value: Value,
+    ) -> Result<Value> {
+        let descriptor = self.load_map(contract_identifier, map_name)?;
+        self.set_entry(contract_identifier, map_name, key, value, &descriptor)
+    }
+
+    pub fn insert_entry_unknown_descriptor(
+        &mut self,
+        contract_identifier: &QualifiedContractIdentifier,
+        map_name: &str,
+        key: Value,
+        value: Value,
+    ) -> Result<Value> {
+        let descriptor = self.load_map(contract_identifier, map_name)?;
+        self.insert_entry(contract_identifier, map_name, key, value, &descriptor)
+    }
+
     pub fn insert_entry(
         &mut self,
         contract_identifier: &QualifiedContractIdentifier,
         map_name: &str,
         key: Value,
         value: Value,
-        map_descriptor: Option<DataMapMetadata>,
+        map_descriptor: &DataMapMetadata,
     ) -> Result<Value> {
         self.inner_set_entry(
             contract_identifier,
@@ -1030,18 +1074,17 @@ impl<'a> ClarityDatabase<'a> {
         key_value: Value,
         value: Value,
         return_if_exists: bool,
-        map_descriptor: Option<DataMapMetadata>,
+        map_descriptor: &DataMapMetadata,
     ) -> Result<Value> {
-        let map_descriptor = match map_descriptor {
-            Some(x) => x,
-            None => self.load_map(contract_identifier, map_name)?,
-        };
-
         if !map_descriptor.key_type.admits(&key_value) {
-            return Err(CheckErrors::TypeValueError(map_descriptor.key_type, key_value).into());
+            return Err(
+                CheckErrors::TypeValueError(map_descriptor.key_type.clone(), key_value).into(),
+            );
         }
         if !map_descriptor.value_type.admits(&value) {
-            return Err(CheckErrors::TypeValueError(map_descriptor.value_type, value).into());
+            return Err(
+                CheckErrors::TypeValueError(map_descriptor.value_type.clone(), value).into(),
+            );
         }
 
         let key = ClarityDatabase::make_key_for_quad(
@@ -1050,7 +1093,7 @@ impl<'a> ClarityDatabase<'a> {
             map_name,
             key_value.serialize(),
         );
-        let stored_type = TypeSignature::new_option(map_descriptor.value_type)?;
+        let stored_type = TypeSignature::new_option(map_descriptor.value_type.clone())?;
 
         if return_if_exists && self.data_map_entry_exists(&key, &stored_type)? {
             return Ok(Value::Bool(false));
@@ -1067,12 +1110,14 @@ impl<'a> ClarityDatabase<'a> {
         contract_identifier: &QualifiedContractIdentifier,
         map_name: &str,
         key_value: &Value,
-        map_descriptor: DataMapMetadata,
+        map_descriptor: &DataMapMetadata,
     ) -> Result<Value> {
         if !map_descriptor.key_type.admits(key_value) {
-            return Err(
-                CheckErrors::TypeValueError(map_descriptor.key_type, (*key_value).clone()).into(),
-            );
+            return Err(CheckErrors::TypeValueError(
+                map_descriptor.key_type.clone(),
+                (*key_value).clone(),
+            )
+            .into());
         }
 
         let key = ClarityDatabase::make_key_for_quad(
@@ -1081,7 +1126,7 @@ impl<'a> ClarityDatabase<'a> {
             map_name,
             key_value.serialize(),
         );
-        let stored_type = TypeSignature::new_option(map_descriptor.value_type)?;
+        let stored_type = TypeSignature::new_option(map_descriptor.value_type.clone())?;
         if !self.data_map_entry_exists(&key, &stored_type)? {
             return Ok(Value::Bool(false));
         }
@@ -1100,7 +1145,7 @@ impl<'a> ClarityDatabase<'a> {
         contract_identifier: &QualifiedContractIdentifier,
         token_name: &str,
         total_supply: &Option<u128>,
-    ) {
+    ) -> FungibleTokenMetadata {
         let data = FungibleTokenMetadata {
             total_supply: total_supply.clone(),
         };
@@ -1115,6 +1160,8 @@ impl<'a> ClarityDatabase<'a> {
             token_name,
         );
         self.put(&supply_key, &(0 as u128));
+
+        data
     }
 
     pub fn load_ft(
@@ -1133,12 +1180,14 @@ impl<'a> ClarityDatabase<'a> {
         contract_identifier: &QualifiedContractIdentifier,
         token_name: &str,
         key_type: &TypeSignature,
-    ) {
+    ) -> NonFungibleTokenMetadata {
         let data = NonFungibleTokenMetadata {
             key_type: key_type.clone(),
         };
         let key = ClarityDatabase::make_metadata_key(StoreType::NonFungibleTokenMeta, token_name);
         self.insert_metadata(contract_identifier, &key, &data);
+
+        data
     }
 
     fn load_nft(
@@ -1157,13 +1206,8 @@ impl<'a> ClarityDatabase<'a> {
         contract_identifier: &QualifiedContractIdentifier,
         token_name: &str,
         amount: u128,
-        descriptor: Option<FungibleTokenMetadata>,
+        descriptor: &FungibleTokenMetadata,
     ) -> Result<()> {
-        let descriptor = match descriptor {
-            Some(x) => x,
-            None => self.load_ft(contract_identifier, token_name)?,
-        };
-
         let key = ClarityDatabase::make_key_for_trip(
             contract_identifier,
             StoreType::CirculatingSupply,
@@ -1217,7 +1261,7 @@ impl<'a> ClarityDatabase<'a> {
         contract_identifier: &QualifiedContractIdentifier,
         token_name: &str,
         principal: &PrincipalData,
-        descriptor: Option<FungibleTokenMetadata>,
+        descriptor: Option<&FungibleTokenMetadata>,
     ) -> Result<u128> {
         if descriptor.is_none() {
             self.load_ft(contract_identifier, token_name)?;
@@ -1276,14 +1320,10 @@ impl<'a> ClarityDatabase<'a> {
         contract_identifier: &QualifiedContractIdentifier,
         asset_name: &str,
         asset: &Value,
-        key_type: Option<TypeSignature>,
+        key_type: &TypeSignature,
     ) -> Result<PrincipalData> {
-        let key_type = match key_type {
-            Some(x) => x,
-            None => self.load_nft(contract_identifier, asset_name)?.key_type,
-        };
         if !key_type.admits(asset) {
-            return Err(CheckErrors::TypeValueError(key_type, (*asset).clone()).into());
+            return Err(CheckErrors::TypeValueError(key_type.clone(), (*asset).clone()).into());
         }
 
         let key = ClarityDatabase::make_key_for_quad(
@@ -1322,14 +1362,10 @@ impl<'a> ClarityDatabase<'a> {
         asset_name: &str,
         asset: &Value,
         principal: &PrincipalData,
-        key_type: Option<TypeSignature>,
+        key_type: &TypeSignature,
     ) -> Result<()> {
-        let key_type = match key_type {
-            Some(x) => x,
-            None => self.load_nft(contract_identifier, asset_name)?.key_type,
-        };
         if !key_type.admits(asset) {
-            return Err(CheckErrors::TypeValueError(key_type, (*asset).clone()).into());
+            return Err(CheckErrors::TypeValueError(key_type.clone(), (*asset).clone()).into());
         }
 
         let key = ClarityDatabase::make_key_for_quad(
@@ -1350,14 +1386,10 @@ impl<'a> ClarityDatabase<'a> {
         contract_identifier: &QualifiedContractIdentifier,
         asset_name: &str,
         asset: &Value,
-        key_type: Option<TypeSignature>,
+        key_type: &TypeSignature,
     ) -> Result<()> {
-        let key_type = match key_type {
-            Some(x) => x,
-            None => self.load_nft(contract_identifier, asset_name)?.key_type,
-        };
         if !key_type.admits(asset) {
-            return Err(CheckErrors::TypeValueError(key_type, (*asset).clone()).into());
+            return Err(CheckErrors::TypeValueError(key_type.clone(), (*asset).clone()).into());
         }
 
         let key = ClarityDatabase::make_key_for_quad(

--- a/src/vm/database/mod.rs
+++ b/src/vm/database/mod.rs
@@ -29,4 +29,7 @@ pub use self::clarity_db::{
 pub use self::key_value_wrapper::{RollbackWrapper, RollbackWrapperPersistedLog};
 pub use self::marf::{ClarityBackingStore, MarfedKV, MemoryBackingStore};
 pub use self::sqlite::SqliteConnection;
-pub use self::structures::{ClarityDeserializable, ClaritySerializable, STXBalance};
+pub use self::structures::{
+    ClarityDeserializable, ClaritySerializable, DataMapMetadata, DataVariableMetadata,
+    FungibleTokenMetadata, NonFungibleTokenMetadata, STXBalance,
+};

--- a/src/vm/functions/assets.rs
+++ b/src/vm/functions/assets.rs
@@ -297,6 +297,7 @@ pub fn special_mint_asset(
             &env.contract_context.contract_identifier,
             asset_name,
             &asset,
+            Some(expected_asset_type.clone()),
         ) {
             Err(Error::Runtime(RuntimeErrorType::NoSuchToken, _)) => Ok(()),
             Ok(_owner) => return clarity_ecode!(MintAssetErrorCodes::ALREADY_EXIST),
@@ -311,6 +312,7 @@ pub fn special_mint_asset(
             asset_name,
             &asset,
             to_principal,
+            Some(expected_asset_type),
         )?;
 
         let asset_identifier = AssetIdentifier {
@@ -362,6 +364,7 @@ pub fn special_transfer_asset(
             &env.contract_context.contract_identifier,
             asset_name,
             &asset,
+            Some(expected_asset_type.clone()),
         ) {
             Ok(owner) => Ok(owner),
             Err(Error::Runtime(RuntimeErrorType::NoSuchToken, _)) => {
@@ -382,6 +385,7 @@ pub fn special_transfer_asset(
             asset_name,
             &asset,
             to_principal,
+            Some(expected_asset_type),
         )?;
 
         env.global_context.log_asset_transfer(
@@ -555,6 +559,7 @@ pub fn special_get_owner(
         &env.contract_context.contract_identifier,
         asset_name,
         &asset,
+        Some(expected_asset_type),
     ) {
         Ok(owner) => {
             Ok(Value::some(Value::Principal(owner))
@@ -683,6 +688,7 @@ pub fn special_burn_asset(
             &env.contract_context.contract_identifier,
             asset_name,
             &asset,
+            Some(expected_asset_type.clone()),
         ) {
             Err(Error::Runtime(RuntimeErrorType::NoSuchToken, _)) => {
                 return clarity_ecode!(BurnAssetErrorCodes::DOES_NOT_EXIST)
@@ -702,6 +708,7 @@ pub fn special_burn_asset(
             &env.contract_context.contract_identifier,
             asset_name,
             &asset,
+            Some(expected_asset_type),
         )?;
 
         env.global_context.log_asset_transfer(

--- a/src/vm/functions/database.rs
+++ b/src/vm/functions/database.rs
@@ -214,7 +214,7 @@ pub fn special_fetch_variable(
 
     env.global_context
         .database
-        .lookup_variable(contract, var_name)
+        .lookup_variable(contract, var_name, Some(data_types))
 }
 
 pub fn special_set_variable(
@@ -251,7 +251,7 @@ pub fn special_set_variable(
 
     env.global_context
         .database
-        .set_variable(contract, var_name, value)
+        .set_variable(contract, var_name, value, Some(data_types))
 }
 
 pub fn special_fetch_entry(
@@ -279,7 +279,7 @@ pub fn special_fetch_entry(
 
     env.global_context
         .database
-        .fetch_entry(contract, map_name, &key)
+        .fetch_entry(contract, map_name, &key, Some(data_types))
 }
 
 pub fn special_at_block(
@@ -343,7 +343,7 @@ pub fn special_set_entry(
 
     env.global_context
         .database
-        .set_entry(contract, map_name, key, value)
+        .set_entry(contract, map_name, key, value, Some(data_types))
 }
 
 pub fn special_insert_entry(
@@ -380,7 +380,7 @@ pub fn special_insert_entry(
 
     env.global_context
         .database
-        .insert_entry(contract, map_name, key, value)
+        .insert_entry(contract, map_name, key, value, Some(data_types))
 }
 
 pub fn special_delete_entry(
@@ -414,7 +414,7 @@ pub fn special_delete_entry(
 
     env.global_context
         .database
-        .delete_entry(contract, map_name, &key)
+        .delete_entry(contract, map_name, &key, data_types)
 }
 
 pub fn special_get_block_info(

--- a/src/vm/functions/database.rs
+++ b/src/vm/functions/database.rs
@@ -199,13 +199,12 @@ pub fn special_fetch_variable(
 
     let contract = &env.contract_context.contract_identifier;
 
-    // optimization todo: db metadata like this should just get stored
-    //   in the contract object, so that it gets loaded in when the contract
-    //   is loaded from the db.
     let data_types = env
-        .global_context
-        .database
-        .load_variable(contract, var_name)?;
+        .contract_context
+        .meta_data_var
+        .get(var_name)
+        .ok_or(CheckErrors::NoSuchDataVariable(var_name.to_string()))?;
+
     runtime_cost(
         ClarityCostFunction::FetchVar,
         env,
@@ -214,7 +213,7 @@ pub fn special_fetch_variable(
 
     env.global_context
         .database
-        .lookup_variable(contract, var_name, Some(data_types))
+        .lookup_variable(contract, var_name, data_types)
 }
 
 pub fn special_set_variable(
@@ -234,13 +233,12 @@ pub fn special_set_variable(
 
     let contract = &env.contract_context.contract_identifier;
 
-    // optimization todo: db metadata like this should just get stored
-    //   in the contract object, so that it gets loaded in when the contract
-    //   is loaded from the db.
     let data_types = env
-        .global_context
-        .database
-        .load_variable(contract, var_name)?;
+        .contract_context
+        .meta_data_var
+        .get(var_name)
+        .ok_or(CheckErrors::NoSuchDataVariable(var_name.to_string()))?;
+
     runtime_cost(
         ClarityCostFunction::SetVar,
         env,
@@ -251,7 +249,7 @@ pub fn special_set_variable(
 
     env.global_context
         .database
-        .set_variable(contract, var_name, value, Some(data_types))
+        .set_variable(contract, var_name, value, data_types)
 }
 
 pub fn special_fetch_entry(
@@ -267,10 +265,12 @@ pub fn special_fetch_entry(
 
     let contract = &env.contract_context.contract_identifier;
 
-    // optimization todo: db metadata like this should just get stored
-    //   in the contract object, so that it gets loaded in when the contract
-    //   is loaded from the db.
-    let data_types = env.global_context.database.load_map(contract, map_name)?;
+    let data_types = env
+        .contract_context
+        .meta_data_map
+        .get(map_name)
+        .ok_or(CheckErrors::NoSuchMap(map_name.to_string()))?;
+
     runtime_cost(
         ClarityCostFunction::FetchEntry,
         env,
@@ -279,7 +279,7 @@ pub fn special_fetch_entry(
 
     env.global_context
         .database
-        .fetch_entry(contract, map_name, &key, Some(data_types))
+        .fetch_entry(contract, map_name, &key, data_types)
 }
 
 pub fn special_at_block(
@@ -328,10 +328,12 @@ pub fn special_set_entry(
 
     let contract = &env.contract_context.contract_identifier;
 
-    // optimization todo: db metadata like this should just get stored
-    //   in the contract object, so that it gets loaded in when the contract
-    //   is loaded from the db.
-    let data_types = env.global_context.database.load_map(contract, map_name)?;
+    let data_types = env
+        .contract_context
+        .meta_data_map
+        .get(map_name)
+        .ok_or(CheckErrors::NoSuchMap(map_name.to_string()))?;
+
     runtime_cost(
         ClarityCostFunction::SetEntry,
         env,
@@ -343,7 +345,7 @@ pub fn special_set_entry(
 
     env.global_context
         .database
-        .set_entry(contract, map_name, key, value, Some(data_types))
+        .set_entry(contract, map_name, key, value, data_types)
 }
 
 pub fn special_insert_entry(
@@ -365,10 +367,12 @@ pub fn special_insert_entry(
 
     let contract = &env.contract_context.contract_identifier;
 
-    // optimization todo: db metadata like this should just get stored
-    //   in the contract object, so that it gets loaded in when the contract
-    //   is loaded from the db.
-    let data_types = env.global_context.database.load_map(contract, map_name)?;
+    let data_types = env
+        .contract_context
+        .meta_data_map
+        .get(map_name)
+        .ok_or(CheckErrors::NoSuchMap(map_name.to_string()))?;
+
     runtime_cost(
         ClarityCostFunction::SetEntry,
         env,
@@ -380,7 +384,7 @@ pub fn special_insert_entry(
 
     env.global_context
         .database
-        .insert_entry(contract, map_name, key, value, Some(data_types))
+        .insert_entry(contract, map_name, key, value, data_types)
 }
 
 pub fn special_delete_entry(
@@ -400,10 +404,12 @@ pub fn special_delete_entry(
 
     let contract = &env.contract_context.contract_identifier;
 
-    // optimization todo: db metadata like this should just get stored
-    //   in the contract object, so that it gets loaded in when the contract
-    //   is loaded from the db.
-    let data_types = env.global_context.database.load_map(contract, map_name)?;
+    let data_types = env
+        .contract_context
+        .meta_data_map
+        .get(map_name)
+        .ok_or(CheckErrors::NoSuchMap(map_name.to_string()))?;
+
     runtime_cost(
         ClarityCostFunction::SetEntry,
         env,

--- a/src/vm/functions/mod.rs
+++ b/src/vm/functions/mod.rs
@@ -442,7 +442,7 @@ fn special_print(
     runtime_cost(ClarityCostFunction::Print, env, input.size())?;
 
     if cfg!(feature = "developer-mode") {
-        eprintln!("{}", &input);
+        info!("{}", &input);
     }
 
     env.register_print_event(input.clone())?;

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -281,8 +281,8 @@ fn eval_all(
 
                     global_context.add_memory(value.size() as u64)?;
 
-                    global_context.database.create_variable(&contract_context.contract_identifier, &name, value_type);
-                    global_context.database.set_variable(&contract_context.contract_identifier, &name, value)?;
+                    let data_type = global_context.database.create_variable(&contract_context.contract_identifier, &name, value_type);
+                    global_context.database.set_variable(&contract_context.contract_identifier, &name, value, Some(data_type))?;
                 },
                 DefineResult::Map(name, key_type, value_type) => {
                     runtime_cost(ClarityCostFunction::CreateMap, global_context,

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -282,7 +282,9 @@ fn eval_all(
                     global_context.add_memory(value.size() as u64)?;
 
                     let data_type = global_context.database.create_variable(&contract_context.contract_identifier, &name, value_type);
-                    global_context.database.set_variable(&contract_context.contract_identifier, &name, value, Some(data_type))?;
+                    global_context.database.set_variable(&contract_context.contract_identifier, &name, value, &data_type)?;
+
+                    contract_context.meta_data_var.insert(name, data_type);
                 },
                 DefineResult::Map(name, key_type, value_type) => {
                     runtime_cost(ClarityCostFunction::CreateMap, global_context,
@@ -295,7 +297,9 @@ fn eval_all(
                     global_context.add_memory(value_type.type_size()
                                               .expect("type size should be realizable") as u64)?;
 
-                    global_context.database.create_map(&contract_context.contract_identifier, &name, key_type, value_type);
+                    let data_type = global_context.database.create_map(&contract_context.contract_identifier, &name, key_type, value_type);
+
+                    contract_context.meta_data_map.insert(name, data_type);
                 },
                 DefineResult::FungibleToken(name, total_supply) => {
                     runtime_cost(ClarityCostFunction::CreateFt, global_context, 0)?;
@@ -304,7 +308,9 @@ fn eval_all(
                     global_context.add_memory(TypeSignature::UIntType.type_size()
                                               .expect("type size should be realizable") as u64)?;
 
-                    global_context.database.create_fungible_token(&contract_context.contract_identifier, &name, &total_supply);
+                    let data_type = global_context.database.create_fungible_token(&contract_context.contract_identifier, &name, &total_supply);
+
+                    contract_context.meta_ft.insert(name, data_type);
                 },
                 DefineResult::NonFungibleAsset(name, asset_type) => {
                     runtime_cost(ClarityCostFunction::CreateNft, global_context, asset_type.size())?;
@@ -313,7 +319,9 @@ fn eval_all(
                     global_context.add_memory(asset_type.type_size()
                                               .expect("type size should be realizable") as u64)?;
 
-                    global_context.database.create_non_fungible_token(&contract_context.contract_identifier, &name, &asset_type);
+                    let data_type = global_context.database.create_non_fungible_token(&contract_context.contract_identifier, &name, &asset_type);
+
+                    contract_context.meta_nft.insert(name, data_type);
                 },
                 DefineResult::Trait(name, trait_type) => {
                     contract_context.defined_traits.insert(name, trait_type);

--- a/src/vm/tests/costs.rs
+++ b/src/vm/tests/costs.rs
@@ -372,11 +372,10 @@ fn test_cost_contract_short_circuits() {
         let mut store = marf_kv.begin(&StacksBlockId([3 as u8; 32]), &StacksBlockId([4 as u8; 32]));
         let mut db = store.as_clarity_db(&NULL_HEADER_DB, &NULL_BURN_STATE_DB);
         db.begin();
-        db.set_variable(
+        db.set_variable_unknown_descriptor(
             &STACKS_BOOT_COST_VOTE_CONTRACT,
             "confirmed-proposal-count",
             Value::UInt(1),
-            None,
         )
         .unwrap();
         let value = format!(
@@ -387,12 +386,11 @@ fn test_cost_contract_short_circuits() {
                  confirmed-height: u1 }}",
             intercepted, "\"intercepted-function\"", cost_definer, "\"cost-definition\""
         );
-        db.set_entry(
+        db.set_entry_unknown_descriptor(
             &STACKS_BOOT_COST_VOTE_CONTRACT,
             "confirmed-proposals",
             execute("{ confirmed-id: u0 }"),
             execute(&value),
-            None,
         )
         .unwrap();
         db.commit();
@@ -652,11 +650,10 @@ fn test_cost_voting_integration() {
         let mut db = store.as_clarity_db(&NULL_HEADER_DB, &NULL_BURN_STATE_DB);
         db.begin();
 
-        db.set_variable(
+        db.set_variable_unknown_descriptor(
             &STACKS_BOOT_COST_VOTE_CONTRACT,
             "confirmed-proposal-count",
             Value::UInt(bad_proposals as u128),
-            None,
         )
         .unwrap();
 
@@ -671,12 +668,11 @@ fn test_cost_voting_integration() {
                      confirmed-height: u1 }}",
                 intercepted_ct, intercepted_f, cost_ct, cost_f
             );
-            db.set_entry(
+            db.set_entry_unknown_descriptor(
                 &STACKS_BOOT_COST_VOTE_CONTRACT,
                 "confirmed-proposals",
                 execute(&format!("{{ confirmed-id: u{} }}", ix)),
                 execute(&value),
-                None,
             )
             .unwrap();
         }
@@ -749,11 +745,10 @@ fn test_cost_voting_integration() {
         db.begin();
 
         let good_proposals = good_cases.len() as u128;
-        db.set_variable(
+        db.set_variable_unknown_descriptor(
             &STACKS_BOOT_COST_VOTE_CONTRACT,
             "confirmed-proposal-count",
             Value::UInt(bad_proposals as u128 + good_proposals),
-            None,
         )
         .unwrap();
 
@@ -768,12 +763,11 @@ fn test_cost_voting_integration() {
                     confirmed-height: u1 }}",
                 intercepted_ct, intercepted_f, cost_ct, cost_f
             );
-            db.set_entry(
+            db.set_entry_unknown_descriptor(
                 &STACKS_BOOT_COST_VOTE_CONTRACT,
                 "confirmed-proposals",
                 execute(&format!("{{ confirmed-id: u{} }}", ix + bad_proposals)),
                 execute(&value),
-                None,
             )
             .unwrap();
         }

--- a/src/vm/tests/costs.rs
+++ b/src/vm/tests/costs.rs
@@ -376,6 +376,7 @@ fn test_cost_contract_short_circuits() {
             &STACKS_BOOT_COST_VOTE_CONTRACT,
             "confirmed-proposal-count",
             Value::UInt(1),
+            None,
         )
         .unwrap();
         let value = format!(
@@ -391,6 +392,7 @@ fn test_cost_contract_short_circuits() {
             "confirmed-proposals",
             execute("{ confirmed-id: u0 }"),
             execute(&value),
+            None,
         )
         .unwrap();
         db.commit();
@@ -654,6 +656,7 @@ fn test_cost_voting_integration() {
             &STACKS_BOOT_COST_VOTE_CONTRACT,
             "confirmed-proposal-count",
             Value::UInt(bad_proposals as u128),
+            None,
         )
         .unwrap();
 
@@ -673,6 +676,7 @@ fn test_cost_voting_integration() {
                 "confirmed-proposals",
                 execute(&format!("{{ confirmed-id: u{} }}", ix)),
                 execute(&value),
+                None,
             )
             .unwrap();
         }
@@ -749,6 +753,7 @@ fn test_cost_voting_integration() {
             &STACKS_BOOT_COST_VOTE_CONTRACT,
             "confirmed-proposal-count",
             Value::UInt(bad_proposals as u128 + good_proposals),
+            None,
         )
         .unwrap();
 
@@ -768,6 +773,7 @@ fn test_cost_voting_integration() {
                 "confirmed-proposals",
                 execute(&format!("{{ confirmed-id: u{} }}", ix + bad_proposals)),
                 execute(&value),
+                None,
             )
             .unwrap();
         }

--- a/src/vm/variables.rs
+++ b/src/vm/variables.rs
@@ -20,6 +20,9 @@ use vm::errors::{InterpreterResult as Result, RuntimeErrorType};
 use vm::types::BuffData;
 use vm::types::Value;
 
+use vm::costs::cost_functions::ClarityCostFunction;
+use vm::costs::runtime_cost;
+
 define_named_enum!(NativeVariables {
     ContractCaller("contract-caller"), TxSender("tx-sender"), BlockHeight("block-height"),
     BurnBlockHeight("burn-block-height"), NativeNone("none"),
@@ -54,10 +57,12 @@ pub fn lookup_reserved_variable(
                 Ok(Some(sender))
             }
             NativeVariables::BlockHeight => {
+                runtime_cost(ClarityCostFunction::FetchVar, env, 1)?;
                 let block_height = env.global_context.database.get_current_block_height();
                 Ok(Some(Value::UInt(block_height as u128)))
             }
             NativeVariables::BurnBlockHeight => {
+                runtime_cost(ClarityCostFunction::FetchVar, env, 1)?;
                 let burn_block_height = env
                     .global_context
                     .database
@@ -68,6 +73,7 @@ pub fn lookup_reserved_variable(
             NativeVariables::NativeTrue => Ok(Some(Value::Bool(true))),
             NativeVariables::NativeFalse => Ok(Some(Value::Bool(false))),
             NativeVariables::TotalLiquidMicroSTX => {
+                runtime_cost(ClarityCostFunction::FetchVar, env, 1)?;
                 let liq = env.global_context.database.get_total_liquid_ustx();
                 Ok(Some(Value::UInt(liq)))
             }

--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -400,6 +400,14 @@ pub const HELIUM_BLOCK_LIMIT: ExecutionCost = ExecutionCost {
     runtime: 1_00_000_000,
 };
 
+pub const MAINNET_BLOCK_LIMIT: ExecutionCost = ExecutionCost {
+    write_length: 15_000_000, // roughly 15 mb
+    write_count: 3_750,
+    read_length: 100_000_000,
+    read_count: 3_750,
+    runtime: 5_000_000_000,
+};
+
 impl Config {
     pub fn from_config_file(config_file: ConfigFile) -> Config {
         let default_node_config = NodeConfig::default();
@@ -734,23 +742,27 @@ impl Config {
             None => HELIUM_DEFAULT_CONNECTION_OPTIONS.clone(),
         };
 
-        let block_limit = match config_file.block_limit {
-            Some(opts) => ExecutionCost {
-                write_length: opts
-                    .write_length
-                    .unwrap_or(HELIUM_BLOCK_LIMIT.write_length.clone()),
-                write_count: opts
-                    .write_count
-                    .unwrap_or(HELIUM_BLOCK_LIMIT.write_count.clone()),
-                read_length: opts
-                    .read_length
-                    .unwrap_or(HELIUM_BLOCK_LIMIT.read_length.clone()),
-                read_count: opts
-                    .read_count
-                    .unwrap_or(HELIUM_BLOCK_LIMIT.read_count.clone()),
-                runtime: opts.runtime.unwrap_or(HELIUM_BLOCK_LIMIT.runtime.clone()),
-            },
-            None => HELIUM_BLOCK_LIMIT.clone(),
+        let block_limit = if burnchain.mode == "mainnet" || burnchain.mode == "xenon" {
+            MAINNET_BLOCK_LIMIT.clone()
+        } else {
+            match config_file.block_limit {
+                Some(opts) => ExecutionCost {
+                    write_length: opts
+                        .write_length
+                        .unwrap_or(HELIUM_BLOCK_LIMIT.write_length.clone()),
+                    write_count: opts
+                        .write_count
+                        .unwrap_or(HELIUM_BLOCK_LIMIT.write_count.clone()),
+                    read_length: opts
+                        .read_length
+                        .unwrap_or(HELIUM_BLOCK_LIMIT.read_length.clone()),
+                    read_count: opts
+                        .read_count
+                        .unwrap_or(HELIUM_BLOCK_LIMIT.read_count.clone()),
+                    runtime: opts.runtime.unwrap_or(HELIUM_BLOCK_LIMIT.runtime.clone()),
+                },
+                None => HELIUM_BLOCK_LIMIT.clone(),
+            }
         };
 
         Config {

--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -397,7 +397,8 @@ pub const HELIUM_BLOCK_LIMIT: ExecutionCost = ExecutionCost {
     write_count: 5_0_000,
     read_length: 1_000_000_000,
     read_count: 5_0_000,
-    runtime: 1_00_000_000,
+    // allow much more runtime in helium blocks than mainnet
+    runtime: 100_000_000_000,
 };
 
 pub const MAINNET_BLOCK_LIMIT: ExecutionCost = ExecutionCost {

--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -403,9 +403,9 @@ pub const HELIUM_BLOCK_LIMIT: ExecutionCost = ExecutionCost {
 
 pub const MAINNET_BLOCK_LIMIT: ExecutionCost = ExecutionCost {
     write_length: 15_000_000, // roughly 15 mb
-    write_count: 3_750,
+    write_count: 7_750,
     read_length: 100_000_000,
-    read_count: 3_750,
+    read_count: 7_750,
     runtime: 5_000_000_000,
 };
 

--- a/testnet/stacks-node/src/tests/integrations.rs
+++ b/testnet/stacks-node/src/tests/integrations.rs
@@ -1234,7 +1234,7 @@ fn block_limit_runtime_test() {
 
     // use a shorter runtime limit. the current runtime limit
     //    is _painfully_ slow in a opt-level=0 build (i.e., `cargo test`)
-    conf.block_limit.runtime = 1_000_000;
+    conf.block_limit.runtime = 1_000_000_000;
     conf.burnchain.commit_anchor_block_within = 5000;
 
     let num_rounds = 6;
@@ -1309,7 +1309,7 @@ fn block_limit_runtime_test() {
             match round {
                 2 => {
                     // Block #1 should have 3 txs -- coinbase + 2 contract calls...
-                    assert!(block.block.txs.len() == 3);
+                    assert_eq!(block.block.txs.len(), 3);
                 }
                 3 | 4 | 5 => {
                     // Block >= 2 should have 4 txs -- coinbase + 3 contract calls


### PR DESCRIPTION
This sets initial pessimistic block limits for mainnet. These are set based on evaluating:

* `stx-transfer?`
* `stx-stack`
* Simple large contract analysis
* `secp256k1-verify`

Far and way, of those, `stx-stack` is the most expensive, and governs the limits imposed on the `write-count` and `read-count` for the MARF. With these block settings, at most 50 such operations could occur in a block. On simple tests, even 50 such operations take around a minute to process (the test MARF is seeded with 500,000 account entries).


The benchmarking tests can be found in the `feat/block-limits` branch, which is separated here, because there's code in that branch to support benchmarking and profiling which should not necessarily be merged yet.
