### PR TITLE
Ability to configure the satoshi_per_byte for BTC transactions

### DIFF
--- a/deployment/helm/stacks-blockchain/values.yaml
+++ b/deployment/helm/stacks-blockchain/values.yaml
@@ -227,7 +227,7 @@ config:
     mode: krypton
     peer_host: bitcoind.blockstack.org
     # process_exit_at_block_height: 5340
-    # burnchain_op_tx_fee: 5500
+    # satoshis_per_block_commit_output: 5500
     # commit_anchor_block_within: 10000
     rpc_port: 18443
     peer_port: 18444
@@ -258,7 +258,7 @@ config:
   #   mode = "krypton"
   #   peer_host = "bitcoind.blockstack.org"
   #   #process_exit_at_block_height = 5340
-  #   #burnchain_op_tx_fee = 5500
+  #   #satoshis_per_block_commit_output = 5500
   #   #commit_anchor_block_within = 10000
   #   rpc_port = 18443
   #   peer_port = 18444

--- a/deployment/helm/stacks-blockchain/values.yaml
+++ b/deployment/helm/stacks-blockchain/values.yaml
@@ -227,7 +227,6 @@ config:
     mode: krypton
     peer_host: bitcoind.blockstack.org
     # process_exit_at_block_height: 5340
-    # satoshis_per_block_commit_output: 5500
     # commit_anchor_block_within: 10000
     rpc_port: 18443
     peer_port: 18444
@@ -258,7 +257,6 @@ config:
   #   mode = "krypton"
   #   peer_host = "bitcoind.blockstack.org"
   #   #process_exit_at_block_height = 5340
-  #   #satoshis_per_block_commit_output = 5500
   #   #commit_anchor_block_within = 10000
   #   rpc_port = 18443
   #   peer_port = 18444

--- a/testnet/stacks-node/Stacks.toml
+++ b/testnet/stacks-node/Stacks.toml
@@ -23,7 +23,7 @@ rpc_bind = "127.0.0.1:20443"
 # password = "secret"
 # timeout = 30
 # local_mining_public_key = "04ee0b1602eb18fef7986887a7e8769a30c9df981d33c8380d255edef003abdcd243a0eb74afdf6740e6c423e62aec631519a24cf5b1d62bf8a3e06ddc695dcb77"
-# satoshis_per_block_commit_op = 1000
+# satoshis_per_block_commit_op = 5500
 # commit_anchor_block_within = 3000
 
 ## Settings for public testnet, relying on a remote bitcoind server
@@ -33,7 +33,7 @@ rpc_bind = "127.0.0.1:20443"
 # chain = "bitcoin"
 # mode = "argon"
 # peer_host = "argon.blockstack.org"
-# satoshis_per_block_commit_op = 1000
+# satoshis_per_block_commit_op = 5500
 # commit_anchor_block_within = 10000
 # rpc_port = 3000
 # peer_port = 18444

--- a/testnet/stacks-node/Stacks.toml
+++ b/testnet/stacks-node/Stacks.toml
@@ -23,7 +23,7 @@ rpc_bind = "127.0.0.1:20443"
 # password = "secret"
 # timeout = 30
 # local_mining_public_key = "04ee0b1602eb18fef7986887a7e8769a30c9df981d33c8380d255edef003abdcd243a0eb74afdf6740e6c423e62aec631519a24cf5b1d62bf8a3e06ddc695dcb77"
-# burnchain_op_tx_fee = 1000
+# satoshis_per_block_commit_op = 1000
 # commit_anchor_block_within = 3000
 
 ## Settings for public testnet, relying on a remote bitcoind server
@@ -33,7 +33,7 @@ rpc_bind = "127.0.0.1:20443"
 # chain = "bitcoin"
 # mode = "argon"
 # peer_host = "argon.blockstack.org"
-# burnchain_op_tx_fee = 1000
+# satoshis_per_block_commit_op = 1000
 # commit_anchor_block_within = 10000
 # rpc_port = 3000
 # peer_port = 18444

