### PR TITLE
Stacks 2.0 Settings

### DIFF
--- a/src/burnchains/burnchain.rs
+++ b/src/burnchains/burnchain.rs
@@ -98,6 +98,8 @@ impl BurnchainStateTransitionOps {
 
 use core::MINING_COMMITMENT_WINDOW;
 
+use crate::core::STACKS_2_0_LAST_BLOCK_TO_PROCESS;
+
 impl BurnchainStateTransition {
     pub fn noop() -> BurnchainStateTransition {
         BurnchainStateTransition {
@@ -1345,6 +1347,7 @@ impl Burnchain {
             })
             .unwrap();
 
+        let is_mainnet = self.is_mainnet();
         let db_thread: thread::JoinHandle<Result<BurnchainBlockHeader, burnchain_error>> =
             thread::Builder::new()
                 .name("burnchain-db".to_string())
@@ -1355,6 +1358,19 @@ impl Burnchain {
 
                         if burnchain_block.block_height() == 0 {
                             continue;
+                        }
+
+                        if is_mainnet {
+                            if last_processed.block_height == STACKS_2_0_LAST_BLOCK_TO_PROCESS {
+                                info!("Reached Stacks 2.0 last block to processed, ignoring subsequent burn blocks";
+                                      "block_height" => last_processed.block_height);
+                                continue;
+                            } else if last_processed.block_height > STACKS_2_0_LAST_BLOCK_TO_PROCESS {
+                                debug!("Reached Stacks 2.0 last block to processed, ignoring subsequent burn blocks";
+                                       "last_block" => STACKS_2_0_LAST_BLOCK_TO_PROCESS,
+                                       "block_height" => last_processed.block_height);
+                                continue;
+                            }
                         }
 
                         let insert_start = get_epoch_time_ms();

--- a/src/chainstate/stacks/boot/genesis.clar
+++ b/src/chainstate/stacks/boot/genesis.clar
@@ -1,2 +1,2 @@
 ;; Stacks 2.0 Genesis
-(print "\"A completely separate network and separate blockchain, yet it shares CPU power with Bitcoin\" - Satoshi Nakamoto")
+(print "``A completely separate network and separate blockchain, yet it shares CPU power with Bitcoin`` - Satoshi Nakamoto")

--- a/src/chainstate/stacks/boot/genesis.clar
+++ b/src/chainstate/stacks/boot/genesis.clar
@@ -1,0 +1,2 @@
+;; Stacks 2.0 Genesis
+(print "\"A completely separate network and separate blockchain, yet it shares CPU power with Bitcoin\" - Satoshi Nakamoto")

--- a/src/chainstate/stacks/boot/mod.rs
+++ b/src/chainstate/stacks/boot/mod.rs
@@ -60,6 +60,7 @@ const BOOT_CODE_LOCKUP: &'static str = std::include_str!("lockup.clar");
 pub const BOOT_CODE_COSTS: &'static str = std::include_str!("costs.clar");
 const BOOT_CODE_COST_VOTING_MAINNET: &'static str = std::include_str!("cost-voting.clar");
 const BOOT_CODE_BNS: &'static str = std::include_str!("bns.clar");
+const BOOT_CODE_GENESIS: &'static str = std::include_str!("genesis.clar");
 
 lazy_static! {
     static ref BOOT_CODE_POX_MAINNET: String =
@@ -67,19 +68,21 @@ lazy_static! {
     pub static ref BOOT_CODE_POX_TESTNET: String =
         format!("{}\n{}", BOOT_CODE_POX_TESTNET_CONSTS, BOOT_CODE_POX_BODY);
     pub static ref BOOT_CODE_COST_VOTING_TESTNET: String = make_testnet_cost_voting();
-    pub static ref STACKS_BOOT_CODE_MAINNET: [(&'static str, &'static str); 5] = [
+    pub static ref STACKS_BOOT_CODE_MAINNET: [(&'static str, &'static str); 6] = [
         ("pox", &BOOT_CODE_POX_MAINNET),
         ("lockup", BOOT_CODE_LOCKUP),
         ("costs", BOOT_CODE_COSTS),
         ("cost-voting", BOOT_CODE_COST_VOTING_MAINNET),
         ("bns", &BOOT_CODE_BNS),
+        ("genesis", &BOOT_CODE_GENESIS),
     ];
-    pub static ref STACKS_BOOT_CODE_TESTNET: [(&'static str, &'static str); 5] = [
+    pub static ref STACKS_BOOT_CODE_TESTNET: [(&'static str, &'static str); 6] = [
         ("pox", &BOOT_CODE_POX_TESTNET),
         ("lockup", BOOT_CODE_LOCKUP),
         ("costs", BOOT_CODE_COSTS),
         ("cost-voting", &BOOT_CODE_COST_VOTING_TESTNET),
         ("bns", &BOOT_CODE_BNS),
+        ("genesis", &BOOT_CODE_GENESIS),
     ];
 }
 

--- a/src/chainstate/stacks/db/mod.rs
+++ b/src/chainstate/stacks/db/mod.rs
@@ -2108,7 +2108,7 @@ pub mod test {
         // Just update the expected value
         assert_eq!(
             genesis_root_hash.to_string(),
-            "bb845a40e6d9ed4d6e8e1b914ccc60c93cfddcd19e2627c6ade7c263aa5771c8"
+            "70a0948e195d9c7bd9a75fda90c54f6c3c2e1f477b0f9bfcaec4df0248e88717"
         );
     }
 

--- a/src/chainstate/stacks/db/mod.rs
+++ b/src/chainstate/stacks/db/mod.rs
@@ -2108,7 +2108,7 @@ pub mod test {
         // Just update the expected value
         assert_eq!(
             genesis_root_hash.to_string(),
-            "70a0948e195d9c7bd9a75fda90c54f6c3c2e1f477b0f9bfcaec4df0248e88717"
+            "8b03c434921ffb9476a9ae93bfc6ebfd01e6e9778173676c320e9162a137b8f9"
         );
     }
 

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -49,6 +49,8 @@ pub const INITIAL_MINING_BONUS_WINDOW: u16 = 10;
 #[cfg(not(test))]
 pub const INITIAL_MINING_BONUS_WINDOW: u16 = 10_000;
 
+pub const STACKS_2_0_LAST_BLOCK_TO_PROCESS: u64 = 700_000;
+
 // first burnchain block hash
 // TODO: update once we know the true first burnchain block
 pub const FIRST_BURNCHAIN_CONSENSUS_HASH: ConsensusHash = ConsensusHash([0u8; 20]);

--- a/testnet/stacks-node/src/run_loop/neon.rs
+++ b/testnet/stacks-node/src/run_loop/neon.rs
@@ -247,6 +247,7 @@ impl RunLoop {
             self.config.burnchain.poll_time_secs,
             self.config.connection_options.timeout,
             self.config.node.pox_sync_sample_secs,
+            self.config.node.pox_sync_sample_secs == 0,
         )
         .unwrap();
 

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -68,7 +68,7 @@ fn neon_integration_test_conf() -> (Config, StacksAddress) {
     assert_eq!(magic_bytes.as_bytes(), &['X' as u8, '4' as u8]);
     conf.burnchain.magic_bytes = magic_bytes;
     conf.burnchain.poll_time_secs = 1;
-    conf.node.pox_sync_sample_secs = 1;
+    conf.node.pox_sync_sample_secs = 0;
 
     let miner_account = keychain.origin_address().unwrap();
 


### PR DESCRIPTION
This PR does a couple things:

1. Sets a last burn block to process to burn block `700_000` -- this is enforced by skipping the burnchain processing once `last_block` has reached the limit.
2. Adds a `genesis.clar` contract that prints a message when the genesis block is processed.
3. Alters the interaction between `neon`, `neon_integrations` and `syncctl` such that the `neon_integrations` tests always unconditionally download burn blocks.