### PR TITLE
Pick initial peers at random

### DIFF
--- a/src/net/db.rs
+++ b/src/net/db.rs
@@ -844,7 +844,7 @@ impl PeerDB {
         conn: &DBConn,
         network_id: u32,
     ) -> Result<Vec<Neighbor>, db_error> {
-        let sql = "SELECT * FROM frontier WHERE allowed < 0 AND network_id = ?1";
+        let sql = "SELECT * FROM frontier WHERE allowed < 0 AND network_id = ?1 ORDER BY RANDOM()";
         let allow_rows = query_rows::<Neighbor, _>(conn, sql, &[&network_id])?;
         Ok(allow_rows)
     }


### PR DESCRIPTION
Pick initial peers at random, so when the neighbor walk tries to keep a bootstrap node in the neighbor set, it picks one at random.