### PR TITLE
Feature: Do not mine while node is initially syncing Stacks blocks

### DIFF
--- a/.github/actions/bitcoin-int-tests/Dockerfile.bitcoin-tests
+++ b/.github/actions/bitcoin-int-tests/Dockerfile.bitcoin-tests
@@ -1,10 +1,11 @@
 FROM rust:buster
 
-WORKDIR /src
+WORKDIR /src/
 
 COPY . .
 
-RUN cargo test --no-run --workspace
+WORKDIR /src/testnet/stacks-node
+RUN cargo test --no-run
 
 RUN cd / && wget https://bitcoin.org/bin/bitcoin-core-0.20.0/bitcoin-0.20.0-x86_64-linux-gnu.tar.gz
 RUN cd / && tar -xvzf bitcoin-0.20.0-x86_64-linux-gnu.tar.gz
@@ -12,7 +13,6 @@ RUN cd / && tar -xvzf bitcoin-0.20.0-x86_64-linux-gnu.tar.gz
 RUN ln -s /bitcoin-0.20.0/bin/bitcoind /bin/
 
 ENV BITCOIND_TEST 1
-WORKDIR /src/testnet/stacks-node
 RUN cargo test -- --test-threads 1 --ignored tests::neon_integrations::microblock_integration_test
 RUN cargo test -- --test-threads 1 --ignored tests::neon_integrations::size_check_integration_test
 RUN cargo test -- --test-threads 1 --ignored tests::neon_integrations::cost_voting_integration

--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -292,16 +292,8 @@ impl ConfigFile {
             "02afeae522aab5f8c99a00ddf75fbcb4a641e052dd48836408d9cf437344b63516@seed-1.mainnet.stacks.co:20444",
             "03652212ea76be0ed4cd83a25c06e57819993029a7b9999f7d63c36340b34a4e62@seed-2.mainnet.stacks.co:20444"].join(",");
 
-        let height_hint_nodes = [
-            "seed-0.mainnet.stacks.co:20443",
-            "seed-1.mainnet.stacks.co:20443",
-            "seed-2.mainnet.stacks.co:20443",
-        ]
-        .join(",");
-
         let node = NodeConfigFile {
             bootstrap_node: Some(bootstrap_nodes),
-            height_hint_nodes: Some(height_hint_nodes),
             miner: Some(false),
             ..NodeConfigFile::default()
         };
