### PR TITLE
Feature: Check transfer semantics before mempool admission

### DIFF
--- a/src/core/mempool.rs
+++ b/src/core/mempool.rs
@@ -55,6 +55,9 @@ use core::FIRST_STACKS_BLOCK_HASH;
 
 use rusqlite::Error as SqliteError;
 
+use chainstate::stacks::TransactionPayload;
+use vm::types::PrincipalData;
+
 // maximum number of confirmations a transaction can have before it's garbage-collected
 pub const MEMPOOL_MAX_TRANSACTION_AGE: u64 = 256;
 pub const MAXIMUM_MEMPOOL_TX_CHAINING: u64 = 25;
@@ -76,7 +79,6 @@ impl MemPoolAdmitter {
         self.cur_consensus_hash = cur_consensus_hash.clone();
         self.cur_block = cur_block.clone();
     }
-
     pub fn will_admit_tx(
         &mut self,
         chainstate: &mut StacksChainState,

--- a/src/vm/clarity.rs
+++ b/src/vm/clarity.rs
@@ -251,6 +251,10 @@ impl ClarityInstance {
         f(self.datastore.get_marf())
     }
 
+    pub fn is_mainnet(&self) -> bool {
+        self.mainnet
+    }
+
     pub fn begin_block<'a>(
         &'a mut self,
         current: &StacksBlockId,

--- a/testnet/stacks-node/src/tests/mod.rs
+++ b/testnet/stacks-node/src/tests/mod.rs
@@ -86,13 +86,31 @@ pub fn serialize_sign_standard_single_sig_tx_anchor_mode(
     tx_fee: u64,
     anchor_mode: TransactionAnchorMode,
 ) -> Vec<u8> {
+    serialize_sign_standard_single_sig_tx_anchor_mode_version(
+        payload,
+        sender,
+        nonce,
+        tx_fee,
+        anchor_mode,
+        TransactionVersion::Testnet,
+    )
+}
+
+pub fn serialize_sign_standard_single_sig_tx_anchor_mode_version(
+    payload: TransactionPayload,
+    sender: &StacksPrivateKey,
+    nonce: u64,
+    tx_fee: u64,
+    anchor_mode: TransactionAnchorMode,
+    version: TransactionVersion,
+) -> Vec<u8> {
     let mut spending_condition =
         TransactionSpendingCondition::new_singlesig_p2pkh(StacksPublicKey::from_private(sender))
             .expect("Failed to create p2pkh spending condition from public key.");
     spending_condition.set_nonce(nonce);
     spending_condition.set_tx_fee(tx_fee);
     let auth = TransactionAuth::Standard(spending_condition);
-    let mut unsigned_tx = StacksTransaction::new(TransactionVersion::Testnet, auth, payload);
+    let mut unsigned_tx = StacksTransaction::new(version, auth, payload);
     unsigned_tx.anchor_mode = anchor_mode;
     unsigned_tx.post_condition_mode = TransactionPostConditionMode::Allow;
     unsigned_tx.chain_id = CHAIN_ID_TESTNET;


### PR DESCRIPTION
This implements #2354, applying some checks to transfer transactions before admitting them to the mempool:

1. If `recipient = origin`, then reject the transaction from the mempool
2. If `amt == 0`, then reject the transaction from the mempool

Either of these would already disqualify the transaction from being included in a block, but by applying these checks before mempool admission, clients are able to correct the error.