### PR TITLE
Use display fmt for panic output

### DIFF
--- a/testnet/stacks-node/src/main.rs
+++ b/testnet/stacks-node/src/main.rs
@@ -53,11 +53,7 @@ use backtrace::Backtrace;
 
 fn main() {
     panic::set_hook(Box::new(|panic_info| {
-        if let Some(s) = panic_info.payload().downcast_ref::<&str>() {
-            eprintln!("Process abort due to thread panic: {:?}", s);
-        } else {
-            eprintln!("Process abort due to thread panic");
-        }
+        eprintln!("Process abort due to thread panic: {}", panic_info);
         let bt = Backtrace::new();
         eprintln!("{:?}", &bt);
 


### PR DESCRIPTION
This is an update on the previous panic output fix PR which uses the display fmt to produce the panic output. This produces nice outputs for cases like `.unwrap()` and `.expect()` while the previous approach only worked for `panic!` macro invocations:


```
$ stacks-node start
...
Process abort due to thread panic: panicked at 'called `Result::unwrap()` on an `Err` value: MissingOption(Keys(["--config", ""]))', testnet/stacks-node/src/main.rs:123:71
```