### PR TITLE
Fix/2407

### DIFF
--- a/.github/actions/bitcoin-int-tests/Dockerfile.bitcoin-tests
+++ b/.github/actions/bitcoin-int-tests/Dockerfile.bitcoin-tests
@@ -26,3 +26,4 @@ RUN cargo test -- --test-threads 1 --ignored tests::bitcoin_regtest::bitcoind_in
 RUN cargo test -- --test-threads 1 --ignored tests::should_succeed_handling_malformed_and_valid_txs
 RUN cargo test -- --test-threads 1 --ignored tests::neon_integrations::size_overflow_unconfirmed_microblocks_integration_test
 RUN cargo test -- --test-threads 1 --ignored tests::neon_integrations::runtime_overflow_unconfirmed_microblocks_integration_test
+RUN cargo test -- --test-threads 1 --ignored tests::neon_integrations::antientropy_integration_test

--- a/src/chainstate/burn/db/sortdb.rs
+++ b/src/chainstate/burn/db/sortdb.rs
@@ -1970,6 +1970,10 @@ impl PoxId {
         }
         (ret, count)
     }
+
+    pub fn num_inventory_reward_cycles(&self) -> usize {
+        self.0.len() - 1
+    }
 }
 
 impl FromStr for PoxId {

--- a/src/chainstate/burn/db/sortdb.rs
+++ b/src/chainstate/burn/db/sortdb.rs
@@ -1972,7 +1972,7 @@ impl PoxId {
     }
 
     pub fn num_inventory_reward_cycles(&self) -> usize {
-        self.0.len() - 1
+        self.0.len().saturating_sub(1)
     }
 }
 

