### PR TITLE
Streamline usage of PEER_VERSION

### DIFF
--- a/src/blockstack_cli.rs
+++ b/src/blockstack_cli.rs
@@ -30,7 +30,7 @@ use blockstack_lib::chainstate::stacks::{
     TransactionSpendingCondition, TransactionVersion, C32_ADDRESS_VERSION_MAINNET_SINGLESIG,
     C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
 };
-use blockstack_lib::core::{CHAIN_ID_TESTNET, CHAIN_ID_MAINNET};
+use blockstack_lib::core::{CHAIN_ID_MAINNET, CHAIN_ID_TESTNET};
 use blockstack_lib::net::{Error as NetError, StacksMessageCodec};
 use blockstack_lib::util::{
     hash::hex_bytes, hash::to_hex, log, retry::LogReader, strings::StacksString,

--- a/src/blockstack_cli.rs
+++ b/src/blockstack_cli.rs
@@ -30,6 +30,7 @@ use blockstack_lib::chainstate::stacks::{
     TransactionSpendingCondition, TransactionVersion, C32_ADDRESS_VERSION_MAINNET_SINGLESIG,
     C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
 };
+use blockstack_lib::core::{CHAIN_ID_TESTNET, CHAIN_ID_MAINNET};
 use blockstack_lib::net::{Error as NetError, StacksMessageCodec};
 use blockstack_lib::util::{
     hash::hex_bytes, hash::to_hex, log, retry::LogReader, strings::StacksString,
@@ -49,9 +50,6 @@ use blockstack_lib::address::b58;
 use blockstack_lib::burnchains::bitcoin::address::{
     ADDRESS_VERSION_MAINNET_SINGLESIG, ADDRESS_VERSION_TESTNET_SINGLESIG,
 };
-
-const TESTNET_CHAIN_ID: u32 = 0x80000000;
-const MAINNET_CHAIN_ID: u32 = 0x00000001;
 
 const USAGE: &str = "blockstack-cli (options) [method] [args...]
 
@@ -756,9 +754,9 @@ fn main_handler(mut argv: Vec<String>) -> Result<String, CliError> {
     };
 
     let chain_id = if tx_version == TransactionVersion::Testnet {
-        TESTNET_CHAIN_ID
+        CHAIN_ID_TESTNET
     } else {
-        MAINNET_CHAIN_ID
+        CHAIN_ID_MAINNET
     };
 
     if let Some((method, args)) = argv.split_first() {

--- a/src/burnchains/burnchain.rs
+++ b/src/burnchains/burnchain.rs
@@ -79,8 +79,8 @@ use util::vrf::VRFPublicKey;
 
 use core::NETWORK_ID_MAINNET;
 use core::NETWORK_ID_TESTNET;
-use core::PEER_VERSION_TESTNET;
 use core::PEER_VERSION_MAINNET;
+use core::PEER_VERSION_TESTNET;
 
 impl BurnchainStateTransitionOps {
     pub fn noop() -> BurnchainStateTransitionOps {

--- a/src/burnchains/burnchain.rs
+++ b/src/burnchains/burnchain.rs
@@ -79,7 +79,8 @@ use util::vrf::VRFPublicKey;
 
 use core::NETWORK_ID_MAINNET;
 use core::NETWORK_ID_TESTNET;
-use core::PEER_VERSION;
+use core::PEER_VERSION_TESTNET;
+use core::PEER_VERSION_MAINNET;
 
 impl BurnchainStateTransitionOps {
     pub fn noop() -> BurnchainStateTransitionOps {
@@ -421,18 +422,21 @@ impl Burnchain {
         chain_name: &str,
         network_name: &str,
     ) -> Result<Burnchain, burnchain_error> {
-        let (params, pox_constants) = match (chain_name, network_name) {
+        let (params, pox_constants, peer_version) = match (chain_name, network_name) {
             ("bitcoin", "mainnet") => (
                 BurnchainParameters::bitcoin_mainnet(),
                 PoxConstants::mainnet_default(),
+                PEER_VERSION_MAINNET,
             ),
             ("bitcoin", "testnet") => (
                 BurnchainParameters::bitcoin_testnet(),
                 PoxConstants::testnet_default(),
+                PEER_VERSION_TESTNET,
             ),
             ("bitcoin", "regtest") => (
                 BurnchainParameters::bitcoin_regtest(),
                 PoxConstants::regtest_default(),
+                PEER_VERSION_TESTNET,
             ),
             (_, _) => {
                 return Err(burnchain_error::UnsupportedBurnchain);
@@ -440,7 +444,7 @@ impl Burnchain {
         };
 
         Ok(Burnchain {
-            peer_version: PEER_VERSION,
+            peer_version,
             network_id: params.network_id,
             chain_name: params.chain_name.clone(),
             network_name: params.network_name.clone(),

--- a/src/chainstate/stacks/db/mod.rs
+++ b/src/chainstate/stacks/db/mod.rs
@@ -842,7 +842,7 @@ impl StacksChainState {
         mainnet: bool,
         boot_data: &mut ChainStateBootData,
     ) -> Result<Vec<StacksTransactionReceipt>, Error> {
-        debug!("Begin install boot code");
+        info!("Building genesis block");
 
         let tx_version = if mainnet {
             TransactionVersion::Mainnet
@@ -918,10 +918,12 @@ impl StacksChainState {
             }
 
             let mut allocation_events: Vec<StacksTransactionEvent> = vec![];
-            warn!(
-                "Seeding {} balances coming from the config",
-                boot_data.initial_balances.len()
-            );
+            if boot_data.initial_balances.len() > 0 {
+                warn!(
+                    "Seeding {} balances coming from the config",
+                    boot_data.initial_balances.len()
+                );    
+            }
             for (address, amount) in boot_data.initial_balances.iter() {
                 clarity_tx.connection().as_transaction(|clarity| {
                     StacksChainState::account_genesis_credit(clarity, address, (*amount).into())
@@ -1178,6 +1180,7 @@ impl StacksChainState {
                         })
                         .unwrap();
                 }
+                info!("Saving Genesis block. This could take a while");
             });
 
             let allocations_tx = StacksTransaction::new(
@@ -1211,7 +1214,6 @@ impl StacksChainState {
                 })
                 .expect("FATAL: `ust-liquid-supply` overflowed");
 
-            info!("Committing Genesis transaction. This could take a while");
             clarity_tx.commit_to_block(&FIRST_BURNCHAIN_CONSENSUS_HASH, &FIRST_STACKS_BLOCK_HASH);
         }
 

--- a/src/chainstate/stacks/db/mod.rs
+++ b/src/chainstate/stacks/db/mod.rs
@@ -922,7 +922,7 @@ impl StacksChainState {
                 warn!(
                     "Seeding {} balances coming from the config",
                     boot_data.initial_balances.len()
-                );    
+                );
             }
             for (address, amount) in boot_data.initial_balances.iter() {
                 clarity_tx.connection().as_transaction(|clarity| {

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -27,8 +27,13 @@ pub use self::mempool::MemPoolDB;
 // fork set identifier -- to be mixed with the consensus hash (encodes the version)
 pub const SYSTEM_FORK_SET_VERSION: [u8; 4] = [23u8, 0u8, 0u8, 0u8];
 
-// p2p network version
-pub const PEER_VERSION: u32 = 0x18000000; // 24.0.0.0
+// chain id
+pub const TESTNET_CHAIN_ID: u32 = 0x80000000;
+pub const MAINNET_CHAIN_ID: u32 = 0x00000001;
+
+// peer version
+pub const MAINNET_PEER_VERSION: u32 = 0x18000000; // 24.0.0.0
+pub const TESTNET_PEER_VERSION: u32 = 0xfacade01;
 
 // network identifiers
 pub const NETWORK_ID_MAINNET: u32 = 0x17000000;

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -28,12 +28,12 @@ pub use self::mempool::MemPoolDB;
 pub const SYSTEM_FORK_SET_VERSION: [u8; 4] = [23u8, 0u8, 0u8, 0u8];
 
 // chain id
-pub const TESTNET_CHAIN_ID: u32 = 0x80000000;
-pub const MAINNET_CHAIN_ID: u32 = 0x00000001;
+pub const CHAIN_ID_MAINNET: u32 = 0x00000001;
+pub const CHAIN_ID_TESTNET: u32 = 0x80000000;
 
 // peer version
-pub const MAINNET_PEER_VERSION: u32 = 0x18000000; // 24.0.0.0
-pub const TESTNET_PEER_VERSION: u32 = 0xfacade01;
+pub const PEER_VERSION_MAINNET: u32 = 0x18000000; // 24.0.0.0
+pub const PEER_VERSION_TESTNET: u32 = 0xfacade01;
 
 // network identifiers
 pub const NETWORK_ID_MAINNET: u32 = 0x17000000;

--- a/src/net/chat.rs
+++ b/src/net/chat.rs
@@ -2336,7 +2336,7 @@ mod test {
 
     use net::test::*;
 
-    use core::{NETWORK_P2P_PORT, PEER_VERSION};
+    use core::{NETWORK_P2P_PORT, TESTNET_PEER_VERSION};
 
     fn make_test_chain_dbs(
         testname: &str,
@@ -2533,7 +2533,7 @@ mod test {
         .unwrap();
 
         Burnchain {
-            peer_version: PEER_VERSION,
+            peer_version: TESTNET_PEER_VERSION,
             network_id: 0,
             chain_name: "bitcoin".to_string(),
             network_name: "testnet".to_string(),

--- a/src/net/chat.rs
+++ b/src/net/chat.rs
@@ -2336,7 +2336,7 @@ mod test {
 
     use net::test::*;
 
-    use core::{NETWORK_P2P_PORT, TESTNET_PEER_VERSION};
+    use core::{NETWORK_P2P_PORT, PEER_VERSION_TESTNET};
 
     fn make_test_chain_dbs(
         testname: &str,
@@ -2533,7 +2533,7 @@ mod test {
         .unwrap();
 
         Burnchain {
-            peer_version: TESTNET_PEER_VERSION,
+            peer_version: PEER_VERSION_TESTNET,
             network_id: 0,
             chain_name: "bitcoin".to_string(),
             network_name: "testnet".to_string(),

--- a/src/net/codec.rs
+++ b/src/net/codec.rs
@@ -46,7 +46,7 @@ use net::db::LocalPeer;
 use net::Error as net_error;
 use net::*;
 
-use core::TESTNET_PEER_VERSION;
+use core::PEER_VERSION_TESTNET;
 
 use sha2::Digest;
 use sha2::Sha512Trunc256;
@@ -2271,7 +2271,7 @@ pub mod test {
             StacksPublicKeyBuffer::from_public_key(&Secp256k1PublicKey::from_private(&privkey));
 
         let mut ping = StacksMessage::new(
-            TESTNET_PEER_VERSION,
+            PEER_VERSION_TESTNET,
             0x9abcdef0,
             12345,
             &BurnchainHeaderHash([0x11; 32]),

--- a/src/net/codec.rs
+++ b/src/net/codec.rs
@@ -46,7 +46,7 @@ use net::db::LocalPeer;
 use net::Error as net_error;
 use net::*;
 
-use core::PEER_VERSION;
+use core::TESTNET_PEER_VERSION;
 
 use sha2::Digest;
 use sha2::Sha512Trunc256;
@@ -2271,7 +2271,7 @@ pub mod test {
             StacksPublicKeyBuffer::from_public_key(&Secp256k1PublicKey::from_private(&privkey));
 
         let mut ping = StacksMessage::new(
-            PEER_VERSION,
+            TESTNET_PEER_VERSION,
             0x9abcdef0,
             12345,
             &BurnchainHeaderHash([0x11; 32]),

--- a/src/net/neighbors.rs
+++ b/src/net/neighbors.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use core::PEER_VERSION;
+use core::TESTNET_PEER_VERSION;
 
 use net::asn::ASEntry4;
 use net::db::PeerDB;
@@ -976,8 +976,9 @@ impl NeighborWalk {
         );
         for (naddr, mut rh) in unresolved_handshake_neighbors.drain() {
             if let Err(_e) = network.saturate_p2p_socket(rh.get_event_id(), &mut rh) {
+
                 self.result.add_dead(NeighborKey::from_neighbor_address(
-                    PEER_VERSION,
+                    network.peer_version,
                     self.local_peer.network_id,
                     &naddr,
                 ));
@@ -1081,7 +1082,7 @@ impl NeighborWalk {
                                 &self.local_peer, naddr, &e
                             );
                             self.result.add_dead(NeighborKey::from_neighbor_address(
-                                PEER_VERSION,
+                                network.peer_version,
                                 self.local_peer.network_id,
                                 &naddr,
                             ));
@@ -4673,7 +4674,7 @@ mod test {
         conf.connection_opts.disable_block_download = true;
 
         let j = i as u32;
-        conf.burnchain.peer_version = PEER_VERSION | (j << 16) | (j << 8) | j; // different non-major versions for each peer
+        conf.burnchain.peer_version = TESTNET_PEER_VERSION | (j << 16) | (j << 8) | j; // different non-major versions for each peer
         conf
     }
 

--- a/src/net/neighbors.rs
+++ b/src/net/neighbors.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use core::TESTNET_PEER_VERSION;
+use core::PEER_VERSION_TESTNET;
 
 use net::asn::ASEntry4;
 use net::db::PeerDB;
@@ -4674,7 +4674,7 @@ mod test {
         conf.connection_opts.disable_block_download = true;
 
         let j = i as u32;
-        conf.burnchain.peer_version = TESTNET_PEER_VERSION | (j << 16) | (j << 8) | j; // different non-major versions for each peer
+        conf.burnchain.peer_version = PEER_VERSION_TESTNET | (j << 16) | (j << 8) | j; // different non-major versions for each peer
         conf
     }
 

--- a/src/net/neighbors.rs
+++ b/src/net/neighbors.rs
@@ -976,7 +976,6 @@ impl NeighborWalk {
         );
         for (naddr, mut rh) in unresolved_handshake_neighbors.drain() {
             if let Err(_e) = network.saturate_p2p_socket(rh.get_event_id(), &mut rh) {
-
                 self.result.add_dead(NeighborKey::from_neighbor_address(
                     network.peer_version,
                     self.local_peer.network_id,

--- a/src/net/p2p.rs
+++ b/src/net/p2p.rs
@@ -2194,7 +2194,7 @@ impl PeerNetwork {
                 Ok(message) => match message.payload {
                     StacksMessageType::NatPunchReply(data) => {
                         // peer offers us our public IP address.
-                        info!(
+                        debug!(
                             "{:?}: learned that my IP address is {:?}",
                             &self.local_peer, &data.addrbytes
                         );
@@ -2920,7 +2920,7 @@ impl PeerNetwork {
                                 }
                             }
                             Err(e) => {
-                                info!("Failed to query public IP ({:?}; skipping", &e);
+                                info!("Failed to query public IP ({:?}) skipping", &e);
                                 self.work_state = PeerNetworkWorkState::BlockInvSync;
                             }
                         }

--- a/src/net/relay.rs
+++ b/src/net/relay.rs
@@ -984,7 +984,10 @@ impl Relayer {
         bad_neighbors.append(&mut new_bad_neighbors);
 
         if new_blocks.len() > 0 {
-            info!("Processing newly received Stacks blocks: {}", new_blocks.len());
+            info!(
+                "Processing newly received Stacks blocks: {}",
+                new_blocks.len()
+            );
             if let Some(coord_comms) = coord_comms {
                 if !coord_comms.announce_new_stacks_block() {
                     return Err(net_error::CoordinatorClosed);

--- a/src/net/relay.rs
+++ b/src/net/relay.rs
@@ -984,7 +984,7 @@ impl Relayer {
         bad_neighbors.append(&mut new_bad_neighbors);
 
         if new_blocks.len() > 0 {
-            info!("Processing newly received blocks: {}", new_blocks.len());
+            info!("Processing newly received Stacks blocks: {}", new_blocks.len());
             if let Some(coord_comms) = coord_comms {
                 if !coord_comms.announce_new_stacks_block() {
                     return Err(net_error::CoordinatorClosed);

--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -6,6 +6,9 @@ use rand::RngCore;
 
 use stacks::burnchains::bitcoin::BitcoinNetworkType;
 use stacks::burnchains::{MagicBytes, BLOCKSTACK_MAGIC_MAINNET};
+use stacks::core::{
+    MAINNET_CHAIN_ID, PEER_VERSION_MAINNET, PEER_VERSION_TESTNET, TESTNET_CHAIN_ID,
+};
 use stacks::net::connection::ConnectionOptions;
 use stacks::net::{Neighbor, NeighborKey, PeerAddress};
 use stacks::util::hash::{hex_bytes, to_hex};
@@ -13,7 +16,6 @@ use stacks::util::secp256k1::Secp256k1PrivateKey;
 use stacks::util::secp256k1::Secp256k1PublicKey;
 use stacks::vm::costs::ExecutionCost;
 use stacks::vm::types::{AssetIdentifier, PrincipalData, QualifiedContractIdentifier};
-use stacks::core::{MAINNET_CHAIN_ID, TESTNET_CHAIN_ID, PEER_VERSION_MAINNET, PEER_VERSION_TESTNET};
 
 const DEFAULT_SATS_PER_VB: u64 = 50;
 const LEADER_KEY_TX_ESTIM_SIZE: u64 = 290;

--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -13,7 +13,7 @@ use stacks::util::secp256k1::Secp256k1PrivateKey;
 use stacks::util::secp256k1::Secp256k1PublicKey;
 use stacks::vm::costs::ExecutionCost;
 use stacks::vm::types::{AssetIdentifier, PrincipalData, QualifiedContractIdentifier};
-use stacks::core::{MAINNET_CHAIN_ID, TESTNET_CHAIN_ID, MAINNET_PEER_VERSION, TESTNET_PEER_VERSION};
+use stacks::core::{MAINNET_CHAIN_ID, TESTNET_CHAIN_ID, PEER_VERSION_MAINNET, PEER_VERSION_TESTNET};
 
 const DEFAULT_SATS_PER_VB: u64 = 50;
 const LEADER_KEY_TX_ESTIM_SIZE: u64 = 290;
@@ -517,9 +517,9 @@ impl Config {
                         TESTNET_CHAIN_ID
                     },
                     peer_version: if &burnchain_mode == "mainnet" {
-                        MAINNET_PEER_VERSION
+                        PEER_VERSION_MAINNET
                     } else {
-                        TESTNET_PEER_VERSION
+                        PEER_VERSION_TESTNET
                     },
                     mode: burnchain_mode.clone(),
                     burn_fee_cap: burnchain
@@ -943,7 +943,7 @@ impl BurnchainConfig {
             chain: "bitcoin".to_string(),
             mode: "mocknet".to_string(),
             chain_id: TESTNET_CHAIN_ID,
-            peer_version: TESTNET_PEER_VERSION,
+            peer_version: PEER_VERSION_TESTNET,
             burn_fee_cap: 20000,
             commit_anchor_block_within: 5000,
             peer_host: "0.0.0.0".to_string(),

--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -13,12 +13,7 @@ use stacks::util::secp256k1::Secp256k1PrivateKey;
 use stacks::util::secp256k1::Secp256k1PublicKey;
 use stacks::vm::costs::ExecutionCost;
 use stacks::vm::types::{AssetIdentifier, PrincipalData, QualifiedContractIdentifier};
-
-pub const TESTNET_CHAIN_ID: u32 = 0x80000000;
-pub const TESTNET_PEER_VERSION: u32 = 0xfacade01;
-
-pub const MAINNET_CHAIN_ID: u32 = 0x00000001;
-pub const MAINNET_PEER_VERSION: u32 = 0x18000000;
+use stacks::core::{MAINNET_CHAIN_ID, TESTNET_CHAIN_ID, MAINNET_PEER_VERSION, TESTNET_PEER_VERSION};
 
 const DEFAULT_SATS_PER_VB: u64 = 50;
 const LEADER_KEY_TX_ESTIM_SIZE: u64 = 290;

--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -7,7 +7,7 @@ use rand::RngCore;
 use stacks::burnchains::bitcoin::BitcoinNetworkType;
 use stacks::burnchains::{MagicBytes, BLOCKSTACK_MAGIC_MAINNET};
 use stacks::core::{
-    CHAIN_ID_MAINNET, PEER_VERSION_MAINNET, PEER_VERSION_TESTNET, CHAIN_ID_TESTNET,
+    CHAIN_ID_MAINNET, CHAIN_ID_TESTNET, PEER_VERSION_MAINNET, PEER_VERSION_TESTNET,
 };
 use stacks::net::connection::ConnectionOptions;
 use stacks::net::{Neighbor, NeighborKey, PeerAddress};

--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -7,7 +7,7 @@ use rand::RngCore;
 use stacks::burnchains::bitcoin::BitcoinNetworkType;
 use stacks::burnchains::{MagicBytes, BLOCKSTACK_MAGIC_MAINNET};
 use stacks::core::{
-    MAINNET_CHAIN_ID, PEER_VERSION_MAINNET, PEER_VERSION_TESTNET, TESTNET_CHAIN_ID,
+    CHAIN_ID_MAINNET, PEER_VERSION_MAINNET, PEER_VERSION_TESTNET, CHAIN_ID_TESTNET,
 };
 use stacks::net::connection::ConnectionOptions;
 use stacks::net::{Neighbor, NeighborKey, PeerAddress};
@@ -514,9 +514,9 @@ impl Config {
                 BurnchainConfig {
                     chain: burnchain.chain.unwrap_or(default_burnchain_config.chain),
                     chain_id: if &burnchain_mode == "mainnet" {
-                        MAINNET_CHAIN_ID
+                        CHAIN_ID_MAINNET
                     } else {
-                        TESTNET_CHAIN_ID
+                        CHAIN_ID_TESTNET
                     },
                     peer_version: if &burnchain_mode == "mainnet" {
                         PEER_VERSION_MAINNET
@@ -944,7 +944,7 @@ impl BurnchainConfig {
         BurnchainConfig {
             chain: "bitcoin".to_string(),
             mode: "mocknet".to_string(),
-            chain_id: TESTNET_CHAIN_ID,
+            chain_id: CHAIN_ID_TESTNET,
             peer_version: PEER_VERSION_TESTNET,
             burn_fee_cap: 20000,
             commit_anchor_block_within: 5000,

--- a/testnet/stacks-node/src/monitoring/prometheus.rs
+++ b/testnet/stacks-node/src/monitoring/prometheus.rs
@@ -44,10 +44,7 @@ pub fn start_serving_prometheus_metrics(bind_address: String) {
 }
 
 async fn accept(addr: String, stream: TcpStream) -> http_types::Result<()> {
-    debug!(
-        "Handle Prometheus polling ({})",
-        stream.peer_addr()?
-    );
+    debug!("Handle Prometheus polling ({})", stream.peer_addr()?);
     async_h1::accept(&addr, stream.clone(), |_| async {
         let encoder = TextEncoder::new();
         let metric_families = gather();

--- a/testnet/stacks-node/src/monitoring/prometheus.rs
+++ b/testnet/stacks-node/src/monitoring/prometheus.rs
@@ -44,8 +44,8 @@ pub fn start_serving_prometheus_metrics(bind_address: String) {
 }
 
 async fn accept(addr: String, stream: TcpStream) -> http_types::Result<()> {
-    info!(
-        "Prometheus monitoring: starting new connection from {}",
+    debug!(
+        "Handle Prometheus polling ({})",
         stream.peer_addr()?
     );
     async_h1::accept(&addr, stream.clone(), |_| async {

--- a/testnet/stacks-node/src/tenure.rs
+++ b/testnet/stacks-node/src/tenure.rs
@@ -110,7 +110,7 @@ impl<'a> Tenure {
 
     #[cfg(test)]
     pub fn open_chainstate(&self) -> StacksChainState {
-        use super::config::CHAIN_ID_TESTNET;
+        use stacks::core::CHAIN_ID_TESTNET;
 
         let (chain_state, _) = StacksChainState::open_with_block_limit(
             false,

--- a/testnet/stacks-node/src/tenure.rs
+++ b/testnet/stacks-node/src/tenure.rs
@@ -110,11 +110,11 @@ impl<'a> Tenure {
 
     #[cfg(test)]
     pub fn open_chainstate(&self) -> StacksChainState {
-        use super::config::TESTNET_CHAIN_ID;
+        use super::config::CHAIN_ID_TESTNET;
 
         let (chain_state, _) = StacksChainState::open_with_block_limit(
             false,
-            TESTNET_CHAIN_ID,
+            CHAIN_ID_TESTNET,
             &self.config.get_chainstate_path(),
             self.config.block_limit.clone(),
         )

--- a/testnet/stacks-node/src/tests/mempool.rs
+++ b/testnet/stacks-node/src/tests/mempool.rs
@@ -22,7 +22,7 @@ use std::sync::Mutex;
 use crate::helium::RunLoop;
 use crate::Keychain;
 
-use crate::config::CHAIN_ID_TESTNET;
+use stacks::core::CHAIN_ID_TESTNET;
 
 use super::{
     make_coinbase, make_contract_call, make_contract_publish, make_poison, make_stacks_transfer,

--- a/testnet/stacks-node/src/tests/mempool.rs
+++ b/testnet/stacks-node/src/tests/mempool.rs
@@ -22,7 +22,7 @@ use std::sync::Mutex;
 use crate::helium::RunLoop;
 use crate::Keychain;
 
-use crate::config::TESTNET_CHAIN_ID;
+use crate::config::CHAIN_ID_TESTNET;
 
 use super::{
     make_coinbase, make_contract_call, make_contract_publish, make_poison, make_stacks_transfer,
@@ -55,7 +55,7 @@ pub fn make_bad_stacks_transfer(
     let auth = TransactionAuth::Standard(spending_condition);
 
     let mut unsigned_tx = StacksTransaction::new(TransactionVersion::Testnet, auth, payload);
-    unsigned_tx.chain_id = TESTNET_CHAIN_ID;
+    unsigned_tx.chain_id = CHAIN_ID_TESTNET;
 
     let mut tx_signer = StacksTransactionSigner::new(&unsigned_tx);
 
@@ -196,7 +196,7 @@ fn mempool_setup_chainstate() {
 
             let chainstate_path = { CHAINSTATE_PATH.lock().unwrap().clone().unwrap() };
 
-            let _mempool = MemPoolDB::open(false, TESTNET_CHAIN_ID, &chainstate_path).unwrap();
+            let _mempool = MemPoolDB::open(false, CHAIN_ID_TESTNET, &chainstate_path).unwrap();
 
             if round == 3 {
                 let block_header = chain_tip.metadata.clone();

--- a/testnet/stacks-node/src/tests/mod.rs
+++ b/testnet/stacks-node/src/tests/mod.rs
@@ -22,7 +22,7 @@ use stacks::vm::types::PrincipalData;
 use stacks::vm::{ClarityName, ContractName, Value};
 
 use super::burnchains::bitcoin_regtest_controller::ParsedUTXO;
-use super::config::TESTNET_CHAIN_ID;
+use super::config::CHAIN_ID_TESTNET;
 use super::Config;
 use crate::helium::RunLoop;
 use rand::RngCore;
@@ -95,7 +95,7 @@ pub fn serialize_sign_standard_single_sig_tx_anchor_mode(
     let mut unsigned_tx = StacksTransaction::new(TransactionVersion::Testnet, auth, payload);
     unsigned_tx.anchor_mode = anchor_mode;
     unsigned_tx.post_condition_mode = TransactionPostConditionMode::Allow;
-    unsigned_tx.chain_id = TESTNET_CHAIN_ID;
+    unsigned_tx.chain_id = CHAIN_ID_TESTNET;
 
     let mut tx_signer = StacksTransactionSigner::new(&unsigned_tx);
     tx_signer.sign_origin(sender).unwrap();
@@ -365,7 +365,7 @@ fn should_succeed_mining_valid_txs() {
 
                     // Transaction #1 should be the coinbase from the leader
                     let coinbase_tx = &chain_tip.block.txs[0];
-                    assert!(coinbase_tx.chain_id == TESTNET_CHAIN_ID);
+                    assert!(coinbase_tx.chain_id == CHAIN_ID_TESTNET);
                     assert!(match coinbase_tx.payload {
                         TransactionPayload::Coinbase(_) => true,
                         _ => false,
@@ -373,7 +373,7 @@ fn should_succeed_mining_valid_txs() {
 
                     // Transaction #2 should be the smart contract published
                     let contract_tx = &chain_tip.block.txs[1];
-                    assert!(contract_tx.chain_id == TESTNET_CHAIN_ID);
+                    assert!(contract_tx.chain_id == CHAIN_ID_TESTNET);
                     assert!(match contract_tx.payload {
                         TransactionPayload::SmartContract(_) => true,
                         _ => false,
@@ -397,7 +397,7 @@ fn should_succeed_mining_valid_txs() {
 
                     // Transaction #1 should be the coinbase from the leader
                     let coinbase_tx = &chain_tip.block.txs[0];
-                    assert!(coinbase_tx.chain_id == TESTNET_CHAIN_ID);
+                    assert!(coinbase_tx.chain_id == CHAIN_ID_TESTNET);
                     assert!(match coinbase_tx.payload {
                         TransactionPayload::Coinbase(_) => true,
                         _ => false,
@@ -405,7 +405,7 @@ fn should_succeed_mining_valid_txs() {
 
                     // Transaction #2 should be the get-value contract-call
                     let contract_tx = &chain_tip.block.txs[1];
-                    assert!(contract_tx.chain_id == TESTNET_CHAIN_ID);
+                    assert!(contract_tx.chain_id == CHAIN_ID_TESTNET);
                     assert!(match contract_tx.payload {
                         TransactionPayload::ContractCall(_) => true,
                         _ => false,
@@ -429,7 +429,7 @@ fn should_succeed_mining_valid_txs() {
 
                     // Transaction #1 should be the coinbase from the leader
                     let coinbase_tx = &chain_tip.block.txs[0];
-                    assert!(coinbase_tx.chain_id == TESTNET_CHAIN_ID);
+                    assert!(coinbase_tx.chain_id == CHAIN_ID_TESTNET);
                     assert!(match coinbase_tx.payload {
                         TransactionPayload::Coinbase(_) => true,
                         _ => false,
@@ -437,7 +437,7 @@ fn should_succeed_mining_valid_txs() {
 
                     // Transaction #2 should be the set-value contract-call
                     let contract_tx = &chain_tip.block.txs[1];
-                    assert!(contract_tx.chain_id == TESTNET_CHAIN_ID);
+                    assert!(contract_tx.chain_id == CHAIN_ID_TESTNET);
                     assert!(match contract_tx.payload {
                         TransactionPayload::ContractCall(_) => true,
                         _ => false,
@@ -470,7 +470,7 @@ fn should_succeed_mining_valid_txs() {
 
                     // Transaction #1 should be the coinbase from the leader
                     let coinbase_tx = &chain_tip.block.txs[0];
-                    assert!(coinbase_tx.chain_id == TESTNET_CHAIN_ID);
+                    assert!(coinbase_tx.chain_id == CHAIN_ID_TESTNET);
                     assert!(match coinbase_tx.payload {
                         TransactionPayload::Coinbase(_) => true,
                         _ => false,
@@ -478,7 +478,7 @@ fn should_succeed_mining_valid_txs() {
 
                     // Transaction #2 should be the get-value contract-call
                     let contract_tx = &chain_tip.block.txs[1];
-                    assert!(contract_tx.chain_id == TESTNET_CHAIN_ID);
+                    assert!(contract_tx.chain_id == CHAIN_ID_TESTNET);
                     assert!(match contract_tx.payload {
                         TransactionPayload::ContractCall(_) => true,
                         _ => false,
@@ -511,7 +511,7 @@ fn should_succeed_mining_valid_txs() {
 
                     // Transaction #1 should be the coinbase from the leader
                     let coinbase_tx = &chain_tip.block.txs[0];
-                    assert!(coinbase_tx.chain_id == TESTNET_CHAIN_ID);
+                    assert!(coinbase_tx.chain_id == CHAIN_ID_TESTNET);
                     assert!(match coinbase_tx.payload {
                         TransactionPayload::Coinbase(_) => true,
                         _ => false,
@@ -519,7 +519,7 @@ fn should_succeed_mining_valid_txs() {
 
                     // Transaction #2 should be the STX transfer
                     let contract_tx = &chain_tip.block.txs[1];
-                    assert!(contract_tx.chain_id == TESTNET_CHAIN_ID);
+                    assert!(contract_tx.chain_id == CHAIN_ID_TESTNET);
 
                     assert!(match contract_tx.payload {
                         TransactionPayload::TokenTransfer(_, _, _) => true,
@@ -611,7 +611,7 @@ fn should_succeed_handling_malformed_and_valid_txs() {
 
                     // Transaction #1 should be the coinbase from the leader
                     let coinbase_tx = &chain_tip.block.txs[0];
-                    assert!(coinbase_tx.chain_id == TESTNET_CHAIN_ID);
+                    assert!(coinbase_tx.chain_id == CHAIN_ID_TESTNET);
                     assert!(match coinbase_tx.payload {
                         TransactionPayload::Coinbase(_) => true,
                         _ => false,
@@ -627,7 +627,7 @@ fn should_succeed_handling_malformed_and_valid_txs() {
 
                     // Transaction #1 should be the coinbase from the leader
                     let coinbase_tx = &chain_tip.block.txs[0];
-                    assert!(coinbase_tx.chain_id == TESTNET_CHAIN_ID);
+                    assert!(coinbase_tx.chain_id == CHAIN_ID_TESTNET);
                     assert!(match coinbase_tx.payload {
                         TransactionPayload::Coinbase(_) => true,
                         _ => false,
@@ -635,7 +635,7 @@ fn should_succeed_handling_malformed_and_valid_txs() {
 
                     // Transaction #2 should be the smart contract published
                     let contract_tx = &chain_tip.block.txs[1];
-                    assert!(contract_tx.chain_id == TESTNET_CHAIN_ID);
+                    assert!(contract_tx.chain_id == CHAIN_ID_TESTNET);
                     assert!(match contract_tx.payload {
                         TransactionPayload::SmartContract(_) => true,
                         _ => false,
@@ -651,7 +651,7 @@ fn should_succeed_handling_malformed_and_valid_txs() {
 
                     // Transaction #1 should be the coinbase from the leader
                     let coinbase_tx = &chain_tip.block.txs[0];
-                    assert!(coinbase_tx.chain_id == TESTNET_CHAIN_ID);
+                    assert!(coinbase_tx.chain_id == CHAIN_ID_TESTNET);
                     assert!(match coinbase_tx.payload {
                         TransactionPayload::Coinbase(_) => true,
                         _ => false,
@@ -667,7 +667,7 @@ fn should_succeed_handling_malformed_and_valid_txs() {
 
                     // Transaction #1 should be the coinbase from the leader
                     let coinbase_tx = &chain_tip.block.txs[0];
-                    assert!(coinbase_tx.chain_id == TESTNET_CHAIN_ID);
+                    assert!(coinbase_tx.chain_id == CHAIN_ID_TESTNET);
                     assert!(match coinbase_tx.payload {
                         TransactionPayload::Coinbase(_) => true,
                         _ => false,
@@ -683,7 +683,7 @@ fn should_succeed_handling_malformed_and_valid_txs() {
 
                     // Transaction #1 should be the coinbase from the leader
                     let coinbase_tx = &chain_tip.block.txs[0];
-                    assert!(coinbase_tx.chain_id == TESTNET_CHAIN_ID);
+                    assert!(coinbase_tx.chain_id == CHAIN_ID_TESTNET);
                     assert!(match coinbase_tx.payload {
                         TransactionPayload::Coinbase(_) => true,
                         _ => false,
@@ -691,7 +691,7 @@ fn should_succeed_handling_malformed_and_valid_txs() {
 
                     // Transaction #2 should be the contract-call
                     let contract_tx = &chain_tip.block.txs[1];
-                    assert!(contract_tx.chain_id == TESTNET_CHAIN_ID);
+                    assert!(contract_tx.chain_id == CHAIN_ID_TESTNET);
                     assert!(match contract_tx.payload {
                         TransactionPayload::ContractCall(_) => true,
                         _ => false,

--- a/testnet/stacks-node/src/tests/mod.rs
+++ b/testnet/stacks-node/src/tests/mod.rs
@@ -15,6 +15,7 @@ use stacks::chainstate::stacks::{
     TransactionSmartContract, TransactionSpendingCondition, TransactionVersion,
     C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
 };
+use stacks::core::CHAIN_ID_TESTNET;
 use stacks::net::StacksMessageCodec;
 use stacks::util::hash::hex_bytes;
 use stacks::util::strings::StacksString;
@@ -22,7 +23,6 @@ use stacks::vm::types::PrincipalData;
 use stacks::vm::{ClarityName, ContractName, Value};
 
 use super::burnchains::bitcoin_regtest_controller::ParsedUTXO;
-use super::config::CHAIN_ID_TESTNET;
 use super::Config;
 use crate::helium::RunLoop;
 use rand::RngCore;

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -8,8 +8,10 @@ use stacks::chainstate::stacks::{
     StacksPublicKey, StacksTransaction, TransactionPayload,
 };
 use stacks::core;
+use stacks::core::CHAIN_ID_TESTNET;
 use stacks::net::StacksMessageCodec;
 use stacks::util::secp256k1::Secp256k1PublicKey;
+use stacks::vm::database::ClarityDeserializable;
 use stacks::vm::execute;
 use stacks::vm::types::PrincipalData;
 use stacks::vm::Value;
@@ -18,14 +20,11 @@ use stacks::{
     vm::costs::ExecutionCost,
 };
 
-use stacks::vm::database::ClarityDeserializable;
-
 use super::bitcoin_regtest::BitcoinCoreController;
 use crate::{
     burnchains::bitcoin_regtest_controller::UTXO, config::EventKeyType,
-    config::EventObserverConfig, config::InitialBalance, config::CHAIN_ID_TESTNET, neon,
-    operations::BurnchainOpSigner, BitcoinRegtestController, BurnchainController, Config,
-    ConfigFile, Keychain,
+    config::EventObserverConfig, config::InitialBalance, neon, operations::BurnchainOpSigner,
+    BitcoinRegtestController, BurnchainController, Config, ConfigFile, Keychain,
 };
 use stacks::net::{
     AccountEntryResponse, GetAttachmentResponse, PostTransactionRequestBody, RPCPeerInfoData,

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -23,7 +23,7 @@ use stacks::vm::database::ClarityDeserializable;
 use super::bitcoin_regtest::BitcoinCoreController;
 use crate::{
     burnchains::bitcoin_regtest_controller::UTXO, config::EventKeyType,
-    config::EventObserverConfig, config::InitialBalance, config::TESTNET_CHAIN_ID, neon,
+    config::EventObserverConfig, config::InitialBalance, config::CHAIN_ID_TESTNET, neon,
     operations::BurnchainOpSigner, BitcoinRegtestController, BurnchainController, Config,
     ConfigFile, Keychain,
 };
@@ -886,7 +886,7 @@ fn microblock_integration_test() {
             find_microblock_privkey(&conf, &stacks_block.header.microblock_pubkey_hash, 1024)
                 .unwrap();
         let (mut chainstate, _) =
-            StacksChainState::open(false, TESTNET_CHAIN_ID, &conf.get_chainstate_path()).unwrap();
+            StacksChainState::open(false, CHAIN_ID_TESTNET, &conf.get_chainstate_path()).unwrap();
 
         chainstate
             .reload_unconfirmed_state(&btc_regtest_controller.sortdb_ref().index_conn(), tip_hash)

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -64,7 +64,7 @@ fn neon_integration_test_conf() -> (Config, StacksAddress) {
     let magic_bytes = Config::from_config_file(ConfigFile::xenon())
         .burnchain
         .magic_bytes;
-    assert_eq!(magic_bytes.as_bytes(), &['X' as u8, '4' as u8]);
+    assert_eq!(magic_bytes.as_bytes(), &['X' as u8, '5' as u8]);
     conf.burnchain.magic_bytes = magic_bytes;
     conf.burnchain.poll_time_secs = 1;
     conf.node.pox_sync_sample_secs = 0;


### PR DESCRIPTION
We want to re-deploy a Xenon (based on `v2.0.1`) for an ongoing Hackathon, and we're experiencing the issue with the PEER_VERSION that we were experiencing for Mainnet launch, which probably means that a codepath recently changed, revealing that discrepancy.

This PR is streamlining the usage of `PEER_VERSION`, and fixing a few places where it's being hard coded.

This PR should not affect Mainnet, but will fix our Testnet.