### PR TITLE
Fix key registration spanning over multiple blocks

### DIFF
--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -957,7 +957,7 @@ fn spawn_miner_relayer(
 }
 
 enum LeaderKeyRegistrationState {
-    None,
+    Inactive,
     Pending,
     Active(RegisteredKey),
 }
@@ -1128,7 +1128,7 @@ impl InitializedNeonNode {
             is_miner,
             sleep_before_tenure,
             atlas_config,
-            leader_key_registration_state: LeaderKeyRegistrationState::None,
+            leader_key_registration_state: LeaderKeyRegistrationState::Inactive,
         }
     }
 
@@ -1150,7 +1150,7 @@ impl InitializedNeonNode {
                         .send(RelayerDirective::RunTenure(key.clone(), burnchain_tip))
                         .is_ok()
                 }
-                LeaderKeyRegistrationState::None => {
+                LeaderKeyRegistrationState::Inactive => {
                     warn!("Skipped tenure because no active VRF key. Trying to register one.");
                     self.leader_key_registration_state = LeaderKeyRegistrationState::Pending;
                     self.relay_channel

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -1149,14 +1149,14 @@ impl InitializedNeonNode {
                     self.relay_channel
                         .send(RelayerDirective::RunTenure(key.clone(), burnchain_tip))
                         .is_ok()
-                },
+                }
                 LeaderKeyRegistrationState::None => {
                     warn!("Skipped tenure because no active VRF key. Trying to register one.");
                     self.leader_key_registration_state = LeaderKeyRegistrationState::Pending;
                     self.relay_channel
                         .send(RelayerDirective::RegisterKey(burnchain_tip))
-                        .is_ok() 
-                },
+                        .is_ok()
+                }
                 LeaderKeyRegistrationState::Pending => true,
             }
         } else {
@@ -1699,14 +1699,14 @@ impl InitializedNeonNode {
                 if !ibd {
                     // not in initial block download, so we're not just replaying an old key.
                     // Registered key has been mined
-                    if let LeaderKeyRegistrationState::Pending = self.leader_key_registration_state {
-                        self.leader_key_registration_state = LeaderKeyRegistrationState::Active(
-                            RegisteredKey {
+                    if let LeaderKeyRegistrationState::Pending = self.leader_key_registration_state
+                    {
+                        self.leader_key_registration_state =
+                            LeaderKeyRegistrationState::Active(RegisteredKey {
                                 vrf_public_key: op.public_key,
                                 block_height: op.block_height as u64,
                                 op_vtxindex: op.vtxindex as u32,
-                            }
-                        );
+                            });
                     }
                 }
             }

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -90,10 +90,10 @@ pub struct InitializedNeonNode {
     relay_channel: SyncSender<RelayerDirective>,
     burnchain_signer: BurnchainSigner,
     last_burn_block: Option<BlockSnapshot>,
-    active_keys: Vec<RegisteredKey>,
     sleep_before_tenure: u64,
     is_miner: bool,
     pub atlas_config: AtlasConfig,
+    leader_key_registration_state: LeaderKeyRegistrationState,
 }
 
 pub struct NeonGenesisNode {
@@ -745,8 +745,6 @@ fn spawn_miner_relayer(
     let mut last_microblock_tenure_time = 0;
 
     let _relayer_handle = thread::Builder::new().name("relayer".to_string()).spawn(move || {
-        let mut did_register_key = false;
-        let mut key_registered_at_block = 0;
         while let Ok(mut directive) = relay_channel.recv() {
             match directive {
                 RelayerDirective::HandleNetResult(ref mut net_result) => {
@@ -915,20 +913,12 @@ fn spawn_miner_relayer(
                     last_mined_blocks.insert(burn_header_hash, last_mined_blocks_vec);
                 }
                 RelayerDirective::RegisterKey(ref last_burn_block) => {
-                    // Ensure that we're submitting this one time per block.
-                    if did_register_key && key_registered_at_block == last_burn_block.block_height {
-                        debug!("Relayer: Received RegisterKey directive - ignoring");
-                        continue;
-                    }
-                    did_register_key = rotate_vrf_and_register(
+                    rotate_vrf_and_register(
                         is_mainnet,
                         &mut keychain,
                         last_burn_block,
                         &mut bitcoin_controller,
                     );
-                    if did_register_key {
-                        key_registered_at_block = last_burn_block.block_height;
-                    }
                     bump_processed_counter(&blocks_processed);
                 }
                 RelayerDirective::RunMicroblockTenure => {
@@ -964,6 +954,12 @@ fn spawn_miner_relayer(
     }).unwrap();
 
     Ok(())
+}
+
+enum LeaderKeyRegistrationState {
+    None,
+    Pending,
+    Active(RegisteredKey),
 }
 
 impl InitializedNeonNode {
@@ -1123,7 +1119,6 @@ impl InitializedNeonNode {
 
         let is_miner = miner;
 
-        let active_keys = vec![];
         let atlas_config = AtlasConfig::default();
         InitializedNeonNode {
             config: config.clone(),
@@ -1132,8 +1127,8 @@ impl InitializedNeonNode {
             burnchain_signer,
             is_miner,
             sleep_before_tenure,
-            active_keys,
             atlas_config,
+            leader_key_registration_state: LeaderKeyRegistrationState::None,
         }
     }
 
@@ -1145,19 +1140,24 @@ impl InitializedNeonNode {
         }
 
         if let Some(burnchain_tip) = self.last_burn_block.clone() {
-            if let Some(key) = self.active_keys.first() {
-                debug!("Using key {:?}", &key.vrf_public_key);
-                // sleep a little before building the anchor block, to give any broadcasted
-                //   microblocks time to propagate.
-                thread::sleep(std::time::Duration::from_millis(self.sleep_before_tenure));
-                self.relay_channel
-                    .send(RelayerDirective::RunTenure(key.clone(), burnchain_tip))
-                    .is_ok()
-            } else {
-                warn!("Skipped tenure because no active VRF key. Trying to register one.");
-                self.relay_channel
-                    .send(RelayerDirective::RegisterKey(burnchain_tip))
-                    .is_ok()
+            match self.leader_key_registration_state {
+                LeaderKeyRegistrationState::Active(ref key) => {
+                    debug!("Using key {:?}", &key.vrf_public_key);
+                    // sleep a little before building the anchor block, to give any broadcasted
+                    //   microblocks time to propagate.
+                    thread::sleep(std::time::Duration::from_millis(self.sleep_before_tenure));
+                    self.relay_channel
+                        .send(RelayerDirective::RunTenure(key.clone(), burnchain_tip))
+                        .is_ok()
+                },
+                LeaderKeyRegistrationState::None => {
+                    warn!("Skipped tenure because no active VRF key. Trying to register one.");
+                    self.leader_key_registration_state = LeaderKeyRegistrationState::Pending;
+                    self.relay_channel
+                        .send(RelayerDirective::RegisterKey(burnchain_tip))
+                        .is_ok() 
+                },
+                LeaderKeyRegistrationState::Pending => true,
             }
         } else {
             warn!("Do not know the last burn block. As a miner, this is bad.");
@@ -1699,11 +1699,15 @@ impl InitializedNeonNode {
                 if !ibd {
                     // not in initial block download, so we're not just replaying an old key.
                     // Registered key has been mined
-                    self.active_keys.push(RegisteredKey {
-                        vrf_public_key: op.public_key,
-                        block_height: op.block_height as u64,
-                        op_vtxindex: op.vtxindex as u32,
-                    });
+                    if let LeaderKeyRegistrationState::Pending = self.leader_key_registration_state {
+                        self.leader_key_registration_state = LeaderKeyRegistrationState::Active(
+                            RegisteredKey {
+                                vrf_public_key: op.public_key,
+                                block_height: op.block_height as u64,
+                                op_vtxindex: op.vtxindex as u32,
+                            }
+                        );
+                    }
                 }
             }
         }


### PR DESCRIPTION
This PR is improving a patch for a bug that I spotted a few months ago (https://github.com/blockstack/stacks-blockchain/commit/750687e86a98b5f0820b1a5c818266d68e6c1ebb).
The patch above was essentially inefficient when a key_register op is sitting in the mempool during multiple blocks.