### PR TITLE
Fix/replace by fee incorrect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ compatible with prior chainstate directories.
 - The `/v2/pox` RPC endpoint was updated to include more useful
   information about the current and next PoX cycles. For details, see
   `docs/rpc-endpoints.md`
+  
+## Fixed 
+- Fixed faulty logic in the mempool that was still treating the transaction fee
+  as a fee rate, which prevented replace-by-fee from working as expected.
 
 ## [2.0.9]
 


### PR DESCRIPTION
## Description

Altered logic in `mempool.rs` to avoid treating fee as a fee rate. 

Fixes issue #2481.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No

## Are documentation updates required?
No

## Testing information
Ran `cargo test`. 
Wrote test in `mempool.rs` that tries to replace a tx with a tx that has a smaller payload. It passes only if the fee is no longer treated as a fee rate. 

The test fails when ran on the tip of the `develop` branch. Here is an INFO message that prints before the test fails:
```
INFO [1615406406.228656] [src/core/mempool.rs:888] [core::mempool::mempool_db_test_rbf] TX conflicts with sponsor/origin nonce in same fork with >= fee, new_txid: ef76985e6e501e9f75f883c498ce2f8630e7906f6b055af6d67b070dceb1cdb0, old_txid: ac59200518dc3b5896ae36056f426ce7c188fac8dab1b5e7f766cf3343a7acca, origin_addr: SP1S7EZE5F588C3B6HE1M3MW95XA7QY145RGGFHBN, origin_nonce: 123, sponsor_addr: SP36V01MRY0NFV4MZZAZA621M1YMSNGNFN0KKE6CG, sponsor_nonce: 123, new_fee: 22320, old_fee: 24600 
```

