### PR TITLE
Fix version info in distributables

### DIFF
--- a/.github/workflows/stacks-blockchain.yml
+++ b/.github/workflows/stacks-blockchain.yml
@@ -70,12 +70,24 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - name: Set Vars
+        run: |
+          echo "GITHUB_SHA_SHORT=${GITHUB_SHA::7}" >> $GITHUB_ENV
+          echo "GITHUB_REF_SHORT=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
 
       - name: Build distributable
-        env:
-          DIST_TARGET_FILTER: ${{ matrix.platform }}
-        run: build-scripts/build-dist.sh
-
+        uses: docker/build-push-action@v2.2.1
+        with:
+          file: build-scripts/Dockerfile.${{ matrix.platform }}
+          outputs: dist/${{ matrix.platform }}
+          build-args: |
+            STACKS_NODE_VERSION=${{ github.event.inputs.tag || env.GITHUB_SHA_SHORT }}
+            GIT_BRANCH=${{ env.GITHUB_REF_SHORT }}
+            GIT_COMMIT=${{ env.GITHUB_SHA_SHORT }}
+          
       - name: Compress artifact
         run: zip --junk-paths ${{ matrix.platform }} ./dist/${{ matrix.platform }}/*
 

--- a/build-scripts/Dockerfile.linux-arm64
+++ b/build-scripts/Dockerfile.linux-arm64
@@ -1,5 +1,9 @@
 FROM rust:stretch as build
 
+ARG STACKS_NODE_VERSION="No Version Info"
+ARG GIT_BRANCH='No Branch Info'
+ARG GIT_COMMIT='No Commit Info'
+
 WORKDIR /src
 
 COPY . .

--- a/build-scripts/Dockerfile.linux-armv7
+++ b/build-scripts/Dockerfile.linux-armv7
@@ -1,5 +1,9 @@
 FROM rust:stretch as build
 
+ARG STACKS_NODE_VERSION="No Version Info"
+ARG GIT_BRANCH='No Branch Info'
+ARG GIT_COMMIT='No Commit Info'
+
 WORKDIR /src
 
 COPY . .

--- a/build-scripts/Dockerfile.linux-musl-x64
+++ b/build-scripts/Dockerfile.linux-musl-x64
@@ -1,5 +1,9 @@
 FROM rust:stretch as build
 
+ARG STACKS_NODE_VERSION="No Version Info"
+ARG GIT_BRANCH='No Branch Info'
+ARG GIT_COMMIT='No Commit Info'
+
 WORKDIR /src
 
 COPY . .

--- a/build-scripts/Dockerfile.linux-x64
+++ b/build-scripts/Dockerfile.linux-x64
@@ -1,5 +1,9 @@
 FROM rust:stretch as build
 
+ARG STACKS_NODE_VERSION="No Version Info"
+ARG GIT_BRANCH='No Branch Info'
+ARG GIT_COMMIT='No Commit Info'
+
 WORKDIR /src
 
 COPY . .

--- a/build-scripts/Dockerfile.macos-x64
+++ b/build-scripts/Dockerfile.macos-x64
@@ -1,5 +1,9 @@
 FROM rust:stretch as build
 
+ARG STACKS_NODE_VERSION="No Version Info"
+ARG GIT_BRANCH='No Branch Info'
+ARG GIT_COMMIT='No Commit Info'
+
 WORKDIR /src
 
 COPY . .

--- a/build-scripts/Dockerfile.windows-x64
+++ b/build-scripts/Dockerfile.windows-x64
@@ -1,5 +1,9 @@
 FROM rust:stretch as build
 
+ARG STACKS_NODE_VERSION="No Version Info"
+ARG GIT_BRANCH='No Branch Info'
+ARG GIT_COMMIT='No Commit Info'
+
 WORKDIR /src
 
 COPY . .


### PR DESCRIPTION
Fixes the version info in distributables:

```
./stacks-node version
stacks-node 92d9860 (binary-version-fix:92d9860+, release build, macos [x86_64])
```

Closes https://github.com/blockstack/stacks-blockchain/issues/2299

## Type of Change
- [ ] New feature
- [X] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No

## Are documentation updates required?
No

## Testing information
[All distros can be downloaded and tested here](https://github.com/blockstack/stacks-blockchain/actions/runs/473111235)
