### PR TITLE
Upgrade `time` crate to version `0.2.23`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -269,7 +269,7 @@ dependencies = [
  "slog-json",
  "slog-term",
  "stx-genesis",
- "time 0.2.16",
+ "time 0.2.23",
  "tini",
  "url",
 ]
@@ -412,6 +412,12 @@ checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 dependencies = [
  "bitflags",
 ]
+
+[[package]]
+name = "const_fn"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28b9d6de7f49e22cf97ad17fc4036ece69300032f45f78f30b4a4482cdc3f4a6"
 
 [[package]]
 name = "constant_time_eq"
@@ -2512,11 +2518,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.2.16"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a51cadc5b1eec673a685ff7c33192ff7b7603d0b75446fb354939ee615acb15"
+checksum = "bcdaeea317915d59b2b4cd3b5efcd156c309108664277793f5351700c02ce98b"
 dependencies = [
- "cfg-if 0.1.10",
+ "const_fn",
  "libc",
  "standback",
  "stdweb",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,7 @@ version = "=2.0.0"
 features = ["serde"]
 
 [dependencies.time]
-version = "0.2.1"
+version = "0.2.23"
 features = ["std"]
 
 [dev-dependencies]


### PR DESCRIPTION
Addresses the following from `cargo audit`:

	ID:       RUSTSEC-2020-0071
	Crate:    time
	Version:  0.2.16
	Date:     2020-11-18
	URL:      https://rustsec.org/advisories/RUSTSEC-2020-0071
	Title:    Potential segfault in the time crate
	Solution:  upgrade to >= 0.2.23
	Dependency tree:
	time 0.2.16

Besides `rusqlite`, there are a few other dependencies flagged by `cargo
audit`, but upgrading them is a bit more invasive.
