### PR TITLE
Fix: atlas attachment serving + broken test

### DIFF
--- a/.github/workflows/bitcoin-tests.yml
+++ b/.github/workflows/bitcoin-tests.yml
@@ -16,9 +16,6 @@ jobs:
           DOCKER_BUILDKIT: 1
         run: docker build -f ./.github/actions/bitcoin-int-tests/Dockerfile.bitcoin-tests .
   atlas-test:
-    # disable this job/test for now, since we haven't seen this pass
-    #  on github actions in a while
-    if: ${{ false }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/src/net/atlas/db.rs
+++ b/src/net/atlas/db.rs
@@ -387,7 +387,7 @@ impl AtlasDB {
         content_hash: &Hash160,
     ) -> Result<Option<Attachment>, db_error> {
         let hex_content_hash = to_hex(&content_hash.0[..]);
-        let qry = "SELECT content, hash FROM attachments WHERE hash = ?1 AND was_instantiated = 0"
+        let qry = "SELECT content, hash FROM attachments WHERE hash = ?1 AND was_instantiated = 1"
             .to_string();
         let args = [&hex_content_hash as &dyn ToSql];
         let row = query_row::<Attachment, _>(&self.conn, &qry, &args)?;

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -2065,7 +2065,7 @@ fn atlas_integration_test() {
             "namespace-preorder",
             &[
                 Value::buff_from(hashed_namespace.to_bytes().to_vec()).unwrap(),
-                Value::UInt(1000),
+                Value::UInt(1000000000),
             ],
         );
 
@@ -2213,12 +2213,10 @@ fn atlas_integration_test() {
             panic!("");
         }
 
-        // From there, let's mine these transaction, and build an extra block.
+        // From there, let's mine these transaction, and build more blocks.
         let mut sort_height = channel.get_sortitions_processed();
-        eprintln!("=> Sort height: {}", sort_height);
-        let few_blocks = sort_height + 1 + 1;
+        let few_blocks = sort_height + 5;
 
-        // now let's mine until the next reward cycle starts ...
         while sort_height < few_blocks {
             next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
             sort_height = channel.get_sortitions_processed();
@@ -2237,10 +2235,9 @@ fn atlas_integration_test() {
             _ => panic!("Bootstrap node could nod boot. Aborting test."),
         };
 
-        // From there, let's mine these transaction, and build an extra block.
+        // From there, let's mine these transaction, and build more blocks.
         let mut sort_height = channel.get_sortitions_processed();
-        eprintln!("=> Sort height: {}", sort_height);
-        let few_blocks = sort_height + 1 + 1;
+        let few_blocks = sort_height + 5;
 
         while sort_height < few_blocks {
             next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);


### PR DESCRIPTION
After investigation, it turns out the atlas test was broken for a good reason.
- Attachment serving broke with a recent refactoring
- The BNS pricing table changed and the value provided was too low, as a consequence the `namespace-preorder` contract call was failing.