### PR TITLE
Fix: improved analysis db storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.8] - 2021-03-02
+
+This is a hotfix release for improved handling of static analysis storage and
+improved `at-block` behavior. The chainstate directory of 2.0.8 is compatible with
+the 2.0.7 chainstate.
+
+## Fixed
+
+- Improved static analysis storage
+- `at-block` behavior in `clarity-cli` and unit tests (no changes in `stacks-node`
+  behavior).
+
 ## [2.0.7] - 2021-02-26
 
 This is an emergency hotfix that prevents the node from accidentally deleting

--- a/src/chainstate/stacks/db/transactions.rs
+++ b/src/chainstate/stacks/db/transactions.rs
@@ -1039,7 +1039,13 @@ impl StacksChainState {
                     .expect("BUG: total block cost decreased");
 
                 let (asset_map, events) = match initialize_resp {
-                    Ok(x) => x,
+                    Ok(x) => {
+                        // store analysis -- if this fails, then the have some pretty bad problems
+                        clarity_tx
+                            .save_analysis(&contract_id, &contract_analysis)
+                            .expect("FATAL: failed to store contract analysis");
+                        x
+                    }
                     Err(e) => match handle_clarity_runtime_error(e) {
                         ClarityRuntimeTxError::Acceptable { error, err_type } => {
                             info!("Smart-contract processed with {}", err_type;
@@ -1075,11 +1081,6 @@ impl StacksChainState {
                         }
                     },
                 };
-
-                // store analysis -- if this fails, then the have some pretty bad problems
-                clarity_tx
-                    .save_analysis(&contract_id, &contract_analysis)
-                    .expect("FATAL: failed to store contract analysis");
 
                 let receipt = StacksTransactionReceipt::from_smart_contract(
                     tx.clone(),


### PR DESCRIPTION
This is a hotfix release for improved handling of static analysis storage and improved `at-block` behavior. The chainstate directory of 2.0.8 is compatible with the 2.0.7 chainstate. More details in `CHANGELOG`.