### PR TITLE
fix/block store push tocttou (master)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.9]
+
+This is a hotfix release for improved handling of arriving Stacks blocks through
+both the RPC interface and the P2P ineterface.  The chainstate directory of
+2.0.9 is compatible with the 2.0.8 chainstate.
+
+## Fixed
+
+- TOCTTOU bug fixed in the chain processing logic that, which now ensures that
+  an arriving Stacks block is processed at most once.
+
 ## [2.0.8] - 2021-03-02
 
 This is a hotfix release for improved handling of static analysis storage and

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,7 +91,9 @@ features = ["std"]
 
 [dev-dependencies]
 assert-json-diff = "1.0.0"
-criterion = "0.3"
+# a nightly rustc regression (35dbef235 2021-03-02) prevents criterion from compiling
+#  but it isn't necessary for tests: only benchmarks. therefore, commenting out for now.
+# criterion = "0.3"
 stx_genesis = { package = "stx-genesis", path = "./stx-genesis/."}
 
 [features]


### PR DESCRIPTION
Backport #2496 to master.

EDIT: Closing #2496 in favor of this one.  The original PR text follows.

Fix a TOCTTOU bug in the code that checks that the node doesn't yet have an anchored block (this is important now, because both the p2p thread and relayer thread can store new anchored blocks).