### PR TITLE
Update default read-only limits for network calls

### DIFF
--- a/src/net/connection.rs
+++ b/src/net/connection.rs
@@ -423,8 +423,8 @@ impl std::default::Default for ConnectionOptions {
                 write_length: 0,
                 write_count: 0,
                 read_length: 100000,
-                read_count: 10,
-                runtime: 10000000,
+                read_count: 30,
+                runtime: 1_000_000_000,
             },
             maximum_call_argument_size: 20 * BOUND_VALUE_SERIALIZATION_HEX,
             max_block_push_bandwidth: 0, // infinite upload bandwidth allowed


### PR DESCRIPTION
The latest Xenon reset (2.0.0-rc1) increased the initial costs of Clarity functions (and increased the block limit), but did not increase the default runtime limit for read-only calls over the API interface. This PR does that.