### PR TITLE
Fix/2.0.11 rc2 integration tests

### DIFF
--- a/.github/actions/bitcoin-int-tests/Dockerfile.atlas-test
+++ b/.github/actions/bitcoin-int-tests/Dockerfile.atlas-test
@@ -14,3 +14,4 @@ RUN ln -s /bitcoin-0.20.0/bin/bitcoind /bin/
 ENV BITCOIND_TEST 1
 WORKDIR /src/testnet/stacks-node
 RUN cargo test -- --test-threads 1 --ignored tests::neon_integrations::atlas_integration_test
+RUN cargo test -- --test-threads 1 --ignored tests::neon_integrations::atlas_stress_integration_test

--- a/.github/actions/bitcoin-int-tests/Dockerfile.bitcoin-tests
+++ b/.github/actions/bitcoin-int-tests/Dockerfile.bitcoin-tests
@@ -27,3 +27,4 @@ RUN cargo test -- --test-threads 1 --ignored tests::should_succeed_handling_malf
 RUN cargo test -- --test-threads 1 --ignored tests::neon_integrations::size_overflow_unconfirmed_microblocks_integration_test
 RUN cargo test -- --test-threads 1 --ignored tests::neon_integrations::runtime_overflow_unconfirmed_microblocks_integration_test
 RUN cargo test -- --test-threads 1 --ignored tests::neon_integrations::antientropy_integration_test
+RUN cargo test -- --test-threads 1 --ignored tests::neon_integrations::atlas_stress_integration_test

--- a/.github/actions/bitcoin-int-tests/Dockerfile.bitcoin-tests
+++ b/.github/actions/bitcoin-int-tests/Dockerfile.bitcoin-tests
@@ -27,4 +27,3 @@ RUN cargo test -- --test-threads 1 --ignored tests::should_succeed_handling_malf
 RUN cargo test -- --test-threads 1 --ignored tests::neon_integrations::size_overflow_unconfirmed_microblocks_integration_test
 RUN cargo test -- --test-threads 1 --ignored tests::neon_integrations::runtime_overflow_unconfirmed_microblocks_integration_test
 RUN cargo test -- --test-threads 1 --ignored tests::neon_integrations::antientropy_integration_test
-RUN cargo test -- --test-threads 1 --ignored tests::neon_integrations::atlas_stress_integration_test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2240,6 +2240,7 @@ dependencies = [
  "rand 0.7.2",
  "reqwest",
  "ring",
+ "rusqlite",
  "serde",
  "serde_derive",
  "serde_json",

--- a/src/chainstate/stacks/db/mod.rs
+++ b/src/chainstate/stacks/db/mod.rs
@@ -1218,7 +1218,7 @@ impl StacksChainState {
                             .map_err(|e| e.into())
                     })
                 })
-                .expect("FATAL: `ust-liquid-supply` overflowed");
+                .expect("FATAL: `ustx-liquid-supply` overflowed");
 
             clarity_tx.commit_to_block(&FIRST_BURNCHAIN_CONSENSUS_HASH, &FIRST_STACKS_BLOCK_HASH);
         }

