### PR TITLE
fix: add get-name #2322

### DIFF
--- a/bns-test/package.json
+++ b/bns-test/package.json
@@ -28,8 +28,8 @@
     "/contracts"
   ],
   "dependencies": {
-    "@blockstack/clarity": "^0.3.0",
-    "@blockstack/clarity-native-bin": "^0.3.0",
+    "@blockstack/clarity": "^0.3.7",
+    "@blockstack/clarity-native-bin": "^0.3.7",
     "@types/ripemd160": "^2.0.0",
     "@types/sha.js": "^2.4.0",
     "ripemd160": "^2.0.2",

--- a/bns-test/src/bns-client.ts
+++ b/bns-test/src/bns-client.ts
@@ -328,13 +328,13 @@ export class BNSClient extends Client {
     return res;
   }
 
-    // (get-resolvable-name (owner principal)
-    async getResolvableName(owner: string): Promise<Receipt> {
+    // (resolve-principal (owner principal)
+    async resolvePrincipal(owner: string): Promise<Receipt> {
       const args = [`'${owner}`];
       const query = this.createQuery({
         atChaintip: true,
         method: {
-          name: "get-resolvable-name",
+          name: "resolve-principal",
           args: args
         }
       });

--- a/bns-test/src/bns-client.ts
+++ b/bns-test/src/bns-client.ts
@@ -314,20 +314,6 @@ export class BNSClient extends Client {
     return res;
   }
 
-  // (get-name (owner principal)
-  async getName(owner: string): Promise<Receipt> {
-    const args = [`'${owner}`];
-    const query = this.createQuery({
-      atChaintip: true,
-      method: {
-        name: "get-name",
-        args: args
-      }
-    });
-    const res = await this.submitQuery(query);
-    return res;
-  }
-
     // (resolve-principal (owner principal)
     async resolvePrincipal(owner: string): Promise<Receipt> {
       const args = [`'${owner}`];

--- a/bns-test/src/bns-client.ts
+++ b/bns-test/src/bns-client.ts
@@ -314,6 +314,34 @@ export class BNSClient extends Client {
     return res;
   }
 
+  // (get-name (owner principal)
+  async getName(owner: string): Promise<Receipt> {
+    const args = [`'${owner}`];
+    const query = this.createQuery({
+      atChaintip: true,
+      method: {
+        name: "get-name",
+        args: args
+      }
+    });
+    const res = await this.submitQuery(query);
+    return res;
+  }
+
+    // (get-resolvable-name (owner principal)
+    async getResolvableName(owner: string): Promise<Receipt> {
+      const args = [`'${owner}`];
+      const query = this.createQuery({
+        atChaintip: true,
+        method: {
+          name: "get-resolvable-name",
+          args: args
+        }
+      });
+      const res = await this.submitQuery(query);
+      return res;
+    }
+
   // (get-name-price (namespace (buff 20))
   //                      (name (buff 48))
   async getNamePrice(namespace: string,

--- a/bns-test/test/name_register.test.ts
+++ b/bns-test/test/name_register.test.ts
@@ -98,7 +98,13 @@ describe("BNS Test Suite - NAME_REGISTER", () => {
   it("should fail if no matching pre-order can be found", async () => {
     await mineBlocks(bns, 20);
 
-    var receipt = await bns.nameRegister(
+    var receipt = await bns.getName(cases[0].nameOwner)
+    expect(receipt.result).include('2013');
+
+    receipt = await bns.getResolvableName(cases[0].nameOwner)
+    expect(receipt.result).include('2013');
+
+    receipt = await bns.nameRegister(
       cases[0].namespace,
       "bob",
       cases[0].salt,
@@ -260,6 +266,12 @@ describe("BNS Test Suite - NAME_REGISTER", () => {
     expect(receipt.result).include('0x30303030');
     expect(receipt.success).eq(true);
 
+    receipt = await bns.getName(cases[0].nameOwner)
+    expect(receipt.result).include('0x626f62');
+
+    receipt = await bns.getResolvableName(cases[0].nameOwner)
+    expect(receipt.result).include('0x626f62');
+
     // should fail registering twice
     receipt = await bns.nameRegister(
       cases[0].namespace,
@@ -324,6 +336,12 @@ describe("BNS Test Suite - NAME_REGISTER", () => {
 
     // should succeed once 'bob.blockstack' is expired
     await mineBlocks(bns, cases[0].renewalRule + 5000);
+
+    receipt = await bns.getName(cases[0].nameOwner)
+    expect(receipt.result).include('0x626f62');
+
+    receipt = await bns.getResolvableName(cases[0].nameOwner)
+    expect(receipt.result).include('2008');
 
     receipt = await bns.namePreorder(
       cases[0].namespace,

--- a/bns-test/test/name_register.test.ts
+++ b/bns-test/test/name_register.test.ts
@@ -333,6 +333,7 @@ describe("BNS Test Suite - NAME_REGISTER", () => {
 
     receipt = await bns.resolvePrincipal(cases[0].nameOwner)
     expect(receipt.result).include('2008');
+    expect(receipt.result).include('0x626f62');
 
     receipt = await bns.namePreorder(
       cases[0].namespace,

--- a/bns-test/test/name_register.test.ts
+++ b/bns-test/test/name_register.test.ts
@@ -98,10 +98,7 @@ describe("BNS Test Suite - NAME_REGISTER", () => {
   it("should fail if no matching pre-order can be found", async () => {
     await mineBlocks(bns, 20);
 
-    var receipt = await bns.getName(cases[0].nameOwner)
-    expect(receipt.result).include('2013');
-
-    receipt = await bns.resolvePrincipal(cases[0].nameOwner)
+    var receipt = await bns.resolvePrincipal(cases[0].nameOwner)
     expect(receipt.result).include('2013');
 
     receipt = await bns.nameRegister(
@@ -266,9 +263,6 @@ describe("BNS Test Suite - NAME_REGISTER", () => {
     expect(receipt.result).include('0x30303030');
     expect(receipt.success).eq(true);
 
-    receipt = await bns.getName(cases[0].nameOwner)
-    expect(receipt.result).include('0x626f62');
-
     receipt = await bns.resolvePrincipal(cases[0].nameOwner)
     expect(receipt.result).include('0x626f62');
 
@@ -336,9 +330,6 @@ describe("BNS Test Suite - NAME_REGISTER", () => {
 
     // should succeed once 'bob.blockstack' is expired
     await mineBlocks(bns, cases[0].renewalRule + 5000);
-
-    receipt = await bns.getName(cases[0].nameOwner)
-    expect(receipt.result).include('0x626f62');
 
     receipt = await bns.resolvePrincipal(cases[0].nameOwner)
     expect(receipt.result).include('2008');

--- a/bns-test/test/name_register.test.ts
+++ b/bns-test/test/name_register.test.ts
@@ -101,7 +101,7 @@ describe("BNS Test Suite - NAME_REGISTER", () => {
     var receipt = await bns.getName(cases[0].nameOwner)
     expect(receipt.result).include('2013');
 
-    receipt = await bns.getResolvableName(cases[0].nameOwner)
+    receipt = await bns.resolvePrincipal(cases[0].nameOwner)
     expect(receipt.result).include('2013');
 
     receipt = await bns.nameRegister(
@@ -269,7 +269,7 @@ describe("BNS Test Suite - NAME_REGISTER", () => {
     receipt = await bns.getName(cases[0].nameOwner)
     expect(receipt.result).include('0x626f62');
 
-    receipt = await bns.getResolvableName(cases[0].nameOwner)
+    receipt = await bns.resolvePrincipal(cases[0].nameOwner)
     expect(receipt.result).include('0x626f62');
 
     // should fail registering twice
@@ -340,7 +340,7 @@ describe("BNS Test Suite - NAME_REGISTER", () => {
     receipt = await bns.getName(cases[0].nameOwner)
     expect(receipt.result).include('0x626f62');
 
-    receipt = await bns.getResolvableName(cases[0].nameOwner)
+    receipt = await bns.resolvePrincipal(cases[0].nameOwner)
     expect(receipt.result).include('2008');
 
     receipt = await bns.namePreorder(

--- a/src/chainstate/stacks/boot/bns.clar
+++ b/src/chainstate/stacks/boot/bns.clar
@@ -883,7 +883,7 @@
     name (ok name)
     (err ERR_NAME_NOT_FOUND)))
 
-(define-read-only (get-resolvable-name (owner principal))
+(define-read-only (resolve-principal (owner principal))
   (match (map-get? owner-name owner)
     name (match (name-resolve (get namespace name) (get name name))
       resolved-name (ok name)

--- a/src/chainstate/stacks/boot/bns.clar
+++ b/src/chainstate/stacks/boot/bns.clar
@@ -879,7 +879,9 @@
           (<= block-height (+ (+ lifetime lease-started-at) NAME_GRACE_PERIOD_DURATION)))))))
 
 (define-read-only (get-name (owner principal))
-  (ok (map-get? owner-name owner)))
+  (match (map-get? owner-name owner)
+    name (ok name)
+    (err ERR_NAME_NOT_FOUND)))
 
 (define-read-only (can-receive-name (owner principal))
   (let ((current-owned-name (map-get? owner-name owner)))

--- a/src/chainstate/stacks/boot/bns.clar
+++ b/src/chainstate/stacks/boot/bns.clar
@@ -882,8 +882,8 @@
   (match (map-get? owner-name owner)
     name (match (name-resolve (get namespace name) (get name name))
       resolved-name (ok name)
-      error (err error))
-    (err ERR_NAME_NOT_FOUND)))
+      error (err {code: error, name: (some name)}))
+    (err {code: ERR_NAME_NOT_FOUND, name: none})))
 
 (define-read-only (can-receive-name (owner principal))
   (let ((current-owned-name (map-get? owner-name owner)))

--- a/src/chainstate/stacks/boot/bns.clar
+++ b/src/chainstate/stacks/boot/bns.clar
@@ -878,6 +878,10 @@
           (> block-height (+ lifetime lease-started-at)) 
           (<= block-height (+ (+ lifetime lease-started-at) NAME_GRACE_PERIOD_DURATION)))))))
 
+(define-read-only (get-name (owner principal))
+  (ok (map-get? owner-name owner))
+)
+
 (define-read-only (can-receive-name (owner principal))
   (let ((current-owned-name (map-get? owner-name owner)))
     (if (is-none current-owned-name)

--- a/src/chainstate/stacks/boot/bns.clar
+++ b/src/chainstate/stacks/boot/bns.clar
@@ -878,11 +878,6 @@
           (> block-height (+ lifetime lease-started-at)) 
           (<= block-height (+ (+ lifetime lease-started-at) NAME_GRACE_PERIOD_DURATION)))))))
 
-(define-read-only (get-name (owner principal))
-  (match (map-get? owner-name owner)
-    name (ok name)
-    (err ERR_NAME_NOT_FOUND)))
-
 (define-read-only (resolve-principal (owner principal))
   (match (map-get? owner-name owner)
     name (match (name-resolve (get namespace name) (get name name))

--- a/src/chainstate/stacks/boot/bns.clar
+++ b/src/chainstate/stacks/boot/bns.clar
@@ -883,6 +883,13 @@
     name (ok name)
     (err ERR_NAME_NOT_FOUND)))
 
+(define-read-only (get-resolvable-name (owner principal))
+  (match (map-get? owner-name owner)
+    name (match (name-resolve (get namespace name) (get name name))
+      resolved-name (ok name)
+      error (err error))
+    (err ERR_NAME_NOT_FOUND)))
+
 (define-read-only (can-receive-name (owner principal))
   (let ((current-owned-name (map-get? owner-name owner)))
     (if (is-none current-owned-name)

--- a/src/chainstate/stacks/boot/bns.clar
+++ b/src/chainstate/stacks/boot/bns.clar
@@ -879,8 +879,7 @@
           (<= block-height (+ (+ lifetime lease-started-at) NAME_GRACE_PERIOD_DURATION)))))))
 
 (define-read-only (get-name (owner principal))
-  (ok (map-get? owner-name owner))
-)
+  (ok (map-get? owner-name owner)))
 
 (define-read-only (can-receive-name (owner principal))
   (let ((current-owned-name (map-get? owner-name owner)))

--- a/src/chainstate/stacks/db/mod.rs
+++ b/src/chainstate/stacks/db/mod.rs
@@ -2108,12 +2108,11 @@ pub mod test {
         // Just update the expected value
         assert_eq!(
             genesis_root_hash.to_string(),
-            "8b03c434921ffb9476a9ae93bfc6ebfd01e6e9778173676c320e9162a137b8f9"
+            "c8cfd391ad889c2afd563223ba10f02b2d046346d4d4c998ad32167f8d0072f3"
         );
     }
 
     #[test]
-    #[ignore]
     fn test_chainstate_full_genesis_consistency() {
         // Test root hash for the final chainstate data set
         // TODO(test): update the fields (first_burnchain_block_hash, first_burnchain_block_height, first_burnchain_block_timestamp)
@@ -2198,7 +2197,7 @@ pub mod test {
         // Just update the expected value
         assert_eq!(
             format!("{}", genesis_root_hash),
-            "a2fcaeb9fcc41d54e91062d9a69d76c301155fabf87e7139bdb1ca9b6e3d9705"
+            "01913a865d57a627cdc207de8fc7337eb2bebe5e1539f525a3c6a35a74d5f1de"
         );
     }
 }


### PR DESCRIPTION
## Description

As a contract developer I want to check properties of the user based on the username
This PR
* adds a method `get-name` that returns the username of a given principal
* fixes #2322 

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No

## Are documentation updates required?
- [ ] Link to documentation updates: https://github.com/blockstack/docs/pull/1024

## Testing information
No tests

## Checklist
- [x] Tag 1 of @lgalabru  or @agraebe 