--- a/src/net/connection.rs
+++ b/src/net/connection.rs
@@ -369,6 +369,7 @@ pub struct ConnectionOptions {
     pub max_block_push: u64,
     pub max_microblock_push: u64,
     pub antientropy_retry: u64,
+    pub antientropy_public: bool,
     pub max_buffered_blocks_available: u64,
     pub max_buffered_microblocks_available: u64,
     pub max_buffered_blocks: u64,
@@ -448,8 +449,9 @@ impl std::default::Default for ConnectionOptions {
             public_ip_timeout: 3600,       // re-learn the public IP ever hour, if it's not given
             public_ip_max_retries: 3, // maximum number of retries before self-throttling for $public_ip_timeout
             max_block_push: 10, // maximum number of blocksData messages to push out via our anti-entropy protocol
-            max_microblock_push: 10, // maximum number of microblocks messages to push out via our anti-entrop protocol
-            antientropy_retry: 3600 * 24, // retry pushing data only once every day
+            max_microblock_push: 10, // maximum number of microblocks messages to push out via our anti-entropy protocol
+            antientropy_retry: 3600, // retry pushing data only once every hour
+            antientropy_public: true, // run antientropy even if we're NOT NAT'ed
             max_buffered_blocks_available: 1,
             max_buffered_microblocks_available: 1,
             max_buffered_blocks: 1,

--- a/src/net/connection.rs
+++ b/src/net/connection.rs
@@ -49,7 +49,7 @@ use net::StacksP2P;
 use net::MAX_MESSAGE_LEN;
 
 use net::download::BLOCK_DOWNLOAD_INTERVAL;
-use net::inv::INV_SYNC_INTERVAL;
+use net::inv::{FULL_INV_SYNC_INTERVAL, INV_REWARD_CYCLES, INV_SYNC_INTERVAL};
 use net::neighbors::{
     NEIGHBOR_REQUEST_TIMEOUT, NEIGHBOR_WALK_INTERVAL, NUM_INITIAL_WALKS, WALK_MAX_DURATION,
     WALK_MIN_DURATION, WALK_RESET_INTERVAL, WALK_RESET_PROB, WALK_RETRY_COUNT, WALK_STATE_TIMEOUT,
@@ -348,6 +348,8 @@ pub struct ConnectionOptions {
     pub walk_reset_interval: u64,
     pub walk_state_timeout: u64,
     pub inv_sync_interval: u64,
+    pub full_inv_sync_interval: u64,
+    pub inv_reward_cycles: u64,
     pub download_interval: u64,
     pub pingback_timeout: u64,
     pub dns_timeout: u128,
@@ -421,6 +423,8 @@ impl std::default::Default for ConnectionOptions {
             walk_reset_interval: WALK_RESET_INTERVAL,
             walk_state_timeout: WALK_STATE_TIMEOUT,
             inv_sync_interval: INV_SYNC_INTERVAL, // how often to synchronize block inventories
+            full_inv_sync_interval: FULL_INV_SYNC_INTERVAL, // how often to synchronize the *full* inventory
+            inv_reward_cycles: INV_REWARD_CYCLES, // how many reward cycles of blocks to sync in a non-full inventory sync
             download_interval: BLOCK_DOWNLOAD_INTERVAL, // how often to scan for blocks to download
             pingback_timeout: 60,
             dns_timeout: 15_000,            // DNS timeout, in millis

--- a/src/net/download.rs
+++ b/src/net/download.rs
@@ -939,7 +939,10 @@ impl BlockDownloader {
             self.next_microblock_sortition_height = target_height;
         }
 
-        debug!("Awaken downloader to restart scanning");
+        debug!(
+            "Awaken downloader to restart scanning at sortition height {}",
+            target_height
+        );
     }
 
     // are we doing the initial block download?

--- a/src/net/inv.rs
+++ b/src/net/inv.rs
@@ -1409,8 +1409,10 @@ impl PeerNetwork {
                     }
                 };
 
-                let max_reward_cycle =
-                    cmp::min(self.pox_id.num_inventory_reward_cycles() as u64, tip_reward_cycle);
+                let max_reward_cycle = cmp::min(
+                    self.pox_id.num_inventory_reward_cycles() as u64,
+                    tip_reward_cycle,
+                );
                 test_debug!(
                     "{:?}: request up to reward cycle min({},{}) = {}",
                     &self.local_peer,
@@ -1807,7 +1809,7 @@ impl PeerNetwork {
                     .truncate_block_inventories(&self.burnchain, stats.target_pox_reward_cycle);
 
                 // proceed with block scan.
-                // If we're in IBD, then this is an always-allowed peer and we should 
+                // If we're in IBD, then this is an always-allowed peer and we should
                 // react to divergences by deepening our rescan.
                 let scan_start = self.get_block_scan_start(ibd);
                 debug!(
@@ -2018,7 +2020,7 @@ impl PeerNetwork {
         stats: &mut NeighborBlockStats,
         request_timeout: u64,
         full_rescan: bool,
-        ibd: bool
+        ibd: bool,
     ) -> Result<bool, net_error> {
         while !stats.done {
             if !stats.is_peer_online() {
@@ -2070,7 +2072,10 @@ impl PeerNetwork {
         };
 
         // find the lowest reward cycle whose bit has since changed from a 0 to a 1.
-        let num_reward_cycles = cmp::min(new_pox_id.num_inventory_reward_cycles(), self.pox_id.num_inventory_reward_cycles());
+        let num_reward_cycles = cmp::min(
+            new_pox_id.num_inventory_reward_cycles(),
+            self.pox_id.num_inventory_reward_cycles(),
+        );
         for i in 0..num_reward_cycles {
             if !self.pox_id.has_ith_anchor_block(i) && new_pox_id.has_ith_anchor_block(i) {
                 // we learned of a new anchor block intermittently.  Invalidate all cached state at and after this reward cycle.
@@ -2153,7 +2158,7 @@ impl PeerNetwork {
                         stats,
                         inv_state.request_timeout,
                         inv_state.hint_do_full_rescan,
-                        ibd
+                        ibd,
                     ) {
                         Ok(d) => d,
                         Err(net_error::StaleView) => {

--- a/src/net/inv.rs
+++ b/src/net/inv.rs
@@ -675,8 +675,8 @@ impl NeighborBlockStats {
                         debug!("Remote always-allowed neighbor {:?} NACKed us because it does not recognize our consensus hash.  Treating as Diverged.", _nk);
                         diverged = true;
                     } else {
-                        debug!("Remote neighbor {:?} NACKed us because it does not recognize our consensus hash.  Treating as Broken.", _nk);
-                        broken = true;
+                        debug!("Remote neighbor {:?} NACKed us because it does not recognize our consensus hash.  Treating as Diverged.", _nk);
+                        diverged = true;
                     }
                 }
             }

--- a/src/net/inv.rs
+++ b/src/net/inv.rs
@@ -92,7 +92,7 @@ pub const FULL_INV_SYNC_INTERVAL: u64 = 12 * 3600;
 pub const FULL_INV_SYNC_INTERVAL: u64 = 120;
 
 #[cfg(not(test))]
-pub const INV_REWARD_CYCLES: u64 = 3;
+pub const INV_REWARD_CYCLES: u64 = 6;
 #[cfg(test)]
 pub const INV_REWARD_CYCLES: u64 = 1;
 

--- a/src/net/inv.rs
+++ b/src/net/inv.rs
@@ -3730,7 +3730,7 @@ mod test {
 
         // should be stable; but got nacked (so this would be inappropriate)
         assert_eq!(
-            NodeStatus::Broken,
+            NodeStatus::Diverged,
             NeighborBlockStats::diagnose_nack(
                 &neighbor_key,
                 nack_no_block.clone(),

--- a/src/net/inv.rs
+++ b/src/net/inv.rs
@@ -92,7 +92,7 @@ pub const FULL_INV_SYNC_INTERVAL: u64 = 12 * 3600;
 pub const FULL_INV_SYNC_INTERVAL: u64 = 120;
 
 #[cfg(not(test))]
-pub const INV_REWARD_CYCLES: u64 = 6;
+pub const INV_REWARD_CYCLES: u64 = 3;
 #[cfg(test)]
 pub const INV_REWARD_CYCLES: u64 = 1;
 

--- a/src/net/inv.rs
+++ b/src/net/inv.rs
@@ -1410,7 +1410,7 @@ impl PeerNetwork {
                 };
 
                 let max_reward_cycle =
-                    cmp::min(self.pox_id.num_inventory_reward_cycles(), tip_reward_cycle as u64);
+                    cmp::min(self.pox_id.num_inventory_reward_cycles() as u64, tip_reward_cycle);
                 test_debug!(
                     "{:?}: request up to reward cycle min({},{}) = {}",
                     &self.local_peer,
@@ -2032,7 +2032,7 @@ impl PeerNetwork {
                     .inv_getpoxinv_begin(sortdb, nk, stats, request_timeout, full_rescan)
                     .and_then(|_| Ok(true))?,
                 InvWorkState::GetPoxInvFinish => {
-                    self.inv_getpoxinv_try_finish(nk, stats, full_scan, ibd)?
+                    self.inv_getpoxinv_try_finish(nk, stats, full_rescan, ibd)?
                 }
                 InvWorkState::GetBlocksInvBegin => self
                     .inv_getblocksinv_begin(sortdb, nk, stats, request_timeout)

--- a/src/net/inv.rs
+++ b/src/net/inv.rs
@@ -1822,10 +1822,10 @@ impl PeerNetwork {
                 // proceed with block scan.
                 // If we're in IBD, then this is an always-allowed peer and we should
                 // react to divergences by deepening our rescan.
-                let scan_start = self.get_block_scan_start(ibd);
+                let scan_start = self.get_block_scan_start(ibd || full_rescan);
                 debug!(
-                    "{:?}: proceeding to block inventory scan for {:?} (diverged) at reward cycle {} (ibd={})",
-                    &self.local_peer, nk, scan_start, ibd
+                    "{:?}: proceeding to block inventory scan for {:?} (diverged) at reward cycle {} (ibd={}, full={})",
+                    &self.local_peer, nk, scan_start, ibd, full_rescan
                 );
                 stats.reset_block_scan(scan_start);
             }

--- a/src/net/p2p.rs
+++ b/src/net/p2p.rs
@@ -2988,7 +2988,7 @@ impl PeerNetwork {
                                         }
 
                                         if stats.inv.num_reward_cycles
-                                            >= (self.pox_id.len() - 1) as u64
+                                            >= self.pox_id.num_inventory_reward_cycles() as u64
                                         {
                                             debug!(
                                                 "{:?}: Fully-sync'ed PoX inventory from {}",

--- a/src/net/p2p.rs
+++ b/src/net/p2p.rs
@@ -314,7 +314,7 @@ pub struct PeerNetwork {
     antientropy_blocks: HashMap<NeighborKey, HashMap<StacksBlockId, u64>>,
     antientropy_microblocks: HashMap<NeighborKey, HashMap<StacksBlockId, u64>>,
     antientropy_start_reward_cycle: u64,
-    antientropy_last_push_ts: u64,
+    pub antientropy_last_push_ts: u64,
 
     // pending messages (BlocksAvailable, MicroblocksAvailable, BlocksData, Microblocks) that we
     // can't process yet, but might be able to process on the next chain view update

--- a/src/net/p2p.rs
+++ b/src/net/p2p.rs
@@ -2676,15 +2676,17 @@ impl PeerNetwork {
             neighbor_keys.push(nk.clone());
         }
 
-        let reward_cycle_start = 
-            if let Some(ref inv_state) = self.inv_state {
-                let lowest_reward_cycle = self.burnchain.block_height_to_reward_cycle(inv_state.block_sortition_start + sortdb.first_block_height)
-                    .unwrap_or(0);
-                (self.pox_id.len() as u64).saturating_sub(lowest_reward_cycle + 1)
-            }
-            else {
-                0
-            };
+        let reward_cycle_start = if let Some(ref inv_state) = self.inv_state {
+            let lowest_reward_cycle = self
+                .burnchain
+                .block_height_to_reward_cycle(
+                    inv_state.block_sortition_start + sortdb.first_block_height,
+                )
+                .unwrap_or(0);
+            (self.pox_id.len() as u64).saturating_sub(lowest_reward_cycle + 1)
+        } else {
+            0
+        };
 
         debug!(
             "{:?}: Run anti-entropy protocol for {} neighbors, starting at reward cycle {}",
@@ -3028,7 +3030,10 @@ impl PeerNetwork {
                             let start_download_sortition = if let Some(ref inv_state) =
                                 self.inv_state
                             {
-                                debug!("{:?}: Begin downloader synchronization at sortition height {}", &self.local_peer, inv_state.block_sortition_start);
+                                debug!(
+                                    "{:?}: Begin downloader synchronization at sortition height {}",
+                                    &self.local_peer, inv_state.block_sortition_start
+                                );
                                 inv_state.block_sortition_start
                             } else {
                                 // really unreachable, but why tempt fate?

--- a/src/net/p2p.rs
+++ b/src/net/p2p.rs
@@ -3114,16 +3114,22 @@ impl PeerNetwork {
                     }
                 }
                 PeerNetworkWorkState::AntiEntropy => {
-                    match self.try_push_local_data(sortdb, chainstate) {
-                        Ok(_) => {}
-                        Err(e) => {
-                            debug!(
-                                "{:?}: Failed to push local data: {:?}",
-                                &self.local_peer, &e
-                            );
-                        }
-                    };
-
+                    if ibd {
+                        debug!(
+                            "{:?}: Skip AntiEntropy while in initial block download",
+                            &self.local_peer
+                        );
+                    } else {
+                        match self.try_push_local_data(sortdb, chainstate) {
+                            Ok(_) => {}
+                            Err(e) => {
+                                debug!(
+                                    "{:?}: Failed to push local data: {:?}",
+                                    &self.local_peer, &e
+                                );
+                            }
+                        };
+                    }
                     self.work_state = PeerNetworkWorkState::Prune;
                 }
                 PeerNetworkWorkState::Prune => {

--- a/src/net/p2p.rs
+++ b/src/net/p2p.rs
@@ -3010,6 +3010,29 @@ impl PeerNetwork {
                                 "{:?}: Finished full inventory state-machine pass ({})",
                                 &self.local_peer, self.num_inv_sync_passes
                             );
+
+                            if ibd {
+                                // hint to the downloader to start scanning at the sortition
+                                // height we just synchronized
+                                let start_download_sortition = if let Some(ref inv_state) =
+                                    self.inv_state
+                                {
+                                    debug!("{:?}: Begin downloader synchronization at sortition height {}", &self.local_peer, inv_state.block_sortition_start);
+                                    inv_state.block_sortition_start
+                                } else {
+                                    // really unreachable, but why tempt fate?
+                                    0
+                                };
+
+                                if let Some(ref mut downloader) = self.block_downloader {
+                                    downloader.hint_block_sortition_height_available(
+                                        start_download_sortition,
+                                    );
+                                    downloader.hint_microblock_sortition_height_available(
+                                        start_download_sortition,
+                                    );
+                                }
+                            }
                         }
                     }
                 }

--- a/src/net/p2p.rs
+++ b/src/net/p2p.rs
@@ -2629,6 +2629,7 @@ impl PeerNetwork {
 
     /// Push any blocks and microblock streams that we're holding onto out to our neighbors, if we have no public inbound
     /// connections.
+    /// Start scanning at the same height as the last inv sync.
     fn try_push_local_data(
         &mut self,
         sortdb: &SortitionDB,
@@ -2675,16 +2676,27 @@ impl PeerNetwork {
             neighbor_keys.push(nk.clone());
         }
 
+        let reward_cycle_start = 
+            if let Some(ref inv_state) = self.inv_state {
+                let lowest_reward_cycle = self.burnchain.block_height_to_reward_cycle(inv_state.block_sortition_start + sortdb.first_block_height)
+                    .unwrap_or(0);
+                (self.pox_id.len() as u64).saturating_sub(lowest_reward_cycle + 1)
+            }
+            else {
+                0
+            };
+
         debug!(
-            "{:?}: Run anti-entropy protocol for {} neighbors",
+            "{:?}: Run anti-entropy protocol for {} neighbors, starting at reward cycle {}",
             &self.local_peer,
-            &neighbor_keys.len()
+            &neighbor_keys.len(),
+            reward_cycle_start
         );
         if neighbor_keys.len() == 0 {
             return Ok(());
         }
 
-        for reward_cycle in (0..(self.pox_id.len() as u64)).rev() {
+        for reward_cycle in (reward_cycle_start..(self.pox_id.len() as u64)).rev() {
             let local_blocks_inv = match self.get_local_blocks_inv(sortdb, chainstate, reward_cycle)
             {
                 Ok(inv) => inv,
@@ -3011,27 +3023,25 @@ impl PeerNetwork {
                                 &self.local_peer, self.num_inv_sync_passes
                             );
 
-                            if ibd {
-                                // hint to the downloader to start scanning at the sortition
-                                // height we just synchronized
-                                let start_download_sortition = if let Some(ref inv_state) =
-                                    self.inv_state
-                                {
-                                    debug!("{:?}: Begin downloader synchronization at sortition height {}", &self.local_peer, inv_state.block_sortition_start);
-                                    inv_state.block_sortition_start
-                                } else {
-                                    // really unreachable, but why tempt fate?
-                                    0
-                                };
+                            // hint to the downloader to start scanning at the sortition
+                            // height we just synchronized
+                            let start_download_sortition = if let Some(ref inv_state) =
+                                self.inv_state
+                            {
+                                debug!("{:?}: Begin downloader synchronization at sortition height {}", &self.local_peer, inv_state.block_sortition_start);
+                                inv_state.block_sortition_start
+                            } else {
+                                // really unreachable, but why tempt fate?
+                                0
+                            };
 
-                                if let Some(ref mut downloader) = self.block_downloader {
-                                    downloader.hint_block_sortition_height_available(
-                                        start_download_sortition,
-                                    );
-                                    downloader.hint_microblock_sortition_height_available(
-                                        start_download_sortition,
-                                    );
-                                }
+                            if let Some(ref mut downloader) = self.block_downloader {
+                                downloader.hint_block_sortition_height_available(
+                                    start_download_sortition,
+                                );
+                                downloader.hint_microblock_sortition_height_available(
+                                    start_download_sortition,
+                                );
                             }
                         }
                     }

--- a/src/net/relay.rs
+++ b/src/net/relay.rs
@@ -934,10 +934,6 @@ impl Relayer {
 
         {
             let sort_ic = sortdb.index_conn();
-            let cur_pox_id = {
-                let sortdb_reader = SortitionHandleConn::open_reader(&sort_ic, &tip_sort_id)?;
-                sortdb_reader.get_pox_id()?
-            };
 
             // process blocks we downloaded
             let new_dled_blocks =

--- a/src/net/relay.rs
+++ b/src/net/relay.rs
@@ -930,8 +930,6 @@ impl Relayer {
         let mut new_confirmed_microblocks = HashSet::new();
         let mut bad_neighbors = vec![];
 
-        let tip_sort_id = SortitionDB::get_canonical_sortition_tip(sortdb.conn())?;
-
         {
             let sort_ic = sortdb.index_conn();
 

--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -24,6 +24,7 @@ const DEFAULT_SATS_PER_VB: u64 = 50;
 const DEFAULT_RBF_FEE_RATE_INCREMENT: u64 = 5;
 const LEADER_KEY_TX_ESTIM_SIZE: u64 = 290;
 const BLOCK_COMMIT_TX_ESTIM_SIZE: u64 = 350;
+const INV_REWARD_CYCLES_TESTNET: u64 = 6;
 
 #[derive(Clone, Deserialize, Default)]
 pub struct ConfigFile {
@@ -782,7 +783,21 @@ impl Config {
                         HELIUM_DEFAULT_CONNECTION_OPTIONS.download_interval.clone()
                     }),
                     inv_sync_interval: opts.inv_sync_interval.unwrap_or_else(|| {
-                        HELIUM_DEFAULT_CONNECTION_OPTIONS.inv_sync_interval.clone()
+                        HELIUM_DEFAULT_CONNECTION_OPTIONS.inv_sync_interval
+                    }),
+                    full_inv_sync_interval: opts.full_inv_sync_interval.unwrap_or_else(|| {
+                        HELIUM_DEFAULT_CONNECTION_OPTIONS.full_inv_sync_interval
+                    }),
+                    inv_reward_cycles: opts.inv_reward_cycles.unwrap_or_else(|| {
+                        if burnchain.mode == "mainnet" {
+                            HELIUM_DEFAULT_CONNECTION_OPTIONS.inv_reward_cycles
+                        }
+                        else {
+                            // testnet reward cycles are a bit smaller (and blocks can go by
+                            // faster), so make our inventory
+                            // reward cycle depth a bit longer to compensate
+                            INV_REWARD_CYCLES_TESTNET
+                        }
                     }),
                     public_ip_address: ip_addr,
                     disable_inbound_walks: opts.disable_inbound_walks.unwrap_or(false),
@@ -1224,6 +1239,8 @@ pub struct ConnectionOptionsFile {
     pub maximum_call_argument_size: Option<u32>,
     pub download_interval: Option<u64>,
     pub inv_sync_interval: Option<u64>,
+    pub full_inv_sync_interval: Option<u64>,
+    pub inv_reward_cycles: Option<u64>,
     pub public_ip_address: Option<String>,
     pub disable_inbound_walks: Option<bool>,
     pub disable_inbound_handshakes: Option<bool>,

--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -782,17 +782,16 @@ impl Config {
                     download_interval: opts.download_interval.unwrap_or_else(|| {
                         HELIUM_DEFAULT_CONNECTION_OPTIONS.download_interval.clone()
                     }),
-                    inv_sync_interval: opts.inv_sync_interval.unwrap_or_else(|| {
-                        HELIUM_DEFAULT_CONNECTION_OPTIONS.inv_sync_interval
-                    }),
+                    inv_sync_interval: opts
+                        .inv_sync_interval
+                        .unwrap_or_else(|| HELIUM_DEFAULT_CONNECTION_OPTIONS.inv_sync_interval),
                     full_inv_sync_interval: opts.full_inv_sync_interval.unwrap_or_else(|| {
                         HELIUM_DEFAULT_CONNECTION_OPTIONS.full_inv_sync_interval
                     }),
                     inv_reward_cycles: opts.inv_reward_cycles.unwrap_or_else(|| {
                         if burnchain.mode == "mainnet" {
                             HELIUM_DEFAULT_CONNECTION_OPTIONS.inv_reward_cycles
-                        }
-                        else {
+                        } else {
                             // testnet reward cycles are a bit smaller (and blocks can go by
                             // faster), so make our inventory
                             // reward cycle depth a bit longer to compensate

--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -801,6 +801,7 @@ impl Config {
                     public_ip_address: ip_addr,
                     disable_inbound_walks: opts.disable_inbound_walks.unwrap_or(false),
                     disable_inbound_handshakes: opts.disable_inbound_handshakes.unwrap_or(false),
+                    disable_block_download: opts.disable_block_download.unwrap_or(false),
                     force_disconnect_interval: opts.force_disconnect_interval,
                     max_http_clients: opts.max_http_clients.unwrap_or_else(|| {
                         HELIUM_DEFAULT_CONNECTION_OPTIONS.max_http_clients.clone()
@@ -808,6 +809,7 @@ impl Config {
                     connect_timeout: opts.connect_timeout.unwrap_or(10),
                     handshake_timeout: opts.connect_timeout.unwrap_or(5),
                     max_sockets: opts.max_sockets.unwrap_or(800) as usize,
+                    antientropy_public: opts.antientropy_public.unwrap_or(true),
                     ..ConnectionOptions::default()
                 }
             }
@@ -1243,7 +1245,9 @@ pub struct ConnectionOptionsFile {
     pub public_ip_address: Option<String>,
     pub disable_inbound_walks: Option<bool>,
     pub disable_inbound_handshakes: Option<bool>,
+    pub disable_block_download: Option<bool>,
     pub force_disconnect_interval: Option<u64>,
+    pub antientropy_public: Option<bool>,
 }
 
 #[derive(Clone, Default, Deserialize)]

--- a/testnet/stacks-node/src/run_loop/neon.rs
+++ b/testnet/stacks-node/src/run_loop/neon.rs
@@ -360,21 +360,16 @@ impl RunLoop {
             debug!("Wait until we reach steady-state before processing more burnchain blocks...");
 
             // wait until it's okay to process the next sortitions
-            let ibd = {
-                let ibd = pox_watchdog.pox_sync_wait(
-                    &burnchain_config,
-                    &burnchain_tip,
-                    burnchain_height,
-                    num_sortitions_in_last_cycle,
-                );
+            let ibd = pox_watchdog.pox_sync_wait(
+                &burnchain_config,
+                &burnchain_tip,
                 if learned_burnchain_height {
-                    ibd
+                    Some(burnchain_height)
                 } else {
-                    // just assume we're in the initial block download if we haven't ever called
-                    // .sync()
-                    true
-                }
-            };
+                    None
+                },
+                num_sortitions_in_last_cycle,
+            );
 
             // will recalculate this
             num_sortitions_in_last_cycle = 0;


### PR DESCRIPTION
Fixes #2407.  The node will only scan the last N reward cycles of a remote peer's inventory, but every so often (e.g. 12 hours), it will scan everyone's.