### PR TITLE
Follow up #2271

### DIFF
--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -833,6 +833,10 @@ impl Config {
             _ => false,
         }
     }
+
+    pub fn is_node_event_driven() {
+        self.events_observers.len() > 0
+    }
 }
 
 impl std::default::Default for Config {

--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -834,7 +834,7 @@ impl Config {
         }
     }
 
-    pub fn is_node_event_driven() {
+    pub fn is_node_event_driven(&self) -> bool {
         self.events_observers.len() > 0
     }
 }

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -652,6 +652,9 @@ fn spawn_peer(
                     }
                     Err(e) => {
                         error!("P2P: Failed to process network dispatch: {:?}", &e);
+                        if config.is_node_event_driven() {
+                            panic!();
+                        }
                     }
                 };
 


### PR DESCRIPTION
This PR is following up on #2271
Its goal is to let the node crash when the p2p run loop failed, and the chain events are being observed.