### PR TITLE
Fix: address #2347

### DIFF
--- a/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
+++ b/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
@@ -751,7 +751,7 @@ impl BitcoinRegtestController {
         let btc_miner_fee = self.config.burnchain.block_commit_tx_estimated_size
             * self.config.burnchain.satoshis_per_byte;
 
-        let rbf_fee = attempt.saturating_sub(1) * btc_miner_fee;
+        let rbf_fee = attempt.saturating_sub(1) * self.config.burnchain.block_commit_tx_estimated_size;
         let budget_for_outputs = value_per_transfer * number_of_transfers + sunset_fee;
 
         let total_required = btc_miner_fee + budget_for_outputs + rbf_fee;

--- a/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
+++ b/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
@@ -60,7 +60,6 @@ pub struct BitcoinRegtestController {
     use_coordinator: Option<CoordinatorChannels>,
     burnchain_config: Option<Burnchain>,
     last_utxos: Vec<UTXO>,
-    min_relay_fee: u64, // satoshis/byte
 }
 
 const DUST_UTXO_LIMIT: u64 = 5500;
@@ -120,7 +119,6 @@ impl BitcoinRegtestController {
             chain_tip: None,
             burnchain_config,
             last_utxos: vec![],
-            min_relay_fee: 1024, // TODO: learn from bitcoind
         }
     }
 
@@ -156,7 +154,6 @@ impl BitcoinRegtestController {
             chain_tip: None,
             burnchain_config: None,
             last_utxos: vec![],
-            min_relay_fee: 1024, // TODO: learn from bitcoind
         }
     }
 

--- a/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
+++ b/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
@@ -751,7 +751,8 @@ impl BitcoinRegtestController {
         let btc_miner_fee = self.config.burnchain.block_commit_tx_estimated_size
             * self.config.burnchain.satoshis_per_byte;
 
-        let rbf_fee = attempt.saturating_sub(1) * self.config.burnchain.block_commit_tx_estimated_size;
+        let rbf_fee =
+            attempt.saturating_sub(1) * self.config.burnchain.block_commit_tx_estimated_size;
         let budget_for_outputs = value_per_transfer * number_of_transfers + sunset_fee;
 
         let total_required = btc_miner_fee + budget_for_outputs + rbf_fee;

--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -21,8 +21,8 @@ pub const MAINNET_CHAIN_ID: u32 = 0x00000001;
 pub const MAINNET_PEER_VERSION: u32 = 0x18000000;
 
 const DEFAULT_SATS_PER_VB: u64 = 50;
-const LEADER_KEY_TX_ESTIM_SIZE: u64 = 290;
-const BLOCK_COMMIT_TX_ESTIM_SIZE: u64 = 350;
+const LEADER_KEY_TX_ESTIM_SIZE: u64 = 291;
+const BLOCK_COMMIT_TX_ESTIM_SIZE: u64 = 352;
 
 #[derive(Clone, Deserialize, Default)]
 pub struct ConfigFile {


### PR DESCRIPTION
This PR aims at fixing issue #2347.
Instead of using the computed size of the initial transaction for computing the RBF value, we'll reuse the constant, coming from the config.
On that note, after looking at a few transactions in the explorer, using 352 bytes instead of 350 and  291 instead of 290 would be more accurate.