### PR TITLE
Fix: peer version to 0x18 rather than 0x17

### DIFF
--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -28,7 +28,7 @@ pub use self::mempool::MemPoolDB;
 pub const SYSTEM_FORK_SET_VERSION: [u8; 4] = [23u8, 0u8, 0u8, 0u8];
 
 // p2p network version
-pub const PEER_VERSION: u32 = 0x17000000; // 23.0.0.0
+pub const PEER_VERSION: u32 = 0x18000000; // 24.0.0.0
 
 // network identifiers
 pub const NETWORK_ID_MAINNET: u32 = 0x17000000;


### PR DESCRIPTION
This corrects the peer version to match the config peer version in `stacks-node::config`