### PR TITLE
Fix: serde_json depth limit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -270,6 +270,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
+ "serde_stacker",
  "sha2 0.8.2",
  "sha2-asm",
  "sha3",
@@ -1677,6 +1678,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d883f78645c21b7281d21305181aa1f4dd9e9363e7cf2566c93121552cff003e"
 
 [[package]]
+name = "psm"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3abf49e5417290756acfd26501536358560c4a5cc4a0934d390939acb3e7083a"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2202,6 +2212,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_stacker"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c92391a63e3b83f77334d8beaaf11bac4c900f3769483e543bf76a81bf8ee2"
+dependencies = [
+ "serde",
+ "stacker",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2350,6 +2370,19 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "stacker"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3f47e840d001df3b785fbc3b84c7228519bdf63d4fb61b9e9f50f7fa153ce10"
+dependencies = [
+ "cc",
+ "cfg-if 1.0.0",
+ "libc",
+ "psm",
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "stacks-node"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ rand = "=0.7.2"
 rand_chacha = "=0.2.2"
 serde = "1"
 serde_derive = "1"
+serde_stacker = "0.1"
 sha3 = "0.8.2"
 ripemd160 = "0.8.0"
 regex = "1"
@@ -66,7 +67,7 @@ libc = "0.2.82"
 
 [dependencies.serde_json]
 version = "1.0"
-features = ["arbitrary_precision"]
+features = ["arbitrary_precision", "unbounded_depth"]
 
 [dependencies.secp256k1]
 version = "0.19.0"

--- a/src/vm/database/structures.rs
+++ b/src/vm/database/structures.rs
@@ -56,6 +56,8 @@ macro_rules! clarity_serializable {
                 // serde's default 128 depth limit can be exhausted
                 //  by a 64-stack-depth AST, so disable the recursion limit
                 deserializer.disable_recursion_limit();
+                // use stacker to prevent the deserializer from overflowing.
+                //  this will instead spill to the heap
                 let deserializer = serde_stacker::Deserializer::new(&mut deserializer);
                 Deserialize::deserialize(deserializer).expect("Failed to deserialize vm.Value")
             }


### PR DESCRIPTION
This gets around `serde_json`'s default depth limit, using a `stacker` enabled deserializer.