### PR TITLE
Fix: boot_contract_id with testnet address hard-coded

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,4 @@ net-test/mnt/bitcoin-*
 net-test/mnt/chainstate-*
 net-test/mnt/*.log
 net-test/mnt/archive/*
+*.log

--- a/benches/block_limits.rs
+++ b/benches/block_limits.rs
@@ -19,7 +19,10 @@ use blockstack_lib::{
         Value,
     },
 };
-use chainstate::{burn::VRFSeed, stacks::{StacksAddress, boot::boot_code_id}};
+use chainstate::{
+    burn::VRFSeed,
+    stacks::{boot::boot_code_id, StacksAddress},
+};
 
 use std::fs;
 use std::process;

--- a/benches/block_limits.rs
+++ b/benches/block_limits.rs
@@ -7,7 +7,7 @@ use blockstack_lib::{
     chainstate::{
         self,
         burn::BlockHeaderHash,
-        stacks::boot::STACKS_BOOT_POX_CONTRACT,
+        stacks::boot,
         stacks::{index::MarfTrieId, StacksBlockId},
     },
     vm::clarity::ClarityInstance,
@@ -19,7 +19,7 @@ use blockstack_lib::{
         Value,
     },
 };
-use chainstate::{burn::VRFSeed, stacks::StacksAddress};
+use chainstate::{burn::VRFSeed, stacks::{StacksAddress, boot::boot_code_id}};
 
 use std::fs;
 use std::process;
@@ -84,7 +84,7 @@ fn transfer_test(buildup_count: u32, scaling: u32, genesis_size: u32) -> Executi
     let start = Instant::now();
 
     let marf = setup_chain_state(genesis_size);
-    let mut clarity_instance = ClarityInstance::new(marf, ExecutionCost::max_value());
+    let mut clarity_instance = ClarityInstance::new(false, marf_kv, ExecutionCost::max_value());
     let blocks: Vec<_> = (0..(buildup_count + 1))
         .into_iter()
         .map(|i| StacksBlockId(as_hash(i)))
@@ -166,7 +166,7 @@ fn setup_chain_state(scaling: u32) -> MarfedKV {
 
     if fs::metadata(&pre_initialized_path).is_err() {
         let marf = MarfedKV::open(&pre_initialized_path, None).unwrap();
-        let mut clarity_instance = ClarityInstance::new(marf, ExecutionCost::max_value());
+        let mut clarity_instance = ClarityInstance::new(false, marf_kv, ExecutionCost::max_value());
         let mut conn = clarity_instance.begin_test_genesis_block(
             &StacksBlockId::sentinel(),
             &StacksBlockId(as_hash(0)),
@@ -209,7 +209,7 @@ fn test_via_raw_contract(
 
     let marf = setup_chain_state(genesis_size);
 
-    let mut clarity_instance = ClarityInstance::new(marf, ExecutionCost::max_value());
+    let mut clarity_instance = ClarityInstance::new(false, marf_kv, ExecutionCost::max_value());
     let blocks: Vec<_> = (0..(buildup_count + 1))
         .into_iter()
         .map(|i| StacksBlockId(as_hash(i)))
@@ -302,7 +302,7 @@ fn smart_contract_test(scaling: u32, buildup_count: u32, genesis_size: u32) -> E
 
     let marf = setup_chain_state(genesis_size);
 
-    let mut clarity_instance = ClarityInstance::new(marf, ExecutionCost::max_value());
+    let mut clarity_instance = ClarityInstance::new(false, marf_kv, ExecutionCost::max_value());
     let blocks: Vec<_> = (0..(buildup_count + 1))
         .into_iter()
         .map(|i| StacksBlockId(as_hash(i)))
@@ -388,7 +388,7 @@ fn stack_stx_test(buildup_count: u32, genesis_size: u32, scaling: u32) -> Execut
     let start = Instant::now();
     let marf = setup_chain_state(genesis_size);
 
-    let mut clarity_instance = ClarityInstance::new(marf, ExecutionCost::max_value());
+    let mut clarity_instance = ClarityInstance::new(false, marf_kv, ExecutionCost::max_value());
     let blocks: Vec<_> = (0..(buildup_count + 1))
         .into_iter()
         .map(|i| StacksBlockId(as_hash(i)))
@@ -460,7 +460,7 @@ fn stack_stx_test(buildup_count: u32, genesis_size: u32, scaling: u32) -> Execut
             let result = tx
                 .run_contract_call(
                     stacker,
-                    &*STACKS_BOOT_POX_CONTRACT,
+                    &*boot_code_id("pox", false),
                     "stack-stx",
                     &[
                         Value::UInt(stacker_balance),

--- a/benches/large_contract_bench.rs
+++ b/benches/large_contract_bench.rs
@@ -15,7 +15,7 @@ use criterion::Criterion;
 
 pub fn rollback_log_memory_test() {
     let marf = MarfedKV::temporary();
-    let mut clarity_instance = ClarityInstance::new(marf, ExecutionCost::max_value());
+    let mut clarity_instance = ClarityInstance::new(false, marf_kv, ExecutionCost::max_value());
     let EXPLODE_N = 100;
 
     let contract_identifier = QualifiedContractIdentifier::local("foo").unwrap();
@@ -59,7 +59,7 @@ pub fn rollback_log_memory_test() {
 
 pub fn ccall_memory_test() {
     let marf = MarfedKV::temporary();
-    let mut clarity_instance = ClarityInstance::new(marf, ExecutionCost::max_value());
+    let mut clarity_instance = ClarityInstance::new(false, marf_kv, ExecutionCost::max_value());
     let COUNT_PER_CONTRACT = 20;
     let CONTRACTS = 5;
 

--- a/src/chainstate/coordinator/mod.rs
+++ b/src/chainstate/coordinator/mod.rs
@@ -30,9 +30,7 @@ use chainstate::burn::{
     BlockHeaderHash, BlockSnapshot, ConsensusHash,
 };
 use chainstate::stacks::{
-    boot::{
-        boot_code_id,
-    },
+    boot::boot_code_id,
     db::{
         accounts::MinerReward, ChainStateBootData, ClarityTx, MinerRewardInfo, StacksChainState,
         StacksHeaderInfo,

--- a/src/chainstate/coordinator/mod.rs
+++ b/src/chainstate/coordinator/mod.rs
@@ -31,7 +31,7 @@ use chainstate::burn::{
 };
 use chainstate::stacks::{
     boot::{
-        boot_code_id, STACKS_BOOT_CODE_CONTRACT_ADDRESS, STACKS_BOOT_CODE_CONTRACT_ADDRESS_STR,
+        boot_code_id,
     },
     db::{
         accounts::MinerReward, ChainStateBootData, ClarityTx, MinerRewardInfo, StacksChainState,
@@ -351,7 +351,7 @@ impl<'a, T: BlockEventDispatcher, U: RewardSetProvider> ChainsCoordinator<'a, T,
             reward_set_provider,
             notifier: (),
             attachments_tx,
-            atlas_config: AtlasConfig::default(),
+            atlas_config: AtlasConfig::default(false),
         }
     }
 }

--- a/src/chainstate/coordinator/tests.rs
+++ b/src/chainstate/coordinator/tests.rs
@@ -255,11 +255,7 @@ pub fn setup_states(
         let mut boot_data = ChainStateBootData::new(&burnchain, initial_balances.clone(), None);
 
         let post_flight_callback = move |clarity_tx: &mut ClarityTx| {
-            let contract = QualifiedContractIdentifier::parse(&format!(
-                "{}.pox",
-                STACKS_BOOT_CODE_CONTRACT_ADDRESS_STR
-            ))
-            .expect("Failed to construct boot code contract address");
+            let contract = boot::boot_code_id("pox", false);
             let sender = PrincipalData::from(contract.clone());
 
             clarity_tx.connection().as_transaction(|conn| {
@@ -987,6 +983,7 @@ fn missed_block_commits() {
                 &StacksBlockId::new(&stacks_tip.0, &stacks_tip.1),
                 |conn| conn
                     .with_readonly_clarity_env(
+                        false,
                         PrincipalData::parse("SP3Q4A5WWZ80REGBN0ZXNE540ECJ9JZ4A765Q5K2Q").unwrap(),
                         LimitedCostTracker::new_free(),
                         |env| env.eval_raw("block-height")
@@ -1147,6 +1144,7 @@ fn test_simple_setup() {
                 &StacksBlockId::new(&stacks_tip.0, &stacks_tip.1),
                 |conn| conn
                     .with_readonly_clarity_env(
+                        false,
                         PrincipalData::parse("SP3Q4A5WWZ80REGBN0ZXNE540ECJ9JZ4A765Q5K2Q").unwrap(),
                         LimitedCostTracker::new_free(),
                         |env| env.eval_raw("block-height")
@@ -1444,6 +1442,7 @@ fn test_sortition_with_reward_set() {
                 &StacksBlockId::new(&stacks_tip.0, &stacks_tip.1),
                 |conn| conn
                     .with_readonly_clarity_env(
+                        false,
                         PrincipalData::parse("SP3Q4A5WWZ80REGBN0ZXNE540ECJ9JZ4A765Q5K2Q").unwrap(),
                         LimitedCostTracker::new_free(),
                         |env| env.eval_raw("block-height")
@@ -1676,6 +1675,7 @@ fn test_sortition_with_burner_reward_set() {
                 &StacksBlockId::new(&stacks_tip.0, &stacks_tip.1),
                 |conn| conn
                     .with_readonly_clarity_env(
+                        false,
                         PrincipalData::parse("SP3Q4A5WWZ80REGBN0ZXNE540ECJ9JZ4A765Q5K2Q").unwrap(),
                         LimitedCostTracker::new_free(),
                         |env| env.eval_raw("block-height")
@@ -1936,6 +1936,7 @@ fn test_pox_btc_ops() {
                 &StacksBlockId::new(&stacks_tip.0, &stacks_tip.1),
                 |conn| conn
                     .with_readonly_clarity_env(
+                        false,
                         PrincipalData::parse("SP3Q4A5WWZ80REGBN0ZXNE540ECJ9JZ4A765Q5K2Q").unwrap(),
                         LimitedCostTracker::new_free(),
                         |env| env.eval_raw("block-height")
@@ -2232,6 +2233,7 @@ fn test_stx_transfer_btc_ops() {
                 &StacksBlockId::new(&stacks_tip.0, &stacks_tip.1),
                 |conn| conn
                     .with_readonly_clarity_env(
+                        false,
                         PrincipalData::parse("SP3Q4A5WWZ80REGBN0ZXNE540ECJ9JZ4A765Q5K2Q").unwrap(),
                         LimitedCostTracker::new_free(),
                         |env| env.eval_raw("block-height")
@@ -2457,6 +2459,7 @@ fn test_initial_coinbase_reward_distributions() {
                 &StacksBlockId::new(&stacks_tip.0, &stacks_tip.1),
                 |conn| conn
                     .with_readonly_clarity_env(
+                        false,
                         PrincipalData::parse("SP3Q4A5WWZ80REGBN0ZXNE540ECJ9JZ4A765Q5K2Q").unwrap(),
                         LimitedCostTracker::new_free(),
                         |env| env.eval_raw("block-height")
@@ -2720,6 +2723,7 @@ fn test_sortition_with_sunset() {
                 &StacksBlockId::new(&stacks_tip.0, &stacks_tip.1),
                 |conn| conn
                     .with_readonly_clarity_env(
+                        false,
                         PrincipalData::parse("SP3Q4A5WWZ80REGBN0ZXNE540ECJ9JZ4A765Q5K2Q").unwrap(),
                         LimitedCostTracker::new_free(),
                         |env| env.eval_raw("block-height")
@@ -3543,6 +3547,7 @@ fn eval_at_chain_tip(chainstate_path: &str, sort_db: &SortitionDB, eval: &str) -
             &StacksBlockId::new(&stacks_tip.0, &stacks_tip.1),
             |conn| {
                 conn.with_readonly_clarity_env(
+                    false,
                     PrincipalData::parse("SP3Q4A5WWZ80REGBN0ZXNE540ECJ9JZ4A765Q5K2Q").unwrap(),
                     LimitedCostTracker::new_free(),
                     |env| env.eval_raw(eval),

--- a/src/chainstate/stacks/boot/contract_tests.rs
+++ b/src/chainstate/stacks/boot/contract_tests.rs
@@ -60,7 +60,8 @@ lazy_static! {
         &FIRST_STACKS_BLOCK_HASH
     );
     static ref POX_CONTRACT_TESTNET: QualifiedContractIdentifier = boot_code_id("pox", false);
-    static ref COST_VOTING_CONTRACT_TESTNET: QualifiedContractIdentifier = boot_code_id("cost-voting", false);
+    static ref COST_VOTING_CONTRACT_TESTNET: QualifiedContractIdentifier =
+        boot_code_id("cost-voting", false);
     static ref USER_KEYS: Vec<StacksPrivateKey> =
         (0..50).map(|_| StacksPrivateKey::new()).collect();
     static ref POX_ADDRS: Vec<Value> = (0..50u64)

--- a/src/chainstate/stacks/boot/contract_tests.rs
+++ b/src/chainstate/stacks/boot/contract_tests.rs
@@ -15,7 +15,7 @@ use std::convert::TryInto;
 
 use burnchains::BurnchainHeaderHash;
 use chainstate::burn::{BlockHeaderHash, ConsensusHash, VRFSeed};
-use chainstate::stacks::boot::STACKS_BOOT_CODE_CONTRACT_ADDRESS_STR;
+use chainstate::stacks::boot::boot_code_id;
 use chainstate::stacks::db::{MinerPaymentSchedule, StacksHeaderInfo};
 use chainstate::stacks::index::proofs::TrieMerkleProof;
 use chainstate::stacks::index::MarfTrieId;
@@ -59,16 +59,8 @@ lazy_static! {
         &FIRST_BURNCHAIN_CONSENSUS_HASH,
         &FIRST_STACKS_BLOCK_HASH
     );
-    static ref POX_CONTRACT: QualifiedContractIdentifier = QualifiedContractIdentifier::parse(
-        &format!("{}.pox", STACKS_BOOT_CODE_CONTRACT_ADDRESS_STR)
-    )
-    .unwrap();
-    static ref COST_VOTING_CONTRACT: QualifiedContractIdentifier =
-        QualifiedContractIdentifier::parse(&format!(
-            "{}.cost-voting",
-            STACKS_BOOT_CODE_CONTRACT_ADDRESS_STR
-        ))
-        .unwrap();
+    static ref POX_CONTRACT_TESTNET: QualifiedContractIdentifier = boot_code_id("pox", false);
+    static ref COST_VOTING_CONTRACT_TESTNET: QualifiedContractIdentifier = boot_code_id("cost-voting", false);
     static ref USER_KEYS: Vec<StacksPrivateKey> =
         (0..50).map(|_| StacksPrivateKey::new()).collect();
     static ref POX_ADDRS: Vec<Value> = (0..50u64)
@@ -285,7 +277,7 @@ fn recency_tests() {
     let delegator = StacksPrivateKey::new();
 
     sim.execute_next_block(|env| {
-        env.initialize_contract(POX_CONTRACT.clone(), &BOOT_CODE_POX_TESTNET)
+        env.initialize_contract(POX_CONTRACT_TESTNET.clone(), &BOOT_CODE_POX_TESTNET)
             .unwrap()
     });
     sim.execute_next_block(|env| {
@@ -293,7 +285,7 @@ fn recency_tests() {
         assert_eq!(
             env.execute_transaction(
                 (&USER_KEYS[0]).into(),
-                POX_CONTRACT.clone(),
+                POX_CONTRACT_TESTNET.clone(),
                 "stack-stx",
                 &symbols_from_values(vec![
                     Value::UInt(USTX_PER_HOLDER),
@@ -312,7 +304,7 @@ fn recency_tests() {
         assert_eq!(
             env.execute_transaction(
                 (&USER_KEYS[0]).into(),
-                POX_CONTRACT.clone(),
+                POX_CONTRACT_TESTNET.clone(),
                 "delegate-stx",
                 &symbols_from_values(vec![
                     Value::UInt(2 * USTX_PER_HOLDER),
@@ -329,7 +321,7 @@ fn recency_tests() {
         assert_eq!(
             env.execute_transaction(
                 (&delegator).into(),
-                POX_CONTRACT.clone(),
+                POX_CONTRACT_TESTNET.clone(),
                 "delegate-stack-stx",
                 &symbols_from_values(vec![
                     (&USER_KEYS[0]).into(),
@@ -353,14 +345,14 @@ fn delegation_tests() {
     let delegator = StacksPrivateKey::new();
 
     sim.execute_next_block(|env| {
-        env.initialize_contract(POX_CONTRACT.clone(), &BOOT_CODE_POX_TESTNET)
+        env.initialize_contract(POX_CONTRACT_TESTNET.clone(), &BOOT_CODE_POX_TESTNET)
             .unwrap()
     });
     sim.execute_next_block(|env| {
         assert_eq!(
             env.execute_transaction(
                 (&USER_KEYS[0]).into(),
-                POX_CONTRACT.clone(),
+                POX_CONTRACT_TESTNET.clone(),
                 "delegate-stx",
                 &symbols_from_values(vec![
                     Value::UInt(2 * USTX_PER_HOLDER),
@@ -378,7 +370,7 @@ fn delegation_tests() {
         assert_eq!(
             env.execute_transaction(
                 (&USER_KEYS[0]).into(),
-                POX_CONTRACT.clone(),
+                POX_CONTRACT_TESTNET.clone(),
                 "delegate-stx",
                 &symbols_from_values(vec![
                     Value::UInt(USTX_PER_HOLDER),
@@ -395,7 +387,7 @@ fn delegation_tests() {
         assert_eq!(
             env.execute_transaction(
                 (&USER_KEYS[1]).into(),
-                POX_CONTRACT.clone(),
+                POX_CONTRACT_TESTNET.clone(),
                 "delegate-stx",
                 &symbols_from_values(vec![
                     Value::UInt(USTX_PER_HOLDER),
@@ -411,7 +403,7 @@ fn delegation_tests() {
         assert_eq!(
             env.execute_transaction(
                 (&USER_KEYS[2]).into(),
-                POX_CONTRACT.clone(),
+                POX_CONTRACT_TESTNET.clone(),
                 "delegate-stx",
                 &symbols_from_values(vec![
                     Value::UInt(USTX_PER_HOLDER),
@@ -428,7 +420,7 @@ fn delegation_tests() {
         assert_eq!(
             env.execute_transaction(
                 (&USER_KEYS[3]).into(),
-                POX_CONTRACT.clone(),
+                POX_CONTRACT_TESTNET.clone(),
                 "delegate-stx",
                 &symbols_from_values(vec![
                     Value::UInt(USTX_PER_HOLDER),
@@ -445,7 +437,7 @@ fn delegation_tests() {
         assert_eq!(
             env.execute_transaction(
                 (&USER_KEYS[4]).into(),
-                POX_CONTRACT.clone(),
+                POX_CONTRACT_TESTNET.clone(),
                 "delegate-stx",
                 &symbols_from_values(vec![
                     Value::UInt(USTX_PER_HOLDER),
@@ -466,7 +458,7 @@ fn delegation_tests() {
         assert_eq!(
             env.execute_transaction(
                 (&delegator).into(),
-                POX_CONTRACT.clone(),
+                POX_CONTRACT_TESTNET.clone(),
                 "delegate-stack-stx",
                 &symbols_from_values(vec![
                     (&USER_KEYS[0]).into(),
@@ -486,7 +478,7 @@ fn delegation_tests() {
         assert_eq!(
             env.execute_transaction(
                 (&delegator).into(),
-                POX_CONTRACT.clone(),
+                POX_CONTRACT_TESTNET.clone(),
                 "delegate-stack-stx",
                 &symbols_from_values(vec![
                     (&USER_KEYS[0]).into(),
@@ -506,7 +498,7 @@ fn delegation_tests() {
         assert_eq!(
             env.execute_transaction(
                 (&delegator).into(),
-                POX_CONTRACT.clone(),
+                POX_CONTRACT_TESTNET.clone(),
                 "delegate-stack-stx",
                 &symbols_from_values(vec![
                     (&USER_KEYS[0]).into(),
@@ -528,7 +520,7 @@ fn delegation_tests() {
 
         assert_eq!(
             env.eval_read_only(
-                &POX_CONTRACT,
+                &POX_CONTRACT_TESTNET,
                 &format!("(stx-get-balance '{})", &Value::from(&USER_KEYS[0]))
             )
             .unwrap()
@@ -540,7 +532,7 @@ fn delegation_tests() {
         assert_eq!(
             env.execute_transaction(
                 (&delegator).into(),
-                POX_CONTRACT.clone(),
+                POX_CONTRACT_TESTNET.clone(),
                 "stack-aggregation-commit",
                 &symbols_from_values(vec![POX_ADDRS[1].clone(), Value::UInt(1)])
             )
@@ -554,7 +546,7 @@ fn delegation_tests() {
         assert_eq!(
             env.execute_transaction(
                 (&delegator).into(),
-                POX_CONTRACT.clone(),
+                POX_CONTRACT_TESTNET.clone(),
                 "delegate-stack-stx",
                 &symbols_from_values(vec![
                     (&USER_KEYS[1]).into(),
@@ -574,7 +566,7 @@ fn delegation_tests() {
         assert_eq!(
             env.execute_transaction(
                 (&delegator).into(),
-                POX_CONTRACT.clone(),
+                POX_CONTRACT_TESTNET.clone(),
                 "delegate-stack-stx",
                 &symbols_from_values(vec![
                     (&USER_KEYS[0]).into(),
@@ -594,7 +586,7 @@ fn delegation_tests() {
         assert_eq!(
             env.execute_transaction(
                 (&delegator).into(),
-                POX_CONTRACT.clone(),
+                POX_CONTRACT_TESTNET.clone(),
                 "delegate-stack-stx",
                 &symbols_from_values(vec![
                     (&USER_KEYS[2]).into(),
@@ -614,7 +606,7 @@ fn delegation_tests() {
         assert_eq!(
             env.execute_transaction(
                 (&delegator).into(),
-                POX_CONTRACT.clone(),
+                POX_CONTRACT_TESTNET.clone(),
                 "delegate-stack-stx",
                 &symbols_from_values(vec![
                     (&USER_KEYS[2]).into(),
@@ -636,7 +628,7 @@ fn delegation_tests() {
 
         assert_eq!(
             env.eval_read_only(
-                &POX_CONTRACT,
+                &POX_CONTRACT_TESTNET,
                 &format!("(stx-get-balance '{})", &Value::from(&USER_KEYS[2]))
             )
             .unwrap()
@@ -646,7 +638,7 @@ fn delegation_tests() {
 
         assert_eq!(
             env.eval_read_only(
-                &POX_CONTRACT,
+                &POX_CONTRACT_TESTNET,
                 &format!("(stx-get-balance '{})", &Value::from(&USER_KEYS[0]))
             )
             .unwrap()
@@ -656,7 +648,7 @@ fn delegation_tests() {
 
         assert_eq!(
             env.eval_read_only(
-                &POX_CONTRACT,
+                &POX_CONTRACT_TESTNET,
                 &format!("(stx-get-balance '{})", &Value::from(&USER_KEYS[1]))
             )
             .unwrap()
@@ -668,7 +660,7 @@ fn delegation_tests() {
         assert_eq!(
             env.execute_transaction(
                 (&delegator).into(),
-                POX_CONTRACT.clone(),
+                POX_CONTRACT_TESTNET.clone(),
                 "stack-aggregation-commit",
                 &symbols_from_values(vec![POX_ADDRS[1].clone(), Value::UInt(1)])
             )
@@ -679,14 +671,14 @@ fn delegation_tests() {
         );
 
         assert_eq!(
-            env.eval_read_only(&POX_CONTRACT, "(get-reward-set-size u1)")
+            env.eval_read_only(&POX_CONTRACT_TESTNET, "(get-reward-set-size u1)")
                 .unwrap()
                 .0
                 .to_string(),
             "u1"
         );
         assert_eq!(
-            env.eval_read_only(&POX_CONTRACT, "(get-reward-set-pox-address u1 u0)")
+            env.eval_read_only(&POX_CONTRACT_TESTNET, "(get-reward-set-pox-address u1 u0)")
                 .unwrap()
                 .0,
             execute(&format!(
@@ -700,7 +692,7 @@ fn delegation_tests() {
         assert_eq!(
             env.execute_transaction(
                 (&delegator).into(),
-                POX_CONTRACT.clone(),
+                POX_CONTRACT_TESTNET.clone(),
                 "stack-aggregation-commit",
                 &symbols_from_values(vec![POX_ADDRS[1].clone(), Value::UInt(1)])
             )
@@ -718,7 +710,7 @@ fn delegation_tests() {
         assert_eq!(
             env.execute_transaction(
                 (&delegator).into(),
-                POX_CONTRACT.clone(),
+                POX_CONTRACT_TESTNET.clone(),
                 "delegate-stack-stx",
                 &symbols_from_values(vec![
                     (&USER_KEYS[3]).into(),
@@ -740,7 +732,7 @@ fn delegation_tests() {
 
         assert_eq!(
             env.eval_read_only(
-                &POX_CONTRACT,
+                &POX_CONTRACT_TESTNET,
                 &format!("(stx-get-balance '{})", &Value::from(&USER_KEYS[3]))
             )
             .unwrap()
@@ -752,7 +744,7 @@ fn delegation_tests() {
         assert_eq!(
             env.execute_transaction(
                 (&delegator).into(),
-                POX_CONTRACT.clone(),
+                POX_CONTRACT_TESTNET.clone(),
                 "stack-aggregation-commit",
                 &symbols_from_values(vec![POX_ADDRS[1].clone(), Value::UInt(2)])
             )
@@ -766,7 +758,7 @@ fn delegation_tests() {
         assert_eq!(
             env.execute_transaction(
                 (&delegator).into(),
-                POX_CONTRACT.clone(),
+                POX_CONTRACT_TESTNET.clone(),
                 "stack-aggregation-commit",
                 &symbols_from_values(vec![POX_ADDRS[1].clone(), Value::UInt(1)])
             )
@@ -779,14 +771,14 @@ fn delegation_tests() {
         // check reward sets for round 2 and round 1...
 
         assert_eq!(
-            env.eval_read_only(&POX_CONTRACT, "(get-reward-set-size u2)")
+            env.eval_read_only(&POX_CONTRACT_TESTNET, "(get-reward-set-size u2)")
                 .unwrap()
                 .0
                 .to_string(),
             "u1"
         );
         assert_eq!(
-            env.eval_read_only(&POX_CONTRACT, "(get-reward-set-pox-address u2 u0)")
+            env.eval_read_only(&POX_CONTRACT_TESTNET, "(get-reward-set-pox-address u2 u0)")
                 .unwrap()
                 .0,
             execute(&format!(
@@ -797,14 +789,14 @@ fn delegation_tests() {
         );
 
         assert_eq!(
-            env.eval_read_only(&POX_CONTRACT, "(get-reward-set-size u1)")
+            env.eval_read_only(&POX_CONTRACT_TESTNET, "(get-reward-set-size u1)")
                 .unwrap()
                 .0
                 .to_string(),
             "u2"
         );
         assert_eq!(
-            env.eval_read_only(&POX_CONTRACT, "(get-reward-set-pox-address u1 u0)")
+            env.eval_read_only(&POX_CONTRACT_TESTNET, "(get-reward-set-pox-address u1 u0)")
                 .unwrap()
                 .0,
             execute(&format!(
@@ -814,7 +806,7 @@ fn delegation_tests() {
             ))
         );
         assert_eq!(
-            env.eval_read_only(&POX_CONTRACT, "(get-reward-set-pox-address u1 u1)")
+            env.eval_read_only(&POX_CONTRACT_TESTNET, "(get-reward-set-pox-address u1 u1)")
                 .unwrap()
                 .0,
             execute(&format!(
@@ -829,7 +821,7 @@ fn delegation_tests() {
         assert_eq!(
             env.execute_transaction(
                 (&delegator).into(),
-                POX_CONTRACT.clone(),
+                POX_CONTRACT_TESTNET.clone(),
                 "delegate-stack-stx",
                 &symbols_from_values(vec![
                     (&USER_KEYS[1]).into(),
@@ -853,7 +845,7 @@ fn delegation_tests() {
         assert_eq!(
             env.execute_transaction(
                 (&USER_KEYS[4]).into(),
-                POX_CONTRACT.clone(),
+                POX_CONTRACT_TESTNET.clone(),
                 "revoke-delegate-stx",
                 &[]
             )
@@ -866,7 +858,7 @@ fn delegation_tests() {
         assert_eq!(
             env.execute_transaction(
                 (&USER_KEYS[4]).into(),
-                POX_CONTRACT.clone(),
+                POX_CONTRACT_TESTNET.clone(),
                 "revoke-delegate-stx",
                 &[]
             )
@@ -879,7 +871,7 @@ fn delegation_tests() {
         assert_eq!(
             env.execute_transaction(
                 (&delegator).into(),
-                POX_CONTRACT.clone(),
+                POX_CONTRACT_TESTNET.clone(),
                 "delegate-stack-stx",
                 &symbols_from_values(vec![
                     (&USER_KEYS[4]).into(),
@@ -902,14 +894,14 @@ fn test_vote_withdrawal() {
     let mut sim = ClarityTestSim::new();
 
     sim.execute_next_block(|env| {
-        env.initialize_contract(COST_VOTING_CONTRACT.clone(), &BOOT_CODE_COST_VOTING)
+        env.initialize_contract(COST_VOTING_CONTRACT_TESTNET.clone(), &BOOT_CODE_COST_VOTING)
             .unwrap();
 
         // Submit a proposal
         assert_eq!(
             env.execute_transaction(
                 (&USER_KEYS[0]).into(),
-                COST_VOTING_CONTRACT.clone(),
+                COST_VOTING_CONTRACT_TESTNET.clone(),
                 "submit-proposal",
                 &symbols_from_values(vec![
                     Value::Principal(
@@ -939,7 +931,7 @@ fn test_vote_withdrawal() {
         // Vote on the proposal
         env.execute_transaction(
             (&USER_KEYS[0]).into(),
-            COST_VOTING_CONTRACT.clone(),
+            COST_VOTING_CONTRACT_TESTNET.clone(),
             "vote-proposal",
             &symbols_from_values(vec![Value::UInt(0), Value::UInt(10)]),
         )
@@ -950,7 +942,7 @@ fn test_vote_withdrawal() {
         assert_eq!(
             env.execute_transaction(
                 (&USER_KEYS[0]).into(),
-                COST_VOTING_CONTRACT.clone(),
+                COST_VOTING_CONTRACT_TESTNET.clone(),
                 "get-proposal-votes",
                 &symbols_from_values(vec![Value::UInt(0)])
             )
@@ -964,7 +956,7 @@ fn test_vote_withdrawal() {
         // Vote again on the proposal
         env.execute_transaction(
             (&USER_KEYS[0]).into(),
-            COST_VOTING_CONTRACT.clone(),
+            COST_VOTING_CONTRACT_TESTNET.clone(),
             "vote-proposal",
             &symbols_from_values(vec![Value::UInt(0), Value::UInt(5)]),
         )
@@ -975,7 +967,7 @@ fn test_vote_withdrawal() {
         assert_eq!(
             env.execute_transaction(
                 (&USER_KEYS[0]).into(),
-                COST_VOTING_CONTRACT.clone(),
+                COST_VOTING_CONTRACT_TESTNET.clone(),
                 "get-proposal-votes",
                 &symbols_from_values(vec![Value::UInt(0)])
             )
@@ -990,7 +982,7 @@ fn test_vote_withdrawal() {
         assert_eq!(
             env.execute_transaction(
                 (&USER_KEYS[0]).into(),
-                COST_VOTING_CONTRACT.clone(),
+                COST_VOTING_CONTRACT_TESTNET.clone(),
                 "get-principal-votes",
                 &symbols_from_values(vec![
                     Value::Principal(StandardPrincipalData::from(&USER_KEYS[0]).into()),
@@ -1008,7 +1000,7 @@ fn test_vote_withdrawal() {
         assert_eq!(
             env.execute_transaction(
                 (&USER_KEYS[0]).into(),
-                COST_VOTING_CONTRACT.clone(),
+                COST_VOTING_CONTRACT_TESTNET.clone(),
                 "withdraw-votes",
                 &symbols_from_values(vec![Value::UInt(0), Value::UInt(20)]),
             )
@@ -1023,7 +1015,7 @@ fn test_vote_withdrawal() {
         // Withdraw votes
         env.execute_transaction(
             (&USER_KEYS[0]).into(),
-            COST_VOTING_CONTRACT.clone(),
+            COST_VOTING_CONTRACT_TESTNET.clone(),
             "withdraw-votes",
             &symbols_from_values(vec![Value::UInt(0), Value::UInt(5)]),
         )
@@ -1033,7 +1025,7 @@ fn test_vote_withdrawal() {
         assert_eq!(
             env.execute_transaction(
                 (&USER_KEYS[0]).into(),
-                COST_VOTING_CONTRACT.clone(),
+                COST_VOTING_CONTRACT_TESTNET.clone(),
                 "get-proposal-votes",
                 &symbols_from_values(vec![Value::UInt(0)])
             )
@@ -1054,7 +1046,7 @@ fn test_vote_withdrawal() {
         // Withdraw STX after proposal expires
         env.execute_transaction(
             (&USER_KEYS[0]).into(),
-            COST_VOTING_CONTRACT.clone(),
+            COST_VOTING_CONTRACT_TESTNET.clone(),
             "withdraw-votes",
             &symbols_from_values(vec![Value::UInt(0), Value::UInt(10)]),
         )
@@ -1065,7 +1057,7 @@ fn test_vote_withdrawal() {
         // Assert that stx balance is correct
         assert_eq!(
             env.eval_read_only(
-                &COST_VOTING_CONTRACT,
+                &COST_VOTING_CONTRACT_TESTNET,
                 &format!("(stx-get-balance '{})", &Value::from(&USER_KEYS[0]))
             )
             .unwrap()
@@ -1081,14 +1073,14 @@ fn test_vote_fail() {
 
     // Test voting in a proposal
     sim.execute_next_block(|env| {
-        env.initialize_contract(COST_VOTING_CONTRACT.clone(), &BOOT_CODE_COST_VOTING)
+        env.initialize_contract(COST_VOTING_CONTRACT_TESTNET.clone(), &BOOT_CODE_COST_VOTING)
             .unwrap();
 
         // Submit a proposal
         assert_eq!(
             env.execute_transaction(
                 (&USER_KEYS[0]).into(),
-                COST_VOTING_CONTRACT.clone(),
+                COST_VOTING_CONTRACT_TESTNET.clone(),
                 "submit-proposal",
                 &symbols_from_values(vec![
                     Value::Principal(
@@ -1119,7 +1111,7 @@ fn test_vote_fail() {
         assert_eq!(
             env.execute_transaction(
                 (&USER_KEYS[0]).into(),
-                COST_VOTING_CONTRACT.clone(),
+                COST_VOTING_CONTRACT_TESTNET.clone(),
                 "confirm-votes",
                 &symbols_from_values(vec![Value::UInt(0)])
             )
@@ -1135,7 +1127,7 @@ fn test_vote_fail() {
         assert_eq!(
             env.execute_transaction(
                 (&USER_KEYS[0]).into(),
-                COST_VOTING_CONTRACT.clone(),
+                COST_VOTING_CONTRACT_TESTNET.clone(),
                 "vote-proposal",
                 &symbols_from_values(vec![Value::UInt(0), Value::UInt(USTX_PER_HOLDER + 1)]),
             )
@@ -1151,7 +1143,7 @@ fn test_vote_fail() {
         for user in USER_KEYS.iter() {
             env.execute_transaction(
                 user.into(),
-                COST_VOTING_CONTRACT.clone(),
+                COST_VOTING_CONTRACT_TESTNET.clone(),
                 "vote-proposal",
                 &symbols_from_values(vec![Value::UInt(0), Value::UInt(USTX_PER_HOLDER)]),
             )
@@ -1163,7 +1155,7 @@ fn test_vote_fail() {
         assert_eq!(
             env.execute_transaction(
                 (&USER_KEYS[0]).into(),
-                COST_VOTING_CONTRACT.clone(),
+                COST_VOTING_CONTRACT_TESTNET.clone(),
                 "confirm-votes",
                 &symbols_from_values(vec![Value::UInt(0)])
             )
@@ -1179,7 +1171,7 @@ fn test_vote_fail() {
     sim.execute_next_block(|env| {
         env.execute_transaction(
             (&MINER_KEY.clone()).into(),
-            COST_VOTING_CONTRACT.clone(),
+            COST_VOTING_CONTRACT_TESTNET.clone(),
             "veto",
             &symbols_from_values(vec![Value::UInt(0)]),
         )
@@ -1188,7 +1180,7 @@ fn test_vote_fail() {
         assert_eq!(
             env.execute_transaction(
                 (&USER_KEYS[0]).into(),
-                COST_VOTING_CONTRACT.clone(),
+                COST_VOTING_CONTRACT_TESTNET.clone(),
                 "get-proposal-vetos",
                 &symbols_from_values(vec![Value::UInt(0)])
             )
@@ -1206,7 +1198,7 @@ fn test_vote_fail() {
         sim.execute_next_block(|env| {
             env.execute_transaction(
                 (&MINER_KEY.clone()).into(),
-                COST_VOTING_CONTRACT.clone(),
+                COST_VOTING_CONTRACT_TESTNET.clone(),
                 "veto",
                 &symbols_from_values(vec![Value::UInt(0)]),
             )
@@ -1216,7 +1208,7 @@ fn test_vote_fail() {
             assert_eq!(
                 env.execute_transaction(
                     (&MINER_KEY.clone()).into(),
-                    COST_VOTING_CONTRACT.clone(),
+                    COST_VOTING_CONTRACT_TESTNET.clone(),
                     "veto",
                     &symbols_from_values(vec![Value::UInt(0)])
                 )
@@ -1239,7 +1231,7 @@ fn test_vote_fail() {
         assert_eq!(
             env.execute_transaction(
                 (&USER_KEYS[0]).into(),
-                COST_VOTING_CONTRACT.clone(),
+                COST_VOTING_CONTRACT_TESTNET.clone(),
                 "confirm-miners",
                 &symbols_from_values(vec![Value::UInt(0)])
             )
@@ -1263,7 +1255,7 @@ fn test_vote_fail() {
         assert_eq!(
             env.execute_transaction(
                 (&USER_KEYS[0]).into(),
-                COST_VOTING_CONTRACT.clone(),
+                COST_VOTING_CONTRACT_TESTNET.clone(),
                 "confirm-miners",
                 &symbols_from_values(vec![Value::UInt(0)])
             )
@@ -1282,14 +1274,14 @@ fn test_vote_confirm() {
     let mut sim = ClarityTestSim::new();
 
     sim.execute_next_block(|env| {
-        env.initialize_contract(COST_VOTING_CONTRACT.clone(), &BOOT_CODE_COST_VOTING)
+        env.initialize_contract(COST_VOTING_CONTRACT_TESTNET.clone(), &BOOT_CODE_COST_VOTING)
             .unwrap();
 
         // Submit a proposal
         assert_eq!(
             env.execute_transaction(
                 (&USER_KEYS[0]).into(),
-                COST_VOTING_CONTRACT.clone(),
+                COST_VOTING_CONTRACT_TESTNET.clone(),
                 "submit-proposal",
                 &symbols_from_values(vec![
                     Value::Principal(
@@ -1320,7 +1312,7 @@ fn test_vote_confirm() {
         assert_eq!(
             env.execute_transaction(
                 (&USER_KEYS[0]).into(),
-                COST_VOTING_CONTRACT.clone(),
+                COST_VOTING_CONTRACT_TESTNET.clone(),
                 "confirm-votes",
                 &symbols_from_values(vec![Value::UInt(0)])
             )
@@ -1336,7 +1328,7 @@ fn test_vote_confirm() {
         for user in USER_KEYS.iter() {
             env.execute_transaction(
                 user.into(),
-                COST_VOTING_CONTRACT.clone(),
+                COST_VOTING_CONTRACT_TESTNET.clone(),
                 "vote-proposal",
                 &symbols_from_values(vec![Value::UInt(0), Value::UInt(USTX_PER_HOLDER)]),
             )
@@ -1348,7 +1340,7 @@ fn test_vote_confirm() {
         assert_eq!(
             env.execute_transaction(
                 (&USER_KEYS[0]).into(),
-                COST_VOTING_CONTRACT.clone(),
+                COST_VOTING_CONTRACT_TESTNET.clone(),
                 "confirm-votes",
                 &symbols_from_values(vec![Value::UInt(0)])
             )
@@ -1375,7 +1367,7 @@ fn test_vote_confirm() {
         assert_eq!(
             env.execute_transaction(
                 (&USER_KEYS[0]).into(),
-                COST_VOTING_CONTRACT.clone(),
+                COST_VOTING_CONTRACT_TESTNET.clone(),
                 "confirm-miners",
                 &symbols_from_values(vec![Value::UInt(0)])
             )
@@ -1395,7 +1387,7 @@ fn test_vote_too_many_confirms() {
 
     let MAX_CONFIRMATIONS_PER_BLOCK = 10;
     sim.execute_next_block(|env| {
-        env.initialize_contract(COST_VOTING_CONTRACT.clone(), &BOOT_CODE_COST_VOTING)
+        env.initialize_contract(COST_VOTING_CONTRACT_TESTNET.clone(), &BOOT_CODE_COST_VOTING)
             .unwrap();
 
         // Submit a proposal
@@ -1403,7 +1395,7 @@ fn test_vote_too_many_confirms() {
             assert_eq!(
                 env.execute_transaction(
                     (&USER_KEYS[0]).into(),
-                    COST_VOTING_CONTRACT.clone(),
+                    COST_VOTING_CONTRACT_TESTNET.clone(),
                     "submit-proposal",
                     &symbols_from_values(vec![
                         Value::Principal(
@@ -1437,7 +1429,7 @@ fn test_vote_too_many_confirms() {
                 assert_eq!(
                     env.execute_transaction(
                         user.into(),
-                        COST_VOTING_CONTRACT.clone(),
+                        COST_VOTING_CONTRACT_TESTNET.clone(),
                         "vote-proposal",
                         &symbols_from_values(vec![
                             Value::UInt(i as u128),
@@ -1454,7 +1446,7 @@ fn test_vote_too_many_confirms() {
             assert_eq!(
                 env.execute_transaction(
                     (&USER_KEYS[0]).into(),
-                    COST_VOTING_CONTRACT.clone(),
+                    COST_VOTING_CONTRACT_TESTNET.clone(),
                     "confirm-votes",
                     &symbols_from_values(vec![Value::UInt(i as u128)])
                 )
@@ -1467,7 +1459,7 @@ fn test_vote_too_many_confirms() {
             for user in USER_KEYS.iter() {
                 env.execute_transaction(
                     user.into(),
-                    COST_VOTING_CONTRACT.clone(),
+                    COST_VOTING_CONTRACT_TESTNET.clone(),
                     "withdraw-votes",
                     &symbols_from_values(vec![
                         Value::UInt(i as u128),
@@ -1495,7 +1487,7 @@ fn test_vote_too_many_confirms() {
             assert_eq!(
                 env.execute_transaction(
                     (&USER_KEYS[0]).into(),
-                    COST_VOTING_CONTRACT.clone(),
+                    COST_VOTING_CONTRACT_TESTNET.clone(),
                     "confirm-miners",
                     &symbols_from_values(vec![Value::UInt(i as u128)])
                 )
@@ -1509,7 +1501,7 @@ fn test_vote_too_many_confirms() {
         assert_eq!(
             env.execute_transaction(
                 (&USER_KEYS[0]).into(),
-                COST_VOTING_CONTRACT.clone(),
+                COST_VOTING_CONTRACT_TESTNET.clone(),
                 "confirm-miners",
                 &symbols_from_values(vec![Value::UInt(MAX_CONFIRMATIONS_PER_BLOCK)])
             )

--- a/src/chainstate/stacks/boot/mod.rs
+++ b/src/chainstate/stacks/boot/mod.rs
@@ -53,8 +53,6 @@ use std::cmp;
 use std::convert::TryFrom;
 use std::convert::TryInto;
 
-pub const STACKS_BOOT_CODE_CONTRACT_ADDRESS_STR: &'static str = "ST000000000000000000002AMW42H";
-
 const BOOT_CODE_POX_BODY: &'static str = std::include_str!("pox.clar");
 const BOOT_CODE_POX_TESTNET_CONSTS: &'static str = std::include_str!("pox-testnet.clar");
 const BOOT_CODE_POX_MAINNET_CONSTS: &'static str = std::include_str!("pox-mainnet.clar");
@@ -64,8 +62,6 @@ pub const BOOT_CODE_COST_VOTING: &'static str = std::include_str!("cost-voting.c
 const BOOT_CODE_BNS: &'static str = std::include_str!("bns.clar");
 
 lazy_static! {
-    pub static ref STACKS_BOOT_CODE_CONTRACT_ADDRESS: StacksAddress =
-        StacksAddress::from_string(STACKS_BOOT_CODE_CONTRACT_ADDRESS_STR).unwrap();
     static ref BOOT_CODE_POX_MAINNET: String =
         format!("{}\n{}", BOOT_CODE_POX_MAINNET_CONSTS, BOOT_CODE_POX_BODY);
     pub static ref BOOT_CODE_POX_TESTNET: String =
@@ -84,19 +80,21 @@ lazy_static! {
         ("cost-voting", BOOT_CODE_COST_VOTING),
         ("bns", &BOOT_CODE_BNS),
     ];
-    pub static ref STACKS_BOOT_POX_CONTRACT: QualifiedContractIdentifier = boot_code_id("pox");
-    pub static ref STACKS_BOOT_COST_CONTRACT: QualifiedContractIdentifier = boot_code_id("costs");
-    pub static ref STACKS_BOOT_COST_VOTE_CONTRACT: QualifiedContractIdentifier =
-        boot_code_id("cost-voting");
 }
 
-pub fn boot_code_addr() -> StacksAddress {
-    STACKS_BOOT_CODE_CONTRACT_ADDRESS.clone()
+#[cfg(test)]
+pub fn boot_code_test_addr() -> StacksAddress {
+    boot_code_addr(false)
 }
 
-pub fn boot_code_id(name: &str) -> QualifiedContractIdentifier {
+pub fn boot_code_addr(mainnet: bool) -> StacksAddress {
+    StacksAddress::burn_address(mainnet)
+}
+
+pub fn boot_code_id(name: &str, mainnet: bool) -> QualifiedContractIdentifier {
+    let addr = boot_code_addr(mainnet);
     QualifiedContractIdentifier::new(
-        StandardPrincipalData::from(boot_code_addr()),
+        addr.into(),
         ContractName::try_from(name.to_string()).unwrap(),
     )
 }
@@ -161,7 +159,7 @@ impl StacksChainState {
                 &stacks_block_id,
                 dbconn,
                 &iconn,
-                &boot_code_id(boot_contract_name),
+                &boot_code_id(boot_contract_name, self.mainnet),
                 code,
             )
             .map_err(Error::ClarityError)
@@ -602,7 +600,7 @@ pub mod test {
         let value = peer.chainstate().clarity_eval_read_only(
             &iconn,
             &stacks_block_id,
-            &boot_code_id(boot_contract),
+            &boot_code_id(boot_contract, false),
             expr,
         );
         peer.sortdb = Some(sortdb);
@@ -796,7 +794,7 @@ pub mod test {
         args: Vec<Value>,
     ) -> StacksTransaction {
         let payload =
-            TransactionPayload::new_contract_call(boot_code_addr(), "pox", function_name, args)
+            TransactionPayload::new_contract_call(boot_code_test_addr(), "pox", function_name, args)
                 .unwrap();
 
         make_tx(key, nonce, 0, payload)
@@ -923,7 +921,7 @@ pub mod test {
                 (ok true)
             ))
         )
-        ", boot_code_addr());
+        ", boot_code_test_addr());
         let contract_tx = make_bare_contract(key, nonce, 0, name, &contract);
         contract_tx
     }
@@ -1242,7 +1240,7 @@ pub mod test {
                 if tenure_id == 2 {
                     let alice_test_tx = make_bare_contract(&alice, 1, 0, "nested-stacker", &format!(
                         "(define-public (nested-stack-stx)
-                            (contract-call? '{}.pox stack-stx u5120000000000 (tuple (version 0x00) (hashbytes 0xffffffffffffffffffffffffffffffffffffffff)) burn-block-height u1))", STACKS_BOOT_CODE_CONTRACT_ADDRESS_STR));
+                            (contract-call? '{}.pox stack-stx u5120000000000 (tuple (version 0x00) (hashbytes 0xffffffffffffffffffffffffffffffffffffffff)) burn-block-height u1))", boot_code_test_addr()));
 
                     block_txs.push(alice_test_tx);
                 }
@@ -2420,7 +2418,7 @@ pub mod test {
                               (var-set test-result
                                        (match result ok_value -1 err_value err_value))
                               (var-set test-run true))
-                        ", STACKS_BOOT_CODE_CONTRACT_ADDRESS_STR));
+                        ", boot_code_test_addr().to_string()));
 
                     block_txs.push(bob_test_tx);
 
@@ -2434,7 +2432,7 @@ pub mod test {
                               (var-set test-result
                                        (match result ok_value -1 err_value err_value))
                               (var-set test-run true))
-                        ", STACKS_BOOT_CODE_CONTRACT_ADDRESS_STR));
+                        ", boot_code_test_addr().to_string()));
 
                     block_txs.push(alice_test_tx);
 
@@ -2448,7 +2446,7 @@ pub mod test {
                               (var-set test-result
                                        (match result ok_value -1 err_value err_value))
                               (var-set test-run true))
-                        ", STACKS_BOOT_CODE_CONTRACT_ADDRESS_STR));
+                        ", boot_code_test_addr().to_string()));
 
                     block_txs.push(charlie_test_tx);
                 }
@@ -3831,7 +3829,7 @@ pub mod test {
                              (var-set test-passed (is-eq
                                (err 17)
                                (print (contract-call? '{}.pox stack-stx u10240000000000 {{ version: 0x01, hashbytes: 0x1111111111111111111111111111111111111111 }} burn-block-height u1))))",
-                            boot_code_addr()));
+                               boot_code_test_addr()));
 
                     block_txs.push(charlie_stack);
 
@@ -3845,7 +3843,7 @@ pub mod test {
                              (var-set test-passed (is-eq
                                (err 3)
                                (print (contract-call? '{}.pox reject-pox))))",
-                            boot_code_addr()));
+                               boot_code_test_addr()));
 
                     block_txs.push(alice_reject);
 
@@ -3857,7 +3855,7 @@ pub mod test {
                              (var-set test-passed (is-eq
                                (err 17)
                                (print (contract-call? '{}.pox reject-pox))))",
-                            boot_code_addr()));
+                               boot_code_test_addr()));
 
                     block_txs.push(charlie_reject);
                 }

--- a/src/chainstate/stacks/boot/mod.rs
+++ b/src/chainstate/stacks/boot/mod.rs
@@ -793,9 +793,13 @@ pub mod test {
         function_name: &str,
         args: Vec<Value>,
     ) -> StacksTransaction {
-        let payload =
-            TransactionPayload::new_contract_call(boot_code_test_addr(), "pox", function_name, args)
-                .unwrap();
+        let payload = TransactionPayload::new_contract_call(
+            boot_code_test_addr(),
+            "pox",
+            function_name,
+            args,
+        )
+        .unwrap();
 
         make_tx(key, nonce, 0, payload)
     }

--- a/src/chainstate/stacks/db/blocks.rs
+++ b/src/chainstate/stacks/db/blocks.rs
@@ -3750,6 +3750,7 @@ impl StacksChainState {
         operations: Vec<StackStxOp>,
     ) -> Vec<StacksTransactionReceipt> {
         let mut all_receipts = vec![];
+        let mainnet = clarity_tx.config.mainnet;
         let mut cost_so_far = clarity_tx.cost_so_far();
         for stack_stx_op in operations.into_iter() {
             let StackStxOp {
@@ -3765,7 +3766,7 @@ impl StacksChainState {
             let result = clarity_tx.connection().as_transaction(|tx| {
                 tx.run_contract_call(
                     &sender.into(),
-                    &QualifiedContractIdentifier::boot_contract("pox"),
+                    &boot_code_id("pox", mainnet),
                     "stack-stx",
                     &[
                         Value::UInt(stacked_ustx),
@@ -3946,7 +3947,8 @@ impl StacksChainState {
     pub fn process_stx_unlocks<'a>(
         clarity_tx: &mut ClarityTx<'a>,
     ) -> Result<(u128, Vec<StacksTransactionEvent>), Error> {
-        let lockup_contract_id = boot::boot_code_id("lockup");
+        let mainnet = clarity_tx.config.mainnet;
+        let lockup_contract_id = boot::boot_code_id("lockup", mainnet);
         clarity_tx
             .connection()
             .as_transaction(|tx_connection| {

--- a/src/chainstate/stacks/db/mod.rs
+++ b/src/chainstate/stacks/db/mod.rs
@@ -850,7 +850,8 @@ impl StacksChainState {
             TransactionVersion::Testnet
         };
 
-        let boot_code_address = STACKS_BOOT_CODE_CONTRACT_ADDRESS.clone();
+        let boot_code_address = boot_code_addr(mainnet);
+
         let boot_code_auth = TransactionAuth::Standard(TransactionSpendingCondition::Singlesig(
             SinglesigSpendingCondition {
                 signer: boot_code_address.bytes.clone(),
@@ -886,8 +887,7 @@ impl StacksChainState {
             };
             for (boot_code_name, boot_code_contract) in boot_code.iter() {
                 debug!(
-                    "Instantiate boot code contract '{}.{}' ({} bytes)...",
-                    &STACKS_BOOT_CODE_CONTRACT_ADDRESS_STR,
+                    "Instantiate boot code contract '{}' ({} bytes)...",
                     boot_code_name,
                     boot_code_contract.len()
                 );
@@ -994,7 +994,7 @@ impl StacksChainState {
                         };
                     }
 
-                    let lockup_contract_id = boot_code_id("lockup");
+                    let lockup_contract_id = boot_code_id("lockup", mainnet);
                     clarity
                         .with_clarity_db(|db| {
                             for (block_height, schedule) in lockups_per_block.into_iter() {
@@ -1013,7 +1013,7 @@ impl StacksChainState {
                 }
 
                 // BNS Namespace
-                let bns_contract_id = boot_code_id("bns");
+                let bns_contract_id = boot_code_id("bns", mainnet);
                 if let Some(get_namespaces) = boot_data.get_bulk_initial_namespaces.take() {
                     info!("Initializing chain with namespaces");
                     clarity
@@ -1376,7 +1376,7 @@ impl StacksChainState {
         )
         .map_err(|e| Error::ClarityError(e.into()))?;
 
-        let clarity_state = ClarityInstance::new(vm_state, block_limit.clone());
+        let clarity_state = ClarityInstance::new(mainnet, vm_state, block_limit.clone());
 
         let mut chainstate = StacksChainState {
             mainnet: mainnet,
@@ -2016,7 +2016,7 @@ pub mod test {
 
         for (boot_contract_name, _) in STACKS_BOOT_CODE_TESTNET.iter() {
             let boot_contract_id = QualifiedContractIdentifier::new(
-                StandardPrincipalData::from(STACKS_BOOT_CODE_CONTRACT_ADDRESS.clone()),
+                boot_code_test_addr().into(),
                 ContractName::try_from(boot_contract_name.to_string()).unwrap(),
             );
             let contract_res =

--- a/src/chainstate/stacks/db/unconfirmed.rs
+++ b/src/chainstate/stacks/db/unconfirmed.rs
@@ -64,7 +64,7 @@ impl UnconfirmedState {
     fn new(chainstate: &StacksChainState, tip: StacksBlockId) -> Result<UnconfirmedState, Error> {
         let marf = MarfedKV::open_unconfirmed(&chainstate.clarity_state_index_root, None)?;
 
-        let clarity_instance = ClarityInstance::new(marf, chainstate.block_limit.clone());
+        let clarity_instance = ClarityInstance::new(chainstate.mainnet, marf, chainstate.block_limit.clone());
         let unconfirmed_tip = MARF::make_unconfirmed_chain_tip(&tip);
 
         Ok(UnconfirmedState {
@@ -90,7 +90,7 @@ impl UnconfirmedState {
     ) -> Result<UnconfirmedState, Error> {
         let marf = MarfedKV::open_unconfirmed(&chainstate.clarity_state_index_root, None)?;
 
-        let clarity_instance = ClarityInstance::new(marf, chainstate.block_limit.clone());
+        let clarity_instance = ClarityInstance::new(chainstate.mainnet, marf, chainstate.block_limit.clone());
         let unconfirmed_tip = MARF::make_unconfirmed_chain_tip(&tip);
 
         Ok(UnconfirmedState {

--- a/src/chainstate/stacks/db/unconfirmed.rs
+++ b/src/chainstate/stacks/db/unconfirmed.rs
@@ -64,7 +64,8 @@ impl UnconfirmedState {
     fn new(chainstate: &StacksChainState, tip: StacksBlockId) -> Result<UnconfirmedState, Error> {
         let marf = MarfedKV::open_unconfirmed(&chainstate.clarity_state_index_root, None)?;
 
-        let clarity_instance = ClarityInstance::new(chainstate.mainnet, marf, chainstate.block_limit.clone());
+        let clarity_instance =
+            ClarityInstance::new(chainstate.mainnet, marf, chainstate.block_limit.clone());
         let unconfirmed_tip = MARF::make_unconfirmed_chain_tip(&tip);
 
         Ok(UnconfirmedState {
@@ -90,7 +91,8 @@ impl UnconfirmedState {
     ) -> Result<UnconfirmedState, Error> {
         let marf = MarfedKV::open_unconfirmed(&chainstate.clarity_state_index_root, None)?;
 
-        let clarity_instance = ClarityInstance::new(chainstate.mainnet, marf, chainstate.block_limit.clone());
+        let clarity_instance =
+            ClarityInstance::new(chainstate.mainnet, marf, chainstate.block_limit.clone());
         let unconfirmed_tip = MARF::make_unconfirmed_chain_tip(&tip);
 
         Ok(UnconfirmedState {

--- a/src/clarity.rs
+++ b/src/clarity.rs
@@ -712,8 +712,11 @@ pub fn invoke_command(invoked_by: &str, args: &[String]) {
             let result = in_block(vm_filename, marf_kv, |mut marf| {
                 let result = {
                     let db = marf.as_clarity_db(&header_db, &NULL_BURN_STATE_DB);
-                    let mut vm_env =
-                        OwnedEnvironment::new_cost_limited(false, db, LimitedCostTracker::new_free());
+                    let mut vm_env = OwnedEnvironment::new_cost_limited(
+                        false,
+                        db,
+                        LimitedCostTracker::new_free(),
+                    );
                     vm_env
                         .get_exec_environment(None)
                         .eval_read_only(&evalInput.contract_identifier, &evalInput.content)
@@ -742,8 +745,11 @@ pub fn invoke_command(invoked_by: &str, args: &[String]) {
             let result = at_chaintip(vm_filename, marf_kv, |mut marf| {
                 let result = {
                     let db = marf.as_clarity_db(&header_db, &NULL_BURN_STATE_DB);
-                    let mut vm_env =
-                        OwnedEnvironment::new_cost_limited(false, db, LimitedCostTracker::new_free());
+                    let mut vm_env = OwnedEnvironment::new_cost_limited(
+                        false,
+                        db,
+                        LimitedCostTracker::new_free(),
+                    );
                     vm_env
                         .get_exec_environment(None)
                         .eval_read_only(&evalInput.contract_identifier, &evalInput.content)
@@ -792,8 +798,11 @@ pub fn invoke_command(invoked_by: &str, args: &[String]) {
             let result = at_block(chain_tip, marf_kv, |mut marf| {
                 let result = {
                     let db = marf.as_clarity_db(&header_db, &NULL_BURN_STATE_DB);
-                    let mut vm_env =
-                        OwnedEnvironment::new_cost_limited(false, db, LimitedCostTracker::new_free());
+                    let mut vm_env = OwnedEnvironment::new_cost_limited(
+                        false,
+                        db,
+                        LimitedCostTracker::new_free(),
+                    );
                     vm_env
                         .get_exec_environment(None)
                         .eval_read_only(&contract_identifier, &content)
@@ -933,8 +942,11 @@ pub fn invoke_command(invoked_by: &str, args: &[String]) {
             let result = in_block(vm_filename, marf_kv, |mut marf| {
                 let result = {
                     let db = marf.as_clarity_db(&header_db, &NULL_BURN_STATE_DB);
-                    let mut vm_env =
-                        OwnedEnvironment::new_cost_limited(false, db, LimitedCostTracker::new_free());
+                    let mut vm_env = OwnedEnvironment::new_cost_limited(
+                        false,
+                        db,
+                        LimitedCostTracker::new_free(),
+                    );
                     vm_env.execute_transaction(
                         Value::Principal(sender),
                         contract_identifier,

--- a/src/clarity.rs
+++ b/src/clarity.rs
@@ -600,6 +600,7 @@ pub fn invoke_command(invoked_by: &str, args: &[String]) {
         "repl" => {
             let mut marf = MemoryBackingStore::new();
             let mut vm_env = OwnedEnvironment::new_cost_limited(
+                false,
                 marf.as_clarity_db(),
                 LimitedCostTracker::new_free(),
             );
@@ -672,6 +673,7 @@ pub fn invoke_command(invoked_by: &str, args: &[String]) {
 
             let mut marf = MemoryBackingStore::new();
             let mut vm_env = OwnedEnvironment::new_cost_limited(
+                false,
                 marf.as_clarity_db(),
                 LimitedCostTracker::new_free(),
             );
@@ -711,7 +713,7 @@ pub fn invoke_command(invoked_by: &str, args: &[String]) {
                 let result = {
                     let db = marf.as_clarity_db(&header_db, &NULL_BURN_STATE_DB);
                     let mut vm_env =
-                        OwnedEnvironment::new_cost_limited(db, LimitedCostTracker::new_free());
+                        OwnedEnvironment::new_cost_limited(false, db, LimitedCostTracker::new_free());
                     vm_env
                         .get_exec_environment(None)
                         .eval_read_only(&evalInput.contract_identifier, &evalInput.content)
@@ -741,7 +743,7 @@ pub fn invoke_command(invoked_by: &str, args: &[String]) {
                 let result = {
                     let db = marf.as_clarity_db(&header_db, &NULL_BURN_STATE_DB);
                     let mut vm_env =
-                        OwnedEnvironment::new_cost_limited(db, LimitedCostTracker::new_free());
+                        OwnedEnvironment::new_cost_limited(false, db, LimitedCostTracker::new_free());
                     vm_env
                         .get_exec_environment(None)
                         .eval_read_only(&evalInput.contract_identifier, &evalInput.content)
@@ -791,7 +793,7 @@ pub fn invoke_command(invoked_by: &str, args: &[String]) {
                 let result = {
                     let db = marf.as_clarity_db(&header_db, &NULL_BURN_STATE_DB);
                     let mut vm_env =
-                        OwnedEnvironment::new_cost_limited(db, LimitedCostTracker::new_free());
+                        OwnedEnvironment::new_cost_limited(false, db, LimitedCostTracker::new_free());
                     vm_env
                         .get_exec_environment(None)
                         .eval_read_only(&contract_identifier, &content)
@@ -851,6 +853,7 @@ pub fn invoke_command(invoked_by: &str, args: &[String]) {
                         let result = {
                             let db = marf.as_clarity_db(&header_db, &NULL_BURN_STATE_DB);
                             let mut vm_env = OwnedEnvironment::new_cost_limited(
+                                false,
                                 db,
                                 LimitedCostTracker::new_free(),
                             );
@@ -931,7 +934,7 @@ pub fn invoke_command(invoked_by: &str, args: &[String]) {
                 let result = {
                     let db = marf.as_clarity_db(&header_db, &NULL_BURN_STATE_DB);
                     let mut vm_env =
-                        OwnedEnvironment::new_cost_limited(db, LimitedCostTracker::new_free());
+                        OwnedEnvironment::new_cost_limited(false, db, LimitedCostTracker::new_free());
                     vm_env.execute_transaction(
                         Value::Principal(sender),
                         contract_identifier,

--- a/src/net/atlas/mod.rs
+++ b/src/net/atlas/mod.rs
@@ -33,9 +33,9 @@ pub struct AtlasConfig {
 }
 
 impl AtlasConfig {
-    pub fn default() -> AtlasConfig {
+    pub fn default(mainnet: bool) -> AtlasConfig {
         let mut contracts = HashSet::new();
-        contracts.insert(boot_code_id("bns"));
+        contracts.insert(boot_code_id("bns", mainnet));
         AtlasConfig {
             contracts,
             attachments_max_size: 1_048_576,

--- a/src/net/atlas/tests.rs
+++ b/src/net/atlas/tests.rs
@@ -685,8 +685,8 @@ fn test_downloader_context_attachment_requests() {
 
 #[test]
 fn test_keep_uninstantiated_attachments() {
-    let bns_contract_id = boot_code_id("bns");
-    let pox_contract_id = boot_code_id("pox");
+    let bns_contract_id = boot_code_id("bns", false);
+    let pox_contract_id = boot_code_id("pox", false);
 
     let mut contracts = HashSet::new();
     contracts.insert(bns_contract_id.clone());

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -2291,13 +2291,13 @@ pub mod test {
             .unwrap();
 
             let atlasdb_path = format!("{}/atlas.db", &test_path);
-            let atlasdb = AtlasDB::connect(AtlasConfig::default(false), &atlasdb_path, true).unwrap();
+            let atlasdb =
+                AtlasDB::connect(AtlasConfig::default(false), &atlasdb_path, true).unwrap();
 
             let conf = config.clone();
             let post_flight_callback = move |clarity_tx: &mut ClarityTx| {
                 if conf.setup_code.len() > 0 {
                     clarity_tx.connection().as_transaction(|clarity| {
-                        
                         let boot_code_addr = boot_code_test_addr();
                         let boot_code_account = StacksAccount {
                             principal: boot_code_addr.to_account_principal(),

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -2291,27 +2291,23 @@ pub mod test {
             .unwrap();
 
             let atlasdb_path = format!("{}/atlas.db", &test_path);
-            let atlasdb = AtlasDB::connect(AtlasConfig::default(), &atlasdb_path, true).unwrap();
+            let atlasdb = AtlasDB::connect(AtlasConfig::default(false), &atlasdb_path, true).unwrap();
 
             let conf = config.clone();
             let post_flight_callback = move |clarity_tx: &mut ClarityTx| {
                 if conf.setup_code.len() > 0 {
                     clarity_tx.connection().as_transaction(|clarity| {
-                        let boot_code_address = StacksAddress::from_string(
-                            &STACKS_BOOT_CODE_CONTRACT_ADDRESS.to_string(),
-                        )
-                        .unwrap();
+                        
+                        let boot_code_addr = boot_code_test_addr();
                         let boot_code_account = StacksAccount {
-                            principal: PrincipalData::Standard(StandardPrincipalData::from(
-                                boot_code_address.clone(),
-                            )),
+                            principal: boot_code_addr.to_account_principal(),
                             nonce: 0,
                             stx_balance: STXBalance::zero(),
                         };
 
                         let boot_code_auth = TransactionAuth::Standard(
                             TransactionSpendingCondition::Singlesig(SinglesigSpendingCondition {
-                                signer: boot_code_address.bytes.clone(),
+                                signer: boot_code_addr.bytes.clone(),
                                 hash_mode: SinglesigHashMode::P2PKH,
                                 key_encoding: TransactionPublicKeyEncoding::Uncompressed,
                                 nonce: 0,
@@ -2322,7 +2318,7 @@ pub mod test {
 
                         debug!(
                             "Instantiate test-specific boot code contract '{}.{}' ({} bytes)...",
-                            &STACKS_BOOT_CODE_CONTRACT_ADDRESS.to_string(),
+                            &boot_code_addr.to_string(),
                             &conf.test_name,
                             conf.setup_code.len()
                         );

--- a/src/net/p2p.rs
+++ b/src/net/p2p.rs
@@ -4355,7 +4355,7 @@ mod test {
             initial_neighbors,
         )
         .unwrap();
-        let atlas_config = AtlasConfig::default();
+        let atlas_config = AtlasConfig::default(false);
         let atlasdb = AtlasDB::connect_memory(atlas_config).unwrap();
 
         let local_peer = PeerDB::get_local_peer(db.conn()).unwrap();

--- a/src/vm/analysis/tests/costs.rs
+++ b/src/vm/analysis/tests/costs.rs
@@ -40,7 +40,7 @@ use vm::tests::costs::get_simple_test;
 
 pub fn test_tracked_costs(prog: &str) -> ExecutionCost {
     let marf = MarfedKV::temporary();
-    let mut clarity_instance = ClarityInstance::new(marf, ExecutionCost::max_value());
+    let mut clarity_instance = ClarityInstance::new(false, marf, ExecutionCost::max_value());
 
     let p1 = execute("'SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR");
 

--- a/src/vm/ast/mod.rs
+++ b/src/vm/ast/mod.rs
@@ -91,7 +91,7 @@ mod tests {
         }
 
         let marf = MarfedKV::temporary();
-        let mut clarity_instance = ClarityInstance::new(marf, ExecutionCost::max_value());
+        let mut clarity_instance = ClarityInstance::new(false, marf, ExecutionCost::max_value());
 
         clarity_instance
             .begin_test_genesis_block(

--- a/src/vm/clarity.rs
+++ b/src/vm/clarity.rs
@@ -39,8 +39,8 @@ use chainstate::stacks::Error as ChainstateError;
 use chainstate::stacks::StacksBlockId;
 use chainstate::stacks::StacksMicroblockHeader;
 
-use chainstate::stacks::boot::{boot_code_id,
-    BOOT_CODE_COSTS, BOOT_CODE_COST_VOTING, BOOT_CODE_POX_TESTNET,
+use chainstate::stacks::boot::{
+    boot_code_id, BOOT_CODE_COSTS, BOOT_CODE_COST_VOTING, BOOT_CODE_POX_TESTNET,
 };
 
 use std::error;

--- a/src/vm/clarity.rs
+++ b/src/vm/clarity.rs
@@ -39,9 +39,8 @@ use chainstate::stacks::Error as ChainstateError;
 use chainstate::stacks::StacksBlockId;
 use chainstate::stacks::StacksMicroblockHeader;
 
-use chainstate::stacks::boot::{
-    BOOT_CODE_COSTS, BOOT_CODE_COST_VOTING, BOOT_CODE_POX_TESTNET, STACKS_BOOT_COST_CONTRACT,
-    STACKS_BOOT_COST_VOTE_CONTRACT, STACKS_BOOT_POX_CONTRACT,
+use chainstate::stacks::boot::{boot_code_id,
+    BOOT_CODE_COSTS, BOOT_CODE_COST_VOTING, BOOT_CODE_POX_TESTNET,
 };
 
 use std::error;
@@ -65,6 +64,7 @@ use super::database::marf::ReadOnlyMarfStore;
 pub struct ClarityInstance {
     datastore: MarfedKV,
     block_limit: ExecutionCost,
+    mainnet: bool,
 }
 
 ///
@@ -75,6 +75,7 @@ pub struct ClarityBlockConnection<'a> {
     header_db: &'a dyn HeadersDB,
     burn_state_db: &'a dyn BurnStateDB,
     cost_track: Option<LimitedCostTracker>,
+    mainnet: bool,
 }
 
 ///
@@ -88,6 +89,7 @@ pub struct ClarityTransactionConnection<'a, 'b> {
     header_db: &'a dyn HeadersDB,
     burn_state_db: &'a dyn BurnStateDB,
     cost_track: &'a mut Option<LimitedCostTracker>,
+    mainnet: bool,
 }
 
 pub struct ClarityReadOnlyConnection<'a> {
@@ -233,10 +235,11 @@ impl ClarityBlockConnection<'_> {
 }
 
 impl ClarityInstance {
-    pub fn new(datastore: MarfedKV, block_limit: ExecutionCost) -> ClarityInstance {
+    pub fn new(mainnet: bool, datastore: MarfedKV, block_limit: ExecutionCost) -> ClarityInstance {
         ClarityInstance {
             datastore,
             block_limit,
+            mainnet,
         }
     }
 
@@ -259,7 +262,7 @@ impl ClarityInstance {
         let cost_track = {
             let mut clarity_db = datastore.as_clarity_db(&NULL_HEADER_DB, &NULL_BURN_STATE_DB);
             Some(
-                LimitedCostTracker::new(self.block_limit.clone(), &mut clarity_db)
+                LimitedCostTracker::new(self.mainnet, self.block_limit.clone(), &mut clarity_db)
                     .expect("FAIL: problem instantiating cost tracking"),
             )
         };
@@ -269,6 +272,7 @@ impl ClarityInstance {
             header_db,
             burn_state_db,
             cost_track,
+            mainnet: self.mainnet,
         }
     }
 
@@ -288,6 +292,7 @@ impl ClarityInstance {
             header_db,
             burn_state_db,
             cost_track,
+            mainnet: self.mainnet,
         }
     }
 
@@ -309,15 +314,16 @@ impl ClarityInstance {
             header_db,
             burn_state_db,
             cost_track,
+            mainnet: false,
         };
 
         conn.as_transaction(|clarity_db| {
             let (ast, _) = clarity_db
-                .analyze_smart_contract(&*STACKS_BOOT_COST_CONTRACT, BOOT_CODE_COSTS)
+                .analyze_smart_contract(&boot_code_id("costs", false), BOOT_CODE_COSTS)
                 .unwrap();
             clarity_db
                 .initialize_smart_contract(
-                    &*STACKS_BOOT_COST_CONTRACT,
+                    &boot_code_id("costs", false),
                     &ast,
                     BOOT_CODE_COSTS,
                     |_, _| false,
@@ -327,11 +333,11 @@ impl ClarityInstance {
 
         conn.as_transaction(|clarity_db| {
             let (ast, _) = clarity_db
-                .analyze_smart_contract(&*STACKS_BOOT_COST_VOTE_CONTRACT, BOOT_CODE_COST_VOTING)
+                .analyze_smart_contract(&boot_code_id("cost-voting", false), BOOT_CODE_COST_VOTING)
                 .unwrap();
             clarity_db
                 .initialize_smart_contract(
-                    &*STACKS_BOOT_COST_VOTE_CONTRACT,
+                    &boot_code_id("cost-voting", false),
                     &ast,
                     BOOT_CODE_COST_VOTING,
                     |_, _| false,
@@ -341,11 +347,11 @@ impl ClarityInstance {
 
         conn.as_transaction(|clarity_db| {
             let (ast, _) = clarity_db
-                .analyze_smart_contract(&*STACKS_BOOT_POX_CONTRACT, &*BOOT_CODE_POX_TESTNET)
+                .analyze_smart_contract(&boot_code_id("pox", false), &*BOOT_CODE_POX_TESTNET)
                 .unwrap();
             clarity_db
                 .initialize_smart_contract(
-                    &*STACKS_BOOT_POX_CONTRACT,
+                    &boot_code_id("pox", false),
                     &ast,
                     &*BOOT_CODE_POX_TESTNET,
                     |_, _| false,
@@ -367,7 +373,7 @@ impl ClarityInstance {
         let cost_track = {
             let mut clarity_db = datastore.as_clarity_db(&NULL_HEADER_DB, &NULL_BURN_STATE_DB);
             Some(
-                LimitedCostTracker::new(self.block_limit.clone(), &mut clarity_db)
+                LimitedCostTracker::new(self.mainnet, self.block_limit.clone(), &mut clarity_db)
                     .expect("FAIL: problem instantiating cost tracking"),
             )
         };
@@ -377,6 +383,7 @@ impl ClarityInstance {
             header_db,
             burn_state_db,
             cost_track,
+            mainnet: self.mainnet,
         }
     }
 
@@ -415,7 +422,7 @@ impl ClarityInstance {
     ) -> Result<Value, Error> {
         let mut read_only_conn = self.datastore.begin_read_only(Some(at_block));
         let clarity_db = read_only_conn.as_clarity_db(header_db, burn_state_db);
-        let mut env = OwnedEnvironment::new_free(clarity_db);
+        let mut env = OwnedEnvironment::new_free(self.mainnet, clarity_db);
         env.eval_read_only(contract, program)
             .map(|(x, _, _)| x)
             .map_err(Error::from)
@@ -444,6 +451,7 @@ pub trait ClarityConnection {
 
     fn with_readonly_clarity_env<F, R>(
         &mut self,
+        mainnet: bool,
         sender: PrincipalData,
         cost_track: LimitedCostTracker,
         to_do: F,
@@ -452,7 +460,7 @@ pub trait ClarityConnection {
         F: FnOnce(&mut Environment) -> Result<R, InterpreterError>,
     {
         self.with_clarity_db_readonly_owned(|clarity_db| {
-            let mut vm_env = OwnedEnvironment::new_cost_limited(clarity_db, cost_track);
+            let mut vm_env = OwnedEnvironment::new_cost_limited(mainnet, clarity_db, cost_track);
             let result = vm_env
                 .execute_in_env(sender.into(), to_do)
                 .map(|(result, _, _)| result);
@@ -592,6 +600,7 @@ impl<'a> ClarityBlockConnection<'a> {
         let cost_track = &mut self.cost_track;
         let header_db = &self.header_db;
         let burn_state_db = &self.burn_state_db;
+        let mainnet = self.mainnet;
         let mut log = RollbackWrapperPersistedLog::new();
         log.nest();
         ClarityTransactionConnection {
@@ -600,6 +609,7 @@ impl<'a> ClarityBlockConnection<'a> {
             header_db,
             burn_state_db,
             log: Some(log),
+            mainnet,
         }
     }
 
@@ -764,7 +774,7 @@ impl<'a, 'b> ClarityTransactionConnection<'a, 'b> {
                 // wrap the whole contract-call in a claritydb transaction,
                 //   so we can abort on call_back's boolean retun
                 db.begin();
-                let mut vm_env = OwnedEnvironment::new_cost_limited(db, cost_track);
+                let mut vm_env = OwnedEnvironment::new_cost_limited(self.mainnet, db, cost_track);
                 let result = to_do(&mut vm_env);
                 let (mut db, cost_track) = vm_env
                     .destruct()
@@ -983,7 +993,7 @@ mod tests {
     #[test]
     pub fn bad_syntax_test() {
         let marf = MarfedKV::temporary();
-        let mut clarity_instance = ClarityInstance::new(marf, ExecutionCost::max_value());
+        let mut clarity_instance = ClarityInstance::new(false, marf, ExecutionCost::max_value());
 
         let contract_identifier = QualifiedContractIdentifier::local("foo").unwrap();
 
@@ -1023,7 +1033,7 @@ mod tests {
     #[test]
     pub fn test_initialize_contract_tx_sender_contract_caller() {
         let marf = MarfedKV::temporary();
-        let mut clarity_instance = ClarityInstance::new(marf, ExecutionCost::max_value());
+        let mut clarity_instance = ClarityInstance::new(false, marf, ExecutionCost::max_value());
         let contract_identifier = QualifiedContractIdentifier::local("foo").unwrap();
 
         clarity_instance
@@ -1072,7 +1082,7 @@ mod tests {
     #[test]
     pub fn tx_rollback() {
         let marf = MarfedKV::temporary();
-        let mut clarity_instance = ClarityInstance::new(marf, ExecutionCost::max_value());
+        let mut clarity_instance = ClarityInstance::new(false, marf, ExecutionCost::max_value());
 
         let contract_identifier = QualifiedContractIdentifier::local("foo").unwrap();
         let contract = "(define-public (foo (x int) (y int)) (ok (+ x y)))";
@@ -1158,7 +1168,7 @@ mod tests {
     #[test]
     pub fn simple_test() {
         let marf = MarfedKV::temporary();
-        let mut clarity_instance = ClarityInstance::new(marf, ExecutionCost::max_value());
+        let mut clarity_instance = ClarityInstance::new(false, marf, ExecutionCost::max_value());
 
         let contract_identifier = QualifiedContractIdentifier::local("foo").unwrap();
 
@@ -1217,7 +1227,7 @@ mod tests {
     #[test]
     pub fn test_block_roll_back() {
         let marf = MarfedKV::temporary();
-        let mut clarity_instance = ClarityInstance::new(marf, ExecutionCost::max_value());
+        let mut clarity_instance = ClarityInstance::new(false, marf, ExecutionCost::max_value());
         let contract_identifier = QualifiedContractIdentifier::local("foo").unwrap();
 
         {
@@ -1272,7 +1282,7 @@ mod tests {
 
         let confirmed_marf = MarfedKV::open(test_name, None).unwrap();
         let mut confirmed_clarity_instance =
-            ClarityInstance::new(confirmed_marf, ExecutionCost::max_value());
+            ClarityInstance::new(false, confirmed_marf, ExecutionCost::max_value());
         let contract_identifier = QualifiedContractIdentifier::local("foo").unwrap();
 
         let contract = "
@@ -1302,7 +1312,7 @@ mod tests {
             )
             .unwrap();
 
-        let mut clarity_instance = ClarityInstance::new(marf, ExecutionCost::max_value());
+        let mut clarity_instance = ClarityInstance::new(false, marf, ExecutionCost::max_value());
 
         // make an unconfirmed block off of the confirmed block
         {
@@ -1406,7 +1416,7 @@ mod tests {
     #[test]
     pub fn test_tx_roll_backs() {
         let marf = MarfedKV::temporary();
-        let mut clarity_instance = ClarityInstance::new(marf, ExecutionCost::max_value());
+        let mut clarity_instance = ClarityInstance::new(false, marf, ExecutionCost::max_value());
         let contract_identifier = QualifiedContractIdentifier::local("foo").unwrap();
         let sender = StandardPrincipalData::transient().into();
 
@@ -1544,7 +1554,7 @@ mod tests {
         use util::strings::StacksString;
 
         let marf = MarfedKV::temporary();
-        let mut clarity_instance = ClarityInstance::new(marf, ExecutionCost::max_value());
+        let mut clarity_instance = ClarityInstance::new(false, marf, ExecutionCost::max_value());
         let sender = StandardPrincipalData::transient().into();
 
         let spending_cond = TransactionSpendingCondition::Singlesig(SinglesigSpendingCondition {
@@ -1649,7 +1659,7 @@ mod tests {
     #[test]
     pub fn test_block_limit() {
         let marf = MarfedKV::temporary();
-        let mut clarity_instance = ClarityInstance::new(marf, ExecutionCost::max_value());
+        let mut clarity_instance = ClarityInstance::new(false, marf, ExecutionCost::max_value());
         let contract_identifier = QualifiedContractIdentifier::local("foo").unwrap();
         let sender = StandardPrincipalData::transient().into();
 

--- a/src/vm/contexts.rs
+++ b/src/vm/contexts.rs
@@ -1266,7 +1266,11 @@ impl<'a, 'b> Environment<'a, 'b> {
 
 impl<'a> GlobalContext<'a> {
     // Instantiate a new Global Context
-    pub fn new(mainnet: bool, database: ClarityDatabase, cost_track: LimitedCostTracker) -> GlobalContext {
+    pub fn new(
+        mainnet: bool,
+        database: ClarityDatabase,
+        cost_track: LimitedCostTracker,
+    ) -> GlobalContext {
         GlobalContext {
             database,
             cost_track,

--- a/src/vm/contexts.rs
+++ b/src/vm/contexts.rs
@@ -108,6 +108,7 @@ pub struct GlobalContext<'a> {
     pub database: ClarityDatabase<'a>,
     read_only: Vec<bool>,
     pub cost_track: LimitedCostTracker,
+    pub mainnet: bool,
 }
 
 #[derive(Serialize, Deserialize, Clone)]
@@ -444,7 +445,7 @@ impl<'a> OwnedEnvironment<'a> {
     #[cfg(test)]
     pub fn new(database: ClarityDatabase<'a>) -> OwnedEnvironment<'a> {
         OwnedEnvironment {
-            context: GlobalContext::new(database, LimitedCostTracker::new_free()),
+            context: GlobalContext::new(false, database, LimitedCostTracker::new_free()),
             default_contract: ContractContext::new(QualifiedContractIdentifier::transient()),
             call_stack: CallStack::new(),
         }
@@ -456,26 +457,27 @@ impl<'a> OwnedEnvironment<'a> {
             .expect("FAIL: problem instantiating cost tracking");
 
         OwnedEnvironment {
-            context: GlobalContext::new(database, cost_track),
+            context: GlobalContext::new(false, database, cost_track),
             default_contract: ContractContext::new(QualifiedContractIdentifier::transient()),
             call_stack: CallStack::new(),
         }
     }
 
-    pub fn new_free(database: ClarityDatabase<'a>) -> OwnedEnvironment<'a> {
+    pub fn new_free(mainnet: bool, database: ClarityDatabase<'a>) -> OwnedEnvironment<'a> {
         OwnedEnvironment {
-            context: GlobalContext::new(database, LimitedCostTracker::new_free()),
+            context: GlobalContext::new(mainnet, database, LimitedCostTracker::new_free()),
             default_contract: ContractContext::new(QualifiedContractIdentifier::transient()),
             call_stack: CallStack::new(),
         }
     }
 
     pub fn new_cost_limited(
+        mainnet: bool,
         database: ClarityDatabase<'a>,
         cost_tracker: LimitedCostTracker,
     ) -> OwnedEnvironment<'a> {
         OwnedEnvironment {
-            context: GlobalContext::new(database, cost_tracker),
+            context: GlobalContext::new(mainnet, database, cost_tracker),
             default_contract: ContractContext::new(QualifiedContractIdentifier::transient()),
             call_stack: CallStack::new(),
         }
@@ -1264,13 +1266,14 @@ impl<'a, 'b> Environment<'a, 'b> {
 
 impl<'a> GlobalContext<'a> {
     // Instantiate a new Global Context
-    pub fn new(database: ClarityDatabase, cost_track: LimitedCostTracker) -> GlobalContext {
+    pub fn new(mainnet: bool, database: ClarityDatabase, cost_track: LimitedCostTracker) -> GlobalContext {
         GlobalContext {
             database,
             cost_track,
             read_only: Vec::new(),
             asset_maps: Vec::new(),
             event_batches: Vec::new(),
+            mainnet,
         }
     }
 

--- a/src/vm/costs/mod.rs
+++ b/src/vm/costs/mod.rs
@@ -25,7 +25,7 @@ use std::{cmp, fmt};
 
 use std::collections::{BTreeMap, HashMap};
 
-use chainstate::stacks::boot::{STACKS_BOOT_COST_CONTRACT, STACKS_BOOT_COST_VOTE_CONTRACT};
+use chainstate::stacks::boot::boot_code_id;
 
 use vm::ast::ContractAST;
 use vm::contexts::{ContractContext, Environment, GlobalContext, OwnedEnvironment};
@@ -233,6 +233,7 @@ pub struct LimitedCostTracker {
     memory: u64,
     memory_limit: u64,
     free: bool,
+    mainnet: bool,
 }
 
 #[cfg(test)]
@@ -279,7 +280,9 @@ pub enum CostErrors {
     CostContractLoadFailure,
 }
 
-fn load_state_summary(clarity_db: &mut ClarityDatabase) -> Result<CostStateSummary> {
+fn load_state_summary(mainnet: bool, clarity_db: &mut ClarityDatabase) -> Result<CostStateSummary> {
+    let cost_voting_contract = boot_code_id("cost-voting", mainnet);
+
     let last_processed_at = match clarity_db.get_value(
         "vm-costs::last-processed-at-height",
         &TypeSignature::UIntType,
@@ -291,7 +294,7 @@ fn load_state_summary(clarity_db: &mut ClarityDatabase) -> Result<CostStateSumma
     let metadata_result = clarity_db
         .fetch_metadata_manual::<String>(
             last_processed_at,
-            &STACKS_BOOT_COST_VOTE_CONTRACT,
+            &cost_voting_contract,
             "::state_summary",
         )
         .map_err(|e| CostErrors::CostComputationFailed(e.to_string()))?;
@@ -303,10 +306,12 @@ fn load_state_summary(clarity_db: &mut ClarityDatabase) -> Result<CostStateSumma
 }
 
 fn store_state_summary(
+    mainnet: bool,
     clarity_db: &mut ClarityDatabase,
     to_store: &CostStateSummary,
 ) -> Result<()> {
     let block_height = clarity_db.get_current_block_height();
+    let cost_voting_contract = boot_code_id("cost-voting", mainnet);
 
     clarity_db.put(
         "vm-costs::last-processed-at-height",
@@ -316,7 +321,7 @@ fn store_state_summary(
         serde_json::to_string(&SerializedCostStateSummary::from(to_store.clone()))
             .expect("BUG: failure to serialize cost state summary struct");
     clarity_db.set_metadata(
-        &STACKS_BOOT_COST_VOTE_CONTRACT,
+        &cost_voting_contract,
         "::state_summary",
         &serialized_summary,
     );
@@ -335,6 +340,7 @@ fn store_state_summary(
 ///   fork.
 ///
 fn load_cost_functions(
+    mainnet: bool,
     clarity_db: &mut ClarityDatabase,
     apply_updates: bool,
 ) -> Result<CostStateSummary> {
@@ -342,7 +348,7 @@ fn load_cost_functions(
         .get_value("vm-costs::last_processed_count", &TypeSignature::UIntType)
         .unwrap_or(Value::UInt(0))
         .expect_u128();
-    let cost_voting_contract = &STACKS_BOOT_COST_VOTE_CONTRACT;
+    let cost_voting_contract = boot_code_id("cost-voting", mainnet);
     let confirmed_proposals_count = clarity_db
         .lookup_variable_unknown_descriptor(&cost_voting_contract, "confirmed-proposal-count")
         .map_err(|e| CostErrors::CostComputationFailed(e.to_string()))?
@@ -353,7 +359,7 @@ fn load_cost_functions(
 
     // we need to process any confirmed proposals in the range [fetch-start, fetch-end)
     let (fetch_start, fetch_end) = (last_processed_count, confirmed_proposals_count);
-    let mut state_summary = load_state_summary(clarity_db)?;
+    let mut state_summary = load_state_summary(mainnet, clarity_db)?;
     if !apply_updates {
         return Ok(state_summary);
     }
@@ -499,7 +505,7 @@ fn load_cost_functions(
             }
         };
 
-        if target_contract == *STACKS_BOOT_COST_CONTRACT {
+        if target_contract == boot_code_id("costs", mainnet) {
             // refering to one of the boot code cost functions
             let target = match ClarityCostFunction::lookup_by_name(&target_function) {
                 Some(cost_func) => cost_func,
@@ -557,7 +563,7 @@ fn load_cost_functions(
         }
     }
     if confirmed_proposals_count > last_processed_count {
-        store_state_summary(clarity_db, &state_summary)?;
+        store_state_summary(mainnet, clarity_db, &state_summary)?;
         clarity_db.put(
             "vm-costs::last_processed_count",
             &Value::UInt(confirmed_proposals_count),
@@ -569,6 +575,7 @@ fn load_cost_functions(
 
 impl LimitedCostTracker {
     pub fn new(
+        mainnet: bool,
         limit: ExecutionCost,
         clarity_db: &mut ClarityDatabase,
     ) -> Result<LimitedCostTracker> {
@@ -581,6 +588,7 @@ impl LimitedCostTracker {
             total: ExecutionCost::zero(),
             memory: 0,
             free: false,
+            mainnet,
         };
         assert!(clarity_db.is_stack_empty());
         cost_tracker.load_costs(clarity_db, true)?;
@@ -588,6 +596,7 @@ impl LimitedCostTracker {
     }
 
     pub fn new_mid_block(
+        mainnet: bool,
         limit: ExecutionCost,
         clarity_db: &mut ClarityDatabase,
     ) -> Result<LimitedCostTracker> {
@@ -600,14 +609,16 @@ impl LimitedCostTracker {
             total: ExecutionCost::zero(),
             memory: 0,
             free: false,
+            mainnet,
         };
         cost_tracker.load_costs(clarity_db, false)?;
         Ok(cost_tracker)
     }
 
+    #[cfg(test)]
     pub fn new_max_limit(clarity_db: &mut ClarityDatabase) -> Result<LimitedCostTracker> {
         assert!(clarity_db.is_stack_empty());
-        LimitedCostTracker::new(ExecutionCost::max_value(), clarity_db)
+        LimitedCostTracker::new(false, ExecutionCost::max_value(), clarity_db)
     }
 
     pub fn new_free() -> LimitedCostTracker {
@@ -620,6 +631,7 @@ impl LimitedCostTracker {
             memory: 0,
             memory_limit: CLARITY_MEMORY_LIMIT,
             free: true,
+            mainnet: false,
         }
     }
 
@@ -627,13 +639,14 @@ impl LimitedCostTracker {
     ///   which would need to be applied. if `false`, just load the last computed cost state in this
     ///   fork.
     fn load_costs(&mut self, clarity_db: &mut ClarityDatabase, apply_updates: bool) -> Result<()> {
-        let boot_costs_id = (*STACKS_BOOT_COST_CONTRACT).clone();
+        
+        let boot_costs_id = boot_code_id("costs", self.mainnet);
 
         clarity_db.begin();
         let CostStateSummary {
             contract_call_circuits,
             mut cost_function_references,
-        } = load_cost_functions(clarity_db, apply_updates).map_err(|e| {
+        } = load_cost_functions(self.mainnet, clarity_db, apply_updates).map_err(|e| {
             clarity_db.roll_back();
             e
         })?;
@@ -754,9 +767,10 @@ fn compute_cost(
     cost_function_reference: ClarityCostFunctionReference,
     input_sizes: &[u64],
 ) -> Result<ExecutionCost> {
+    let mainnet = cost_tracker.mainnet;
     let mut null_store = NullBackingStore::new();
     let conn = null_store.as_clarity_db();
-    let mut global_context = GlobalContext::new(conn, LimitedCostTracker::new_free());
+    let mut global_context = GlobalContext::new(mainnet, conn, LimitedCostTracker::new_free());
 
     let cost_contract = cost_tracker
         .cost_contracts

--- a/src/vm/costs/mod.rs
+++ b/src/vm/costs/mod.rs
@@ -639,7 +639,6 @@ impl LimitedCostTracker {
     ///   which would need to be applied. if `false`, just load the last computed cost state in this
     ///   fork.
     fn load_costs(&mut self, clarity_db: &mut ClarityDatabase, apply_updates: bool) -> Result<()> {
-        
         let boot_costs_id = boot_code_id("costs", self.mainnet);
 
         clarity_db.begin();

--- a/src/vm/docs/mod.rs
+++ b/src/vm/docs/mod.rs
@@ -1837,7 +1837,7 @@ mod test {
         let conn = store.as_clarity_db(&DOC_HEADER_DB, &DOC_POX_STATE_DB);
         let contract_id = QualifiedContractIdentifier::local("docs-test").unwrap();
         let mut contract_context = ContractContext::new(contract_id.clone());
-        let mut global_context = GlobalContext::new(conn, LimitedCostTracker::new_free());
+        let mut global_context = GlobalContext::new(false, conn, LimitedCostTracker::new_free());
 
         global_context
             .execute(|g| {

--- a/src/vm/functions/special.rs
+++ b/src/vm/functions/special.rs
@@ -82,7 +82,7 @@ fn handle_pox_api_contract_call(
     if function_name == "stack-stx" || function_name == "delegate-stack-stx" {
         debug!(
             "Handle special-case contract-call to {:?} {} (which returned {:?})",
-            boot_code_id("pox"),
+            boot_code_id("pox", global_context.mainnet),
             function_name,
             value
         );
@@ -143,7 +143,7 @@ pub fn handle_contract_call_special_cases(
     function_name: &str,
     result: &Value,
 ) -> Result<()> {
-    if *contract_id == boot_code_id("pox") {
+    if *contract_id == boot_code_id("pox", global_context.mainnet) {
         return handle_pox_api_contract_call(global_context, sender, function_name, result);
     }
     // TODO: insert more special cases here, as needed

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -360,7 +360,7 @@ pub fn execute(program: &str) -> Result<Option<Value>> {
     let mut contract_context = ContractContext::new(contract_id.clone());
     let mut marf = MemoryBackingStore::new();
     let conn = marf.as_clarity_db();
-    let mut global_context = GlobalContext::new(conn, LimitedCostTracker::new_free());
+    let mut global_context = GlobalContext::new(false, conn, LimitedCostTracker::new_free());
     global_context.execute(|g| {
         let parsed = ast::build_ast(&contract_id, program, &mut ())?.expressions;
         eval_all(&parsed, &mut contract_context, g)
@@ -415,7 +415,7 @@ mod test {
 
         let mut marf = MemoryBackingStore::new();
         let mut global_context =
-            GlobalContext::new(marf.as_clarity_db(), LimitedCostTracker::new_free());
+            GlobalContext::new(false, marf.as_clarity_db(), LimitedCostTracker::new_free());
 
         contract_context
             .variables

--- a/src/vm/tests/contracts.rs
+++ b/src/vm/tests/contracts.rs
@@ -180,7 +180,7 @@ fn test_block_headers(n: u8) -> StacksBlockId {
 
 #[test]
 fn test_simple_token_system() {
-    let mut clarity = ClarityInstance::new(MarfedKV::temporary(), ExecutionCost::max_value());
+    let mut clarity = ClarityInstance::new(false, MarfedKV::temporary(), ExecutionCost::max_value());
     let p1 = PrincipalData::from(
         PrincipalData::parse_standard_principal("SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR")
             .unwrap(),

--- a/src/vm/tests/contracts.rs
+++ b/src/vm/tests/contracts.rs
@@ -180,7 +180,8 @@ fn test_block_headers(n: u8) -> StacksBlockId {
 
 #[test]
 fn test_simple_token_system() {
-    let mut clarity = ClarityInstance::new(false, MarfedKV::temporary(), ExecutionCost::max_value());
+    let mut clarity =
+        ClarityInstance::new(false, MarfedKV::temporary(), ExecutionCost::max_value());
     let p1 = PrincipalData::from(
         PrincipalData::parse_standard_principal("SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR")
             .unwrap(),

--- a/src/vm/tests/costs.rs
+++ b/src/vm/tests/costs.rs
@@ -29,7 +29,7 @@ use vm::tests::{
 use vm::types::{AssetIdentifier, PrincipalData, QualifiedContractIdentifier, ResponseData, Value};
 
 use chainstate::burn::BlockHeaderHash;
-use chainstate::stacks::boot::{STACKS_BOOT_COST_CONTRACT, STACKS_BOOT_COST_VOTE_CONTRACT};
+use chainstate::stacks::boot::{boot_code_id};
 use chainstate::stacks::events::StacksTransactionEvent;
 use chainstate::stacks::index::storage::TrieFileStorage;
 use chainstate::stacks::index::MarfTrieId;
@@ -44,6 +44,10 @@ use chainstate::stacks::StacksBlockHeader;
 use core::FIRST_BURNCHAIN_CONSENSUS_HASH;
 use core::FIRST_STACKS_BLOCK_HASH;
 use vm::costs::cost_functions::ClarityCostFunction;
+
+lazy_static! {
+    static ref COST_VOTING_TESTNET_CONTRACT: QualifiedContractIdentifier = boot_code_id("cost-voting", false);
+}
 
 pub fn get_simple_test(function: &NativeFunctions) -> &'static str {
     use vm::functions::NativeFunctions::*;
@@ -179,7 +183,7 @@ fn test_tracked_costs(prog: &str) -> ExecutionCost {
         QualifiedContractIdentifier::new(p1_principal.clone(), "contract-trait".into());
 
     let marf_kv = MarfedKV::temporary();
-    let mut clarity_instance = ClarityInstance::new(marf_kv, ExecutionCost::max_value());
+    let mut clarity_instance = ClarityInstance::new(false, marf_kv, ExecutionCost::max_value());
     clarity_instance
         .begin_test_genesis_block(
             &StacksBlockId::sentinel(),
@@ -245,7 +249,7 @@ fn test_all() {
 #[test]
 fn test_cost_contract_short_circuits() {
     let marf_kv = MarfedKV::temporary();
-    let mut clarity_instance = ClarityInstance::new(marf_kv, ExecutionCost::max_value());
+    let mut clarity_instance = ClarityInstance::new(false, marf_kv, ExecutionCost::max_value());
     clarity_instance
         .begin_test_genesis_block(
             &StacksBlockId::sentinel(),
@@ -274,7 +278,7 @@ fn test_cost_contract_short_circuits() {
     let caller = QualifiedContractIdentifier::new(p1_principal.clone(), "caller".into());
 
     let mut marf_kv = {
-        let mut clarity_inst = ClarityInstance::new(marf_kv, ExecutionCost::max_value());
+        let mut clarity_inst = ClarityInstance::new(false, marf_kv, ExecutionCost::max_value());
         let mut block_conn = clarity_inst.begin_block(
             &StacksBlockHeader::make_index_block_hash(
                 &FIRST_BURNCHAIN_CONSENSUS_HASH,
@@ -373,7 +377,7 @@ fn test_cost_contract_short_circuits() {
         let mut db = store.as_clarity_db(&NULL_HEADER_DB, &NULL_BURN_STATE_DB);
         db.begin();
         db.set_variable_unknown_descriptor(
-            &STACKS_BOOT_COST_VOTE_CONTRACT,
+            &COST_VOTING_TESTNET_CONTRACT,
             "confirmed-proposal-count",
             Value::UInt(1),
         )
@@ -387,7 +391,7 @@ fn test_cost_contract_short_circuits() {
             intercepted, "\"intercepted-function\"", cost_definer, "\"cost-definition\""
         );
         db.set_entry_unknown_descriptor(
-            &STACKS_BOOT_COST_VOTE_CONTRACT,
+            &COST_VOTING_TESTNET_CONTRACT,
             "confirmed-proposals",
             execute("{ confirmed-id: u0 }"),
             execute(&value),
@@ -449,7 +453,7 @@ fn test_cost_contract_short_circuits() {
 #[test]
 fn test_cost_voting_integration() {
     let marf_kv = MarfedKV::temporary();
-    let mut clarity_instance = ClarityInstance::new(marf_kv, ExecutionCost::max_value());
+    let mut clarity_instance = ClarityInstance::new(false, marf_kv, ExecutionCost::max_value());
     clarity_instance
         .begin_test_genesis_block(
             &StacksBlockId::sentinel(),
@@ -482,7 +486,7 @@ fn test_cost_voting_integration() {
     let caller = QualifiedContractIdentifier::new(p1_principal.clone(), "caller".into());
 
     let mut marf_kv = {
-        let mut clarity_inst = ClarityInstance::new(marf_kv, ExecutionCost::max_value());
+        let mut clarity_inst = ClarityInstance::new(false, marf_kv, ExecutionCost::max_value());
         let mut block_conn = clarity_inst.begin_block(
             &StacksBlockHeader::make_index_block_hash(
                 &FIRST_BURNCHAIN_CONSENSUS_HASH,
@@ -605,7 +609,7 @@ fn test_cost_voting_integration() {
         ),
         // "boot cost" function doesn't exist
         (
-            (*STACKS_BOOT_COST_CONTRACT).clone().into(),
+            boot_code_id("costs", false).into(),
             "non-existent-func",
             cost_definer.clone().into(),
             "cost-definition",
@@ -651,7 +655,7 @@ fn test_cost_voting_integration() {
         db.begin();
 
         db.set_variable_unknown_descriptor(
-            &STACKS_BOOT_COST_VOTE_CONTRACT,
+            &COST_VOTING_TESTNET_CONTRACT,
             "confirmed-proposal-count",
             Value::UInt(bad_proposals as u128),
         )
@@ -669,7 +673,7 @@ fn test_cost_voting_integration() {
                 intercepted_ct, intercepted_f, cost_ct, cost_f
             );
             db.set_entry_unknown_descriptor(
-                &STACKS_BOOT_COST_VOTE_CONTRACT,
+                &COST_VOTING_TESTNET_CONTRACT,
                 "confirmed-proposals",
                 execute(&format!("{{ confirmed-id: u{} }}", ix)),
                 execute(&value),
@@ -703,7 +707,7 @@ fn test_cost_voting_integration() {
         );
         for (target, referenced_function) in tracker.cost_function_references().into_iter() {
             assert_eq!(
-                &referenced_function.contract_id, &*STACKS_BOOT_COST_CONTRACT,
+                &referenced_function.contract_id, &boot_code_id("costs", false),
                 "All cost functions should still point to the boot costs"
             );
             assert_eq!(
@@ -725,7 +729,7 @@ fn test_cost_voting_integration() {
             "cost-definition",
         ),
         (
-            (*STACKS_BOOT_COST_CONTRACT).clone(),
+            boot_code_id("costs", false),
             "cost_le",
             cost_definer.clone(),
             "cost-definition-le",
@@ -746,7 +750,7 @@ fn test_cost_voting_integration() {
 
         let good_proposals = good_cases.len() as u128;
         db.set_variable_unknown_descriptor(
-            &STACKS_BOOT_COST_VOTE_CONTRACT,
+            &COST_VOTING_TESTNET_CONTRACT,
             "confirmed-proposal-count",
             Value::UInt(bad_proposals as u128 + good_proposals),
         )
@@ -764,7 +768,7 @@ fn test_cost_voting_integration() {
                 intercepted_ct, intercepted_f, cost_ct, cost_f
             );
             db.set_entry_unknown_descriptor(
-                &STACKS_BOOT_COST_VOTE_CONTRACT,
+                &COST_VOTING_TESTNET_CONTRACT,
                 "confirmed-proposals",
                 execute(&format!("{{ confirmed-id: u{} }}", ix + bad_proposals)),
                 execute(&value),
@@ -817,7 +821,7 @@ fn test_cost_voting_integration() {
                 assert_eq!(&referenced_function.function_name, "cost-definition-le");
             } else {
                 assert_eq!(
-                    &referenced_function.contract_id, &*STACKS_BOOT_COST_CONTRACT,
+                    &referenced_function.contract_id, &boot_code_id("costs", false),
                     "Cost function should still point to the boot costs"
                 );
                 assert_eq!(

--- a/src/vm/tests/costs.rs
+++ b/src/vm/tests/costs.rs
@@ -29,7 +29,7 @@ use vm::tests::{
 use vm::types::{AssetIdentifier, PrincipalData, QualifiedContractIdentifier, ResponseData, Value};
 
 use chainstate::burn::BlockHeaderHash;
-use chainstate::stacks::boot::{boot_code_id};
+use chainstate::stacks::boot::boot_code_id;
 use chainstate::stacks::events::StacksTransactionEvent;
 use chainstate::stacks::index::storage::TrieFileStorage;
 use chainstate::stacks::index::MarfTrieId;
@@ -46,7 +46,8 @@ use core::FIRST_STACKS_BLOCK_HASH;
 use vm::costs::cost_functions::ClarityCostFunction;
 
 lazy_static! {
-    static ref COST_VOTING_TESTNET_CONTRACT: QualifiedContractIdentifier = boot_code_id("cost-voting", false);
+    static ref COST_VOTING_TESTNET_CONTRACT: QualifiedContractIdentifier =
+        boot_code_id("cost-voting", false);
 }
 
 pub fn get_simple_test(function: &NativeFunctions) -> &'static str {
@@ -707,7 +708,8 @@ fn test_cost_voting_integration() {
         );
         for (target, referenced_function) in tracker.cost_function_references().into_iter() {
             assert_eq!(
-                &referenced_function.contract_id, &boot_code_id("costs", false),
+                &referenced_function.contract_id,
+                &boot_code_id("costs", false),
                 "All cost functions should still point to the boot costs"
             );
             assert_eq!(
@@ -821,7 +823,8 @@ fn test_cost_voting_integration() {
                 assert_eq!(&referenced_function.function_name, "cost-definition-le");
             } else {
                 assert_eq!(
-                    &referenced_function.contract_id, &boot_code_id("costs", false),
+                    &referenced_function.contract_id,
+                    &boot_code_id("costs", false),
                     "Cost function should still point to the boot costs"
                 );
                 assert_eq!(

--- a/src/vm/tests/large_contract.rs
+++ b/src/vm/tests/large_contract.rs
@@ -45,7 +45,7 @@ use vm::types::{
 #[ignore]
 pub fn rollback_log_memory_test() {
     let marf = MarfedKV::temporary();
-    let mut clarity_instance = ClarityInstance::new(marf, ExecutionCost::max_value());
+    let mut clarity_instance = ClarityInstance::new(false, marf, ExecutionCost::max_value());
     let EXPLODE_N = 100;
 
     let contract_identifier = QualifiedContractIdentifier::local("foo").unwrap();
@@ -105,7 +105,7 @@ pub fn rollback_log_memory_test() {
 #[test]
 pub fn let_memory_test() {
     let marf = MarfedKV::temporary();
-    let mut clarity_instance = ClarityInstance::new(marf, ExecutionCost::max_value());
+    let mut clarity_instance = ClarityInstance::new(false, marf, ExecutionCost::max_value());
     let EXPLODE_N = 100;
 
     let contract_identifier = QualifiedContractIdentifier::local("foo").unwrap();
@@ -169,7 +169,7 @@ pub fn let_memory_test() {
 #[test]
 pub fn argument_memory_test() {
     let marf = MarfedKV::temporary();
-    let mut clarity_instance = ClarityInstance::new(marf, ExecutionCost::max_value());
+    let mut clarity_instance = ClarityInstance::new(false, marf, ExecutionCost::max_value());
     let EXPLODE_N = 100;
 
     let contract_identifier = QualifiedContractIdentifier::local("foo").unwrap();
@@ -233,7 +233,7 @@ pub fn argument_memory_test() {
 #[test]
 pub fn fcall_memory_test() {
     let marf = MarfedKV::temporary();
-    let mut clarity_instance = ClarityInstance::new(marf, ExecutionCost::max_value());
+    let mut clarity_instance = ClarityInstance::new(false, marf, ExecutionCost::max_value());
     let COUNT_PER_FUNC = 10;
     let FUNCS = 10;
 
@@ -339,7 +339,7 @@ pub fn fcall_memory_test() {
 #[ignore]
 pub fn ccall_memory_test() {
     let marf = MarfedKV::temporary();
-    let mut clarity_instance = ClarityInstance::new(marf, ExecutionCost::max_value());
+    let mut clarity_instance = ClarityInstance::new(false, marf, ExecutionCost::max_value());
     let COUNT_PER_CONTRACT = 20;
     let CONTRACTS = 5;
 

--- a/src/vm/tests/simple_apply_eval.rs
+++ b/src/vm/tests/simple_apply_eval.rs
@@ -380,7 +380,7 @@ fn test_simple_if_functions() {
         let mut contract_context = ContractContext::new(QualifiedContractIdentifier::transient());
         let mut marf = MemoryBackingStore::new();
         let mut global_context =
-            GlobalContext::new(marf.as_clarity_db(), LimitedCostTracker::new_free());
+            GlobalContext::new(false, marf.as_clarity_db(), LimitedCostTracker::new_free());
 
         contract_context
             .functions

--- a/src/vm/types/mod.rs
+++ b/src/vm/types/mod.rs
@@ -1064,7 +1064,6 @@ impl fmt::Display for Value {
 }
 
 impl PrincipalData {
-
     pub fn version(&self) -> u8 {
         match self {
             PrincipalData::Standard(StandardPrincipalData(version, _)) => *version,

--- a/src/vm/types/mod.rs
+++ b/src/vm/types/mod.rs
@@ -25,7 +25,6 @@ use std::{cmp, fmt};
 use regex::Regex;
 
 use address::c32;
-use chainstate::stacks::boot::STACKS_BOOT_CODE_CONTRACT_ADDRESS;
 use util::hash;
 
 use vm::errors::{
@@ -100,16 +99,6 @@ impl QualifiedContractIdentifier {
         Self {
             issuer: StandardPrincipalData::transient(),
             name,
-        }
-    }
-
-    pub fn boot_contract(contract_name: &str) -> QualifiedContractIdentifier {
-        QualifiedContractIdentifier {
-            issuer: STACKS_BOOT_CODE_CONTRACT_ADDRESS.clone().into(),
-            name: contract_name
-                .to_string()
-                .try_into()
-                .expect("BUG: Bad contract name supplied for a boot contract"),
         }
     }
 
@@ -1075,6 +1064,7 @@ impl fmt::Display for Value {
 }
 
 impl PrincipalData {
+
     pub fn version(&self) -> u8 {
         match self {
             PrincipalData::Standard(StandardPrincipalData(version, _)) => *version,

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -1124,7 +1124,7 @@ impl InitializedNeonNode {
         let is_miner = miner;
 
         let active_keys = vec![];
-        let atlas_config = AtlasConfig::default();
+        let atlas_config = AtlasConfig::default(config.is_mainnet());
         InitializedNeonNode {
             config: config.clone(),
             relay_channel: relay_send,

--- a/testnet/stacks-node/src/node.rs
+++ b/testnet/stacks-node/src/node.rs
@@ -440,7 +440,7 @@ impl Node {
             }
             tx.commit().unwrap();
         }
-        let atlas_config = AtlasConfig::default();
+        let atlas_config = AtlasConfig::default(false);
         let atlasdb =
             AtlasDB::connect(atlas_config, &self.config.get_peer_db_path(), true).unwrap();
 

--- a/testnet/stacks-node/src/run_loop/neon.rs
+++ b/testnet/stacks-node/src/run_loop/neon.rs
@@ -12,10 +12,10 @@ use stacks::chainstate::coordinator::comm::{CoordinatorChannels, CoordinatorRece
 use stacks::chainstate::coordinator::{
     BlockEventDispatcher, ChainsCoordinator, CoordinatorCommunication,
 };
-use stacks::chainstate::stacks::boot::STACKS_BOOT_CODE_CONTRACT_ADDRESS_STR;
+use stacks::chainstate::stacks::boot;
 use stacks::chainstate::stacks::db::{ChainStateBootData, ClarityTx, StacksChainState};
 use stacks::net::atlas::AtlasConfig;
-use stacks::vm::types::{PrincipalData, QualifiedContractIdentifier, Value};
+use stacks::vm::types::{PrincipalData, Value};
 use std::cmp;
 use std::sync::mpsc::sync_channel;
 use std::thread;
@@ -172,11 +172,7 @@ impl RunLoop {
         let pox_rejection_fraction = burnchain_config.pox_constants.pox_rejection_fraction as u128;
 
         let boot_block = Box::new(move |clarity_tx: &mut ClarityTx| {
-            let contract = QualifiedContractIdentifier::parse(&format!(
-                "{}.pox",
-                STACKS_BOOT_CODE_CONTRACT_ADDRESS_STR
-            ))
-            .expect("Failed to construct boot code contract address");
+            let contract = boot::boot_code_id("pox", mainnet);
             let sender = PrincipalData::from(contract.clone());
             let params = vec![
                 Value::UInt(first_block_height),
@@ -224,7 +220,7 @@ impl RunLoop {
         .unwrap();
         coordinator_dispatcher.dispatch_boot_receipts(receipts);
 
-        let atlas_config = AtlasConfig::default();
+        let atlas_config = AtlasConfig::default(mainnet);
         let moved_atlas_config = atlas_config.clone();
 
         thread::Builder::new()


### PR DESCRIPTION
PR is fixing:

```rust
pub const STACKS_BOOT_CODE_CONTRACT_ADDRESS_STR: &'static str = "ST000000000000000000002AMW42H";
```

Consensus critical and error prone. Eyes wide open during the review, please :)
I wonder if we should add an enum, enumerating the Pox contracts names.
