### PR TITLE
Fix/2451

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.6]
+
+### Fixed
+
+- The miner will no longer attempt to mine a new Stacks block if it receives a
+  microblock in a discontinuous microblock stream.
+
 ## [2.0.5] - 2021-02-12
 
 ### Added

--- a/src/chainstate/stacks/db/blocks.rs
+++ b/src/chainstate/stacks/db/blocks.rs
@@ -1356,7 +1356,7 @@ impl StacksChainState {
         let mut ret = vec![];
         let mut tip: Option<StacksMicroblock> = None;
         let mut fork_poison = None;
-        let mut expected_sequence = 0;
+        let mut expected_sequence = start_seq;
 
         // load associated staging microblock data, but best-effort.
         // Stop loading once we find a fork juncture.

--- a/src/chainstate/stacks/db/blocks.rs
+++ b/src/chainstate/stacks/db/blocks.rs
@@ -1356,6 +1356,7 @@ impl StacksChainState {
         let mut ret = vec![];
         let mut tip: Option<StacksMicroblock> = None;
         let mut fork_poison = None;
+        let mut expected_sequence = 0;
 
         // load associated staging microblock data, but best-effort.
         // Stop loading once we find a fork juncture.
@@ -1383,6 +1384,18 @@ impl StacksChainState {
                     break;
                 }
             };
+
+            if mblock.header.sequence > expected_sequence {
+                warn!(
+                    "Discontinuous microblock stream: expected seq {}, got {}",
+                    expected_sequence, mblock.header.sequence
+                );
+                break;
+            }
+
+            // expect forks, so expected_sequence may not always increase
+            expected_sequence =
+                cmp::min(mblock.header.sequence, expected_sequence).saturating_add(1);
 
             if let Some(tip_mblock) = tip {
                 if mblock.header.sequence == tip_mblock.header.sequence {
@@ -6910,6 +6923,133 @@ pub mod test {
             .unwrap(),
             microblocks
         );
+    }
+
+    #[test]
+    fn stacks_db_staging_microblock_stream_load_continuous_streams() {
+        let mut chainstate = instantiate_chainstate(
+            false,
+            0x80000000,
+            "stacks_db_staging_microblock_stream_load_continuous_streams",
+        );
+        let privk = StacksPrivateKey::from_hex(
+            "eb05c83546fdd2c79f10f5ad5434a90dd28f7e3acb7c092157aa1bc3656b012c01",
+        )
+        .unwrap();
+
+        let block = make_empty_coinbase_block(&privk);
+        let microblocks = make_sample_microblock_stream(&privk, &block.block_hash());
+        let mut child_block = make_empty_coinbase_block(&privk);
+
+        child_block.header.parent_block = block.block_hash();
+        child_block.header.parent_microblock = microblocks.first().as_ref().unwrap().block_hash();
+        child_block.header.parent_microblock_sequence =
+            microblocks.first().as_ref().unwrap().header.sequence;
+
+        assert!(StacksChainState::load_staging_microblock(
+            &chainstate.db(),
+            &ConsensusHash([2u8; 20]),
+            &block.block_hash(),
+            &microblocks[0].block_hash()
+        )
+        .unwrap()
+        .is_none());
+        assert!(StacksChainState::load_descendant_staging_microblock_stream(
+            &chainstate.db(),
+            &StacksBlockHeader::make_index_block_hash(
+                &ConsensusHash([2u8; 20]),
+                &block.block_hash()
+            ),
+            0,
+            u16::max_value()
+        )
+        .unwrap()
+        .is_none());
+
+        store_staging_block(
+            &mut chainstate,
+            &ConsensusHash([2u8; 20]),
+            &block,
+            &ConsensusHash([1u8; 20]),
+            1,
+            2,
+        );
+
+        // don't store the first microblock, but store the rest
+        for (i, mb) in microblocks.iter().enumerate() {
+            if i > 0 {
+                store_staging_microblock(
+                    &mut chainstate,
+                    &ConsensusHash([2u8; 20]),
+                    &block.block_hash(),
+                    mb,
+                );
+            }
+        }
+        store_staging_block(
+            &mut chainstate,
+            &ConsensusHash([3u8; 20]),
+            &child_block,
+            &ConsensusHash([2u8; 20]),
+            1,
+            2,
+        );
+
+        // block should be stored to staging
+        assert_block_staging_not_processed(&mut chainstate, &ConsensusHash([2u8; 20]), &block);
+        assert_block_staging_not_processed(
+            &mut chainstate,
+            &ConsensusHash([3u8; 20]),
+            &child_block,
+        );
+        assert_block_not_stored(&mut chainstate, &ConsensusHash([2u8; 20]), &block);
+        assert_block_not_stored(&mut chainstate, &ConsensusHash([3u8; 20]), &child_block);
+
+        // missing head
+        assert!(StacksChainState::load_staging_microblock(
+            &chainstate.db(),
+            &ConsensusHash([2u8; 20]),
+            &block.block_hash(),
+            &microblocks[0].block_hash()
+        )
+        .unwrap()
+        .is_none());
+
+        // subsequent microblock stream should be stored to staging
+        assert!(StacksChainState::load_staging_microblock(
+            &chainstate.db(),
+            &ConsensusHash([2u8; 20]),
+            &block.block_hash(),
+            &microblocks[1].block_hash()
+        )
+        .unwrap()
+        .is_some());
+        assert_eq!(
+            StacksChainState::load_staging_microblock(
+                &chainstate.db(),
+                &ConsensusHash([2u8; 20]),
+                &block.block_hash(),
+                &microblocks[1].block_hash()
+            )
+            .unwrap()
+            .unwrap()
+            .try_into_microblock()
+            .unwrap(),
+            microblocks[1]
+        );
+
+        // can't load descendent stream because missing head
+        assert!(StacksChainState::load_descendant_staging_microblock_stream(
+            &chainstate.db(),
+            &StacksBlockHeader::make_index_block_hash(
+                &ConsensusHash([2u8; 20]),
+                &block.block_hash()
+            ),
+            0,
+            u16::max_value()
+        )
+        .unwrap()
+        .is_none());
     }
 
     #[test]

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -1392,28 +1392,21 @@ impl InitializedNeonNode {
                             u16::MAX,
                         )
                     {
-                        let max_seq = stream.iter().fold(0, |max_seq, mblock| {
-                            if mblock.header.sequence > max_seq {
-                                mblock.header.sequence
-                            } else {
-                                max_seq
-                            }
-                        });
                         if (prev_block.anchored_block.header.parent_microblock
                             == BlockHeaderHash([0u8; 32])
-                            && max_seq == 0)
+                            && stream.len() == 0)
                             || (prev_block.anchored_block.header.parent_microblock
                                 != BlockHeaderHash([0u8; 32])
-                                && (max_seq as u32)
+                                && stream.len()
                                     <= (prev_block.anchored_block.header.parent_microblock_sequence
-                                        as u32)
+                                        as usize)
                                         + 1)
                         {
                             // the chain tip hasn't changed since we attempted to build a block.  Use what we
                             // already have.
                             debug!("Stacks tip is unchanged since we last tried to mine a block ({}/{} at height {} with {} txs, in {} at burn height {}), and no new microblocks ({} <= {})",
                                    &prev_block.parent_consensus_hash, &prev_block.anchored_block.block_hash(), prev_block.anchored_block.header.total_work.work,
-                                   prev_block.anchored_block.txs.len(), prev_block.my_burn_hash, parent_block_burn_height, max_seq, prev_block.anchored_block.header.parent_microblock_sequence);
+                                   prev_block.anchored_block.txs.len(), prev_block.my_burn_hash, parent_block_burn_height, stream.len(), prev_block.anchored_block.header.parent_microblock_sequence);
 
                             return None;
                         } else {
@@ -1423,7 +1416,7 @@ impl InitializedNeonNode {
                             // fee minus the old BTC fee
                             debug!("Stacks tip is unchanged since we last tried to mine a block ({}/{} at height {} with {} txs, in {} at burn height {}), but there are new microblocks ({} > {})",
                                    &prev_block.parent_consensus_hash, &prev_block.anchored_block.block_hash(), prev_block.anchored_block.header.total_work.work,
-                                   prev_block.anchored_block.txs.len(), prev_block.my_burn_hash, parent_block_burn_height, max_seq, prev_block.anchored_block.header.parent_microblock_sequence);
+                                   prev_block.anchored_block.txs.len(), prev_block.my_burn_hash, parent_block_burn_height, stream.len(), prev_block.anchored_block.header.parent_microblock_sequence);
 
                             best_attempt = cmp::max(best_attempt, prev_block.attempt);
                         }

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -1392,21 +1392,28 @@ impl InitializedNeonNode {
                             u16::MAX,
                         )
                     {
+                        let max_seq = stream.iter().fold(0, |max_seq, mblock| {
+                            if mblock.header.sequence > max_seq {
+                                mblock.header.sequence
+                            } else {
+                                max_seq
+                            }
+                        });
                         if (prev_block.anchored_block.header.parent_microblock
                             == BlockHeaderHash([0u8; 32])
-                            && stream.len() == 0)
+                            && max_seq == 0)
                             || (prev_block.anchored_block.header.parent_microblock
                                 != BlockHeaderHash([0u8; 32])
-                                && stream.len()
+                                && (max_seq as u32)
                                     <= (prev_block.anchored_block.header.parent_microblock_sequence
-                                        as usize)
+                                        as u32)
                                         + 1)
                         {
                             // the chain tip hasn't changed since we attempted to build a block.  Use what we
                             // already have.
                             debug!("Stacks tip is unchanged since we last tried to mine a block ({}/{} at height {} with {} txs, in {} at burn height {}), and no new microblocks ({} <= {})",
                                    &prev_block.parent_consensus_hash, &prev_block.anchored_block.block_hash(), prev_block.anchored_block.header.total_work.work,
-                                   prev_block.anchored_block.txs.len(), prev_block.my_burn_hash, parent_block_burn_height, stream.len(), prev_block.anchored_block.header.parent_microblock_sequence);
+                                   prev_block.anchored_block.txs.len(), prev_block.my_burn_hash, parent_block_burn_height, max_seq, prev_block.anchored_block.header.parent_microblock_sequence);
 
                             return None;
                         } else {
@@ -1416,7 +1423,7 @@ impl InitializedNeonNode {
                             // fee minus the old BTC fee
                             debug!("Stacks tip is unchanged since we last tried to mine a block ({}/{} at height {} with {} txs, in {} at burn height {}), but there are new microblocks ({} > {})",
                                    &prev_block.parent_consensus_hash, &prev_block.anchored_block.block_hash(), prev_block.anchored_block.header.total_work.work,
-                                   prev_block.anchored_block.txs.len(), prev_block.my_burn_hash, parent_block_burn_height, stream.len(), prev_block.anchored_block.header.parent_microblock_sequence);
+                                   prev_block.anchored_block.txs.len(), prev_block.my_burn_hash, parent_block_burn_height, max_seq, prev_block.anchored_block.header.parent_microblock_sequence);
 
                             best_attempt = cmp::max(best_attempt, prev_block.attempt);
                         }


### PR DESCRIPTION
This fixes #2451 by making it so that we don't load a microblock stream if the stream's "prefix" is missing.  But, it still permits loading microblock stream forks, so we can mine poison-microblock transactions.  It also modifies the Neon node miner to look at a microblock stream's maximum sequence number (instead of its length) in order to decide when to RBF an in-flight block commit.