@@ -429,7 +421,7 @@ pub const MAINNET_BLOCK_LIMIT: ExecutionCost = ExecutionCost {
 impl Config {
     pub fn from_config_file(config_file: ConfigFile) -> Config {
         let default_node_config = NodeConfig::default();
-        let (mut node, bootstrap_node, height_hint_nodes, deny_nodes) = match config_file.node {
+        let (mut node, bootstrap_node, deny_nodes) = match config_file.node {
             Some(node) => {
                 let rpc_bind = node.rpc_bind.unwrap_or(default_node_config.rpc_bind);
                 let node_config = NodeConfig {
@@ -445,7 +437,6 @@ impl Config {
                     p2p_bind: node.p2p_bind.unwrap_or(default_node_config.p2p_bind),
                     p2p_address: node.p2p_address.unwrap_or(rpc_bind.clone()),
                     bootstrap_node: vec![],
-                    height_hint_nodes: vec![],
                     deny_nodes: vec![],
                     data_url: match node.data_url {
                         Some(data_url) => data_url,
@@ -476,14 +467,9 @@ impl Config {
                         .unwrap_or(default_node_config.pox_sync_sample_secs),
                     use_test_genesis_chainstate: node.use_test_genesis_chainstate,
                 };
-                (
-                    node_config,
-                    node.bootstrap_node,
-                    node.height_hint_nodes,
-                    node.deny_nodes,
-                )
+                (node_config, node.bootstrap_node, node.deny_nodes)
             }
-            None => (default_node_config, None, None, None),
+            None => (default_node_config, None, None),
         };
 
         let default_burnchain_config = BurnchainConfig::default();
@@ -615,19 +601,6 @@ impl Config {
             panic!("Config is missing the setting `burnchain.local_mining_public_key` (mandatory for helium)")
         }
 
-        if let Some(height_hint_node) = height_hint_nodes {
-            node.set_height_hint_nodes(height_hint_node);
-        } else {
-            if burnchain.mode == "mainnet" {
-                node.set_height_hint_nodes(
-                    ConfigFile::mainnet()
-                        .node
-                        .unwrap()
-                        .height_hint_nodes
-                        .unwrap(),
-                );
-            }
-        }
         if let Some(bootstrap_node) = bootstrap_node {
             node.set_bootstrap_nodes(bootstrap_node, burnchain.chain_id, burnchain.peer_version);
         } else {
@@ -1064,7 +1037,6 @@ pub struct NodeConfig {
     pub p2p_address: String,
     pub local_peer_seed: Vec<u8>,
     pub bootstrap_node: Vec<Neighbor>,
-    pub height_hint_nodes: Vec<SocketAddr>,
     pub deny_nodes: Vec<Neighbor>,
     pub miner: bool,
     pub mine_microblocks: bool,
@@ -1103,7 +1075,6 @@ impl NodeConfig {
             data_url: format!("http://127.0.0.1:{}", rpc_port),
             p2p_address: format!("127.0.0.1:{}", rpc_port),
             bootstrap_node: vec![],
-            height_hint_nodes: vec![],
             deny_nodes: vec![],
             local_peer_seed: local_peer_seed.to_vec(),
             miner: false,
@@ -1150,11 +1121,6 @@ impl NodeConfig {
         }
     }
 
-    pub fn add_height_hint_node(&mut self, hostport: &str) {
-        let sockaddr = hostport.to_socket_addrs().unwrap().next().unwrap();
-        self.height_hint_nodes.push(sockaddr);
-    }
-
     pub fn add_bootstrap_node(&mut self, bootstrap_node: &str, chain_id: u32, peer_version: u32) {
         let parts: Vec<&str> = bootstrap_node.split("@").collect();
         if parts.len() != 2 {
@@ -1181,15 +1147,6 @@ impl NodeConfig {
         for part in parts.into_iter() {
             if part.len() > 0 {
                 self.add_bootstrap_node(&part, chain_id, peer_version);
-            }
-        }
-    }
-
-    pub fn set_height_hint_nodes(&mut self, nodes: String) {
-        let parts: Vec<&str> = nodes.split(",").collect();
-        for part in parts.into_iter() {
-            if part.len() > 0 {
-                self.add_height_hint_node(&part);
             }
         }
     }
@@ -1271,7 +1228,6 @@ pub struct NodeConfigFile {
     pub p2p_address: Option<String>,
     pub data_url: Option<String>,
     pub bootstrap_node: Option<String>,
-    pub height_hint_nodes: Option<String>,
     pub local_peer_seed: Option<String>,
     pub miner: Option<bool>,
     pub mine_microblocks: Option<bool>,

--- a/testnet/stacks-node/src/main.rs
+++ b/testnet/stacks-node/src/main.rs
@@ -79,6 +79,17 @@ fn main() {
 
     info!("{}", version());
 
+    let mine_start: Option<u64> = args
+        .opt_value_from_str("--mine-at-height")
+        .expect("Failed to parse --mine-at-height argument");
+
+    if let Some(mine_start) = mine_start {
+        info!(
+            "Will begin mining once Stacks chain has synced to height >= {}",
+            mine_start
+        );
+    }
+
     let config_file = match subcommand.as_str() {
         "mocknet" => {
             args.finish().unwrap();
@@ -144,7 +155,7 @@ fn main() {
         || conf.burnchain.mode == "mainnet"
     {
         let mut run_loop = neon::RunLoop::new(conf);
-        run_loop.start(num_round, None);
+        run_loop.start(None, mine_start.unwrap_or(0));
     } else {
         println!("Burnchain mode '{}' not supported", conf.burnchain.mode);
     }
@@ -196,6 +207,10 @@ start\t\tStart a node with a config of your own. Can be used for joining a netwo
 version\t\tDisplay information about the current version and our release cycle.
 
 help\t\tDisplay this help.
+
+OPTIONAL ARGUMENTS:
+
+\t\t--mine-at-height=<height>: optional argument for a miner to not attempt mining until Stacks block has sync'ed to <height>
 
 ", argv[0]);
 }

--- a/testnet/stacks-node/src/run_loop/neon.rs
+++ b/testnet/stacks-node/src/run_loop/neon.rs
@@ -462,8 +462,8 @@ impl RunLoop {
             if block_height >= burnchain_height && !ibd {
                 let canonical_stacks_tip_height =
                     SortitionDB::get_canonical_burn_chain_tip(burnchain.sortdb_ref().conn())
-                        .expect("Failed to get canonical sortition tip")
-                        .canonical_stacks_tip_height;
+                        .map(|snapshot| snapshot.canonical_stacks_tip_height)
+                        .unwrap_or(0);
                 if canonical_stacks_tip_height < stacks_tip_to_boot_to {
                     info!(
                         "Synchronized full burnchain, but stacks tip height is {}, and we are trying to boot to {}, not mining until reaching chain tip",

--- a/testnet/stacks-node/src/run_loop/neon.rs
+++ b/testnet/stacks-node/src/run_loop/neon.rs
@@ -6,6 +6,8 @@ use crate::{
 };
 use async_std::net::TcpStream;
 use http_types::{Method, Request, Url};
+use stacks::burnchains::bitcoin::address::BitcoinAddress;
+use stacks::burnchains::bitcoin::address::BitcoinAddressType;
 use stacks::burnchains::{Address, Burnchain};
 use stacks::chainstate::burn::db::sortdb::SortitionDB;
 use stacks::chainstate::coordinator::comm::{CoordinatorChannels, CoordinatorReceivers};
@@ -16,8 +18,6 @@ use stacks::chainstate::stacks::boot;
 use stacks::chainstate::stacks::db::{ChainStateBootData, ClarityTx, StacksChainState};
 use stacks::net::atlas::{AtlasConfig, Attachment};
 use stacks::vm::types::{PrincipalData, Value};
-use stacks::{burnchains::bitcoin::address::BitcoinAddress, net::Neighbor};
-use stacks::{burnchains::bitcoin::address::BitcoinAddressType, net::StacksHttp};
 use std::cmp;
 use std::sync::mpsc::sync_channel;
 use std::thread;

--- a/testnet/stacks-node/src/run_loop/neon.rs
+++ b/testnet/stacks-node/src/run_loop/neon.rs
@@ -234,7 +234,7 @@ impl RunLoop {
             .map(|e| (e.address.clone(), e.amount))
             .collect();
 
-        let stacks_tip_to_boot_to = if mainnet {
+        let mut stacks_tip_to_boot_to = if mainnet {
             self.get_seed_stacks_height()
         } else {
             0
@@ -471,6 +471,10 @@ impl RunLoop {
                         stacks_tip_to_boot_to
                     );
                 } else {
+                    // once we've synced to the chain tip once, don't apply this check again.
+                    //  this prevents a possible corner case in the event of a PoX fork.
+                    stacks_tip_to_boot_to = 0;
+
                     // at tip, and not downloading. proceed to mine.
                     debug!(
                         "Synchronized full burnchain up to height {}. Proceeding to mine blocks",

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -314,7 +314,7 @@ fn bitcoind_integration_test() {
 
     let channel = run_loop.get_coordinator_channel().unwrap();
 
-    thread::spawn(move || run_loop.start(0, None));
+    thread::spawn(move || run_loop.start(None, 0));
 
     // give the run loop some time to start up!
     wait_for_runloop(&blocks_processed);
@@ -421,7 +421,7 @@ fn liquid_ustx_integration() {
     let _client = reqwest::blocking::Client::new();
     let channel = run_loop.get_coordinator_channel().unwrap();
 
-    thread::spawn(move || run_loop.start(0, Some(burnchain_config)));
+    thread::spawn(move || run_loop.start(Some(burnchain_config), 0));
 
     // give the run loop some time to start up!
     wait_for_runloop(&blocks_processed);
@@ -544,7 +544,7 @@ fn stx_transfer_btc_integration_test() {
 
     let channel = run_loop.get_coordinator_channel().unwrap();
 
-    thread::spawn(move || run_loop.start(0, None));
+    thread::spawn(move || run_loop.start(None, 0));
 
     // give the run loop some time to start up!
     wait_for_runloop(&blocks_processed);
@@ -718,7 +718,7 @@ fn bitcoind_forking_test() {
 
     let channel = run_loop.get_coordinator_channel().unwrap();
 
-    thread::spawn(move || run_loop.start(0, None));
+    thread::spawn(move || run_loop.start(None, 0));
 
     // give the run loop some time to start up!
     wait_for_runloop(&blocks_processed);
@@ -814,7 +814,7 @@ fn microblock_integration_test() {
 
     let channel = run_loop.get_coordinator_channel().unwrap();
 
-    thread::spawn(move || run_loop.start(0, None));
+    thread::spawn(move || run_loop.start(None, 0));
 
     // give the run loop some time to start up!
     wait_for_runloop(&blocks_processed);
@@ -1168,7 +1168,7 @@ fn size_check_integration_test() {
 
     let channel = run_loop.get_coordinator_channel().unwrap();
 
-    thread::spawn(move || run_loop.start(0, None));
+    thread::spawn(move || run_loop.start(None, 0));
 
     // give the run loop some time to start up!
     wait_for_runloop(&blocks_processed);
@@ -1320,7 +1320,7 @@ fn cost_voting_integration() {
     let blocks_processed = run_loop.get_blocks_processed_arc();
     let channel = run_loop.get_coordinator_channel().unwrap();
 
-    thread::spawn(move || run_loop.start(0, Some(burnchain_config)));
+    thread::spawn(move || run_loop.start(Some(burnchain_config), 0));
 
     // give the run loop some time to start up!
     wait_for_runloop(&blocks_processed);
@@ -1662,7 +1662,7 @@ fn pox_integration_test() {
     let client = reqwest::blocking::Client::new();
     let channel = run_loop.get_coordinator_channel().unwrap();
 
-    thread::spawn(move || run_loop.start(0, Some(burnchain_config)));
+    thread::spawn(move || run_loop.start(Some(burnchain_config), 0));
 
     // give the run loop some time to start up!
     wait_for_runloop(&blocks_processed);
@@ -2021,7 +2021,7 @@ fn atlas_integration_test() {
         let client = reqwest::blocking::Client::new();
         let channel = run_loop.get_coordinator_channel().unwrap();
 
-        thread::spawn(move || run_loop.start(0, Some(burnchain_config)));
+        thread::spawn(move || run_loop.start(Some(burnchain_config), 0));
 
         // give the run loop some time to start up!
         wait_for_runloop(&blocks_processed);
@@ -2309,7 +2309,7 @@ fn atlas_integration_test() {
     let client = reqwest::blocking::Client::new();
     let channel = run_loop.get_coordinator_channel().unwrap();
 
-    thread::spawn(move || run_loop.start(0, Some(burnchain_config)));
+    thread::spawn(move || run_loop.start(Some(burnchain_config), 0));
 
     // give the run loop some time to start up!
     wait_for_runloop(&blocks_processed);

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -1652,7 +1652,7 @@ fn near_full_block_integration_test() {
 
     let channel = run_loop.get_coordinator_channel().unwrap();
 
-    thread::spawn(move || run_loop.start(0, None));
+    thread::spawn(move || run_loop.start(None, 0));
 
     // give the run loop some time to start up!
     wait_for_runloop(&blocks_processed);


### PR DESCRIPTION
This is one method for addressing #2364 -- during initial bootup, a `stacks-node` instance will query a set of "height hint" peers. The node will _not_ begin mining until it reaches the max height returned by those peers.

This PR also sets a default set of height hint nodes, as well as providing more proactive default bootstrap node selection for mainnet configurations (i.e., if the `bootstrap_node` field is _not_ set in the config, but the config is a mainnet config, use the default set).