### PR TITLE
do NOT delete the parent anchored block if the microblock stream is too heavy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.7] - 2021-02-26
+
+This is an emergency hotfix that prevents the node from accidentally deleting
+valid block data if its descendant microblock stream is invalid for some reason.
+
+## Fixed
+
+- Do not delete a valid parent Stacks block.
+
 ## [2.0.6] - 2021-02-15
 
 The database schema has not changed since 2.0.5, so when spinning up a

--- a/src/chainstate/stacks/db/blocks.rs
+++ b/src/chainstate/stacks/db/blocks.rs
@@ -2333,18 +2333,6 @@ impl StacksChainState {
 
             tx.execute(&update_block_children_sql, &update_block_children_args)
                 .map_err(|e| Error::DBError(db_error::SqliteError(e)))?;
-
-            // mark the block as empty if we haven't already
-            let block_path =
-                StacksChainState::get_block_path(blocks_path, consensus_hash, anchored_block_hash)?;
-            match fs::metadata(&block_path) {
-                Ok(_) => {
-                    StacksChainState::free_block(blocks_path, consensus_hash, anchored_block_hash);
-                }
-                Err(_) => {
-                    StacksChainState::atomic_file_write(&block_path, &vec![])?;
-                }
-            }
         }
 
         Ok(())


### PR DESCRIPTION
This is an emergency hotfix that stops the node from accidentally deleting a valid parent block in the event that its descendant microblock stream is invalid for some reason.