### PR TITLE
`tx_fees_streamed_produced` missing from the reward payload

### DIFF
--- a/testnet/stacks-node/src/event_dispatcher.rs
+++ b/testnet/stacks-node/src/event_dispatcher.rs
@@ -469,6 +469,7 @@ impl EventDispatcher {
                             "coinbase_amount": reward.coinbase.to_string(),
                             "tx_fees_anchored": reward.tx_fees_anchored.to_string(),
                             "tx_fees_streamed_confirmed": reward.tx_fees_streamed_confirmed.to_string(),
+                            "tx_fees_streamed_produced": reward.tx_fees_streamed_produced.to_string(),
                             "from_stacks_block_hash": format!("0x{}", &rewards_info.from_stacks_block_hash),
                             "from_index_consensus_hash": format!("0x{}", StacksBlockId::new(&rewards_info.from_block_consensus_hash,
                                                                                             &rewards_info.from_stacks_block_hash)),


### PR DESCRIPTION
See: https://github.com/blockstack/stacks-blockchain-api/pull/430

This change is required by the API to report miner balances correctly.