### PR TITLE
feat: RPC endpoint /v2/traits/<contract-info>/<trait-info>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ compatible with prior chainstate directories.
 - Log transactions in local db table via setting env `STACKS_TRANSACTION_LOG=1`
 - New prometheus metrics for mempool transaction processing times and
   outstanding mempool transactions
+- New RPC endpoint with path `v2/traits/contractAddr/contractName/traitContractName
+  /traitContractAddr/traitName` to determine whether a given trait is implemented 
+  within the specified contract (either explicitly or implicitly).
 
 ## Changed
 

--- a/docs/rpc-endpoints.md
+++ b/docs/rpc-endpoints.md
@@ -338,3 +338,9 @@ object of the following form:
   "cause": "Unchecked(PublicFunctionNotReadOnly(..."
 }
 ```
+
+### GET /v2/traits/[Stacks Address]/[Contract Name]/[Trait Stacks Address]/[Trait Contract Name]/[Trait Name]
+
+Determine whether a given trait is implemented within the specified contract (either explicitly or implicitly).
+
+See OpenAPI [spec](./rpc/openapi.yaml) for details.

--- a/docs/rpc/api/trait/get-is-trait-implemented.example.json
+++ b/docs/rpc/api/trait/get-is-trait-implemented.example.json
@@ -1,0 +1,3 @@
+{
+  "is_implemented": true
+}

--- a/docs/rpc/api/trait/get-is-trait-implemented.schema.json
+++ b/docs/rpc/api/trait/get-is-trait-implemented.schema.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "GET request to get trait implementation information",
+  "title": "IsTraitImplementedSuccessResponse",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["is_implemented"],
+  "properties": {
+    "is_implemented": {
+      "type": "boolean"
+    },
+  }
+}

--- a/docs/rpc/openapi.yaml
+++ b/docs/rpc/openapi.yaml
@@ -332,7 +332,7 @@ paths:
       summary: Get trait implementation details
       description: Determine whether or not a specified trait is implemented (either explicitly or implicitly) within a given contract.
       tags:
-        - Info
+        - Smart Contracts
       operationId: get_is_trait_implemented
       responses:
         200:

--- a/docs/rpc/openapi.yaml
+++ b/docs/rpc/openapi.yaml
@@ -326,3 +326,56 @@ paths:
                 $ref: ./api/core-node/get-pox.schema.json
               example:
                 $ref: ./api/core-node/get-pox.example.json
+
+  /v2/traits/{contract_address}/{contract_name}/{trait_contract_address}/{trait_ contract_name}/{trait_name}:
+    get:
+      summary: Get trait implementation details
+      description: Determine whether or not a specified trait is implemented (either explicitly or implicitly) within a given contract.
+      tags:
+        - Info
+      operationId: get_is_trait_implemented
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: ./api/trait/get-is-trait-implemented.schema.json
+              example:
+                $ref: ./api/trait/get-is-trait-implemented.example.json
+    parameters:
+      - name: contract_address
+        in: path
+        required: true
+        description: Stacks address
+        schema:
+          type: string
+      - name: contract_name
+        in: path
+        required: true
+        description: Contract name
+        schema:
+          type: string
+      - name: trait_contract_address
+        in: path
+        required: true
+        description: Trait Stacks address
+        schema:
+          type: string
+      - name: trait_contract_name
+        in: path
+        required: true
+        description: Trait contract name
+        schema:
+          type: string
+      - name: trait_name
+        in: path
+        required: true
+        description: Trait name
+        schema:
+          type: string
+      - name: tip
+        in: query
+        schema:
+          type: string
+        description: The Stacks chain tip to query from

--- a/src/net/http.rs
+++ b/src/net/http.rs
@@ -92,6 +92,8 @@ use std::time::SystemTime;
 use time;
 
 use chainstate::burn::ConsensusHash;
+use net::Error::ClarityError;
+use vm::types::{StandardPrincipalData, TraitIdentifier};
 
 lazy_static! {
     static ref PATH_GETINFO: Regex = Regex::new(r#"^/v2/info$"#).unwrap();
@@ -127,6 +129,11 @@ lazy_static! {
     static ref PATH_GET_CONTRACT_SRC: Regex = Regex::new(&format!(
         "^/v2/contracts/source/(?P<address>{})/(?P<contract>{})$",
         *STANDARD_PRINCIPAL_REGEX, *CONTRACT_NAME_REGEX
+    ))
+    .unwrap();
+    static ref PATH_GET_IS_TRAIT_IMPLEMENTED: Regex = Regex::new(&format!(
+        "^/v2/traits/(?P<address>{})/(?P<contract>{})/(?P<traitName>{})/(?P<traitContractAddr>{})/(?P<traitContractName>{})$",
+        *STANDARD_PRINCIPAL_REGEX, *CONTRACT_NAME_REGEX, *CLARITY_NAME_REGEX, *STANDARD_PRINCIPAL_REGEX, *CONTRACT_NAME_REGEX
     ))
     .unwrap();
     static ref PATH_GET_CONTRACT_ABI: Regex = Regex::new(&format!(
@@ -1505,6 +1512,11 @@ impl HttpRequestType {
             ),
             (
                 "GET",
+                &PATH_GET_IS_TRAIT_IMPLEMENTED,
+                &HttpRequestType::parse_get_is_trait_implemented,
+            ),
+            (
+                "GET",
                 &PATH_GET_CONTRACT_ABI,
                 &HttpRequestType::parse_get_contract_abi,
             ),
@@ -1868,6 +1880,45 @@ impl HttpRequestType {
                 HttpRequestType::GetContractSrc(preamble, addr, name, tip, with_proof)
             },
         )
+    }
+
+    fn parse_get_is_trait_implemented<R: Read>(
+        _protocol: &mut StacksHttp,
+        preamble: &HttpRequestPreamble,
+        captures: &Captures,
+        query: Option<&str>,
+        _fd: &mut R,
+    ) -> Result<HttpRequestType, net_error> {
+        let tip = HttpRequestType::get_chain_tip_query(query);
+        if preamble.get_content_length() != 0 {
+            return Err(net_error::DeserializeError(
+                "Invalid Http request: expected 0-length body".to_string(),
+            ));
+        }
+
+        let contract_addr = StacksAddress::from_string(&captures["address"]).ok_or_else(|| {
+            net_error::DeserializeError("Failed to parse contract address".into())
+        })?;
+        let contract_name = ContractName::try_from(captures["contract"].to_string())
+            .map_err(|_e| net_error::DeserializeError("Failed to parse contract name".into()))?;
+        let trait_name = ClarityName::try_from(captures["traitName"].to_string())
+            .map_err(|_e| net_error::DeserializeError("Failed to parse trait name".into()))?;
+        let trait_contract_addr = StacksAddress::from_string(&captures["traitContractAddr"])
+            .ok_or_else(|| net_error::DeserializeError("Failed to parse contract address".into()))?
+            .into();
+        let trait_contract_name = ContractName::try_from(captures["traitContractName"].to_string())
+            .map_err(|_e| {
+                net_error::DeserializeError("Failed to parse trait contract name".into())
+            })?;
+        let trait_id = TraitIdentifier::new(trait_contract_addr, trait_contract_name, trait_name);
+
+        Ok(HttpRequestType::GetIsTraitImplemented(
+            HttpRequestMetadata::from_preamble(preamble),
+            contract_addr,
+            contract_name,
+            trait_id,
+            tip,
+        ))
     }
 
     fn parse_getblock<R: Read>(
@@ -2349,6 +2400,7 @@ impl HttpRequestType {
             HttpRequestType::GetTransferCost(ref md) => md,
             HttpRequestType::GetContractABI(ref md, ..) => md,
             HttpRequestType::GetContractSrc(ref md, ..) => md,
+            HttpRequestType::GetIsTraitImplemented(ref md, ..) => md,
             HttpRequestType::CallReadOnlyFunction(ref md, ..) => md,
             HttpRequestType::OptionsPreflight(ref md, ..) => md,
             HttpRequestType::GetAttachmentsInv(ref md, ..) => md,
@@ -2375,6 +2427,7 @@ impl HttpRequestType {
             HttpRequestType::GetTransferCost(ref mut md) => md,
             HttpRequestType::GetContractABI(ref mut md, ..) => md,
             HttpRequestType::GetContractSrc(ref mut md, ..) => md,
+            HttpRequestType::GetIsTraitImplemented(ref mut md, ..) => md,
             HttpRequestType::CallReadOnlyFunction(ref mut md, ..) => md,
             HttpRequestType::OptionsPreflight(ref mut md, ..) => md,
             HttpRequestType::GetAttachmentsInv(ref mut md, ..) => md,
@@ -2462,6 +2515,21 @@ impl HttpRequestType {
                 contract_addr,
                 contract_name.as_str(),
                 HttpRequestType::make_query_string(tip_opt.as_ref(), *with_proof)
+            ),
+            HttpRequestType::GetIsTraitImplemented(
+                _,
+                contract_addr,
+                contract_name,
+                trait_id,
+                tip_opt,
+            ) => format!(
+                "/v2/traits/{}/{}/{}/{}/{}{}",
+                contract_addr,
+                contract_name.as_str(),
+                trait_id.name.to_string(),
+                StacksAddress::from(trait_id.clone().contract_identifier.issuer),
+                trait_id.contract_identifier.name.as_str(),
+                HttpRequestType::make_query_string(tip_opt.as_ref(), true)
             ),
             HttpRequestType::CallReadOnlyFunction(
                 _,
@@ -2942,6 +3010,10 @@ impl HttpResponseType {
                 &HttpResponseType::parse_get_contract_src,
             ),
             (
+                &PATH_GET_IS_TRAIT_IMPLEMENTED,
+                &HttpResponseType::parse_get_is_trait_implemented,
+            ),
+            (
                 &PATH_GET_CONTRACT_ABI,
                 &HttpResponseType::parse_get_contract_abi,
             ),
@@ -3120,6 +3192,21 @@ impl HttpResponseType {
         let src_data =
             HttpResponseType::parse_json(preamble, fd, len_hint, MAX_MESSAGE_LEN as u64)?;
         Ok(HttpResponseType::GetContractSrc(
+            HttpResponseMetadata::from_preamble(request_version, preamble),
+            src_data,
+        ))
+    }
+
+    fn parse_get_is_trait_implemented<R: Read>(
+        _protocol: &mut StacksHttp,
+        request_version: HttpVersion,
+        preamble: &HttpResponsePreamble,
+        fd: &mut R,
+        len_hint: Option<usize>,
+    ) -> Result<HttpResponseType, net_error> {
+        let src_data =
+            HttpResponseType::parse_json(preamble, fd, len_hint, MAX_MESSAGE_LEN as u64)?;
+        Ok(HttpResponseType::GetIsTraitImplemented(
             HttpResponseMetadata::from_preamble(request_version, preamble),
             src_data,
         ))
@@ -3362,6 +3449,7 @@ impl HttpResponseType {
             HttpResponseType::GetAccount(ref md, _) => md,
             HttpResponseType::GetContractABI(ref md, _) => md,
             HttpResponseType::GetContractSrc(ref md, _) => md,
+            HttpResponseType::GetIsTraitImplemented(ref md, _) => md,
             HttpResponseType::CallReadOnlyFunction(ref md, _) => md,
             HttpResponseType::UnconfirmedTransaction(ref md, _) => md,
             HttpResponseType::GetAttachment(ref md, _) => md,
@@ -3451,6 +3539,10 @@ impl HttpResponseType {
                 HttpResponseType::send_json(protocol, md, fd, data)?;
             }
             HttpResponseType::GetContractSrc(ref md, ref data) => {
+                HttpResponsePreamble::ok_JSON_from_md(fd, md)?;
+                HttpResponseType::send_json(protocol, md, fd, data)?;
+            }
+            HttpResponseType::GetIsTraitImplemented(ref md, ref data) => {
                 HttpResponsePreamble::ok_JSON_from_md(fd, md)?;
                 HttpResponseType::send_json(protocol, md, fd, data)?;
             }
@@ -3692,6 +3784,7 @@ impl MessageSequence for StacksHttpMessage {
                 HttpRequestType::GetTransferCost(_) => "HTTP(GetTransferCost)",
                 HttpRequestType::GetContractABI(..) => "HTTP(GetContractABI)",
                 HttpRequestType::GetContractSrc(..) => "HTTP(GetContractSrc)",
+                HttpRequestType::GetIsTraitImplemented(..) => "HTTP(GetIsTraitImplemented)",
                 HttpRequestType::CallReadOnlyFunction(..) => "HTTP(CallReadOnlyFunction)",
                 HttpRequestType::GetAttachment(..) => "HTTP(GetAttachment)",
                 HttpRequestType::GetAttachmentsInv(..) => "HTTP(GetAttachmentsInv)",
@@ -3704,6 +3797,7 @@ impl MessageSequence for StacksHttpMessage {
                 HttpResponseType::GetAccount(_, _) => "HTTP(GetAccount)",
                 HttpResponseType::GetContractABI(..) => "HTTP(GetContractABI)",
                 HttpResponseType::GetContractSrc(..) => "HTTP(GetContractSrc)",
+                HttpResponseType::GetIsTraitImplemented(..) => "HTTP(GetIsTraitImplemented)",
                 HttpResponseType::CallReadOnlyFunction(..) => "HTTP(CallReadOnlyFunction)",
                 HttpResponseType::GetAttachment(_, _) => "HTTP(GetAttachment)",
                 HttpResponseType::GetAttachmentsInv(_, _) => "HTTP(GetAttachmentsInv)",

--- a/src/net/http.rs
+++ b/src/net/http.rs
@@ -132,8 +132,8 @@ lazy_static! {
     ))
     .unwrap();
     static ref PATH_GET_IS_TRAIT_IMPLEMENTED: Regex = Regex::new(&format!(
-        "^/v2/traits/(?P<address>{})/(?P<contract>{})/(?P<traitName>{})/(?P<traitContractAddr>{})/(?P<traitContractName>{})$",
-        *STANDARD_PRINCIPAL_REGEX, *CONTRACT_NAME_REGEX, *CLARITY_NAME_REGEX, *STANDARD_PRINCIPAL_REGEX, *CONTRACT_NAME_REGEX
+        "^/v2/traits/(?P<address>{})/(?P<contract>{})/(?P<traitContractAddr>{})/(?P<traitContractName>{})/(?P<traitName>{})$",
+        *STANDARD_PRINCIPAL_REGEX, *CONTRACT_NAME_REGEX, *STANDARD_PRINCIPAL_REGEX, *CONTRACT_NAME_REGEX, *CLARITY_NAME_REGEX
     ))
     .unwrap();
     static ref PATH_GET_CONTRACT_ABI: Regex = Regex::new(&format!(

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -1100,6 +1100,11 @@ pub struct ContractSrcResponse {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct GetIsTraitImplementedResponse {
+    pub is_implemented: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CallReadOnlyResponse {
     pub okay: bool,
     #[serde(default)]
@@ -1288,6 +1293,13 @@ pub enum HttpRequestType {
     OptionsPreflight(HttpRequestMetadata, String),
     GetAttachment(HttpRequestMetadata, Hash160),
     GetAttachmentsInv(HttpRequestMetadata, Option<StacksBlockId>, HashSet<u32>),
+    GetIsTraitImplemented(
+        HttpRequestMetadata,
+        StacksAddress,
+        ContractName,
+        TraitIdentifier,
+        Option<StacksBlockId>,
+    ),
     /// catch-all for any errors we should surface from parsing
     ClientError(HttpRequestMetadata, ClientError),
 }
@@ -1378,6 +1390,7 @@ pub enum HttpResponseType {
     GetAccount(HttpResponseMetadata, AccountEntryResponse),
     GetContractABI(HttpResponseMetadata, ContractInterface),
     GetContractSrc(HttpResponseMetadata, ContractSrcResponse),
+    GetIsTraitImplemented(HttpResponseMetadata, GetIsTraitImplementedResponse),
     UnconfirmedTransaction(HttpResponseMetadata, UnconfirmedTransactionResponse),
     GetAttachment(HttpResponseMetadata, GetAttachmentResponse),
     GetAttachmentsInv(HttpResponseMetadata, GetAttachmentsInvResponse),
@@ -1508,6 +1521,7 @@ pub trait ProtocolFamily {
 pub struct StacksP2P {}
 
 pub use self::http::StacksHttp;
+use vm::types::TraitIdentifier;
 
 // an array in our protocol can't exceed this many items
 pub const ARRAY_MAX_LEN: u32 = u32::max_value();

--- a/src/net/rpc.rs
+++ b/src/net/rpc.rs
@@ -1360,14 +1360,11 @@ impl ConversationHttp {
                             is_implemented: true,
                         })
                     } else {
-                        let trait_name = trait_id.name.to_string();
-                        let trait_definition = analysis.get_defined_trait(&trait_name)?;
-                        match analysis.check_trait_compliance(trait_id, trait_definition) {
-                            Err(_) => None,
-                            Ok(_) => Some(GetIsTraitImplementedResponse {
-                                is_implemented: true,
-                            }),
-                        }
+                        let trait_definition = analysis.get_defined_trait(&trait_id.name)?;
+                        let is_implemented = analysis
+                            .check_trait_compliance(trait_id, trait_definition)
+                            .is_ok();
+                        Some(GetIsTraitImplementedResponse { is_implemented })
                     }
                 })
             }) {

--- a/src/net/rpc.rs
+++ b/src/net/rpc.rs
@@ -33,7 +33,6 @@ use net::http::*;
 use net::p2p::PeerMap;
 use net::p2p::PeerNetwork;
 use net::relay::Relayer;
-use net::BlocksData;
 use net::ClientError;
 use net::Error as net_error;
 use net::HttpRequestMetadata;
@@ -59,6 +58,7 @@ use net::{
     AccountEntryResponse, AttachmentPage, CallReadOnlyResponse, ContractSrcResponse,
     GetAttachmentResponse, GetAttachmentsInvResponse, MapEntryResponse,
 };
+use net::{BlocksData, GetIsTraitImplementedResponse};
 use net::{RPCNeighbor, RPCNeighborsInfo};
 use net::{RPCPeerInfoData, RPCPoxInfoData};
 use std::collections::HashMap;
@@ -105,8 +105,10 @@ use vm::{
     ClarityName, ContractName, SymbolicExpression, Value,
 };
 
+use chainstate::stacks::db::blocks::CheckError;
 use rand::prelude::*;
 use rand::thread_rng;
+use vm::types::TraitIdentifier;
 
 use super::{RPCPoxCurrentCycleInfo, RPCPoxNextCycleInfo};
 
@@ -1333,6 +1335,57 @@ impl ConversationHttp {
         response.send(http, fd).map(|_| ())
     }
 
+    /// Handle a GET to fetch whether or not a contract implements a certain trait
+    fn handle_get_is_trait_implemented<W: Write>(
+        http: &mut StacksHttp,
+        fd: &mut W,
+        req: &HttpRequestType,
+        sortdb: &SortitionDB,
+        chainstate: &mut StacksChainState,
+        tip: &StacksBlockId,
+        contract_addr: &StacksAddress,
+        contract_name: &ContractName,
+        trait_id: &TraitIdentifier,
+    ) -> Result<(), net_error> {
+        let response_metadata = HttpResponseMetadata::from(req);
+        let contract_identifier =
+            QualifiedContractIdentifier::new(contract_addr.clone().into(), contract_name.clone());
+
+        let response =
+            match chainstate.maybe_read_only_clarity_tx(&sortdb.index_conn(), tip, |clarity_tx| {
+                clarity_tx.with_clarity_db_readonly(|db| {
+                    let mut analysis = db.load_contract_analysis(&contract_identifier)?;
+                    if analysis.implemented_traits.contains(trait_id) {
+                        Some(GetIsTraitImplementedResponse {
+                            is_implemented: true,
+                        })
+                    } else {
+                        let trait_name = trait_id.name.to_string();
+                        let trait_definition = analysis.get_defined_trait(&trait_name)?;
+                        match analysis.check_trait_compliance(trait_id, trait_definition) {
+                            Err(_) => None,
+                            Ok(_) => Some(GetIsTraitImplementedResponse {
+                                is_implemented: true,
+                            }),
+                        }
+                    }
+                })
+            }) {
+                Ok(Some(Some(data))) => {
+                    HttpResponseType::GetIsTraitImplemented(response_metadata, data)
+                }
+                Ok(Some(None)) => HttpResponseType::NotFound(
+                    response_metadata,
+                    "No contract analysis found or trait definition not found".into(),
+                ),
+                Ok(None) | Err(_) => {
+                    HttpResponseType::NotFound(response_metadata, "Chain tip not found".into())
+                }
+            };
+
+        response.send(http, fd).map(|_| ())
+    }
+
     /// Handle a GET to fetch a contract's analysis data, given the chain tip.  Note that this isn't
     /// something that's anchored to the blockchain, and can be different across different versions
     /// of Stacks -- callers must trust the Stacks node to return correct analysis data.
@@ -2204,6 +2257,35 @@ impl ConversationHttp {
                 response
                     .send(&mut self.connection.protocol, &mut reply)
                     .map(|_| ())?;
+                None
+            }
+            HttpRequestType::GetIsTraitImplemented(
+                ref _md,
+                ref contract_addr,
+                ref contract_name,
+                ref trait_id,
+                ref tip_opt,
+            ) => {
+                if let Some(tip) = ConversationHttp::handle_load_stacks_chain_tip(
+                    &mut self.connection.protocol,
+                    &mut reply,
+                    &req,
+                    tip_opt.as_ref(),
+                    sortdb,
+                    chainstate,
+                )? {
+                    ConversationHttp::handle_get_is_trait_implemented(
+                        &mut self.connection.protocol,
+                        &mut reply,
+                        &req,
+                        sortdb,
+                        chainstate,
+                        &tip,
+                        contract_addr,
+                        contract_name,
+                        trait_id,
+                    )?;
+                }
                 None
             }
             HttpRequestType::ClientError(ref _md, ref err) => {

--- a/testnet/stacks-node/src/tests/integrations.rs
+++ b/testnet/stacks-node/src/tests/integrations.rs
@@ -7,8 +7,8 @@ use stacks::chainstate::stacks::{
     StacksPrivateKey, StacksTransaction,
 };
 use stacks::core::mempool::MAXIMUM_MEMPOOL_TX_CHAINING;
-use stacks::net::StacksMessageCodec;
 use stacks::net::{AccountEntryResponse, CallReadOnlyRequestBody, ContractSrcResponse};
+use stacks::net::{GetIsTraitImplementedResponse, StacksMessageCodec};
 use stacks::util::hash::hex_bytes;
 use stacks::vm::clarity::ClarityConnection;
 use stacks::vm::{
@@ -104,6 +104,31 @@ const GET_INFO_CONTRACT: &'static str = "
           (begin
             (unwrap-panic (inner-update-info (- block-height u2)))
             (inner-update-info (- block-height u1))))
+        
+        (define-trait trait-1 (
+            (foo-exec (int) (response int int))))
+
+        (define-trait trait-2 (
+            (get-1 (uint) (response uint uint))
+            (get-2 (uint) (response uint uint))))
+        
+        (define-trait trait-3 (
+            (fn-1 (uint) (response uint uint))
+            (fn-2 (uint) (response uint uint))))
+       ";
+
+const IMPL_TRAIT_CONTRACT: &'static str = "
+        ;; explicit trait compliance for trait 1
+        (impl-trait .get-info.trait-1)
+        (define-private (test-height) burn-block-height)
+        (define-public (foo-exec (a int)) (ok 1))
+    
+        ;; implicit trait compliance for trait-2
+        (define-public (get-1 (x uint)) (ok u1))
+        (define-public (get-2 (x uint)) (ok u1))
+
+        ;; invalid trait compliance for trait-3
+        (define-public (fn-1 (x uint)) (ok u1))
        ";
 
 use std::sync::Mutex;
@@ -160,8 +185,27 @@ fn integration_test_get_info() {
                         publish_tx,
                     )
                     .unwrap();
-            } else if round >= 2 {
-                // block-height > 2
+            } else if round == 2 {
+                // block-height = 3
+                let publish_tx = make_contract_publish(
+                    &contract_sk,
+                    1,
+                    0,
+                    "impl-trait-contract",
+                    IMPL_TRAIT_CONTRACT,
+                );
+                eprintln!("Tenure in 2 started!");
+                tenure
+                    .mem_pool
+                    .submit_raw(
+                        &mut chainstate_copy,
+                        &consensus_hash,
+                        &header_hash,
+                        publish_tx,
+                    )
+                    .unwrap();
+            } else if round >= 3 {
+                // block-height > 3
                 let tx = make_contract_call(
                     &principal_sk,
                     (round - 2).into(),
@@ -198,6 +242,8 @@ fn integration_test_get_info() {
         let contract_addr = to_addr(&StacksPrivateKey::from_hex(SK_1).unwrap());
         let contract_identifier =
             QualifiedContractIdentifier::parse(&format!("{}.{}", &contract_addr, "get-info")).unwrap();
+        let impl_trait_contract_identifier =
+            QualifiedContractIdentifier::parse(&format!("{}.{}", &contract_addr, "impl-trait-contract")).unwrap();
 
         let http_origin = {
             HTTP_BINDING.lock().unwrap().clone().unwrap()
@@ -308,7 +354,15 @@ fn integration_test_get_info() {
                     Value::UInt(2));
 
             },
-            3 => {
+            2 => {
+                // Chain height should be 3
+                let bhh = &chain_tip.metadata.index_block_hash();
+                assert_eq!(
+                    chain_state.clarity_eval_read_only(
+                        burn_dbconn, bhh, &impl_trait_contract_identifier, "(test-height)"),
+                    Value::UInt(3));
+            }
+            4 => {
                 let bhh = &chain_tip.metadata.index_block_hash();
 
                 assert_eq!(Value::Bool(true), chain_state.clarity_eval_read_only(
@@ -642,6 +696,25 @@ fn integration_test_get_info() {
                 assert_eq!(res.get("txid").unwrap().as_str().unwrap(), format!("{}", tx_xfer_invalid_tx.txid()));
                 assert_eq!(res.get("error").unwrap().as_str().unwrap(), "transaction rejected");
                 assert!(res.get("reason").is_some());
+
+                // testing /v2/trait/<contract info>/<trait info>
+                let path = format!("{}/v2/traits/{}/{}/{}/{}/{}", &http_origin, &contract_addr, "get-info", "dummy-trait", &contract_addr, "get-info");
+                eprintln!("Test: GET {}", path);
+                assert_eq!(client.get(&path).send().unwrap().status(), 404);
+
+                let path = format!("{}/v2/traits/{}/{}/{}/{}/{}", &http_origin, &contract_addr, "impl-trait-contract", "trait-1", &contract_addr, "get-info");
+                let res = client.get(&path).send().unwrap().json::<GetIsTraitImplementedResponse>().unwrap();
+                eprintln!("Test: GET {}", path);
+                assert!(res.is_implemented);
+
+                let path = format!("{}/v2/traits/{}/{}/{}/{}/{}", &http_origin, &contract_addr, "impl-trait-contract", "trait-2", &contract_addr, "get-info");
+                let res = client.get(&path).send().unwrap().json::<GetIsTraitImplementedResponse>().unwrap();
+                eprintln!("Test: GET {}", path);
+                assert!(res.is_implemented);
+
+                let path = format!("{}/v2/traits/{}/{}/{}/{}/{}", &http_origin, &contract_addr, "impl-trait-contract", "trait-3", &contract_addr, "get-info");
+                eprintln!("Test: GET {}", path);
+                assert_eq!(client.get(&path).send().unwrap().status(), 404);
             },
             _ => {},
         }

--- a/testnet/stacks-node/src/tests/integrations.rs
+++ b/testnet/stacks-node/src/tests/integrations.rs
@@ -698,23 +698,27 @@ fn integration_test_get_info() {
                 assert!(res.get("reason").is_some());
 
                 // testing /v2/trait/<contract info>/<trait info>
-                let path = format!("{}/v2/traits/{}/{}/{}/{}/{}", &http_origin, &contract_addr, "get-info", "dummy-trait", &contract_addr, "get-info");
+                // trait does not exist
+                let path = format!("{}/v2/traits/{}/{}/{}/{}/{}", &http_origin, &contract_addr, "get-info", &contract_addr, "get-info", "dummy-trait");
                 eprintln!("Test: GET {}", path);
                 assert_eq!(client.get(&path).send().unwrap().status(), 404);
 
-                let path = format!("{}/v2/traits/{}/{}/{}/{}/{}", &http_origin, &contract_addr, "impl-trait-contract", "trait-1", &contract_addr, "get-info");
+                // explicit trait compliance
+                let path = format!("{}/v2/traits/{}/{}/{}/{}/{}", &http_origin, &contract_addr, "impl-trait-contract", &contract_addr, "get-info",  "trait-1");
                 let res = client.get(&path).send().unwrap().json::<GetIsTraitImplementedResponse>().unwrap();
                 eprintln!("Test: GET {}", path);
                 assert!(res.is_implemented);
 
-                let path = format!("{}/v2/traits/{}/{}/{}/{}/{}", &http_origin, &contract_addr, "impl-trait-contract", "trait-2", &contract_addr, "get-info");
+                // implicit trait compliance
+                let path = format!("{}/v2/traits/{}/{}/{}/{}/{}", &http_origin, &contract_addr, "impl-trait-contract", &contract_addr, "get-info", "trait-2");
                 let res = client.get(&path).send().unwrap().json::<GetIsTraitImplementedResponse>().unwrap();
                 eprintln!("Test: GET {}", path);
                 assert!(res.is_implemented);
 
-                let path = format!("{}/v2/traits/{}/{}/{}/{}/{}", &http_origin, &contract_addr, "impl-trait-contract", "trait-3", &contract_addr, "get-info");
+                // invalid trait compliance
+                let path = format!("{}/v2/traits/{}/{}/{}/{}/{}", &http_origin, &contract_addr, "impl-trait-contract", &contract_addr, "get-info", "trait-3");
                 eprintln!("Test: GET {}", path);
-                assert_eq!(client.get(&path).send().unwrap().status(), 404);
+                assert!(!res.is_implemented);
             },
             _ => {},
         }


### PR DESCRIPTION
Added a RPC endpoint to determine if a given trait is implemented in a contract, either explicitly or implicitly.
Fixes #2382 

## Description
For some background, a trait is explicitly implemented in a contract if the contract has `impl-trait <trait info>`. Implicit implementation means a contract implements the traits without the declaration above. 

### Notes 
- I made trait_id (type `TraitIdentifier`) a field in HttpRequestType::GetIsTraitImplemented, even though the GET request independently passes in a trait name, trait contract address, and trait contract name. I did this because I thought it would be cleaner to parse the API path at a higher level, and pass down consolidated information (in the form of the struct `TraitIdentifier`. However, this is not consistent with how the contract data is passed (which is passed separately as contract address and contract name), so let me know if I should avoid consolidating the trait info until the function `handle_get_is_trait_implemented` in `src/net/rpc.rs`. 
- For implicitly implemented traits, I have to check for trait compliance. However, since I am using a read only connection to the clarity database, I am not saving the results of this computation. If I were to save the computation, I would add the implicitly implemented trait by calling `contract_analysis.add_implemented_trait`, and save the updated contract analysis by calling `set_metadata`, which is a method of `ClarityDatabase`. Let me know if I should open a RW connection to the database instead, and commit this information. 

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
List the APIs or describe the functionality that this PR breaks.
Workarounds for or expected timeline for deprecation

## Are documentation updates required?
Want to update the RPC endpoint documentation [here](https://docs.blockstack.org/understand-stacks/stacks-blockchain-api#proxied-stacks-node-rpc-api-endpoints)

## Testing information
Ran `cargo test`. 