### PR TITLE
Fix #2416

### DIFF
--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -1077,6 +1077,14 @@ impl InitializedNeonNode {
             _ => panic!("Unable to retrieve local peer"),
         };
 
+        // force early mempool instantiation
+        let _ = MemPoolDB::open(
+            config.is_mainnet(),
+            config.burnchain.chain_id,
+            &config.get_chainstate_path(),
+        )
+        .expect("BUG: failed to instantiate mempool");
+
         // now we're ready to instantiate a p2p network object, the relayer, and the event dispatcher
         let mut p2p_net = PeerNetwork::new(
             peerdb,


### PR DESCRIPTION
Instantiate the mempool before spawning threads, so the threads don't race each other to do so (and clobber the database in the process).