### PR TITLE
Feature: stacks-node panic handler to print abort messages

### DIFF
--- a/testnet/stacks-node/src/main.rs
+++ b/testnet/stacks-node/src/main.rs
@@ -52,8 +52,12 @@ use std::process;
 use backtrace::Backtrace;
 
 fn main() {
-    panic::set_hook(Box::new(|_| {
-        eprintln!("Process abort due to thread panic");
+    panic::set_hook(Box::new(|panic_info| {
+        if let Some(s) = panic_info.payload().downcast_ref::<&str>() {
+            eprintln!("Process abort due to thread panic: {:?}", s);
+        } else {
+            eprintln!("Process abort due to thread panic");
+        }
         let bt = Backtrace::new();
         eprintln!("{:?}", &bt);
 


### PR DESCRIPTION
This makes the panic handler print out the abort/panic message supplied by the panic.