### PR TITLE
fix: fixed block attachability logic

### DIFF
--- a/src/chainstate/stacks/db/headers.rs
+++ b/src/chainstate/stacks/db/headers.rs
@@ -310,10 +310,9 @@ impl StacksChainState {
         conn: &Connection,
         block_id: &StacksBlockId,
     ) -> Result<Option<StacksBlockId>, Error> {
-        let sql = "SELECT parent_block_id FROM block_headers WHERE index_block_hash = ?1 LIMIT 1"
-            .to_string();
+        let sql = "SELECT parent_block_id FROM block_headers WHERE index_block_hash = ?1 LIMIT 1";
         let args: &[&dyn ToSql] = &[block_id];
-        let mut rows = query_row_columns::<StacksBlockId, _>(conn, &sql, args, "parent_block_id")?;
+        let mut rows = query_row_columns::<StacksBlockId, _>(conn, sql, args, "parent_block_id")?;
         Ok(rows.pop())
     }
 

--- a/src/util/db.rs
+++ b/src/util/db.rs
@@ -325,7 +325,7 @@ where
 /// boilerplate code for querying a column out of a sequence of rows
 pub fn query_row_columns<T, P>(
     conn: &Connection,
-    sql_query: &String,
+    sql_query: &str,
     sql_args: P,
     column_name: &str,
 ) -> Result<Vec<T>, Error>


### PR DESCRIPTION
## Description
Currently when we check if a block is attachable, we check if there exists an unprocessed parent. This PR additionally checks that the block's parent has been received. 

Fixes #2212.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Testing information
Ran `cargo test`. The test `chainstate::stacks::miner::test::test_mempool_mining_heuristics` is failing, but it is also failing on the head of `develop` branch, so it isn't caused by the changes in this PR.