### PR TITLE
fix: update /new_burn_block payload schema

### DIFF
--- a/docs/event-dispatcher.md
+++ b/docs/event-dispatcher.md
@@ -97,7 +97,7 @@ Example:
   "reward_recipients": [
     {
       "recipient": "1C56LYirKa3PFXFsvhSESgDy2acEHVAEt6",
-      "amount": 5000
+      "amt": 5000
     }
   ],
   "burn_amount": 12000


### PR DESCRIPTION
Docs shows `"amount"` rather than the actual field name `"amt"` for burnchain block rewards

See https://github.com/blockstack/stacks-blockchain/blob/ad145207ce9979ed1bf44af2839dd2938c79a0f5/testnet/stacks-node/src/event_dispatcher.rs#L134
