### PR TITLE
Feat/p2p no blocking

### DIFF
--- a/src/burnchains/burnchain.rs
+++ b/src/burnchains/burnchain.rs
@@ -2158,6 +2158,7 @@ pub mod tests {
             tx.commit().unwrap();
 
             block_121_snapshot.index_root = sn121.index_root.clone();
+            block_121_snapshot.parent_sortition_id = sn121.parent_sortition_id.clone();
             assert_eq!(sn121, block_121_snapshot);
         }
         {
@@ -2180,6 +2181,7 @@ pub mod tests {
             tx.commit().unwrap();
 
             block_122_snapshot.index_root = sn122.index_root.clone();
+            block_122_snapshot.parent_sortition_id = sn122.parent_sortition_id.clone();
             assert_eq!(sn122, block_122_snapshot);
         }
         {
@@ -2201,6 +2203,7 @@ pub mod tests {
             tx.commit().unwrap();
 
             block_123_snapshot.index_root = sn123.index_root.clone();
+            block_123_snapshot.parent_sortition_id = sn123.parent_sortition_id.clone();
             assert_eq!(sn123, block_123_snapshot);
         }
 
@@ -2312,6 +2315,7 @@ pub mod tests {
                 tx.commit().unwrap();
 
                 block_124_snapshot.index_root = sn124.index_root.clone();
+                block_124_snapshot.parent_sortition_id = sn124.parent_sortition_id.clone();
                 sn124
             };
 

--- a/src/burnchains/burnchain.rs
+++ b/src/burnchains/burnchain.rs
@@ -340,7 +340,7 @@ impl BurnchainSigner {
         }
     }
 
-    pub fn to_address(&self, network_type: BitcoinNetworkType) -> String {
+    pub fn to_bitcoin_address(&self, network_type: BitcoinNetworkType) -> String {
         let addr_type = match &self.hash_mode {
             AddressHashMode::SerializeP2PKH | AddressHashMode::SerializeP2WPKH => {
                 BitcoinAddressType::PublicKeyHash
@@ -1949,6 +1949,7 @@ pub mod tests {
             block_height: 121,
             burn_header_hash: block_121_hash.clone(),
             sortition_id: SortitionId(block_121_hash.0.clone()),
+            parent_sortition_id: SortitionId(block_121_hash.0.clone()),
             burn_header_timestamp: 121,
             parent_burn_header_hash: first_burn_hash.clone(),
             ops_hash: block_opshash_121.clone(),
@@ -1994,6 +1995,7 @@ pub mod tests {
             block_height: 122,
             burn_header_hash: block_122_hash.clone(),
             sortition_id: SortitionId(block_122_hash.0.clone()),
+            parent_sortition_id: block_121_snapshot.sortition_id.clone(),
             burn_header_timestamp: 122,
             parent_burn_header_hash: block_121_hash.clone(),
             ops_hash: block_opshash_122.clone(),
@@ -2046,6 +2048,7 @@ pub mod tests {
             block_height: 123,
             burn_header_hash: block_123_hash.clone(),
             sortition_id: SortitionId(block_123_hash.0.clone()),
+            parent_sortition_id: block_122_snapshot.sortition_id.clone(),
             burn_header_timestamp: 123,
             parent_burn_header_hash: block_122_hash.clone(),
             ops_hash: block_opshash_123.clone(),
@@ -2243,6 +2246,7 @@ pub mod tests {
                 block_height: 124,
                 burn_header_hash: block_124_hash.clone(),
                 sortition_id: SortitionId(block_124_hash.0.clone()),
+                parent_sortition_id: block_123_snapshot.sortition_id.clone(),
                 burn_header_timestamp: 124,
                 parent_burn_header_hash: block_123_snapshot.burn_header_hash.clone(),
                 ops_hash: block_opshash_124.clone(),

--- a/src/burnchains/db.rs
+++ b/src/burnchains/db.rs
@@ -30,8 +30,8 @@ use chainstate::burn::operations::BlockstackOperationType;
 use chainstate::stacks::index::MarfTrieId;
 
 use util::db::{
-    query_row, query_rows, tx_begin_immediate, tx_busy_handler, u64_to_sql, Error as DBError,
-    FromColumn, FromRow,
+    query_row, query_rows, sql_pragma, tx_begin_immediate, tx_busy_handler, u64_to_sql,
+    Error as DBError, FromColumn, FromRow,
 };
 
 use std::collections::HashMap;
@@ -216,6 +216,7 @@ impl BurnchainDB {
 
         if create_flag {
             let db_tx = db.tx_begin()?;
+            sql_pragma(&db_tx.sql_tx, "PRAGMA journal_mode = WAL;")?;
             db_tx.sql_tx.execute_batch(BURNCHAIN_DB_SCHEMA)?;
 
             let first_block_header = BurnchainBlockHeader {

--- a/src/chainstate/burn/db/sortdb.rs
+++ b/src/chainstate/burn/db/sortdb.rs
@@ -4319,6 +4319,7 @@ pub mod tests {
             let sn_parent = sn.clone();
             sn.parent_burn_header_hash = sn.burn_header_hash.clone();
             sn.sortition_id = SortitionId(next_hash.0.clone());
+            sn.parent_sortition_id = sn_parent.sortition_id.clone();
             sn.burn_header_hash = next_hash;
             sn.block_height += 1;
             sn.num_sortitions += 1;
@@ -5446,6 +5447,7 @@ pub mod tests {
                 0,
                 i + 1,
             ]);
+            next_snapshot.parent_sortition_id = last_snapshot.sortition_id.clone();
             next_snapshot.consensus_hash = ConsensusHash([
                 0,
                 0,
@@ -5587,6 +5589,7 @@ pub mod tests {
                 next_snapshot.num_sortitions = initial_num_sortitions + (j - i) as u64;
                 next_snapshot.parent_burn_header_hash = next_snapshot.burn_header_hash.clone();
                 next_snapshot.sortition_id = SortitionId(block_hash.clone());
+                next_snapshot.parent_sortition_id = last_snapshot.sortition_id.clone();
                 next_snapshot.burn_header_hash = BurnchainHeaderHash(block_hash);
                 next_snapshot.consensus_hash = ConsensusHash([
                     1,
@@ -5672,6 +5675,7 @@ pub mod tests {
                 next_snapshot.num_sortitions = last_snapshot.num_sortitions + 1;
                 next_snapshot.parent_burn_header_hash = last_snapshot.burn_header_hash.clone();
                 next_snapshot.sortition_id = SortitionId(next_block_hash.clone());
+                next_snapshot.parent_sortition_id = last_snapshot.sortition_id.clone();
                 next_snapshot.burn_header_hash = BurnchainHeaderHash(next_block_hash);
                 next_snapshot.consensus_hash = ConsensusHash([
                     2,
@@ -5732,6 +5736,7 @@ pub mod tests {
             next_snapshot.num_sortitions += 1;
             next_snapshot.parent_burn_header_hash = next_snapshot.burn_header_hash.clone();
             next_snapshot.sortition_id = SortitionId(next_block_hash.clone());
+            next_snapshot.parent_sortition_id = last_snapshot.sortition_id.clone();
             next_snapshot.burn_header_hash = BurnchainHeaderHash(next_block_hash);
             next_snapshot.consensus_hash =
                 ConsensusHash(Hash160::from_data(&next_snapshot.consensus_hash.0).0);

--- a/src/chainstate/burn/db/sortdb.rs
+++ b/src/chainstate/burn/db/sortdb.rs
@@ -32,8 +32,8 @@ use std::{cmp, fmt, fs, str::FromStr};
 use util::db::tx_begin_immediate;
 use util::db::Error as db_error;
 use util::db::{
-    db_mkdirs, query_count, query_row, query_row_columns, query_row_panic, query_rows, u64_to_sql,
-    FromColumn, FromRow, IndexDBConn, IndexDBTx,
+    db_mkdirs, query_count, query_row, query_row_columns, query_row_panic, query_rows, sql_pragma,
+    u64_to_sql, DBConn, FromColumn, FromRow, IndexDBConn, IndexDBTx,
 };
 use util::get_epoch_time_secs;
 
@@ -61,6 +61,8 @@ use burnchains::{
     PoxConstants,
 };
 
+use burnchains::bitcoin::BitcoinNetworkType;
+
 use chainstate::stacks::db::{StacksChainState, StacksHeaderInfo};
 use chainstate::stacks::index::marf::MarfConnection;
 use chainstate::stacks::index::marf::MARF;
@@ -86,6 +88,7 @@ use net::neighbors::MAX_NEIGHBOR_BLOCK_DELAY;
 
 use std::collections::HashMap;
 
+use core::FIRST_BURNCHAIN_CONSENSUS_HASH;
 use core::FIRST_STACKS_BLOCK_HASH;
 
 use vm::representations::{ClarityName, ContractName};
@@ -125,6 +128,7 @@ impl FromRow<MissedBlockCommit> for MissedBlockCommit {
         let input =
             serde_json::from_str(&input_json).map_err(|e| db_error::SerializationError(e))?;
         let txid = Txid::from_column(row, "txid")?;
+
         Ok(MissedBlockCommit {
             input,
             txid,
@@ -166,6 +170,7 @@ impl FromRow<BlockSnapshot> for BlockSnapshot {
 
         // identifiers derived from PoX forking state
         let sortition_id = SortitionId::from_column(row, "sortition_id")?;
+        let parent_sortition_id = SortitionId::from_column(row, "parent_sortition_id")?;
         let pox_valid = row.get_unwrap("pox_valid");
 
         let accumulated_coinbase_ustx_str: String = row.get_unwrap("accumulated_coinbase_ustx");
@@ -201,6 +206,7 @@ impl FromRow<BlockSnapshot> for BlockSnapshot {
             canonical_stacks_tip_consensus_hash: canonical_stacks_tip_consensus_hash,
 
             sortition_id,
+            parent_sortition_id,
             pox_valid,
             accumulated_coinbase_ustx,
         };
@@ -436,6 +442,7 @@ const BURNDB_SETUP: &'static [&'static str] = &[
         block_height INTEGER NOT NULL,
         burn_header_hash TEXT NOT NULL,
         sortition_id TEXT UNIQUE NOT NULL,
+        parent_sortition_id TEXT NOT NULL,
         burn_header_timestamp INT NOT NULL,
         parent_burn_header_hash TEXT NOT NULL,
         consensus_hash TEXT UNIQUE NOT NULL,
@@ -2148,6 +2155,9 @@ impl SortitionDB {
         first_burn_header_timestamp: u64,
     ) -> Result<(), db_error> {
         debug!("Instantiate SortDB");
+
+        sql_pragma(self.conn(), "PRAGMA journal_mode = WAL;")?;
+
         let mut db_tx = SortitionHandleTx::begin(self, &SortitionId::sentinel())?;
 
         // create first (sentinel) snapshot
@@ -2290,8 +2300,8 @@ impl<'a> SortitionDBConn<'a> {
             };
 
             debug!(
-                "CACHE MISS {} (height {})",
-                &ancestor_consensus_hash, ancestor_snapshot.block_height
+                "CACHE MISS {} (height {}): {:?}",
+                &ancestor_consensus_hash, ancestor_snapshot.block_height, &header_hash_opt
             );
 
             ret.push((ancestor_snapshot.consensus_hash, header_hash_opt.clone()));
@@ -2308,79 +2318,6 @@ impl<'a> SortitionDBConn<'a> {
 
         ret.reverse();
         Ok(ret)
-    }
-
-    /// Get a burn blockchain snapshot, given a burnchain configuration struct.
-    /// Used mainly by the network code to determine what the chain tip currently looks like.
-    pub fn get_burnchain_view(
-        &self,
-        burnchain: &Burnchain,
-        chain_tip: &BlockSnapshot,
-    ) -> Result<BurnchainView, db_error> {
-        if chain_tip.block_height < burnchain.first_block_height {
-            // should never happen, but don't panic since this is network-callable code
-            error!(
-                "Invalid block height from DB: {}: expected at least {}",
-                chain_tip.block_height, burnchain.first_block_height
-            );
-            return Err(db_error::Corruption);
-        }
-
-        if chain_tip.block_height < burnchain.stable_confirmations as u64 {
-            // should never happen, but don't panic since this is network-callable code
-            error!(
-                "Invalid block height from DB: {}: expected at least {}",
-                chain_tip.block_height, burnchain.stable_confirmations
-            );
-            return Err(db_error::Corruption);
-        }
-
-        let stable_block_height = cmp::max(
-            burnchain.first_block_height,
-            chain_tip.block_height - (burnchain.stable_confirmations as u64),
-        );
-
-        let db_handle = SortitionHandleConn::open_reader(self, &chain_tip.sortition_id)?;
-
-        let stable_snapshot = db_handle.get_block_snapshot_by_height(stable_block_height)?
-            .ok_or_else(|| {
-                // shouldn't be possible, but don't panic since this is network-callable code
-                error!("Failed to load snapshot for block {} from burnchain_header={}, sortition_id={}, first_block_height={}, first_block_height={}",
-                       stable_block_height, &chain_tip.burn_header_hash, &chain_tip.sortition_id, &self.context.first_block_height, burnchain.first_block_height);
-                db_error::Corruption
-            })?;
-
-        // get all burn block hashes between the chain tip, and the stable height back
-        // MAX_NEIGHBOR_BLOCK_DELAY
-        let oldest_height = if stable_snapshot.block_height < MAX_NEIGHBOR_BLOCK_DELAY {
-            0
-        } else {
-            stable_snapshot.block_height - MAX_NEIGHBOR_BLOCK_DELAY
-        };
-
-        let mut last_burn_block_hashes = HashMap::new();
-        for height in oldest_height..chain_tip.block_height {
-            let ancestor_hash =
-                SortitionDB::get_ancestor_snapshot(&self, height as u64, &chain_tip.sortition_id)?
-                    .map(|sn| sn.burn_header_hash)
-                    .unwrap_or(burnchain.first_block_hash.clone());
-            last_burn_block_hashes.insert(height, ancestor_hash);
-        }
-
-        test_debug!(
-            "Chain view: {},{}-{},{}",
-            chain_tip.block_height,
-            chain_tip.burn_header_hash,
-            stable_block_height,
-            stable_snapshot.burn_header_hash
-        );
-        Ok(BurnchainView {
-            burn_block_height: chain_tip.block_height,
-            burn_block_hash: chain_tip.burn_header_hash,
-            burn_stable_block_height: stable_block_height,
-            burn_stable_block_hash: stable_snapshot.burn_header_hash,
-            last_burn_block_hashes: last_burn_block_hashes,
-        })
     }
 
     /// Get the height of a burnchain block
@@ -2672,6 +2609,97 @@ impl SortitionDB {
     ) -> Result<u64, BurnchainError> {
         let db_handle = self.index_handle(sortition_id);
         SortitionDB::get_max_arrival_index(&db_handle).map_err(|e| BurnchainError::from(e))
+    }
+
+    /// Get a burn blockchain snapshot, given a burnchain configuration struct.
+    /// Used mainly by the network code to determine what the chain tip currently looks like.
+    pub fn get_burnchain_view(
+        conn: &DBConn,
+        burnchain: &Burnchain,
+        chain_tip: &BlockSnapshot,
+    ) -> Result<BurnchainView, db_error> {
+        if chain_tip.block_height < burnchain.first_block_height {
+            // should never happen, but don't panic since this is network-callable code
+            error!(
+                "Invalid block height from DB: {}: expected at least {}",
+                chain_tip.block_height, burnchain.first_block_height
+            );
+            return Err(db_error::Corruption);
+        }
+
+        if chain_tip.block_height < burnchain.stable_confirmations as u64 {
+            // should never happen, but don't panic since this is network-callable code
+            error!(
+                "Invalid block height from DB: {}: expected at least {}",
+                chain_tip.block_height, burnchain.stable_confirmations
+            );
+            return Err(db_error::Corruption);
+        }
+
+        let stable_block_height = cmp::max(
+            burnchain.first_block_height,
+            chain_tip.block_height - (burnchain.stable_confirmations as u64),
+        );
+
+        // get all burn block hashes between the chain tip, and the stable height back
+        // MAX_NEIGHBOR_BLOCK_DELAY
+        let oldest_height = if stable_block_height < MAX_NEIGHBOR_BLOCK_DELAY {
+            0
+        } else {
+            stable_block_height - MAX_NEIGHBOR_BLOCK_DELAY
+        };
+
+        let mut last_burn_block_hashes = HashMap::new();
+        let tip_height = chain_tip.block_height;
+
+        let mut cursor = chain_tip.clone();
+        let mut cur_height = cursor.block_height;
+
+        for _height in oldest_height..(tip_height + 1) {
+            let (ancestor_hash, ancestor_height) =
+                if cursor.block_height > burnchain.first_block_height {
+                    match SortitionDB::get_block_snapshot(conn, &cursor.parent_sortition_id) {
+                        Ok(Some(new_cursor)) => {
+                            let ret = (cursor.burn_header_hash.clone(), cursor.block_height);
+
+                            cursor = new_cursor;
+                            assert_eq!(cursor.block_height + 1, cur_height);
+
+                            cur_height = cursor.block_height;
+                            ret
+                        }
+                        _ => {
+                            cur_height = cur_height.saturating_sub(1);
+                            (burnchain.first_block_hash.clone(), cur_height)
+                        }
+                    }
+                } else {
+                    cur_height = cur_height.saturating_sub(1);
+                    (burnchain.first_block_hash.clone(), cur_height)
+                };
+
+            last_burn_block_hashes.insert(ancestor_height, ancestor_hash);
+        }
+
+        let burn_stable_block_hash = last_burn_block_hashes
+            .get(&stable_block_height)
+            .unwrap_or(&burnchain.first_block_hash)
+            .clone();
+
+        test_debug!(
+            "Chain view: {},{}-{},{}",
+            chain_tip.block_height,
+            chain_tip.burn_header_hash,
+            stable_block_height,
+            &burn_stable_block_hash
+        );
+        Ok(BurnchainView {
+            burn_block_height: chain_tip.block_height,
+            burn_block_hash: chain_tip.burn_header_hash,
+            burn_stable_block_height: stable_block_height,
+            burn_stable_block_hash: burn_stable_block_hash,
+            last_burn_block_hashes: last_burn_block_hashes,
+        })
     }
 }
 
@@ -3154,22 +3182,25 @@ impl SortitionDB {
         cache: &mut BlockHeaderCache,
         header_data: &Vec<(ConsensusHash, Option<BlockHeaderHash>)>,
     ) -> () {
-        let mut i = header_data.len() - 1;
-        while i > 0 {
-            let cur_consensus_hash = &header_data[i].0;
-            let cur_block_opt = &header_data[i].1;
+        if header_data.len() > 0 {
+            let mut i = header_data.len() - 1;
+            while i > 0 {
+                let cur_consensus_hash = &header_data[i].0;
+                let cur_block_opt = &header_data[i].1;
 
-            if !cache.contains_key(cur_consensus_hash) {
-                let prev_consensus_hash = header_data[i - 1].0.clone();
-                cache.insert(
-                    (*cur_consensus_hash).clone(),
-                    ((*cur_block_opt).clone(), prev_consensus_hash.clone()),
-                );
+                if let Some((ref cached_block_opt, _)) = cache.get(cur_consensus_hash) {
+                    assert_eq!(cached_block_opt, cur_block_opt);
+                } else {
+                    let prev_consensus_hash = header_data[i - 1].0.clone();
+                    cache.insert(
+                        (*cur_consensus_hash).clone(),
+                        ((*cur_block_opt).clone(), prev_consensus_hash.clone()),
+                    );
+                }
+
+                i -= 1;
             }
-
-            i -= 1;
         }
-
         debug!("Block header cache has {} items", cache.len());
     }
 
@@ -3235,6 +3266,7 @@ impl<'a> SortitionHandleTx<'a> {
             snapshot.parent_burn_header_hash,
             parent_snapshot.burn_header_hash
         );
+        assert_eq!(snapshot.parent_sortition_id, parent_snapshot.sortition_id);
         assert_eq!(parent_snapshot.block_height + 1, snapshot.block_height);
         if snapshot.sortition {
             assert_eq!(parent_snapshot.num_sortitions + 1, snapshot.num_sortitions);
@@ -3357,7 +3389,8 @@ impl<'a> SortitionHandleTx<'a> {
             BlockstackOperationType::LeaderBlockCommit(ref op) => {
                 info!(
                     "ACCEPTED({}) leader block commit {} at {},{}",
-                    op.block_height, &op.txid, op.block_height, op.vtxindex
+                    op.block_height, &op.txid, op.block_height, op.vtxindex;
+                    "apparent_sender" => %op.apparent_sender.to_bitcoin_address(BitcoinNetworkType::Mainnet)
                 );
                 self.insert_block_commit(op, sort_id)
             }
@@ -3597,14 +3630,15 @@ impl<'a> SortitionHandleTx<'a> {
             &snapshot.canonical_stacks_tip_hash,
             &snapshot.canonical_stacks_tip_consensus_hash,
             &snapshot.sortition_id,
+            &snapshot.parent_sortition_id,
             &snapshot.pox_valid,
             &snapshot.accumulated_coinbase_ustx.to_string(),
         ];
 
         self.execute("INSERT INTO snapshots \
                       (block_height, burn_header_hash, burn_header_timestamp, parent_burn_header_hash, consensus_hash, ops_hash, total_burn, sortition, sortition_hash, winning_block_txid, winning_stacks_block_hash, index_root, num_sortitions, \
-                      stacks_block_accepted, stacks_block_height, arrival_index, canonical_stacks_tip_height, canonical_stacks_tip_hash, canonical_stacks_tip_consensus_hash, sortition_id, pox_valid, accumulated_coinbase_ustx) \
-                      VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22)", args)
+                      stacks_block_accepted, stacks_block_height, arrival_index, canonical_stacks_tip_height, canonical_stacks_tip_hash, canonical_stacks_tip_consensus_hash, sortition_id, parent_sortition_id, pox_valid, accumulated_coinbase_ustx) \
+                      VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23)", args)
             .map_err(db_error::SqliteError)?;
 
         Ok(())
@@ -3995,6 +4029,7 @@ pub mod tests {
 
         let sn_parent = sn.clone();
         sn.parent_burn_header_hash = sn.burn_header_hash.clone();
+        sn.parent_sortition_id = sn.sortition_id.clone();
         sn.burn_header_hash = next_hash;
         sn.block_height += 1;
         sn.num_sortitions += 1;
@@ -4537,6 +4572,7 @@ pub mod tests {
                     ])
                     .unwrap(),
                     sortition_id,
+                    parent_sortition_id,
                     parent_burn_header_hash: BurnchainHeaderHash::from_bytes(&[
                         (if i == 0 { 0x10 } else { 0 }) as u8,
                         0,
@@ -4785,6 +4821,7 @@ pub mod tests {
                     ])
                     .unwrap(),
                     sortition_id,
+                    parent_sortition_id,
                     parent_burn_header_hash: BurnchainHeaderHash::from_bytes(&[
                         (if i == 0 { 0x10 } else { 0 }) as u8,
                         0,
@@ -5056,6 +5093,7 @@ pub mod tests {
             burn_header_timestamp: get_epoch_time_secs(),
             burn_header_hash: first_burn_hash.clone(),
             sortition_id: SortitionId(first_burn_hash.0.clone()),
+            parent_sortition_id: SortitionId(first_burn_hash.0.clone()),
             parent_burn_header_hash: BurnchainHeaderHash([0xff; 32]),
             consensus_hash: ConsensusHash::from_hex("0000000000000000000000000000000000000000")
                 .unwrap(),
@@ -5097,6 +5135,10 @@ pub mod tests {
             sortition_id: SortitionId([
                 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                 0, 0, 0, 2,
+            ]),
+            parent_sortition_id: SortitionId([
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 1,
             ]),
             parent_burn_header_hash: BurnchainHeaderHash::from_bytes(&[
                 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -5146,6 +5188,10 @@ pub mod tests {
             sortition_id: SortitionId([
                 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                 0, 0, 0, 1,
+            ]),
+            parent_sortition_id: SortitionId([
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0,
             ]),
             parent_burn_header_hash: BurnchainHeaderHash::from_bytes(&[
                 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -5752,6 +5798,7 @@ pub mod tests {
                             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                             0, 0, 0, 0, 0, 0, 0, i as u8,
                         ]),
+                        parent_sortition_id: last_snapshot.sortition_id.clone(),
                         parent_burn_header_hash: BurnchainHeaderHash::from_bytes(&[
                             (if i == 0 { 0x10 } else { 0 }) as u8,
                             0,
@@ -5827,6 +5874,7 @@ pub mod tests {
                             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                             0, 0, 0, 0, 0, 0, 0, i as u8,
                         ]),
+                        parent_sortition_id: last_snapshot.sortition_id.clone(),
                         parent_burn_header_hash: BurnchainHeaderHash::from_bytes(&[
                             (if i == 0 { 0x10 } else { 0 }) as u8,
                             0,
@@ -6119,6 +6167,7 @@ pub mod tests {
                 burn_header_timestamp: get_epoch_time_secs(),
                 burn_header_hash: BurnchainHeaderHash([(i as u8) | bit_pattern; 32]),
                 sortition_id: SortitionId([(i as u8) | bit_pattern; 32]),
+                parent_sortition_id: last_snapshot.sortition_id.clone(),
                 parent_burn_header_hash: last_snapshot.burn_header_hash.clone(),
                 consensus_hash: ConsensusHash([((i + 1) as u8) | bit_pattern; 20]),
                 ops_hash: OpsHash([(i as u8) | bit_pattern; 32]),

--- a/src/chainstate/burn/mod.rs
+++ b/src/chainstate/burn/mod.rs
@@ -139,6 +139,7 @@ pub struct BlockSnapshot {
     pub canonical_stacks_tip_hash: BlockHeaderHash, // memoized canonical stacks chain tip
     pub canonical_stacks_tip_consensus_hash: ConsensusHash, // memoized canonical stacks chain tip
     pub sortition_id: SortitionId,
+    pub parent_sortition_id: SortitionId,
     pub pox_valid: bool,
     /// the amount of accumulated coinbase ustx that
     ///   will accrue to the sortition winner elected by this block
@@ -427,6 +428,7 @@ mod tests {
                         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                         0, 0, 0, 0, 0, 0, i as u8,
                     ]),
+                    parent_sortition_id: prev_snapshot.sortition_id.clone(),
                     parent_burn_header_hash: BurnchainHeaderHash::from_bytes(&[
                         0,
                         0,

--- a/src/chainstate/burn/operations/leader_key_register.rs
+++ b/src/chainstate/burn/operations/leader_key_register.rs
@@ -572,6 +572,7 @@ pub mod tests {
                     burn_header_timestamp: get_epoch_time_secs(),
                     burn_header_hash: block_header_hashes[i as usize].clone(),
                     sortition_id: SortitionId(block_header_hashes[i as usize].0.clone()),
+                    parent_sortition_id: prev_snapshot.sortition_id.clone(),
                     parent_burn_header_hash: prev_snapshot.burn_header_hash.clone(),
                     consensus_hash: ConsensusHash::from_bytes(&[
                         0,

--- a/src/chainstate/burn/operations/user_burn_support.rs
+++ b/src/chainstate/burn/operations/user_burn_support.rs
@@ -583,6 +583,7 @@ mod tests {
                     burn_header_timestamp: get_epoch_time_secs(),
                     burn_header_hash: block_header_hashes[i as usize].clone(),
                     sortition_id: SortitionId(block_header_hashes[i as usize].0.clone()),
+                    parent_sortition_id: prev_snapshot.sortition_id.clone(),
                     parent_burn_header_hash: prev_snapshot.burn_header_hash.clone(),
                     consensus_hash: ConsensusHash::from_bytes(&[
                         0,

--- a/src/chainstate/burn/sortition.rs
+++ b/src/chainstate/burn/sortition.rs
@@ -80,6 +80,7 @@ impl BlockSnapshot {
             //  we shouldn't need to update this to use PoxId::initial(),
             //  but if we do, we need to update a lot of test cases.
             sortition_id: SortitionId::stubbed(first_burn_header_hash),
+            parent_sortition_id: SortitionId::stubbed(first_burn_header_hash),
             pox_valid: true,
             accumulated_coinbase_ustx: 0,
         }
@@ -232,6 +233,7 @@ impl BlockSnapshot {
                 .canonical_stacks_tip_consensus_hash
                 .clone(),
             sortition_id: sortition_id.clone(),
+            parent_sortition_id: parent_snapshot.sortition_id.clone(),
             pox_valid: true,
             accumulated_coinbase_ustx,
         })
@@ -402,6 +404,7 @@ impl BlockSnapshot {
                 .canonical_stacks_tip_consensus_hash
                 .clone(),
             sortition_id: my_sortition_id.clone(),
+            parent_sortition_id: parent_snapshot.sortition_id.clone(),
             pox_valid: true,
             accumulated_coinbase_ustx,
         })

--- a/src/chainstate/stacks/db/blocks.rs
+++ b/src/chainstate/stacks/db/blocks.rs
@@ -1190,7 +1190,7 @@ impl StacksChainState {
                         parent_consensus_hash, parent_anchored_block_hash, &mblock_hash,
                     )),
                     None => {
-                        debug!(
+                        test_debug!(
                             "No such microblock (processed={}): {}/{}-{} ({})",
                             processed_only,
                             parent_consensus_hash,
@@ -1215,7 +1215,7 @@ impl StacksChainState {
                 }
             }
 
-            debug!(
+            test_debug!(
                 "Loaded microblock {}/{}-{} (parent={}, expect_seq={})",
                 &parent_consensus_hash,
                 &parent_anchored_block_hash,

--- a/src/chainstate/stacks/db/blocks.rs
+++ b/src/chainstate/stacks/db/blocks.rs
@@ -3586,11 +3586,13 @@ impl StacksChainState {
                 let mut candidate = StagingBlock::from_row(&row).map_err(Error::DBError)?;
 
                 debug!(
-                    "Consider block {}/{} whose parent is {}/{}",
+                    "Consider block {}/{} whose parent is {}/{} with {} parent microblocks tailed at {}",
                     &candidate.consensus_hash,
                     &candidate.anchored_block_hash,
                     &candidate.parent_consensus_hash,
-                    &candidate.parent_anchored_block_hash
+                    &candidate.parent_anchored_block_hash,
+                    if candidate.parent_microblock_hash != BlockHeaderHash([0u8; 32]) { (candidate.parent_microblock_seq as u32) + 1 } else { 0 },
+                    &candidate.parent_microblock_hash
                 );
 
                 let can_attach = {

--- a/src/chainstate/stacks/miner.rs
+++ b/src/chainstate/stacks/miner.rs
@@ -401,6 +401,8 @@ impl<'a> StacksMicroblockBuilder<'a> {
                     ) {
                         Ok(true) => {
                             bytes_so_far += mempool_tx.metadata.len;
+
+                            debug!("Include tx {} ({}) in microblock", mempool_tx.tx.txid(), mempool_tx.tx.payload.name());
                             txs_included.push(mempool_tx.tx);
                         }
                         Ok(false) => {
@@ -662,7 +664,7 @@ impl StacksBlockBuilder {
                     _ => e,
                 })?;
 
-            debug!("Include tx {}", tx.txid());
+            debug!("Include tx {} ({}) in anchor block", tx.txid(), tx.payload.name());
 
             // save
             self.txs.push(tx.clone());
@@ -692,6 +694,8 @@ impl StacksBlockBuilder {
                     }
                     _ => e,
                 })?;
+
+            debug!("Include tx {} ({}) in microblock", tx.txid(), tx.payload.name());
 
             // save
             self.micro_txs.push(tx.clone());

--- a/src/chainstate/stacks/miner.rs
+++ b/src/chainstate/stacks/miner.rs
@@ -402,7 +402,11 @@ impl<'a> StacksMicroblockBuilder<'a> {
                         Ok(true) => {
                             bytes_so_far += mempool_tx.metadata.len;
 
-                            debug!("Include tx {} ({}) in microblock", mempool_tx.tx.txid(), mempool_tx.tx.payload.name());
+                            debug!(
+                                "Include tx {} ({}) in microblock",
+                                mempool_tx.tx.txid(),
+                                mempool_tx.tx.payload.name()
+                            );
                             txs_included.push(mempool_tx.tx);
                         }
                         Ok(false) => {
@@ -664,7 +668,11 @@ impl StacksBlockBuilder {
                     _ => e,
                 })?;
 
-            debug!("Include tx {} ({}) in anchor block", tx.txid(), tx.payload.name());
+            debug!(
+                "Include tx {} ({}) in anchor block",
+                tx.txid(),
+                tx.payload.name()
+            );
 
             // save
             self.txs.push(tx.clone());
@@ -695,7 +703,11 @@ impl StacksBlockBuilder {
                     _ => e,
                 })?;
 
-            debug!("Include tx {} ({}) in microblock", tx.txid(), tx.payload.name());
+            debug!(
+                "Include tx {} ({}) in microblock",
+                tx.txid(),
+                tx.payload.name()
+            );
 
             // save
             self.micro_txs.push(tx.clone());

--- a/src/core/mempool.rs
+++ b/src/core/mempool.rs
@@ -47,7 +47,7 @@ use util::db::tx_busy_handler;
 use util::db::u64_to_sql;
 use util::db::Error as db_error;
 use util::db::FromColumn;
-use util::db::{DBConn, DBTx, FromRow};
+use util::db::{sql_pragma, DBConn, DBTx, FromRow};
 use util::get_epoch_time_secs;
 
 use core::FIRST_BURNCHAIN_CONSENSUS_HASH;
@@ -297,6 +297,8 @@ impl MemPoolTxInfo {
 
 impl MemPoolDB {
     fn instantiate_mempool_db(conn: &mut DBConn) -> Result<(), db_error> {
+        sql_pragma(conn, "PRAGMA journal_mode = WAL;")?;
+
         let tx = tx_begin_immediate(conn)?;
 
         for cmd in MEMPOOL_SQL {

--- a/src/net/chat.rs
+++ b/src/net/chat.rs
@@ -2488,6 +2488,7 @@ mod test {
 
             next_snapshot.consensus_hash = ConsensusHash(big_i_bytes_20);
             next_snapshot.sortition_id = SortitionId(big_i_bytes_32.clone());
+            next_snapshot.parent_sortition_id = prev_snapshot.sortition_id.clone();
             next_snapshot.ops_hash = OpsHash::from_bytes(&big_i_bytes_32).unwrap();
             next_snapshot.winning_stacks_block_hash = BlockHeaderHash(big_i_bytes_32.clone());
             next_snapshot.winning_block_txid = Txid(big_i_bytes_32.clone());

--- a/src/net/download.rs
+++ b/src/net/download.rs
@@ -802,7 +802,7 @@ impl BlockDownloader {
                             if stats.inv.has_ith_block(sortition_bit + first_block_height) {
                                 test_debug!(
                                     "BUT! Neighbor {:?} has block bit {} set!: {:?}",
-                                    &nk,
+                                    &_nk,
                                     sortition_bit + first_block_height,
                                     &stats
                                 );

--- a/src/net/download.rs
+++ b/src/net/download.rs
@@ -452,16 +452,16 @@ impl BlockDownloader {
     /// Finish fetching blocks.  Return true once all reply handles have been fulfilled (either
     /// with data, or with an error).
     /// Store blocks as we get them.
-    pub fn getblocks_try_finish(&mut self, http: &mut HttpPeer) -> Result<bool, net_error> {
+    pub fn getblocks_try_finish(&mut self, network: &mut PeerNetwork) -> Result<bool, net_error> {
         assert_eq!(self.state, BlockDownloaderState::GetBlocksFinish);
 
         // requests that are still pending
         let mut pending_block_requests = HashMap::new();
 
         for (block_key, event_id) in self.getblock_requests.drain() {
-            match http.get_conversation(event_id) {
+            match network.http.get_conversation(event_id) {
                 None => {
-                    if http.is_connecting(event_id) {
+                    if network.http.is_connecting(event_id) {
                         debug!(
                             "Event {} ({:?}, {:?} for block {} is not connected yet",
                             event_id,
@@ -471,14 +471,27 @@ impl BlockDownloader {
                         );
                         pending_block_requests.insert(block_key, event_id);
                     } else {
-                        debug!("Event {} ({:?}, {:?} for block {} failed to connect. Temporarily blocking URL", event_id, &block_key.neighbor, &block_key.data_url, &block_key.index_block_hash);
                         self.dead_peers.push(event_id);
 
-                        // don't try this again for a while
-                        self.blocked_urls.insert(
-                            block_key.data_url,
-                            get_epoch_time_secs() + BLOCK_DOWNLOAD_BAN_URL,
-                        );
+                        let is_always_allowed = match PeerDB::get_peer(
+                            &network.peerdb.conn(),
+                            block_key.neighbor.network_id,
+                            &block_key.neighbor.addrbytes,
+                            block_key.neighbor.port,
+                        ) {
+                            Ok(Some(neighbor)) => neighbor.is_always_allowed(),
+                            _ => false,
+                        };
+
+                        if !is_always_allowed {
+                            debug!("Event {} ({:?}, {:?} for block {} failed to connect. Temporarily blocking URL", event_id, &block_key.neighbor, &block_key.data_url, &block_key.index_block_hash);
+
+                            // don't try this again for a while
+                            self.blocked_urls.insert(
+                                block_key.data_url,
+                                get_epoch_time_secs() + BLOCK_DOWNLOAD_BAN_URL,
+                            );
+                        }
                     }
                 }
                 Some(ref mut convo) => {
@@ -555,7 +568,10 @@ impl BlockDownloader {
         self.state = BlockDownloaderState::GetMicroblocksFinish;
     }
 
-    pub fn getmicroblocks_try_finish(&mut self, http: &mut HttpPeer) -> Result<bool, net_error> {
+    pub fn getmicroblocks_try_finish(
+        &mut self,
+        network: &mut PeerNetwork,
+    ) -> Result<bool, net_error> {
         assert_eq!(self.state, BlockDownloaderState::GetMicroblocksFinish);
 
         // requests that are still pending
@@ -563,26 +579,39 @@ impl BlockDownloader {
 
         for (block_key, event_id) in self.getmicroblocks_requests.drain() {
             let rh_block_key = block_key.clone();
-            match http.get_conversation(event_id) {
+            match network.http.get_conversation(event_id) {
                 None => {
-                    if http.is_connecting(event_id) {
+                    if network.http.is_connecting(event_id) {
                         debug!("Event {} ({:?}, {:?} for microblocks built by ({}) is not connected yet", &block_key.neighbor, &block_key.data_url, &block_key.index_block_hash, event_id);
                         pending_microblock_requests.insert(block_key, event_id);
                     } else {
-                        debug!(
-                            "Event {} ({:?}, {:?} for microblocks built by ({}) failed to connect.  Temporarily blocking URL.",
-                            &block_key.neighbor,
-                            &block_key.data_url,
-                            &block_key.index_block_hash,
-                            event_id
-                        );
                         self.dead_peers.push(event_id);
 
-                        // don't try this again for a while
-                        self.blocked_urls.insert(
-                            block_key.data_url,
-                            get_epoch_time_secs() + BLOCK_DOWNLOAD_BAN_URL,
-                        );
+                        let is_always_allowed = match PeerDB::get_peer(
+                            &network.peerdb.conn(),
+                            block_key.neighbor.network_id,
+                            &block_key.neighbor.addrbytes,
+                            block_key.neighbor.port,
+                        ) {
+                            Ok(Some(neighbor)) => neighbor.is_always_allowed(),
+                            _ => false,
+                        };
+
+                        if !is_always_allowed {
+                            debug!(
+                                "Event {} ({:?}, {:?} for microblocks built by ({}) failed to connect.  Temporarily blocking URL.",
+                                event_id,
+                                &block_key.neighbor,
+                                &block_key.data_url,
+                                &block_key.index_block_hash,
+                            );
+
+                            // don't try this again for a while
+                            self.blocked_urls.insert(
+                                block_key.data_url,
+                                get_epoch_time_secs() + BLOCK_DOWNLOAD_BAN_URL,
+                            );
+                        }
                     }
                 }
                 Some(ref mut convo) => {
@@ -732,29 +761,26 @@ impl BlockDownloader {
 
         let mut ret = vec![];
         for (i, (consensus_hash, block_hash_opt)) in local_blocks.into_iter().enumerate() {
-            let sortition_height = sortition_height_start + (i as u64) + 1;
+            let sortition_bit = sortition_height_start + (i as u64) + 1;
             match block_hash_opt {
                 Some(block_hash) => {
                     // a sortition happened at this height
                     let mut neighbors = vec![];
                     for (nk, stats) in inv_state.block_stats.iter() {
                         test_debug!(
-                            "stats for {:?}: {:?}; testing block {}",
+                            "stats for {:?}: {:?}; testing block bit {}",
                             &nk,
                             &stats,
-                            sortition_height + first_block_height
+                            sortition_bit + first_block_height
                         );
-                        if stats
-                            .inv
-                            .has_ith_block(sortition_height + first_block_height)
-                        {
+                        if stats.inv.has_ith_block(sortition_bit + first_block_height) {
                             neighbors.push(nk.clone());
                         }
                     }
                     test_debug!(
-                        "at sortition height {} (block {}): {:?}/{:?} blocks available from {:?}",
-                        sortition_height,
-                        sortition_height + first_block_height,
+                        "at sortition height {} (block bit {}): {:?}/{:?} blocks available from {:?}",
+                        sortition_bit - 1,
+                        sortition_bit + first_block_height,
                         &consensus_hash,
                         &block_hash,
                         &neighbors
@@ -764,12 +790,23 @@ impl BlockDownloader {
                 None => {
                     // no sortition
                     test_debug!(
-                        "at sortition height {} (block {}): {:?}/(no sortition)",
-                        sortition_height,
-                        sortition_height + first_block_height,
+                        "at sortition height {} (block bit {}): {:?}/(no sortition)",
+                        sortition_bit - 1,
+                        sortition_bit + first_block_height,
                         &consensus_hash
                     );
                     ret.push((consensus_hash, None, vec![]));
+
+                    for (nk, stats) in inv_state.block_stats.iter() {
+                        if stats.inv.has_ith_block(sortition_bit + first_block_height) {
+                            test_debug!(
+                                "BUT! Neighbor {:?} has block bit {} set!: {:?}",
+                                &nk,
+                                sortition_bit + first_block_height,
+                                &stats
+                            );
+                        }
+                    }
                 }
             }
         }
@@ -1033,6 +1070,87 @@ impl PeerNetwork {
         Ok(true)
     }
 
+    /// Are we able to download a microblock stream between two blocks at this time?
+    fn can_download_microblock_stream(
+        _local_peer: &LocalPeer,
+        chainstate: &StacksChainState,
+        parent_consensus_hash: &ConsensusHash,
+        parent_block_hash: &BlockHeaderHash,
+        child_consensus_hash: &ConsensusHash,
+        child_block_hash: &BlockHeaderHash,
+    ) -> Result<bool, net_error> {
+        // must already have parent and child
+        if PeerNetwork::need_anchored_block(
+            _local_peer,
+            chainstate,
+            parent_consensus_hash,
+            parent_block_hash,
+        )? {
+            test_debug!(
+                "{:?}: Still need parent anchored block {}/{}",
+                _local_peer,
+                parent_consensus_hash,
+                parent_block_hash
+            );
+            return Ok(false);
+        }
+
+        if PeerNetwork::need_anchored_block(
+            _local_peer,
+            chainstate,
+            child_consensus_hash,
+            child_block_hash,
+        )? {
+            test_debug!(
+                "{:?}: Still need child anchored block {}/{}",
+                _local_peer,
+                child_consensus_hash,
+                child_block_hash
+            );
+            return Ok(false);
+        }
+
+        let child_header = match StacksChainState::load_block_header(
+            &chainstate.blocks_path,
+            child_consensus_hash,
+            child_block_hash,
+        )? {
+            Some(hdr) => hdr,
+            None => {
+                test_debug!(
+                    "{:?}: No child block {}/{}, so cannot load microblock stream it confirms",
+                    _local_peer,
+                    child_consensus_hash,
+                    child_block_hash
+                );
+                return Ok(false);
+            }
+        };
+
+        // try and load the connecting stream.  If we have it, then we're good to go.
+        match StacksChainState::load_microblock_stream_fork(
+            &chainstate.db(),
+            parent_consensus_hash,
+            parent_block_hash,
+            &child_header.parent_microblock,
+        )? {
+            Some(_) => {
+                test_debug!(
+                    "{:?}: Already have stream between {}/{} and {}/{}",
+                    _local_peer,
+                    parent_consensus_hash,
+                    parent_block_hash,
+                    child_consensus_hash,
+                    child_block_hash
+                );
+                return Ok(false);
+            }
+            None => {
+                return Ok(true);
+            }
+        }
+    }
+
     /// Create block request keys for a range of blocks that are available but that we don't have in a given range of
     /// sortitions.  The same keys can be used to fetch confirmed microblock streams.
     fn make_requests(
@@ -1200,8 +1318,15 @@ impl PeerNetwork {
                 };
 
                 if let Some((parent_header, parent_consensus_hash)) = parent_header_opt {
-                    if chainstate.has_processed_microblocks(&index_block_hash)? {
-                        test_debug!("{:?}: Already have microblock stream confirmed by {}/{} (built by {}/{})", &self.local_peer, &consensus_hash, &block_hash, &parent_consensus_hash, &parent_header.block_hash());
+                    if !PeerNetwork::can_download_microblock_stream(
+                        &self.local_peer,
+                        chainstate,
+                        &parent_consensus_hash,
+                        &parent_header.block_hash(),
+                        &consensus_hash,
+                        &block_hash,
+                    )? {
+                        test_debug!("{:?}: Cannot (or will not) download microblock stream confirmed by {}/{} (built by {}/{})", &self.local_peer, &consensus_hash, &block_hash, &parent_consensus_hash, &parent_header.block_hash());
                         continue;
                     }
 
@@ -1842,7 +1967,7 @@ impl PeerNetwork {
     pub fn block_getblocks_try_finish(&mut self) -> Result<bool, net_error> {
         test_debug!("{:?}: block_getblocks_try_finish", &self.local_peer);
         PeerNetwork::with_downloader_state(self, |ref mut network, ref mut downloader| {
-            downloader.getblocks_try_finish(&mut network.http)
+            downloader.getblocks_try_finish(network)
         })
     }
 
@@ -1888,7 +2013,7 @@ impl PeerNetwork {
     pub fn block_getmicroblocks_try_finish(&mut self) -> Result<bool, net_error> {
         test_debug!("{:?}: block_getmicroblocks_try_finish", &self.local_peer);
         PeerNetwork::with_downloader_state(self, |ref mut network, ref mut downloader| {
-            downloader.getmicroblocks_try_finish(&mut network.http)
+            downloader.getmicroblocks_try_finish(network)
         })
     }
 
@@ -2041,7 +2166,7 @@ impl PeerNetwork {
                     downloader.next_microblock_sortition_height;
 
                 if downloader.block_sortition_height + sortdb.first_block_height
-                    >= network.chain_view.burn_block_height
+                    > network.chain_view.burn_block_height
                 {
                     debug!(
                         "{:?}: Downloader for blocks has reached the chain tip",
@@ -2059,7 +2184,7 @@ impl PeerNetwork {
                     downloader.num_blocks_downloaded = 0;
                 }
                 if downloader.microblock_sortition_height + sortdb.first_block_height
-                    >= network.chain_view.burn_block_height
+                    > network.chain_view.burn_block_height
                 {
                     debug!(
                         "{:?}: Downloader for microblocks has reached the chain tip",
@@ -2517,7 +2642,7 @@ pub mod test {
                 .unwrap()
                 .unwrap();
             ic.get_stacks_header_hashes(
-                num_headers,
+                num_headers + 1,
                 &ancestor.consensus_hash,
                 &mut BlockHeaderCache::new(),
             )
@@ -2812,10 +2937,10 @@ pub mod test {
 
     #[test]
     #[ignore]
-    pub fn test_get_blocks_and_microblocks_2_peers_download() {
+    pub fn test_get_blocks_and_microblocks_2_peers_download_plain() {
         with_timeout(600, || {
             run_get_blocks_and_microblocks(
-                "test_get_blocks_and_microblocks_2_peers_download",
+                "test_get_blocks_and_microblocks_2_peers_download_plain",
                 3200,
                 2,
                 |ref mut peer_configs| {

--- a/src/net/download.rs
+++ b/src/net/download.rs
@@ -797,14 +797,16 @@ impl BlockDownloader {
                     );
                     ret.push((consensus_hash, None, vec![]));
 
-                    for (nk, stats) in inv_state.block_stats.iter() {
-                        if stats.inv.has_ith_block(sortition_bit + first_block_height) {
-                            test_debug!(
-                                "BUT! Neighbor {:?} has block bit {} set!: {:?}",
-                                &nk,
-                                sortition_bit + first_block_height,
-                                &stats
-                            );
+                    if cfg!(test) {
+                        for (_nk, stats) in inv_state.block_stats.iter() {
+                            if stats.inv.has_ith_block(sortition_bit + first_block_height) {
+                                test_debug!(
+                                    "BUT! Neighbor {:?} has block bit {} set!: {:?}",
+                                    &nk,
+                                    sortition_bit + first_block_height,
+                                    &stats
+                                );
+                            }
                         }
                     }
                 }

--- a/src/net/inv.rs
+++ b/src/net/inv.rs
@@ -670,13 +670,13 @@ impl NeighborBlockStats {
                 } else if unstable {
                     debug!("Remote neighbor {:?} NACKed us because it's chain tip is different from ours", _nk);
                 } else {
-                    debug!("Remote neighbor {:?} NACKed us because it does not recognize our consensus hash", _nk);
-
                     // if this peer is always allowed, then this isn't a "broken" condition -- it's
                     // a diverged condition.  we trust that it has the correct PoX view.
                     if always_allowed {
+                        debug!("Remote always-allowed neighbor {:?} NACKed us because it does not recognize our consensus hash.  Treating as Diverged.", _nk);
                         diverged = true;
                     } else {
+                        debug!("Remote neighbor {:?} NACKed us because it does not recognize our consensus hash.  Treating as Broken.", _nk);
                         broken = true;
                     }
                 }

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -588,6 +588,18 @@ impl PeerAddress {
     pub fn is_anynet(&self) -> bool {
         self.0 == [0x00; 16] || self == &PeerAddress::from_ipv4(0, 0, 0, 0)
     }
+
+    /// Is this a private IP address?
+    pub fn is_in_private_range(&self) -> bool {
+        if self.is_ipv4() {
+            // 10.0.0.0/8, 172.16.0.0/12, or 192.168.0.0/16
+            self.0[13] == 10
+                || (self.0[13] == 172 && self.0[14] >= 16 && self.0[14] <= 31)
+                || (self.0[13] == 192 && self.0[14] == 168)
+        } else {
+            self.0[0] >= 0xfc
+        }
+    }
 }
 
 /// A container for public keys (compressed secp256k1 public keys)
@@ -1635,6 +1647,10 @@ impl Neighbor {
         self.allowed < 0 || (self.allowed as u64) > get_epoch_time_secs()
     }
 
+    pub fn is_always_allowed(&self) -> bool {
+        self.allowed < 0
+    }
+
     pub fn is_denied(&self) -> bool {
         self.denied < 0 || (self.denied as u64) > get_epoch_time_secs()
     }
@@ -2295,6 +2311,21 @@ pub mod test {
                 Some(&config.initial_neighbors),
             )
             .unwrap();
+            {
+                // bootstrap nodes *always* allowed
+                let mut tx = peerdb.tx_begin().unwrap();
+                for initial_neighbor in config.initial_neighbors.iter() {
+                    PeerDB::set_allow_peer(
+                        &mut tx,
+                        initial_neighbor.addr.network_id,
+                        &initial_neighbor.addr.addrbytes,
+                        initial_neighbor.addr.port,
+                        -1,
+                    )
+                    .unwrap();
+                }
+                tx.commit().unwrap();
+            }
 
             let atlasdb_path = format!("{}/atlas.db", &test_path);
             let atlasdb =
@@ -2431,9 +2462,9 @@ pub mod test {
 
             let local_peer = PeerDB::get_local_peer(peerdb.conn()).unwrap();
             let burnchain_view = {
-                let ic = sortdb.index_conn();
-                let chaintip = SortitionDB::get_canonical_burn_chain_tip(&ic).unwrap();
-                ic.get_burnchain_view(&config.burnchain, &chaintip).unwrap()
+                let chaintip = SortitionDB::get_canonical_burn_chain_tip(&sortdb.conn()).unwrap();
+                SortitionDB::get_burnchain_view(&sortdb.conn(), &config.burnchain, &chaintip)
+                    .unwrap()
             };
             let mut peer_network = PeerNetwork::new(
                 peerdb,
@@ -2466,10 +2497,14 @@ pub mod test {
             let local_peer = PeerDB::get_local_peer(self.network.peerdb.conn()).unwrap();
             let chain_view = match self.sortdb {
                 Some(ref mut sortdb) => {
-                    let ic = sortdb.index_conn();
-                    let chaintip = SortitionDB::get_canonical_burn_chain_tip(&ic).unwrap();
-                    ic.get_burnchain_view(&self.config.burnchain, &chaintip)
-                        .unwrap()
+                    let chaintip =
+                        SortitionDB::get_canonical_burn_chain_tip(sortdb.conn()).unwrap();
+                    SortitionDB::get_burnchain_view(
+                        &sortdb.conn(),
+                        &self.config.burnchain,
+                        &chaintip,
+                    )
+                    .unwrap()
                 }
                 None => panic!("Misconfigured peer: no sortdb"),
             };
@@ -3191,9 +3226,8 @@ pub mod test {
         pub fn get_burnchain_view(&mut self) -> Result<BurnchainView, db_error> {
             let sortdb = self.sortdb.take().unwrap();
             let view_res = {
-                let ic = sortdb.index_conn();
-                let chaintip = SortitionDB::get_canonical_burn_chain_tip(&ic).unwrap();
-                ic.get_burnchain_view(&self.config.burnchain, &chaintip)
+                let chaintip = SortitionDB::get_canonical_burn_chain_tip(&sortdb.conn()).unwrap();
+                SortitionDB::get_burnchain_view(&sortdb.conn(), &self.config.burnchain, &chaintip)
             };
             self.sortdb = Some(sortdb);
             view_res

--- a/src/net/relay.rs
+++ b/src/net/relay.rs
@@ -983,10 +983,11 @@ impl Relayer {
             Relayer::preprocess_pushed_microblocks(network_result, chainstate)?;
         bad_neighbors.append(&mut new_bad_neighbors);
 
-        if new_blocks.len() > 0 {
+        if new_blocks.len() > 0 || new_microblocks.len() > 0 {
             info!(
-                "Processing newly received Stacks blocks: {}",
-                new_blocks.len()
+                "Processing newly received Stacks blocks: {}, microblocks: {}",
+                new_blocks.len(),
+                new_microblocks.len()
             );
             if let Some(coord_comms) = coord_comms {
                 if !coord_comms.announce_new_stacks_block() {

--- a/src/net/relay.rs
+++ b/src/net/relay.rs
@@ -1278,7 +1278,9 @@ impl Relayer {
         let receipts = ProcessedNetReceipts { mempool_txs_added };
 
         // finally, refresh the unconfirmed chainstate, if need be
-        Relayer::refresh_unconfirmed(chainstate, sortdb);
+        if network_result.has_microblocks() {
+            Relayer::refresh_unconfirmed(chainstate, sortdb);
+        }
 
         Ok(receipts)
     }

--- a/src/util/db.rs
+++ b/src/util/db.rs
@@ -382,6 +382,12 @@ where
     query_int(conn, sql_query, sql_args)
 }
 
+/// Run a PRAGMA statement.  This can't always be done via execute(), because it may return a result (and
+/// rusqlite does not like this).
+pub fn sql_pragma(conn: &Connection, pragma_stmt: &str) -> Result<(), Error> {
+    conn.query_row_and_then(pragma_stmt, NO_PARAMS, |_row| Ok(()))
+}
+
 /// Set up an on-disk database with a MARF index if they don't exist yet.
 /// Either way, returns (db path, MARF path)
 pub fn db_mkdirs(path_str: &str) -> Result<(String, String), Error> {
@@ -492,6 +498,7 @@ pub fn tx_busy_handler(run_count: i32) -> bool {
         "Database is locked; sleeping {}ms and trying again",
         &sleep_count
     );
+
     sleep_ms(sleep_count);
     true
 }

--- a/src/util/log.rs
+++ b/src/util/log.rs
@@ -239,6 +239,8 @@ pub fn get_loglevel() -> slog::Level {
         slog::Level::Trace
     } else if env::var("STACKS_LOG_DEBUG") == Ok("1".into()) {
         slog::Level::Debug
+    } else if env::var("BLOCKSTACK_DEBUG") == Ok("1".into()) {
+        slog::Level::Debug
     } else {
         slog::Level::Info
     }

--- a/src/vm/database/sqlite.rs
+++ b/src/vm/database/sqlite.rs
@@ -22,7 +22,7 @@ use rusqlite::{
 
 use chainstate::stacks::StacksBlockId;
 
-use util::db::tx_busy_handler;
+use util::db::{sql_pragma, tx_busy_handler};
 
 use vm::contracts::Contract;
 use vm::errors::{
@@ -159,6 +159,9 @@ impl SqliteConnection {
 
 impl SqliteConnection {
     pub fn initialize_conn(conn: &Connection) -> Result<()> {
+        conn.query_row("PRAGMA journal_mode = WAL;", NO_PARAMS, |_row| Ok(()))
+            .map_err(|x| InterpreterError::SqliteError(IncomparableError { err: x }))?;
+
         conn.execute(
             "CREATE TABLE IF NOT EXISTS data_table
                       (key TEXT PRIMARY KEY, value TEXT)",

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -1191,6 +1191,7 @@ impl InitializedNeonNode {
         }
 
         if let Some(ref snapshot) = &self.last_burn_block {
+            debug!("Notify sortition! Last snapshot is {}/{} ({})", &snapshot.consensus_hash, &snapshot.burn_header_hash, &snapshot.winning_stacks_block_hash);
             if snapshot.sortition {
                 return self
                     .relay_channel
@@ -1201,6 +1202,9 @@ impl InitializedNeonNode {
                     ))
                     .is_ok();
             }
+        }
+        else {
+            debug!("Notify sortition! No last burn block");
         }
         true
     }
@@ -1626,10 +1630,11 @@ impl InitializedNeonNode {
         );
         let mut op_signer = keychain.generate_op_signer();
         debug!(
-            "Submit block-commit for block {} off of {}/{}",
+            "Submit block-commit for block {} off of {}/{} with microblock parent {}",
             &anchored_block.block_hash(),
             &parent_consensus_hash,
-            &anchored_block.header.parent_block
+            &anchored_block.header.parent_block,
+            &anchored_block.header.parent_microblock
         );
 
         let res = bitcoin_controller.submit_operation(op, &mut op_signer, attempt);

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -1191,7 +1191,12 @@ impl InitializedNeonNode {
         }
 
         if let Some(ref snapshot) = &self.last_burn_block {
-            debug!("Notify sortition! Last snapshot is {}/{} ({})", &snapshot.consensus_hash, &snapshot.burn_header_hash, &snapshot.winning_stacks_block_hash);
+            debug!(
+                "Notify sortition! Last snapshot is {}/{} ({})",
+                &snapshot.consensus_hash,
+                &snapshot.burn_header_hash,
+                &snapshot.winning_stacks_block_hash
+            );
             if snapshot.sortition {
                 return self
                     .relay_channel
@@ -1202,8 +1207,7 @@ impl InitializedNeonNode {
                     ))
                     .is_ok();
             }
-        }
-        else {
+        } else {
             debug!("Notify sortition! No last burn block");
         }
         true

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -973,10 +973,9 @@ impl InitializedNeonNode {
             .expect("Error while instantiating sortition db");
 
         let view = {
-            let ic = sortdb.index_conn();
-            let sortition_tip = SortitionDB::get_canonical_burn_chain_tip(&ic)
+            let sortition_tip = SortitionDB::get_canonical_burn_chain_tip(&sortdb.conn())
                 .expect("Failed to get sortition tip");
-            ic.get_burnchain_view(&burnchain, &sortition_tip).unwrap()
+            SortitionDB::get_burnchain_view(&sortdb.conn(), &burnchain, &sortition_tip).unwrap()
         };
 
         // create a new peerdb
@@ -1681,7 +1680,7 @@ impl InitializedNeonNode {
                 info!(
                     "Received burnchain block #{} including block_commit_op (winning) - {} ({})",
                     block_height,
-                    op.apparent_sender.to_address(network),
+                    op.apparent_sender.to_bitcoin_address(network),
                     &op.block_header_hash
                 );
                 last_sortitioned_block = Some((block_snapshot.clone(), op.vtxindex));
@@ -1690,7 +1689,7 @@ impl InitializedNeonNode {
                     info!(
                         "Received burnchain block #{} including block_commit_op - {} ({})",
                         block_height,
-                        op.apparent_sender.to_address(network),
+                        op.apparent_sender.to_bitcoin_address(network),
                         &op.block_header_hash
                     );
                 }

--- a/testnet/stacks-node/src/node.rs
+++ b/testnet/stacks-node/src/node.rs
@@ -367,10 +367,9 @@ impl Node {
         let burnchain = Burnchain::regtest(&self.config.get_burn_db_path());
 
         let view = {
-            let ic = sortdb.index_conn();
-            let sortition_tip = SortitionDB::get_canonical_burn_chain_tip(&ic)
+            let sortition_tip = SortitionDB::get_canonical_burn_chain_tip(&sortdb.conn())
                 .expect("Failed to get sortition tip");
-            ic.get_burnchain_view(&burnchain, &sortition_tip).unwrap()
+            SortitionDB::get_burnchain_view(&sortdb.conn(), &burnchain, &sortition_tip).unwrap()
         };
 
         // create a new peerdb

--- a/testnet/stacks-node/src/run_loop/neon.rs
+++ b/testnet/stacks-node/src/run_loop/neon.rs
@@ -272,7 +272,7 @@ impl RunLoop {
             node.into_initialized_leader_node(
                 burnchain_tip.clone(),
                 self.get_blocks_processed_arc(),
-                coordinator_senders,
+                coordinator_senders.clone(),
                 pox_watchdog.make_comms_handle(),
                 attachments_rx,
                 atlas_config,
@@ -281,7 +281,7 @@ impl RunLoop {
             node.into_initialized_node(
                 burnchain_tip.clone(),
                 self.get_blocks_processed_arc(),
-                coordinator_senders,
+                coordinator_senders.clone(),
                 pox_watchdog.make_comms_handle(),
                 attachments_rx,
                 atlas_config,
@@ -373,6 +373,12 @@ impl RunLoop {
                     "Synchronized burnchain up to block height {} (chain tip height is {})",
                     block_height, burnchain_height
                 );
+            } else if ibd {
+                // drive block processing after we reach the burnchain tip.
+                // we may have downloaded all the blocks already,
+                // so we can't rely on the relayer alone to
+                // drive it.
+                coordinator_senders.announce_new_stacks_block();
             }
 
             if block_height >= burnchain_height && !ibd {

--- a/testnet/stacks-node/src/run_loop/neon.rs
+++ b/testnet/stacks-node/src/run_loop/neon.rs
@@ -332,18 +332,17 @@ impl RunLoop {
                 next_burnchain_height,
                 target_burnchain_block_height + pox_constants.reward_cycle_length as u64,
             );
-            
+
             burnchain_tip = next_burnchain_tip;
             burnchain_height = next_burnchain_height;
 
             let sortition_tip = &burnchain_tip.block_snapshot.sortition_id;
             let next_height = burnchain_tip.block_snapshot.block_height;
-            
+
             debug!(
                 "Downloaded burnchain blocks up to height {}; new target height is {}; next_height = {}, block_height = {}",
                 next_burnchain_height, target_burnchain_block_height, next_height, block_height
             );
-
 
             if next_height > block_height {
                 // first, let's process all blocks in (block_height, next_height]

--- a/testnet/stacks-node/src/run_loop/neon.rs
+++ b/testnet/stacks-node/src/run_loop/neon.rs
@@ -332,16 +332,18 @@ impl RunLoop {
                 next_burnchain_height,
                 target_burnchain_block_height + pox_constants.reward_cycle_length as u64,
             );
-            debug!(
-                "Downloaded burnchain blocks up to height {}; new target height is {}",
-                next_burnchain_height, target_burnchain_block_height
-            );
-
+            
             burnchain_tip = next_burnchain_tip;
             burnchain_height = next_burnchain_height;
 
             let sortition_tip = &burnchain_tip.block_snapshot.sortition_id;
             let next_height = burnchain_tip.block_snapshot.block_height;
+            
+            debug!(
+                "Downloaded burnchain blocks up to height {}; new target height is {}; next_height = {}, block_height = {}",
+                next_burnchain_height, target_burnchain_block_height, next_height, block_height
+            );
+
 
             if next_height > block_height {
                 // first, let's process all blocks in (block_height, next_height]
@@ -368,11 +370,12 @@ impl RunLoop {
                     }
                 }
 
-                block_height = next_height;
                 debug!(
-                    "Synchronized burnchain up to block height {} (chain tip height is {})",
-                    block_height, burnchain_height
+                    "Synchronized burnchain up to block height {} from {} (chain tip height is {})",
+                    next_height, block_height, burnchain_height
                 );
+
+                block_height = next_height;
             } else if ibd {
                 // drive block processing after we reach the burnchain tip.
                 // we may have downloaded all the blocks already,

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -31,7 +31,7 @@ use stacks::net::{
 };
 use stacks::util::hash::Hash160;
 use stacks::util::hash::{bytes_to_hex, hex_bytes};
-use stacks::util::{sleep_ms, get_epoch_time_secs};
+use stacks::util::{get_epoch_time_secs, sleep_ms};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::mpsc;
 use std::sync::Arc;
@@ -196,7 +196,11 @@ fn next_block_and_wait(
     blocks_processed: &Arc<AtomicU64>,
 ) {
     let current = blocks_processed.load(Ordering::SeqCst);
-    eprintln!("Issuing block at {}, waiting for bump ({})", get_epoch_time_secs(), current);
+    eprintln!(
+        "Issuing block at {}, waiting for bump ({})",
+        get_epoch_time_secs(),
+        current
+    );
     btc_controller.build_next_block(1);
     let start = Instant::now();
     while blocks_processed.load(Ordering::SeqCst) <= current {
@@ -206,7 +210,11 @@ fn next_block_and_wait(
         }
         thread::sleep(Duration::from_millis(100));
     }
-    eprintln!("Block bumped at {} ({})", get_epoch_time_secs(), blocks_processed.load(Ordering::SeqCst));
+    eprintln!(
+        "Block bumped at {} ({})",
+        get_epoch_time_secs(),
+        blocks_processed.load(Ordering::SeqCst)
+    );
 }
 
 fn wait_for_runloop(blocks_processed: &Arc<AtomicU64>) {

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -1008,12 +1008,24 @@ fn microblock_integration_test() {
     );
     eprintln!("{:?}", &path);
 
-    let res = client
-        .get(&path)
-        .send()
-        .unwrap()
-        .json::<AccountEntryResponse>()
-        .unwrap();
+    let res = loop {
+        let res = match client
+            .get(&path)
+            .send()
+            .unwrap()
+            .json::<AccountEntryResponse>()
+        {
+            Ok(x) => x,
+            Err(_) => {
+                eprintln!("Failed to query {}; will try again", &path);
+                sleep_ms(1000);
+                continue;
+            }
+        };
+
+        break res;
+    };
+
     eprintln!("{:#?}", res);
     assert_eq!(res.nonce, 2);
     assert_eq!(u128::from_str_radix(&res.balance[2..], 16).unwrap(), 96300);


### PR DESCRIPTION
This PR fixes #2369, #2362, #2361, and #2334.  This makes it so the sortition DB, burnchain DB, and chainstate MARFs all operate in WAL mode, which _significantly_ improves their write performance while also minimizing the chance of a read conflicting with a write.  It also tweaks a few things about the unconfirmed state trie management code to minimize the number of reads and writes that the p2p networking thread will do, which in turn makes the p2p thread much, much more responsive during periods of heavy I/O (I've never seen it wait for more than half a second when testing during bootstrapping).

These changes were guided by printing out a backtrace each time the `tx_busy_handler()` got called.  Using the backtrace, I was able to identify which points in the code were most responsible for causing database contention.  By far the biggest performance fix was making it so that we don't always create a MARF transaction when opening a MARF to initialize its metadata tables (in `src/vm/database/marf.rs`).  The p2p thread had been calling this each and every pass as part of refreshing its unconfirmed state trie view.

The second biggest performance fix was in minimizing the number of times the relayer or p2p threads refreshed the unconfirmed state trie view.  Now, refreshing the read-only view in the p2p thread happens without any I/O on the chainstate database, and refreshing the state trie while mining microblocks or processing microblocks only occurs when there are new microblocks to consider (whereas before, the relayer would create and close a MARF transaction even if there were no new microblocks to apply to the unconfirmed state trie).

There is still a little bit of database lock contention between the burnchain-db thread and the chains-coordinator thread during boot-up -- the burnchain-db thread will be storing burnchain operations while the chains-coordinator is trying to read them and process sortitions.  There is also still a little bit of lock contention between the p2p thread reading the sortition DB to load the canonical chain tip and some of the other threads, but they are quite rare (only four instances detected during a node boot-up).  This lock contention was higher in the past due to the way the p2p thread loaded a burnchain view -- it did a MARF read for each ancestor block hash it had to load.  I removed this entirely by instead making it so each `BlockSnapshot` has a `parent_sortition_id` field that points to its parent sortition in the same sortition fork.  Now, loading a burnchain view doesn't require any MARF reads.