--- a/src/chainstate/stacks/db/transactions.rs
+++ b/src/chainstate/stacks/db/transactions.rs
@@ -914,6 +914,10 @@ impl StacksChainState {
                             (Value::err_none(), AssetMap::new(), vec![])
                         }
                         ClarityRuntimeTxError::AbortedByCallback(value, assets, events) => {
+                            info!("Contract-call aborted by post-condition";
+                                      "contract_name" => %contract_id,
+                                      "function_name" => %contract_call.function_name,
+                                      "function_args" => %VecDisplay(&contract_call.function_args));
                             let receipt = StacksTransactionReceipt::from_condition_aborted_contract_call(
                                     tx.clone(),
                                     events,

--- a/testnet/stacks-node/Cargo.toml
+++ b/testnet/stacks-node/Cargo.toml
@@ -29,6 +29,10 @@ warp = "0.2"
 tokio = "0.2.21"
 reqwest = { version = "0.10", features = ["blocking", "json", "rustls"] }
 
+[dev-dependencies.rusqlite]
+version = "=0.24.2"
+features = ["blob", "serde_json", "i128_blob", "bundled", "trace"]
+
 [[bin]]
 name = "stacks-node"
 path = "src/main.rs"

--- a/testnet/stacks-node/src/syncctl.rs
+++ b/testnet/stacks-node/src/syncctl.rs
@@ -245,7 +245,20 @@ impl PoxSyncWatchdog {
         last_processed_height: u64,
         burnchain_height: u64,
     ) -> bool {
-        last_processed_height + (burnchain.stable_confirmations as u64) < burnchain_height
+        let ibd =
+            last_processed_height + (burnchain.stable_confirmations as u64) < burnchain_height;
+        if ibd {
+            debug!(
+                "PoX watchdog: {} + {} < {}, so iniitial block download",
+                last_processed_height, burnchain.stable_confirmations, burnchain_height
+            );
+        } else {
+            debug!(
+                "PoX watchdog: {} + {} >= {}, so steady-state",
+                last_processed_height, burnchain.stable_confirmations, burnchain_height
+            );
+        }
+        ibd
     }
 
     /// Calculate the first derivative of a list of points
@@ -455,6 +468,11 @@ impl PoxSyncWatchdog {
         }
 
         if self.unconditionally_download {
+            debug!(
+                "PoX watchdog set to unconditionally download (ibd={})",
+                ibbd
+            );
+            self.relayer_comms.set_ibd(ibbd);
             return ibbd;
         }
 
@@ -487,6 +505,8 @@ impl PoxSyncWatchdog {
                     self.steady_state_burnchain_sync_interval
                 );
                 sleep_ms(1000 * self.steady_state_burnchain_sync_interval);
+            } else {
+                debug!("PoX watchdog in last reward cycle -- sync immediately",);
             }
             self.relayer_comms.set_ibd(ibbd);
             return ibbd;

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -3998,6 +3998,7 @@ fn atlas_stress_integration_test() {
         conf_bootstrap_node.clone(),
         None,
         Some(burnchain_config.clone()),
+        None,
     );
     let http_origin = format!("http://{}", &conf_bootstrap_node.node.rpc_bind);
 

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -4591,7 +4591,7 @@ fn atlas_stress_integration_test() {
                     .join(",")
             );
 
-            let attempts = 100;
+            let attempts = 10;
             let ts_begin = get_epoch_time_ms();
             for _ in 0..attempts {
                 let res = client.get(&path).send().unwrap();
@@ -4613,9 +4613,9 @@ fn atlas_stress_integration_test() {
 
             // requests should take no more than 20ms
             assert!(
-                total_time < attempts * 40,
+                total_time < attempts * 50,
                 format!(
-                    "Atlas inventory request is too slow: {} >= {} * 40",
+                    "Atlas inventory request is too slow: {} >= {} * 50",
                     total_time, attempts
                 )
             );
@@ -4625,16 +4625,15 @@ fn atlas_stress_integration_test() {
             if attachments[i] == 0 {
                 continue;
             }
-            let page_index = attachments[i] % 64; // AttachmentInstance::ATTACHMENTS_INV_PAGE_SIZE;
             let content_hash = attachment_hashes
-                .get(&(*ibh, page_index))
+                .get(&(*ibh, attachments[i]))
                 .cloned()
                 .unwrap()
                 .unwrap();
 
             let path = format!("{}/v2/attachments/{}", &http_origin, &content_hash);
 
-            let attempts = 100;
+            let attempts = 10;
             let ts_begin = get_epoch_time_ms();
             for _ in 0..attempts {
                 let res = client.get(&path).send().unwrap();
@@ -4656,9 +4655,9 @@ fn atlas_stress_integration_test() {
 
             // requests should take no more than 40ms
             assert!(
-                total_time < attempts * 40,
+                total_time < attempts * 50,
                 format!(
-                    "Atlas chunk request is too slow: {} >= {} * 40",
+                    "Atlas chunk request is too slow: {} >= {} * 50",
                     total_time, attempts
                 )
             );

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -3954,8 +3954,8 @@ fn atlas_stress_integration_test() {
     let mut initial_balances = vec![];
     let mut users = vec![];
 
-    let batches = 1;
-    let batch_size = 1;
+    let batches = 5;
+    let batch_size = 20;
 
     for _i in 0..(2 * batches * batch_size + 1) {
         let user = StacksPrivateKey::new();


### PR DESCRIPTION
This fixes #2569 and #2572, and adds a new Atlas stress-test that looks for performance regressions that, if passing, will allow us to close #2077 and #2427 (since we will have confirmed that the maximum runtime of these methods is acceptable).