### PR TITLE
Fix: #2389 Mempool walks, add `try-mine` CLI command

### DIFF
--- a/src/chainstate/stacks/miner.rs
+++ b/src/chainstate/stacks/miner.rs
@@ -668,7 +668,7 @@ impl StacksBlockBuilder {
                     _ => e,
                 })?;
 
-            debug!(
+            info!(
                 "Include tx {} ({}) in anchor block",
                 tx.txid(),
                 tx.payload.name()

--- a/src/core/mempool.rs
+++ b/src/core/mempool.rs
@@ -1113,6 +1113,15 @@ mod tests {
         C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
     };
 
+    use crate::{
+        burnchains::BurnchainHeaderHash,
+        chainstate::stacks::{
+            db::StacksHeaderInfo, index::TrieHash, StacksBlockId, StacksWorkScore,
+        },
+        util::vrf::VRFProof,
+        vm::costs::ExecutionCost,
+    };
+
     use super::MemPoolDB;
     use util::db::{DBConn, FromRow};
 
@@ -1135,6 +1144,355 @@ mod tests {
         let _chainstate = instantiate_chainstate(false, 0x80000000, "mempool_db_init");
         let chainstate_path = chainstate_path("mempool_db_init");
         let _mempool = MemPoolDB::open(false, 0x80000000, &chainstate_path).unwrap();
+    }
+
+    #[test]
+    fn mempool_walk_over_fork() {
+        let mut chainstate = instantiate_chainstate_with_balances(
+            false,
+            0x80000000,
+            "mempool_walk_over_fork",
+            vec![],
+        );
+
+        fn make_block(
+            chainstate: &mut StacksChainState,
+            block_consensus: ConsensusHash,
+            parent: &(ConsensusHash, BlockHeaderHash),
+            burn_height: u64,
+            block_height: u64,
+        ) -> (ConsensusHash, BlockHeaderHash) {
+            let (mut chainstate_tx, clar_tx) = chainstate.chainstate_tx_begin().unwrap();
+
+            let anchored_header = StacksBlockHeader {
+                version: 1,
+                total_work: StacksWorkScore {
+                    work: block_height,
+                    burn: 1,
+                },
+                proof: VRFProof::empty(),
+                parent_block: parent.1.clone(),
+                parent_microblock: BlockHeaderHash([0; 32]),
+                parent_microblock_sequence: 0,
+                tx_merkle_root: Sha512Trunc256Sum::empty(),
+                state_index_root: TrieHash::from_empty_data(),
+                microblock_pubkey_hash: Hash160([0; 20]),
+            };
+
+            let block_hash = anchored_header.block_hash();
+
+            let c_tx = StacksChainState::chainstate_block_begin(
+                &chainstate_tx,
+                clar_tx,
+                &NULL_BURN_STATE_DB,
+                &parent.0,
+                &parent.1,
+                &block_consensus,
+                &block_hash,
+            );
+
+            let new_tip_info = StacksHeaderInfo {
+                anchored_header,
+                microblock_tail: None,
+                index_root: TrieHash::from_empty_data(),
+                block_height,
+                consensus_hash: block_consensus.clone(),
+                burn_header_hash: BurnchainHeaderHash([0; 32]),
+                burn_header_height: burn_height as u32,
+                burn_header_timestamp: 0,
+                anchored_block_size: 1,
+            };
+
+            c_tx.commit_block();
+
+            let new_index_hash = StacksBlockId::new(&block_consensus, &block_hash);
+
+            chainstate_tx
+                .put_indexed_begin(&StacksBlockId::new(&parent.0, &parent.1), &new_index_hash)
+                .unwrap();
+
+            StacksChainState::insert_stacks_block_header(
+                &mut chainstate_tx,
+                &new_index_hash,
+                &new_tip_info,
+                &ExecutionCost::zero(),
+            )
+            .unwrap();
+
+            chainstate_tx.commit().unwrap();
+
+            (block_consensus, block_hash)
+        }
+
+        // genesis -> b_1* -> b_2*
+        //               \-> b_3 -> b_4
+        //
+        // *'d blocks accept transactions,
+        //   try to walk at b_4, we should be able to find
+        //   the transaction at b_1
+
+        let b_1 = make_block(
+            &mut chainstate,
+            ConsensusHash([0x1; 20]),
+            &(
+                FIRST_BURNCHAIN_CONSENSUS_HASH.clone(),
+                FIRST_STACKS_BLOCK_HASH.clone(),
+            ),
+            1,
+            1,
+        );
+        let b_2 = make_block(&mut chainstate, ConsensusHash([0x2; 20]), &b_1, 2, 2);
+        let b_5 = make_block(&mut chainstate, ConsensusHash([0x5; 20]), &b_2, 5, 3);
+        let b_3 = make_block(&mut chainstate, ConsensusHash([0x3; 20]), &b_1, 3, 2);
+        let b_4 = make_block(&mut chainstate, ConsensusHash([0x4; 20]), &b_3, 4, 3);
+
+        let chainstate_path = chainstate_path("mempool_walk_over_fork");
+        let mut mempool = MemPoolDB::open(false, 0x80000000, &chainstate_path).unwrap();
+
+        let mut txs = codec_all_transactions(
+            &TransactionVersion::Testnet,
+            0x80000000,
+            &TransactionAnchorMode::Any,
+            &TransactionPostConditionMode::Allow,
+        );
+
+        let blocks_to_broadcast_in = [&b_1, &b_2];
+        let mut txs = [txs.pop().unwrap(), txs.pop().unwrap()];
+        for tx in txs.iter_mut() {
+            tx.set_tx_fee(123);
+        }
+
+        for ix in 0..2 {
+            let mut mempool_tx = mempool.tx_begin().unwrap();
+
+            let block = &blocks_to_broadcast_in[ix];
+            let tx = &txs[ix];
+
+            let origin_address = StacksAddress {
+                version: 22,
+                bytes: Hash160::from_data(&[0; 32]),
+            };
+            let sponsor_address = StacksAddress {
+                version: 22,
+                bytes: Hash160::from_data(&[1; 32]),
+            };
+
+            let txid = tx.txid();
+            let tx_bytes = tx.serialize_to_vec();
+
+            let len = tx_bytes.len() as u64;
+            let estimated_fee = tx.get_tx_fee() * len;
+
+            let height = 1 + ix as u64;
+
+            let origin_nonce = ix as u64;
+            let sponsor_nonce = ix as u64;
+
+            assert!(!MemPoolDB::db_has_tx(&mempool_tx, &txid).unwrap());
+
+            MemPoolDB::try_add_tx(
+                &mut mempool_tx,
+                &mut chainstate,
+                &block.0,
+                &block.1,
+                txid,
+                tx_bytes,
+                estimated_fee,
+                tx.get_tx_fee(),
+                height,
+                &origin_address,
+                origin_nonce,
+                &sponsor_address,
+                sponsor_nonce,
+            )
+            .unwrap();
+
+            assert!(MemPoolDB::db_has_tx(&mempool_tx, &txid).unwrap());
+
+            mempool_tx.commit().unwrap();
+        }
+
+        // genesis -> b_1* -> b_2* -> b_5
+        //               \-> b_3 -> b_4
+        //
+        // *'d blocks accept transactions,
+        //   try to walk at b_4, we should be able to find
+        //   the transaction at b_1
+
+        let mut count_txs = 0;
+        mempool
+            .iterate_candidates::<_, ChainstateError>(
+                &b_2.0,
+                &b_2.1,
+                2,
+                &mut chainstate,
+                |available_txs| {
+                    count_txs += available_txs.len();
+                    Ok(())
+                },
+            )
+            .unwrap();
+        assert_eq!(
+            count_txs, 2,
+            "Mempool should find two transactions from b_2"
+        );
+
+        let mut count_txs = 0;
+        mempool
+            .iterate_candidates::<_, ChainstateError>(
+                &b_5.0,
+                &b_5.1,
+                3,
+                &mut chainstate,
+                |available_txs| {
+                    count_txs += available_txs.len();
+                    Ok(())
+                },
+            )
+            .unwrap();
+        assert_eq!(
+            count_txs, 2,
+            "Mempool should find two transactions from b_5"
+        );
+
+        let mut count_txs = 0;
+        mempool
+            .iterate_candidates::<_, ChainstateError>(
+                &b_3.0,
+                &b_3.1,
+                2,
+                &mut chainstate,
+                |available_txs| {
+                    count_txs += available_txs.len();
+                    Ok(())
+                },
+            )
+            .unwrap();
+        assert_eq!(
+            count_txs, 1,
+            "Mempool should find one transactions from b_3"
+        );
+
+        let mut count_txs = 0;
+        mempool
+            .iterate_candidates::<_, ChainstateError>(
+                &b_4.0,
+                &b_4.1,
+                3,
+                &mut chainstate,
+                |available_txs| {
+                    count_txs += available_txs.len();
+                    Ok(())
+                },
+            )
+            .unwrap();
+        assert_eq!(
+            count_txs, 1,
+            "Mempool should find one transactions from b_4"
+        );
+
+        // let's test replace-across-fork while we're here.
+        let mut mempool_tx = mempool.tx_begin().unwrap();
+        let block = &b_4;
+        let tx = &txs[1];
+        let origin_address = StacksAddress {
+            version: 22,
+            bytes: Hash160::from_data(&[0; 32]),
+        };
+        let sponsor_address = StacksAddress {
+            version: 22,
+            bytes: Hash160::from_data(&[1; 32]),
+        };
+
+        let txid = tx.txid();
+        let tx_bytes = tx.serialize_to_vec();
+
+        let len = tx_bytes.len() as u64;
+        let estimated_fee = tx.get_tx_fee() * len;
+
+        let height = 3;
+        let origin_nonce = 1;
+        let sponsor_nonce = 1;
+
+        // make sure that we already have the transaction we're testing for replace-across-fork
+        assert!(MemPoolDB::db_has_tx(&mempool_tx, &txid).unwrap());
+
+        MemPoolDB::try_add_tx(
+            &mut mempool_tx,
+            &mut chainstate,
+            &block.0,
+            &block.1,
+            txid,
+            tx_bytes,
+            estimated_fee,
+            tx.get_tx_fee(),
+            height,
+            &origin_address,
+            origin_nonce,
+            &sponsor_address,
+            sponsor_nonce,
+        )
+        .unwrap();
+
+        assert!(MemPoolDB::db_has_tx(&mempool_tx, &txid).unwrap());
+
+        mempool_tx.commit().unwrap();
+
+        // after replace-across-fork, tx[1] should have moved from the b_2->b_5 fork
+        //  to b_4
+        let mut count_txs = 0;
+        mempool
+            .iterate_candidates::<_, ChainstateError>(
+                &b_2.0,
+                &b_2.1,
+                2,
+                &mut chainstate,
+                |available_txs| {
+                    count_txs += available_txs.len();
+                    Ok(())
+                },
+            )
+            .unwrap();
+        assert_eq!(
+            count_txs, 1,
+            "After replace, mempool should find one transactions from b_2"
+        );
+
+        let mut count_txs = 0;
+        mempool
+            .iterate_candidates::<_, ChainstateError>(
+                &b_5.0,
+                &b_5.1,
+                3,
+                &mut chainstate,
+                |available_txs| {
+                    count_txs += available_txs.len();
+                    Ok(())
+                },
+            )
+            .unwrap();
+        assert_eq!(
+            count_txs, 1,
+            "After replace, mempool should find one transactions from b_5"
+        );
+
+        let mut count_txs = 0;
+        mempool
+            .iterate_candidates::<_, ChainstateError>(
+                &b_4.0,
+                &b_4.1,
+                3,
+                &mut chainstate,
+                |available_txs| {
+                    count_txs += available_txs.len();
+                    Ok(())
+                },
+            )
+            .unwrap();
+        assert_eq!(
+            count_txs, 2,
+            "After replace, mempool should find *two* transactions from b_4"
+        );
     }
 
     #[test]

--- a/src/core/mempool.rs
+++ b/src/core/mempool.rs
@@ -533,7 +533,7 @@ impl MemPoolDB {
                             next_block_hash,
                             next_height,
                         ) => {
-                            if std::env::var("MEMPOOL_BAD_BEHAVIOR") == Ok("1".into()) {
+                            if std::env::var("STACKS_MEMPOOL_BAD_BEHAVIOR") == Ok("1".into()) {
                                 warn!(
                                 "Stopping mempool walk because no mempool entries at height = {}",
                                 next_height - 1
@@ -596,7 +596,7 @@ impl MemPoolDB {
                             next_block_hash,
                             next_height,
                         ) => {
-                            if std::env::var("MEMPOOL_BAD_BEHAVIOR") == Ok("1".into()) {
+                            if std::env::var("STACKS_MEMPOOL_BAD_BEHAVIOR") == Ok("1".into()) {
                                 warn!(
                                     "Stopping mempool walk because no mempool entries at height = {}",
                                     next_height - 1

--- a/src/core/mempool.rs
+++ b/src/core/mempool.rs
@@ -391,7 +391,7 @@ impl MemPoolDB {
             return Ok(MemPoolWalkResult::Done);
         }
 
-        let mut next_tips = MemPoolDB::get_chain_tips_at_height(&self.db, next_height)?;
+        let next_tips = MemPoolDB::get_chain_tips_at_height(&self.db, next_height)?;
 
         let ancestor_tip = {
             let headers_conn = chainstate.index_conn()?;

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -20,8 +20,10 @@ use burnchains::{Burnchain, BurnchainHeaderHash};
 use chainstate::burn::{BlockHeaderHash, ConsensusHash};
 use chainstate::coordinator::comm::CoordinatorCommunication;
 use util::log;
+use vm::costs::ExecutionCost;
 
 pub mod mempool;
+
 pub use self::mempool::MemPoolDB;
 
 // fork set identifier -- to be mixed with the consensus hash (encodes the version)
@@ -102,6 +104,14 @@ pub const POX_MAXIMAL_SCALING: u128 = 4;
 pub const POX_THRESHOLD_STEPS_USTX: u128 = 10_000 * (MICROSTACKS_PER_STACKS as u128);
 
 pub const POX_MAX_NUM_CYCLES: u8 = 12;
+
+pub const MAINNET_BLOCK_LIMIT: ExecutionCost = ExecutionCost {
+    write_length: 15_000_000, // roughly 15 mb
+    write_count: 7_750,
+    read_length: 100_000_000,
+    read_count: 7_750,
+    runtime: 5_000_000_000,
+};
 
 /// Synchronize burn transactions from the Bitcoin blockchain
 pub fn sync_burnchain_bitcoin(

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -105,7 +105,7 @@ pub const POX_THRESHOLD_STEPS_USTX: u128 = 10_000 * (MICROSTACKS_PER_STACKS as u
 
 pub const POX_MAX_NUM_CYCLES: u8 = 12;
 
-pub const MAINNET_BLOCK_LIMIT: ExecutionCost = ExecutionCost {
+pub const BLOCK_LIMIT_MAINNET: ExecutionCost = ExecutionCost {
     write_length: 15_000_000, // roughly 15 mb
     write_count: 7_750,
     read_length: 100_000_000,

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,8 +27,17 @@ extern crate rusqlite;
 #[macro_use(o, slog_log, slog_trace, slog_debug, slog_info, slog_warn, slog_error)]
 extern crate slog;
 
-use blockstack_lib::burnchains::db::BurnchainBlockData;
 use blockstack_lib::*;
+use blockstack_lib::{
+    burnchains::db::BurnchainBlockData,
+    chainstate::{
+        burn::db::sortdb::SortitionDB,
+        stacks::db::{StacksChainState, StacksHeaderInfo},
+    },
+    core::MemPoolDB,
+    util::{hash::Hash160, vrf::VRFProof},
+    vm::costs::ExecutionCost,
+};
 
 use std::env;
 use std::fs;
@@ -185,6 +194,83 @@ fn main() {
             .unwrap();
 
         println!("{:#?}", &block);
+        process::exit(0);
+    }
+
+    if argv[1] == "try-mine" {
+        if argv.len() < 3 {
+            eprintln!("Usage: {} try-mine <working-dir>", argv[0]);
+            process::exit(1);
+        }
+
+        let sort_db_path = format!("{}/burnchain/db/bitcoin/mainnet/sortition.db", &argv[2]);
+        let chain_state_path = format!("{}/chainstate/", &argv[2]);
+
+        let sort_db = SortitionDB::open(&sort_db_path, false)
+            .expect(&format!("Failed to open {}", &sort_db_path));
+        let chain_id = 1;
+        let (mut chain_state, _) = StacksChainState::open(true, chain_id, &chain_state_path)
+            .expect("Failed to open stacks chain state");
+        let chain_tip = SortitionDB::get_canonical_burn_chain_tip(sort_db.conn())
+            .expect("Failed to get sortition chain tip");
+
+        let mempool_db =
+            MemPoolDB::open(true, chain_id, &chain_state_path).expect("Failed to open mempool db");
+
+        let stacks_block = chain_state.get_stacks_chain_tip(&sort_db).unwrap().unwrap();
+        let parent_header = StacksChainState::get_anchored_block_header_info(
+            chain_state.db(),
+            &stacks_block.consensus_hash,
+            &stacks_block.anchored_block_hash,
+        )
+        .expect("Failed to load chain tip header info")
+        .expect("Failed to load chain tip header info");
+
+        let sk = StacksPrivateKey::new();
+        let mut tx_auth = TransactionAuth::from_p2pkh(&sk).unwrap();
+        tx_auth.set_origin_nonce(0);
+
+        let mut coinbase_tx = StacksTransaction::new(
+            TransactionVersion::Mainnet,
+            tx_auth,
+            TransactionPayload::Coinbase(CoinbasePayload([0u8; 32])),
+        );
+
+        coinbase_tx.chain_id = chain_id;
+        coinbase_tx.anchor_mode = TransactionAnchorMode::OnChainOnly;
+        let mut tx_signer = StacksTransactionSigner::new(&coinbase_tx);
+        tx_signer.sign_origin(&sk);
+        let coinbase_tx = tx_signer.get_tx().unwrap();
+
+        let mainnet_block_limit = ExecutionCost {
+            write_length: 15_000_000, // roughly 15 mb
+            write_count: 7_750,
+            read_length: 100_000_000,
+            read_count: 7_750,
+            runtime: 5_000_000_000,
+        };
+
+        let result = StacksBlockBuilder::build_anchored_block(
+            &chain_state,
+            &sort_db.index_conn(),
+            &mempool_db,
+            &parent_header,
+            chain_tip.total_burn,
+            VRFProof::empty(),
+            Hash160([0; 20]),
+            &coinbase_tx,
+            mainnet_block_limit,
+        );
+
+        println!(
+            "{} mined block @ height = {}",
+            if result.is_ok() {
+                "Successfully"
+            } else {
+                "Failed to"
+            },
+            parent_header.block_height + 1
+        );
         process::exit(0);
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -251,14 +251,6 @@ simulating a miner.
         tx_signer.sign_origin(&sk).unwrap();
         let coinbase_tx = tx_signer.get_tx().unwrap();
 
-        let mainnet_block_limit = ExecutionCost {
-            write_length: 15_000_000, // roughly 15 mb
-            write_count: 7_750,
-            read_length: 100_000_000,
-            read_count: 7_750,
-            runtime: 5_000_000_000,
-        };
-
         let result = StacksBlockBuilder::build_anchored_block(
             &chain_state,
             &sort_db.index_conn(),
@@ -268,7 +260,7 @@ simulating a miner.
             VRFProof::empty(),
             Hash160([0; 20]),
             &coinbase_tx,
-            mainnet_block_limit,
+            core::MAINNET_BLOCK_LIMIT.clone(),
         );
 
         println!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -199,7 +199,16 @@ fn main() {
 
     if argv[1] == "try-mine" {
         if argv.len() < 3 {
-            eprintln!("Usage: {} try-mine <working-dir>", argv[0]);
+            eprintln!(
+                "Usage: {} try-mine <working-dir>
+
+Given a <working-dir>, try to ''mine'' an anchored block. This invokes the miner block
+assembly, but does not attempt to broadcast a block commit. This is useful for determining
+what transactions a given chain state would include in an anchor block, or otherwise
+simulating a miner.
+",
+                argv[0]
+            );
             process::exit(1);
         }
 
@@ -208,8 +217,8 @@ fn main() {
 
         let sort_db = SortitionDB::open(&sort_db_path, false)
             .expect(&format!("Failed to open {}", &sort_db_path));
-        let chain_id = 1;
-        let (mut chain_state, _) = StacksChainState::open(true, chain_id, &chain_state_path)
+        let chain_id = core::CHAIN_ID_MAINNET;
+        let (chain_state, _) = StacksChainState::open(true, chain_id, &chain_state_path)
             .expect("Failed to open stacks chain state");
         let chain_tip = SortitionDB::get_canonical_burn_chain_tip(sort_db.conn())
             .expect("Failed to get sortition chain tip");
@@ -239,7 +248,7 @@ fn main() {
         coinbase_tx.chain_id = chain_id;
         coinbase_tx.anchor_mode = TransactionAnchorMode::OnChainOnly;
         let mut tx_signer = StacksTransactionSigner::new(&coinbase_tx);
-        tx_signer.sign_origin(&sk);
+        tx_signer.sign_origin(&sk).unwrap();
         let coinbase_tx = tx_signer.get_tx().unwrap();
 
         let mainnet_block_limit = ExecutionCost {

--- a/src/main.rs
+++ b/src/main.rs
@@ -260,7 +260,7 @@ simulating a miner.
             VRFProof::empty(),
             Hash160([0; 20]),
             &coinbase_tx,
-            core::MAINNET_BLOCK_LIMIT.clone(),
+            core::BLOCK_LIMIT_MAINNET.clone(),
         );
 
         println!(

--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -7,7 +7,7 @@ use rand::RngCore;
 use stacks::burnchains::bitcoin::BitcoinNetworkType;
 use stacks::burnchains::{MagicBytes, BLOCKSTACK_MAGIC_MAINNET};
 use stacks::core::{
-    CHAIN_ID_MAINNET, CHAIN_ID_TESTNET, MAINNET_BLOCK_LIMIT, PEER_VERSION_MAINNET,
+    BLOCK_LIMIT_MAINNET, CHAIN_ID_MAINNET, CHAIN_ID_TESTNET, PEER_VERSION_MAINNET,
     PEER_VERSION_TESTNET,
 };
 use stacks::net::connection::ConnectionOptions;
@@ -794,7 +794,7 @@ impl Config {
         };
 
         let block_limit = if burnchain.mode == "mainnet" || burnchain.mode == "xenon" {
-            MAINNET_BLOCK_LIMIT.clone()
+            BLOCK_LIMIT_MAINNET.clone()
         } else {
             match config_file.block_limit {
                 Some(opts) => ExecutionCost {

--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -7,7 +7,8 @@ use rand::RngCore;
 use stacks::burnchains::bitcoin::BitcoinNetworkType;
 use stacks::burnchains::{MagicBytes, BLOCKSTACK_MAGIC_MAINNET};
 use stacks::core::{
-    CHAIN_ID_MAINNET, CHAIN_ID_TESTNET, PEER_VERSION_MAINNET, PEER_VERSION_TESTNET,
+    CHAIN_ID_MAINNET, CHAIN_ID_TESTNET, MAINNET_BLOCK_LIMIT, PEER_VERSION_MAINNET,
+    PEER_VERSION_TESTNET,
 };
 use stacks::net::connection::ConnectionOptions;
 use stacks::net::{Neighbor, NeighborKey, PeerAddress};
@@ -408,14 +409,6 @@ pub const HELIUM_BLOCK_LIMIT: ExecutionCost = ExecutionCost {
     read_count: 5_0_000,
     // allow much more runtime in helium blocks than mainnet
     runtime: 100_000_000_000,
-};
-
-pub const MAINNET_BLOCK_LIMIT: ExecutionCost = ExecutionCost {
-    write_length: 15_000_000, // roughly 15 mb
-    write_count: 7_750,
-    read_length: 100_000_000,
-    read_count: 7_750,
-    runtime: 5_000_000_000,
 };
 
 impl Config {

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -38,12 +38,12 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 use std::{env, thread};
 
-use crate::config::MAINNET_BLOCK_LIMIT;
 use stacks::burnchains::bitcoin::address::{BitcoinAddress, BitcoinAddressType};
 use stacks::burnchains::bitcoin::BitcoinNetworkType;
 use stacks::burnchains::{BurnchainHeaderHash, Txid};
 use stacks::chainstate::burn::operations::{BlockstackOperationType, PreStxOp, TransferStxOp};
 use stacks::chainstate::stacks::boot::boot_code_id;
+use stacks::core::MAINNET_BLOCK_LIMIT;
 
 fn neon_integration_test_conf() -> (Config, StacksAddress) {
     let mut conf = super::new_test_conf();

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -43,7 +43,7 @@ use stacks::burnchains::bitcoin::BitcoinNetworkType;
 use stacks::burnchains::{BurnchainHeaderHash, Txid};
 use stacks::chainstate::burn::operations::{BlockstackOperationType, PreStxOp, TransferStxOp};
 use stacks::chainstate::stacks::boot::boot_code_id;
-use stacks::core::MAINNET_BLOCK_LIMIT;
+use stacks::core::BLOCK_LIMIT_MAINNET;
 
 fn neon_integration_test_conf() -> (Config, StacksAddress) {
     let mut conf = super::new_test_conf();
@@ -1623,7 +1623,7 @@ fn near_full_block_integration_test() {
     let (mut conf, miner_account) = neon_integration_test_conf();
 
     // Set block limit
-    conf.block_limit = MAINNET_BLOCK_LIMIT;
+    conf.block_limit = BLOCK_LIMIT_MAINNET;
 
     conf.initial_balances.push(InitialBalance {
         address: addr.clone().into(),


### PR DESCRIPTION
This PR addresses the most immediate mempool issue #2389, by modifying the walk logic to "try again" if there are mempool entries received at a particular height _but not_ in the same fork.

This PR also adds a `try-mine` CLI command, as well as a diagnostic envar `MEMPOOL_BAD_BEHAVIOR` which executes the mempool walk in the manner that causes #2389.

This leaves unaddressed two potential issues:

1. Transactions received into the mempool at block `A`, but block `A` is "forked away". Those transactions will not appear in the miner's walk. However, such transactions will be viable for "replace-across-forks", such that if the transaction is rebroadcasted (not re-signed or fee upgraded), the miner will replace the existing tx in the mempool. (Issue: #2394)
2. Mempool transactions are evaluated in "reverse" order: transactions received later are attempted first. This can impact chained transactions, because higher nonces will be tried first and fail, before the lower nonces are tried. In degenerate cases, this can lead to chained transactions only being included one-per-block. (Issue: #2393)

I think #2389 is much worse than those two issues at the moment, so I'm not sure if we should try to address those issues at the same time, or instead split it into multiple releases.
