### PR TITLE
Fix/2518 and 2491

### DIFF
--- a/src/chainstate/stacks/db/blocks.rs
+++ b/src/chainstate/stacks/db/blocks.rs
@@ -1874,7 +1874,7 @@ impl StacksChainState {
     ) -> Result<bool, Error> {
         StacksChainState::read_i64s(self.db(), "SELECT staging_microblocks.processed
                                                 FROM staging_blocks JOIN staging_microblocks ON staging_blocks.parent_anchored_block_hash = staging_microblocks.anchored_block_hash AND staging_blocks.parent_consensus_hash = staging_microblocks.consensus_hash
-                                                WHERE staging_blocks.index_block_hash = ?1 AND staging_microblocks.microblock_hash = ?2", &[child_index_block_hash, &parent_microblock_hash])
+                                                WHERE staging_blocks.index_block_hash = ?1 AND staging_microblocks.microblock_hash = ?2 AND staging_microblocks.orphaned = 0", &[child_index_block_hash, &parent_microblock_hash])
             .and_then(|processed| {
                 if processed.len() == 0 {
                     Ok(false)

--- a/src/net/download.rs
+++ b/src/net/download.rs
@@ -655,9 +655,11 @@ impl BlockDownloader {
                                 info!("Remote neighbor {:?} ({:?}) does not have microblock stream indexed at {}", &block_key.neighbor, &block_key.data_url, &block_key.index_block_hash);
 
                                 // the fact that we asked this peer means that it's block inv indicated
-                                // it was present, so the absence is the mark of a broken peer
-                                self.broken_peers.push(event_id);
-                                self.broken_neighbors.push(block_key.neighbor.clone());
+                                // it was present, so the absence is the mark of a broken peer.
+                                // HOWEVER, there has been some bugs recently about nodes reporting
+                                // invalid microblock streams as present, even though they are
+                                // truly absent.  Don't punish these peers with a ban; just don't
+                                // talk to them for a while.
                             }
                             _ => {
                                 // wrong message response
@@ -1306,7 +1308,11 @@ impl PeerNetwork {
                     )? {
                         Some(hdr) => hdr,
                         None => {
-                            test_debug!("No such block: {:?}", &index_block_hash);
+                            test_debug!(
+                                "{:?}: No such parent block: {:?}",
+                                &self.local_peer,
+                                &index_block_hash
+                            );
                             continue;
                         }
                     };
@@ -1321,7 +1327,7 @@ impl PeerNetwork {
                         }
                         Err(chainstate_error::DBError(db_error::NotFoundError)) => {
                             // we don't know about this parent block yet
-                            debug!("{:?}: Do not have parent of anchored block {}/{} yet, so cannot ask for the microblocks it produced", &self.local_peer, &consensus_hash, &block_hash);
+                            test_debug!("{:?}: Do not have parent of anchored block {}/{} yet, so cannot ask for the microblocks it produced", &self.local_peer, &consensus_hash, &block_hash);
                             continue;
                         }
                         Err(e) => {
@@ -1359,13 +1365,14 @@ impl PeerNetwork {
                     neighbors.clear();
                     neighbors.append(&mut microblock_stream_neighbors);
 
-                    test_debug!(
-                        "{:?}: Get microblocks produced by {}/{}, confirmed by {}/{}",
+                    debug!(
+                        "{:?}: Get microblocks produced by {}/{}, confirmed by {}/{}, from up to {} neighbors",
                         &self.local_peer,
                         &parent_consensus_hash,
                         &parent_header.block_hash(),
                         &consensus_hash,
-                        &block_hash
+                        &block_hash,
+                        neighbors.len()
                     );
 
                     parent_block_header_opt = Some(parent_header);
@@ -1535,6 +1542,8 @@ impl PeerNetwork {
                 }
             };
 
+        let scan_batch_size = self.burnchain.pox_constants.reward_cycle_length as u64;
+
         if need_blocks {
             PeerNetwork::with_downloader_state(self, |ref mut network, ref mut downloader| {
                 test_debug!("{:?}: needs blocks", &network.local_peer);
@@ -1599,8 +1608,14 @@ impl PeerNetwork {
                     }
 
                     if max_mblock_height == 0 && next_microblocks_to_try.len() == 0 {
-                        // have no microblocks to try in the first place
-                        max_mblock_height = max_height;
+                        // have no microblocks to try in the first place, so just advance to the
+                        // next batch
+                        debug!(
+                            "No microblocks to try; advance max_mblock_height to {}",
+                            mblock_height
+                        );
+                        max_mblock_height = mblock_height;
+                        mblock_height += scan_batch_size;
                     }
 
                     test_debug!("{:?}: at {},{}: {} blocks to get, {} microblock streams to get (up to {},{})", 
@@ -1619,8 +1634,8 @@ impl PeerNetwork {
                     test_debug!("{:?}: End microblock requests", &network.local_peer);
 
                     debug!(
-                        "{:?}: create block, microblock requests up to heights ({},{})",
-                        &network.local_peer, &max_height, &max_mblock_height
+                        "{:?}: create block, microblock requests from heights ({},{}) up to heights ({},{}) (so far: {} blocks, {} microblocks queued)",
+                        &network.local_peer, height, mblock_height, max_height, max_mblock_height, downloader.blocks_to_try.len(), downloader.microblocks_to_try.len()
                     );
 
                     let now = get_epoch_time_secs();
@@ -1707,6 +1722,7 @@ impl PeerNetwork {
                             "BUG: hashmap both contains and does not contain sortition height",
                         );
                         if requests.len() == 0 {
+                            debug!("No microblock requests for {}", mblock_height);
                             mblock_height += 1;
                             continue;
                         }
@@ -1747,12 +1763,14 @@ impl PeerNetwork {
                     }
 
                     debug!(
-                        "{:?}: block download scan now at ({},{}) (was ({},{}))",
+                        "{:?}: block download scan now at ({},{}) (was ({},{})), trying {} blocks and {} microblocks",
                         &network.local_peer,
                         height,
                         mblock_height,
                         block_sortition_height,
-                        microblock_sortition_height
+                        microblock_sortition_height,
+                        downloader.blocks_to_try.len(),
+                        downloader.microblocks_to_try.len(),
                     );
 
                     if max_height <= next_block_sortition_height
@@ -1779,12 +1797,16 @@ impl PeerNetwork {
                     }
                 }
 
-                if downloader.blocks_to_try.len() == 0 && downloader.microblocks_to_try.len() == 0 {
+                if downloader.blocks_to_try.len() == 0 || downloader.microblocks_to_try.len() == 0 {
                     // nothing in this range, so advance sortition range to try for next time
-                    next_block_sortition_height = next_block_sortition_height
-                        + (network.burnchain.pox_constants.reward_cycle_length as u64);
-                    next_microblock_sortition_height = next_microblock_sortition_height
-                        + (network.burnchain.pox_constants.reward_cycle_length as u64);
+                    if downloader.blocks_to_try.len() == 0 {
+                        next_block_sortition_height = next_block_sortition_height
+                            + (network.burnchain.pox_constants.reward_cycle_length as u64);
+                    }
+                    if downloader.microblocks_to_try.len() == 0 {
+                        next_microblock_sortition_height = next_microblock_sortition_height
+                            + (network.burnchain.pox_constants.reward_cycle_length as u64);
+                    }
 
                     debug!("{:?}: Pessimistically increase block and microblock sortition heights to ({},{})", &network.local_peer, next_block_sortition_height, next_microblock_sortition_height);
                 }

--- a/src/net/relay.rs
+++ b/src/net/relay.rs
@@ -995,11 +995,13 @@ impl Relayer {
             Relayer::preprocess_pushed_microblocks(network_result, chainstate)?;
         bad_neighbors.append(&mut new_bad_neighbors);
 
-        if new_blocks.len() > 0 || new_microblocks.len() > 0 {
+        if new_blocks.len() > 0 || new_microblocks.len() > 0 || new_confirmed_microblocks.len() > 0
+        {
             info!(
-                "Processing newly received Stacks blocks: {}, microblocks: {}",
+                "Processing newly received Stacks blocks: {}, microblocks: {}, confirmed microblocks: {}",
                 new_blocks.len(),
-                new_microblocks.len()
+                new_microblocks.len(),
+                new_confirmed_microblocks.len()
             );
             if let Some(coord_comms) = coord_comms {
                 if !coord_comms.announce_new_stacks_block() {


### PR DESCRIPTION
This PR fixes #2518 and #2491, both of which are hindering nodes from bootstrapping (2518 is far more serious than 2491).  It also fixes #2519, and temporarily makes it so a node reporting a microblock stream that turns out to be missing is not a ban-able offense (until which point we can roll this upgrade out).