--- a/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
+++ b/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
@@ -750,6 +750,10 @@ impl BitcoinRegtestController {
 
         let number_of_transfers = payload.commit_outs.len() as u64;
         let value_per_transfer = payload.burn_fee / number_of_transfers;
+        if value_per_transfer < DUST_UTXO_LIMIT {
+            warn!("Unable to submit a LeaderBlockCommit, consider increasing your burn_fee_cap");
+            return None
+        }
 
         let btc_miner_fee = self.config.burnchain.block_commit_tx_estimated_size
             * self.config.burnchain.satoshis_per_byte;

--- a/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
+++ b/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
@@ -716,7 +716,7 @@ impl BitcoinRegtestController {
         tx.output = vec![consensus_output];
         tx.output.push(payload.output.to_bitcoin_tx_out(output_amt));
 
-        self.finalize_tx(&mut tx, output_amt, utxos, signer, 1)?;
+        self.finalize_tx(&mut tx, output_amt, DUST_UTXO_LIMIT, utxos, signer, 1)?;
 
         increment_btc_ops_sent_counter();
 

--- a/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
+++ b/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
@@ -752,7 +752,7 @@ impl BitcoinRegtestController {
         let value_per_transfer = payload.burn_fee / number_of_transfers;
         if value_per_transfer < DUST_UTXO_LIMIT {
             warn!("Unable to submit a LeaderBlockCommit, consider increasing your burn_fee_cap");
-            return None
+            return None;
         }
 
         let btc_miner_fee = self.config.burnchain.block_commit_tx_estimated_size

--- a/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
+++ b/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
@@ -752,8 +752,7 @@ impl BitcoinRegtestController {
         let value_per_transfer = payload.burn_fee / number_of_transfers;
 
         let btc_miner_fee = self.config.burnchain.block_commit_tx_estimated_size
-            * self.config.burnchain.satoshis_per_byte
-            * attempt;
+            * self.config.burnchain.satoshis_per_byte;
 
         let rbf_fee = (attempt.saturating_sub(1) * self.last_tx_len * self.min_relay_fee) / 1000;
         let budget_for_outputs = value_per_transfer * number_of_transfers + sunset_fee;

--- a/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
+++ b/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
@@ -689,7 +689,7 @@ impl BitcoinRegtestController {
     ) -> Option<Transaction> {
         let public_key = signer.get_public_key();
 
-        let output_amt = 2 * (self.config.burnchain.burnchain_op_tx_fee + DUST_UTXO_LIMIT);
+        let output_amt = 2 * (self.config.burnchain.satoshis_per_pox_output + DUST_UTXO_LIMIT);
         let (mut tx, utxos) = self.prepare_tx(&public_key, output_amt, 1)?;
 
         // Serialize the payload
@@ -836,10 +836,6 @@ impl BitcoinRegtestController {
         // spend UTXOs in decreasing order
         utxos.sort_by(|u1, u2| u1.amount.cmp(&u2.amount));
         utxos.reverse();
-
-        // RBF
-        let tx_fee = self.config.burnchain.burnchain_op_tx_fee
-            + ((attempt.saturating_sub(1) * self.last_tx_len * self.min_relay_fee) / 1000);
 
         let public_key = signer.get_public_key();
         let mut total_consumed = 0;

--- a/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
+++ b/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
@@ -743,14 +743,7 @@ impl BitcoinRegtestController {
         };
 
         let number_of_transfers = payload.commit_outs.len() as u64;
-        let value_per_transfer = {
-            let minimum_per_transfer =
-                cmp::max(payload.burn_fee / number_of_transfers, DUST_UTXO_LIMIT);
-            cmp::max(
-                minimum_per_transfer,
-                self.config.burnchain.satoshis_per_block_commit_output,
-            )
-        };
+        let value_per_transfer = payload.burn_fee / number_of_transfers;
 
         let btc_miner_fee = self.config.burnchain.block_commit_tx_estimated_size
             * self.config.burnchain.satoshis_per_byte

--- a/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
+++ b/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
@@ -525,7 +525,8 @@ impl BitcoinRegtestController {
     ) -> Option<Transaction> {
         let public_key = signer.get_public_key();
 
-        let btc_miner_fee = self.config.burnchain.leader_key_tx_estimated_size * self.config.burnchain.satoshis_per_byte;
+        let btc_miner_fee = self.config.burnchain.leader_key_tx_estimated_size
+            * self.config.burnchain.satoshis_per_byte;
         let budget_for_outputs = DUST_UTXO_LIMIT;
         let total_required = btc_miner_fee + budget_for_outputs;
 
@@ -557,7 +558,14 @@ impl BitcoinRegtestController {
 
         tx.output.push(identifier_output);
 
-        self.finalize_tx(&mut tx, budget_for_outputs, btc_miner_fee, utxos, signer, attempt)?;
+        self.finalize_tx(
+            &mut tx,
+            budget_for_outputs,
+            btc_miner_fee,
+            utxos,
+            signer,
+            attempt,
+        )?;
 
         increment_btc_ops_sent_counter();
 
@@ -736,11 +744,17 @@ impl BitcoinRegtestController {
 
         let number_of_transfers = payload.commit_outs.len() as u64;
         let value_per_transfer = {
-            let minimum_per_transfer = cmp::max(payload.burn_fee / number_of_transfers, DUST_UTXO_LIMIT);
-            cmp::max(minimum_per_transfer, self.config.burnchain.satoshis_per_block_commit_output)
+            let minimum_per_transfer =
+                cmp::max(payload.burn_fee / number_of_transfers, DUST_UTXO_LIMIT);
+            cmp::max(
+                minimum_per_transfer,
+                self.config.burnchain.satoshis_per_block_commit_output,
+            )
         };
 
-        let btc_miner_fee = self.config.burnchain.block_commit_tx_estimated_size * self.config.burnchain.satoshis_per_byte * attempt;
+        let btc_miner_fee = self.config.burnchain.block_commit_tx_estimated_size
+            * self.config.burnchain.satoshis_per_byte
+            * attempt;
         let rbf_fee = btc_miner_fee * attempt.saturating_sub(1);
         let budget_for_outputs = value_per_transfer * number_of_transfers + sunset_fee;
 
@@ -800,7 +814,6 @@ impl BitcoinRegtestController {
         total_required: u64,
         attempt: u64,
     ) -> Option<(Transaction, Vec<UTXO>)> {
-
         let utxos = if attempt > 1 && self.last_utxos.len() > 0 {
             // in RBF, you have to consume the same UTXOs
             self.last_utxos.clone()
@@ -860,8 +873,7 @@ impl BitcoinRegtestController {
         if total_consumed < total_to_spend {
             warn!(
                 "Consumed total {} is less than intended spend: {}",
-                total_consumed,
-                total_to_spend
+                total_consumed, total_to_spend
             );
             return None;
         }

--- a/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
+++ b/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
@@ -60,8 +60,6 @@ pub struct BitcoinRegtestController {
     use_coordinator: Option<CoordinatorChannels>,
     burnchain_config: Option<Burnchain>,
     last_utxos: Vec<UTXO>,
-    last_tx_len: u64,
-    min_relay_fee: u64, // satoshis/byte
 }
 
 const DUST_UTXO_LIMIT: u64 = 5500;
@@ -121,8 +119,6 @@ impl BitcoinRegtestController {
             chain_tip: None,
             burnchain_config,
             last_utxos: vec![],
-            last_tx_len: 0,
-            min_relay_fee: 1024, // TODO: learn from bitcoind
         }
     }
 
@@ -158,8 +154,6 @@ impl BitcoinRegtestController {
             chain_tip: None,
             burnchain_config: None,
             last_utxos: vec![],
-            last_tx_len: 0,
-            min_relay_fee: 1024, // TODO: learn from bitcoind
         }
     }
 
@@ -438,7 +432,7 @@ impl BitcoinRegtestController {
     pub fn get_utxos(
         &self,
         public_key: &Secp256k1PublicKey,
-        amount_required: u64,
+        total_required: u64,
     ) -> Option<Vec<UTXO>> {
         // Configure UTXO filter
         let pkh = Hash160::from_data(&public_key.to_bytes())
@@ -455,7 +449,7 @@ impl BitcoinRegtestController {
                 &self.config,
                 filter_addresses.clone(),
                 false,
-                amount_required,
+                total_required,
             );
 
             // Perform request
@@ -487,7 +481,7 @@ impl BitcoinRegtestController {
                     &self.config,
                     filter_addresses.clone(),
                     false,
-                    amount_required,
+                    total_required,
                 );
 
                 utxos = match result {
@@ -510,11 +504,11 @@ impl BitcoinRegtestController {
         };
 
         let total_unspent: u64 = utxos.iter().map(|o| o.amount).sum();
-        if total_unspent < amount_required {
+        if total_unspent < total_required {
             warn!(
                 "Total unspent {} < {} for {:?}",
                 total_unspent,
-                amount_required,
+                total_required,
                 &public_key.to_hex()
             );
             return None;
@@ -531,7 +525,11 @@ impl BitcoinRegtestController {
     ) -> Option<Transaction> {
         let public_key = signer.get_public_key();
 
-        let (mut tx, utxos) = self.prepare_tx(&public_key, DUST_UTXO_LIMIT, attempt)?;
+        let btc_miner_fee = self.config.burnchain.leader_key_tx_estimated_size * self.config.burnchain.satoshis_per_byte;
+        let budget_for_outputs = DUST_UTXO_LIMIT;
+        let total_required = btc_miner_fee + budget_for_outputs;
+
+        let (mut tx, utxos) = self.prepare_tx(&public_key, total_required, attempt)?;
 
         // Serialize the payload
         let op_bytes = {
@@ -559,7 +557,7 @@ impl BitcoinRegtestController {
 
         tx.output.push(identifier_output);
 
-        self.finalize_tx(&mut tx, DUST_UTXO_LIMIT, utxos, signer, attempt)?;
+        self.finalize_tx(&mut tx, budget_for_outputs, btc_miner_fee, utxos, signer, attempt)?;
 
         increment_btc_ops_sent_counter();
 
@@ -730,7 +728,25 @@ impl BitcoinRegtestController {
     ) -> Option<Transaction> {
         let public_key = signer.get_public_key();
 
-        let (mut tx, utxos) = self.prepare_tx(&public_key, payload.burn_fee, attempt)?;
+        let sunset_fee = if payload.sunset_burn > 0 {
+            cmp::max(payload.sunset_burn, DUST_UTXO_LIMIT)
+        } else {
+            0
+        };
+
+        let number_of_transfers = payload.commit_outs.len() as u64;
+        let value_per_transfer = {
+            let minimum_per_transfer = cmp::max(payload.burn_fee / number_of_transfers, DUST_UTXO_LIMIT);
+            cmp::max(minimum_per_transfer, self.config.burnchain.satoshis_per_block_commit_output)
+        };
+
+        let btc_miner_fee = self.config.burnchain.block_commit_tx_estimated_size * self.config.burnchain.satoshis_per_byte * attempt;
+        let rbf_fee = btc_miner_fee * attempt.saturating_sub(1);
+        let budget_for_outputs = value_per_transfer * number_of_transfers + sunset_fee;
+
+        let total_required = btc_miner_fee + budget_for_outputs + rbf_fee;
+
+        let (mut tx, utxos) = self.prepare_tx(&public_key, total_required, attempt)?;
 
         // Serialize the payload
         let op_bytes = {
@@ -743,14 +759,8 @@ impl BitcoinRegtestController {
             buffer
         };
 
-        let sunset_burn = if payload.sunset_burn > 0 {
-            cmp::max(payload.sunset_burn, DUST_UTXO_LIMIT)
-        } else {
-            0
-        };
-
         let consensus_output = TxOut {
-            value: sunset_burn,
+            value: sunset_fee,
             script_pubkey: Builder::new()
                 .push_opcode(opcodes::All::OP_RETURN)
                 .push_slice(&op_bytes)
@@ -759,11 +769,6 @@ impl BitcoinRegtestController {
 
         tx.output = vec![consensus_output];
 
-        let value_per_transfer = payload.burn_fee / (payload.commit_outs.len() as u64);
-        if value_per_transfer < DUST_UTXO_LIMIT {
-            error!("Total burn fee not enough for number of outputs");
-            return None;
-        }
         for commit_to in payload.commit_outs.iter() {
             tx.output
                 .push(commit_to.to_bitcoin_tx_out(value_per_transfer));
@@ -771,7 +776,8 @@ impl BitcoinRegtestController {
 
         self.finalize_tx(
             &mut tx,
-            payload.burn_fee + sunset_burn,
+            budget_for_outputs,
+            btc_miner_fee + rbf_fee,
             utxos,
             signer,
             attempt,
@@ -791,18 +797,16 @@ impl BitcoinRegtestController {
     fn prepare_tx(
         &mut self,
         public_key: &Secp256k1PublicKey,
-        ops_fee: u64,
+        total_required: u64,
         attempt: u64,
     ) -> Option<(Transaction, Vec<UTXO>)> {
-        let tx_fee = self.config.burnchain.burnchain_op_tx_fee;
-        let amount_required = tx_fee + ops_fee;
 
         let utxos = if attempt > 1 && self.last_utxos.len() > 0 {
             // in RBF, you have to consume the same UTXOs
             self.last_utxos.clone()
         } else {
             // Fetch some UTXOs
-            let new_utxos = match self.get_utxos(&public_key, amount_required) {
+            let new_utxos = match self.get_utxos(&public_key, total_required) {
                 Some(utxos) => utxos,
                 None => {
                     debug!("No UTXOs for {}", &public_key.to_hex());
@@ -810,7 +814,6 @@ impl BitcoinRegtestController {
                 }
             };
             self.last_utxos = new_utxos.clone();
-            self.last_tx_len = 0;
             new_utxos
         };
 
@@ -828,7 +831,8 @@ impl BitcoinRegtestController {
     fn finalize_tx(
         &mut self,
         tx: &mut Transaction,
-        total_spent: u64,
+        budget_for_outputs: u64,
+        btc_miner_fee: u64,
         mut utxos: Vec<UTXO>,
         signer: &mut BurnchainOpSigner,
         attempt: u64,
@@ -840,29 +844,32 @@ impl BitcoinRegtestController {
         let public_key = signer.get_public_key();
         let mut total_consumed = 0;
 
+        let total_to_spend = btc_miner_fee + budget_for_outputs;
+
         // select UTXOs until we have enough to cover the cost
         let mut utxos_consumed = vec![];
         for utxo in utxos.into_iter() {
             total_consumed += utxo.amount;
             utxos_consumed.push(utxo);
 
-            if total_consumed >= total_spent + tx_fee {
+            if total_consumed >= total_to_spend {
                 break;
             }
         }
 
-        // Append the change output
-        let change_address_hash = Hash160::from_data(&public_key.to_bytes());
-        if total_consumed < total_spent + tx_fee {
+        if total_consumed < total_to_spend {
             warn!(
                 "Consumed total {} is less than intended spend: {}",
                 total_consumed,
-                total_spent + tx_fee
+                total_to_spend
             );
             return None;
         }
-        let value = total_consumed - total_spent - tx_fee;
-        debug!("Payments value: {:?}, total_consumed: {:?}, total_spent: {:?}, tx_fee: {:?}, attempt: {:?}", value, total_consumed, total_spent, tx_fee, attempt);
+
+        // Append the change output
+        let change_address_hash = Hash160::from_data(&public_key.to_bytes());
+        let value = total_consumed - total_to_spend;
+        debug!("Payments value: {:?}, total_consumed: {:?}, total_spent: {:?}, tx_fee: {:?}, attempt: {:?}", value, total_consumed, total_to_spend, btc_miner_fee, attempt);
         if value >= DUST_UTXO_LIMIT {
             let change_output = BitcoinAddress::to_p2pkh_tx_out(&change_address_hash, value);
             tx.output.push(change_output);
@@ -908,8 +915,6 @@ impl BitcoinRegtestController {
         // remember how long the transaction is, in case we need to RBF
         let tx_bytes = SerializedTx::new(tx.clone());
         debug!("Send transaction: {:?}", tx_bytes.to_hex());
-
-        self.last_tx_len = tx_bytes.bytes.len() as u64;
 
         Some(())
     }

--- a/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
+++ b/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
@@ -695,7 +695,7 @@ impl BitcoinRegtestController {
     ) -> Option<Transaction> {
         let public_key = signer.get_public_key();
 
-        let output_amt = 2 * (self.config.burnchain.satoshis_per_pox_output + DUST_UTXO_LIMIT);
+        let output_amt = 2 * DUST_UTXO_LIMIT;
         let (mut tx, utxos) = self.prepare_tx(&public_key, output_amt, 1)?;
 
         // Serialize the payload

--- a/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
+++ b/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
@@ -658,7 +658,7 @@ impl BitcoinRegtestController {
         tx.output
             .push(payload.recipient.to_bitcoin_tx_out(DUST_UTXO_LIMIT));
 
-        self.finalize_tx(&mut tx, DUST_UTXO_LIMIT, utxos, signer, 1)?;
+        self.finalize_tx(&mut tx, DUST_UTXO_LIMIT, DUST_UTXO_LIMIT, utxos, signer, 1)?;
 
         increment_btc_ops_sent_counter();
 

--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -531,9 +531,9 @@ impl Config {
                         })
                         .unwrap_or(default_burnchain_config.magic_bytes),
                     local_mining_public_key: burnchain.local_mining_public_key,
-                    burnchain_op_tx_fee: burnchain
-                        .burnchain_op_tx_fee
-                        .unwrap_or(default_burnchain_config.burnchain_op_tx_fee),
+                    satoshis_per_block_commit_output: burnchain
+                        .satoshis_per_block_commit_output
+                        .unwrap_or(default_burnchain_config.satoshis_per_block_commit_output),
                     process_exit_at_block_height: burnchain.process_exit_at_block_height,
                     poll_time_secs: burnchain
                         .poll_time_secs
@@ -880,7 +880,7 @@ pub struct BurnchainConfig {
     pub spv_headers_path: String,
     pub magic_bytes: MagicBytes,
     pub local_mining_public_key: Option<String>,
-    pub burnchain_op_tx_fee: u64,
+    pub satoshis_per_block_commit_output: u64,
     pub process_exit_at_block_height: Option<u64>,
     pub poll_time_secs: u64,
 }
@@ -904,7 +904,7 @@ impl BurnchainConfig {
             spv_headers_path: "./spv-headers.dat".to_string(),
             magic_bytes: BLOCKSTACK_MAGIC_MAINNET.clone(),
             local_mining_public_key: None,
-            burnchain_op_tx_fee: MINIMUM_DUST_FEE,
+            satoshis_per_block_commit_output: MINIMUM_DUST_FEE,
             process_exit_at_block_height: None,
             poll_time_secs: 10, // TODO: this is a testnet specific value.
         }
@@ -954,7 +954,7 @@ pub struct BurnchainConfigFile {
     pub spv_headers_path: Option<String>,
     pub magic_bytes: Option<String>,
     pub local_mining_public_key: Option<String>,
-    pub burnchain_op_tx_fee: Option<u64>,
+    pub satoshis_per_block_commit_output: Option<u64>,
     pub process_exit_at_block_height: Option<u64>,
     pub poll_time_secs: Option<u64>,
 }

--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -538,6 +538,16 @@ impl Config {
                     poll_time_secs: burnchain
                         .poll_time_secs
                         .unwrap_or(default_burnchain_config.poll_time_secs),
+                    satoshis_per_byte: burnchain
+                        .satoshis_per_byte
+                        .unwrap_or(default_burnchain_config.satoshis_per_byte),
+                    leader_key_tx_estimated_size: burnchain
+                        .leader_key_tx_estimated_size
+                        .unwrap_or(default_burnchain_config.leader_key_tx_estimated_size),
+                    block_commit_tx_estimated_size: burnchain
+                        .block_commit_tx_estimated_size
+                        .unwrap_or(default_burnchain_config.block_commit_tx_estimated_size),
+
                 }
             }
             None => default_burnchain_config,
@@ -883,6 +893,9 @@ pub struct BurnchainConfig {
     pub satoshis_per_block_commit_output: u64,
     pub process_exit_at_block_height: Option<u64>,
     pub poll_time_secs: u64,
+    pub satoshis_per_byte: u64,
+    pub leader_key_tx_estimated_size: u64,
+    pub block_commit_tx_estimated_size: u64,
 }
 
 impl BurnchainConfig {
@@ -907,6 +920,9 @@ impl BurnchainConfig {
             satoshis_per_block_commit_output: MINIMUM_DUST_FEE,
             process_exit_at_block_height: None,
             poll_time_secs: 10, // TODO: this is a testnet specific value.
+            satoshis_per_byte: 50,
+            leader_key_tx_estimated_size: 290,
+            block_commit_tx_estimated_size: 350,        
         }
     }
 
@@ -957,6 +973,9 @@ pub struct BurnchainConfigFile {
     pub satoshis_per_block_commit_output: Option<u64>,
     pub process_exit_at_block_height: Option<u64>,
     pub poll_time_secs: Option<u64>,
+    pub satoshis_per_byte: Option<u64>,
+    pub leader_key_tx_estimated_size: Option<u64>,
+    pub block_commit_tx_estimated_size: Option<u64>,
 }
 
 #[derive(Clone, Debug, Default)]

--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -20,7 +20,9 @@ pub const TESTNET_PEER_VERSION: u32 = 0xfacade01;
 pub const MAINNET_CHAIN_ID: u32 = 0x00000001;
 pub const MAINNET_PEER_VERSION: u32 = 0x18000000;
 
-const MINIMUM_DUST_FEE: u64 = 5500;
+const DEFAULT_SATS_PER_VB: u64 = 50;
+const LEADER_KEY_TX_ESTIM_SIZE: u64 = 290;
+const BLOCK_COMMIT_TX_ESTIM_SIZE: u64 = 350;
 
 #[derive(Clone, Deserialize, Default)]
 pub struct ConfigFile {
@@ -531,9 +533,6 @@ impl Config {
                         })
                         .unwrap_or(default_burnchain_config.magic_bytes),
                     local_mining_public_key: burnchain.local_mining_public_key,
-                    satoshis_per_block_commit_output: burnchain
-                        .satoshis_per_block_commit_output
-                        .unwrap_or(default_burnchain_config.satoshis_per_block_commit_output),
                     process_exit_at_block_height: burnchain.process_exit_at_block_height,
                     poll_time_secs: burnchain
                         .poll_time_secs
@@ -889,7 +888,6 @@ pub struct BurnchainConfig {
     pub spv_headers_path: String,
     pub magic_bytes: MagicBytes,
     pub local_mining_public_key: Option<String>,
-    pub satoshis_per_block_commit_output: u64,
     pub process_exit_at_block_height: Option<u64>,
     pub poll_time_secs: u64,
     pub satoshis_per_byte: u64,
@@ -916,12 +914,11 @@ impl BurnchainConfig {
             spv_headers_path: "./spv-headers.dat".to_string(),
             magic_bytes: BLOCKSTACK_MAGIC_MAINNET.clone(),
             local_mining_public_key: None,
-            satoshis_per_block_commit_output: MINIMUM_DUST_FEE,
             process_exit_at_block_height: None,
             poll_time_secs: 10, // TODO: this is a testnet specific value.
-            satoshis_per_byte: 50,
-            leader_key_tx_estimated_size: 290,
-            block_commit_tx_estimated_size: 350,
+            satoshis_per_byte: DEFAULT_SATS_PER_VB,
+            leader_key_tx_estimated_size: LEADER_KEY_TX_ESTIM_SIZE,
+            block_commit_tx_estimated_size: BLOCK_COMMIT_TX_ESTIM_SIZE,
         }
     }
 
@@ -969,7 +966,6 @@ pub struct BurnchainConfigFile {
     pub spv_headers_path: Option<String>,
     pub magic_bytes: Option<String>,
     pub local_mining_public_key: Option<String>,
-    pub satoshis_per_block_commit_output: Option<u64>,
     pub process_exit_at_block_height: Option<u64>,
     pub poll_time_secs: Option<u64>,
     pub satoshis_per_byte: Option<u64>,

--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -547,7 +547,6 @@ impl Config {
                     block_commit_tx_estimated_size: burnchain
                         .block_commit_tx_estimated_size
                         .unwrap_or(default_burnchain_config.block_commit_tx_estimated_size),
-
                 }
             }
             None => default_burnchain_config,
@@ -922,7 +921,7 @@ impl BurnchainConfig {
             poll_time_secs: 10, // TODO: this is a testnet specific value.
             satoshis_per_byte: 50,
             leader_key_tx_estimated_size: 290,
-            block_commit_tx_estimated_size: 350,        
+            block_commit_tx_estimated_size: 350,
         }
     }
 


### PR DESCRIPTION
Motivated by the current surges on Mainnet, this PR is introducing 3 new settings:
- `satoshis_per_byte`
- `leader_key_tx_estimated_size`
- `block_commit_tx_estimated_size`

And getting rid of `burnchain_op_tx_fee`.

The current default is 50 sats/bytes, it's been tested on Testnet for a [key registration](https://mempool.space/testnet/tx/2f4e3187b3b8bf9d7aafc8e618159f19e2616d667e5bf684d242600144563fa7) and a [block commit](https://mempool.space/testnet/tx/36292112c685da83a0066b8b9aaf4177a10964dfd31204d3003a6d536f17b1dc). 
I took some time to refactor the logic for satoshis allocation, which will squash a few bugs with the UTXOs filtering (minimum amount was incorrect).

I see a TODO about RBF, any action we should take here?