### PR TITLE
Fix/updated bitcoind

### DIFF
--- a/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
+++ b/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
@@ -567,6 +567,11 @@ impl BitcoinRegtestController {
         result_vec
     }
 
+    pub fn create_wallet(&self, wallet_name: &str) {
+        BitcoinRPCRequest::create_wallet(&self.config, wallet_name)
+            .expect("Wallet creation failed");
+    }
+
     pub fn get_utxos(
         &self,
         public_key: &Secp256k1PublicKey,
@@ -1872,6 +1877,18 @@ impl BitcoinRPCRequest {
         let payload = BitcoinRPCRequest {
             method: "importaddress".to_string(),
             params: vec![address.to_b58().into(), label.into(), rescan.into()],
+            id: "stacks".to_string(),
+            jsonrpc: "2.0".to_string(),
+        };
+
+        BitcoinRPCRequest::send(&config, payload)?;
+        Ok(())
+    }
+
+    pub fn create_wallet(config: &Config, wallet_name: &str) -> RPCResult<()> {
+        let payload = BitcoinRPCRequest {
+            method: "createwallet".to_string(),
+            params: vec![wallet_name.into()],
             id: "stacks".to_string(),
             jsonrpc: "2.0".to_string(),
         };

--- a/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
+++ b/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
@@ -570,12 +570,25 @@ impl BitcoinRegtestController {
     /// Checks if there is a default wallet with the name of "".
     /// If the default wallet does not exist, this function creates a wallet with name "".
     pub fn create_wallet_if_dne(&self) {
-        let wallets =
-            BitcoinRPCRequest::list_wallets(&self.config).expect("Call to listwallets failed");
+        let wallet_res = BitcoinRPCRequest::list_wallets(&self.config);
+        let wallets = match wallet_res {
+            Ok(wallets) => wallets,
+            Err(e) => {
+                warn!("Call to listwallets failed during wallet creation: {:?}", e);
+                return;
+            }
+        };
 
         if !wallets.contains(&("".to_string())) {
-            BitcoinRPCRequest::create_wallet(&self.config, "")
-                .expect("Call to createwallet failed");
+            match BitcoinRPCRequest::create_wallet(&self.config, "") {
+                Err(e) => {
+                    warn!(
+                        "Call to createwallet failed during wallet creation: {:?}",
+                        e
+                    );
+                }
+                _ => {}
+            }
         }
     }
 
@@ -1919,7 +1932,7 @@ impl BitcoinRPCRequest {
                     }
                 }
                 _ => {
-                    warn!("Failed to get wallet");
+                    warn!("Failed to get wallets");
                 }
             },
             _ => {

--- a/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
+++ b/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
@@ -1546,6 +1546,11 @@ impl BurnchainController for BitcoinRegtestController {
                     panic!();
                 }
             }
+            info!("Creating wallet if it does not exist");
+            match self.create_wallet_if_dne() {
+                Err(e) => warn!("Error when creating wallet: {:?}", e),
+                _ => {}
+            }
         }
     }
 }

--- a/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
+++ b/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
@@ -569,27 +569,13 @@ impl BitcoinRegtestController {
 
     /// Checks if there is a default wallet with the name of "".
     /// If the default wallet does not exist, this function creates a wallet with name "".
-    pub fn create_wallet_if_dne(&self) {
-        let wallet_res = BitcoinRPCRequest::list_wallets(&self.config);
-        let wallets = match wallet_res {
-            Ok(wallets) => wallets,
-            Err(e) => {
-                warn!("Call to listwallets failed during wallet creation: {:?}", e);
-                return;
-            }
-        };
+    pub fn create_wallet_if_dne(&self) -> RPCResult<()> {
+        let wallets = BitcoinRPCRequest::list_wallets(&self.config)?;
 
         if !wallets.contains(&("".to_string())) {
-            match BitcoinRPCRequest::create_wallet(&self.config, "") {
-                Err(e) => {
-                    warn!(
-                        "Call to createwallet failed during wallet creation: {:?}",
-                        e
-                    );
-                }
-                _ => {}
-            }
+            BitcoinRPCRequest::create_wallet(&self.config, "")?;
         }
+        Ok(())
     }
 
     pub fn get_utxos(
@@ -1701,7 +1687,7 @@ struct BitcoinRPCRequest {
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
-enum RPCError {
+pub enum RPCError {
     Network(String),
     Parsing(String),
     Bitcoind(String),

--- a/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
+++ b/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
@@ -567,9 +567,16 @@ impl BitcoinRegtestController {
         result_vec
     }
 
-    pub fn create_wallet(&self, wallet_name: &str) {
-        BitcoinRPCRequest::create_wallet(&self.config, wallet_name)
-            .expect("Wallet creation failed");
+    /// Checks if there is a default wallet with the name of "".
+    /// If the default wallet does not exist, this function creates a wallet with name "".
+    pub fn create_wallet_if_dne(&self) {
+        let wallets =
+            BitcoinRPCRequest::list_wallets(&self.config).expect("Call to listwallets failed");
+
+        if !wallets.contains(&("".to_string())) {
+            BitcoinRPCRequest::create_wallet(&self.config, "")
+                .expect("Call to createwallet failed");
+        }
     }
 
     pub fn get_utxos(
@@ -1885,6 +1892,45 @@ impl BitcoinRPCRequest {
         Ok(())
     }
 
+    /// Calls `listwallets` method through RPC call and returns wallet names as a vector of Strings
+    pub fn list_wallets(config: &Config) -> RPCResult<Vec<String>> {
+        let payload = BitcoinRPCRequest {
+            method: "listwallets".to_string(),
+            params: vec![],
+            id: "stacks".to_string(),
+            jsonrpc: "2.0".to_string(),
+        };
+
+        let mut res = BitcoinRPCRequest::send(&config, payload)?;
+        let mut wallets = Vec::new();
+        match res.as_object_mut() {
+            Some(ref mut object) => match object.get_mut("result") {
+                Some(serde_json::Value::Array(entries)) => {
+                    while let Some(entry) = entries.pop() {
+                        let parsed_wallet_name: String = match serde_json::from_value(entry) {
+                            Ok(wallet_name) => wallet_name,
+                            Err(err) => {
+                                warn!("Failed parsing wallet name: {}", err);
+                                continue;
+                            }
+                        };
+
+                        wallets.push(parsed_wallet_name);
+                    }
+                }
+                _ => {
+                    warn!("Failed to get wallet");
+                }
+            },
+            _ => {
+                warn!("Failed to get wallets");
+            }
+        };
+
+        Ok(wallets)
+    }
+
+    /// Tries to create a wallet with the given name
     pub fn create_wallet(config: &Config, wallet_name: &str) -> RPCResult<()> {
         let payload = BitcoinRPCRequest {
             method: "createwallet".to_string(),

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -758,8 +758,8 @@ fn spawn_miner_relayer(
     coord_comms: CoordinatorChannels,
     unconfirmed_txs: Arc<Mutex<UnconfirmedTxMap>>,
 ) -> Result<JoinHandle<()>, NetError> {
-    // Note: the relayer is *the* block processor, it is responsible for writes to the chainstate --
-    //   no other codepaths should be writing once this is spawned.
+    // Note: the chainstate coordinator is *the* block processor, it is responsible for writes to
+    // the chainstate -- eventually, no other codepaths should be writing to it.
     //
     // the relayer _should not_ be modifying the sortdb,
     //   however, it needs a mut reference to create read TXs.

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -425,6 +425,7 @@ fn try_mine_microblock(
             if microblock_miner.parent_consensus_hash == *ch
                 && microblock_miner.parent_block_hash == *bhh
             {
+                // this check is redundant (checked that microblock frequency is not exceeded in p2p thread)
                 if microblock_miner.last_mined + (microblock_miner.frequency as u128)
                     < get_epoch_time_ms()
                 {
@@ -987,6 +988,7 @@ fn spawn_miner_relayer(
                 RelayerDirective::RunMicroblockTenure => {
                     if last_microblock_tenure_time + (config.node.microblock_frequency as u128) > get_epoch_time_ms() {
                         // only mine when necessary -- the deadline to begin hasn't passed yet
+                        // this check is redundant (checked that microblock frequency is not exceeded in p2p thread)
                         continue;
                     }
                     last_microblock_tenure_time = get_epoch_time_ms();

--- a/testnet/stacks-node/src/run_loop/neon.rs
+++ b/testnet/stacks-node/src/run_loop/neon.rs
@@ -121,10 +121,12 @@ impl RunLoop {
             Some(should_keep_running.clone()),
         );
         let pox_constants = burnchain.get_pox_constants();
-        // Initialize the wallet.
-        burnchain.create_wallet_if_dne();
 
         let is_miner = if self.config.node.miner {
+            // Initialize the wallet.
+            info!("Miner node: creating the wallet if it does not exist");
+            burnchain.create_wallet_if_dne();
+
             let keychain = Keychain::default(self.config.node.seed.clone());
             let node_address = Keychain::address_from_burnchain_signer(
                 &keychain.get_burnchain_signer(),

--- a/testnet/stacks-node/src/run_loop/neon.rs
+++ b/testnet/stacks-node/src/run_loop/neon.rs
@@ -90,6 +90,18 @@ impl RunLoop {
     #[cfg(not(test))]
     fn bump_blocks_processed(&self) {}
 
+    #[cfg(test)]
+    fn create_wallet_if_dne(&self, burnchain: &BitcoinRegtestController) {
+        info!("Miner node: creating the wallet if it does not exist");
+        match burnchain.create_wallet_if_dne() {
+            Err(e) => warn!("Error when creating wallet: {:?}", e),
+            _ => {}
+        }
+    }
+
+    #[cfg(not(test))]
+    fn create_wallet_if_dne(&self, burnchain: &BitcoinRegtestController) {}
+
     /// Starts the testnet runloop.
     ///
     /// This function will block by looping infinitely.
@@ -124,8 +136,7 @@ impl RunLoop {
 
         let is_miner = if self.config.node.miner {
             // Initialize the wallet.
-            info!("Miner node: creating the wallet if it does not exist");
-            burnchain.create_wallet_if_dne();
+            self.create_wallet_if_dne(&burnchain);
 
             let keychain = Keychain::default(self.config.node.seed.clone());
             let node_address = Keychain::address_from_burnchain_signer(

--- a/testnet/stacks-node/src/run_loop/neon.rs
+++ b/testnet/stacks-node/src/run_loop/neon.rs
@@ -122,7 +122,7 @@ impl RunLoop {
         );
         let pox_constants = burnchain.get_pox_constants();
         // Initialize the wallet.
-        burnchain.create_wallet("test");
+        burnchain.create_wallet_if_dne();
 
         let is_miner = if self.config.node.miner {
             let keychain = Keychain::default(self.config.node.seed.clone());

--- a/testnet/stacks-node/src/run_loop/neon.rs
+++ b/testnet/stacks-node/src/run_loop/neon.rs
@@ -90,18 +90,6 @@ impl RunLoop {
     #[cfg(not(test))]
     fn bump_blocks_processed(&self) {}
 
-    #[cfg(test)]
-    fn create_wallet_if_dne(&self, burnchain: &BitcoinRegtestController) {
-        info!("Miner node: creating the wallet if it does not exist");
-        match burnchain.create_wallet_if_dne() {
-            Err(e) => warn!("Error when creating wallet: {:?}", e),
-            _ => {}
-        }
-    }
-
-    #[cfg(not(test))]
-    fn create_wallet_if_dne(&self, burnchain: &BitcoinRegtestController) {}
-
     /// Starts the testnet runloop.
     ///
     /// This function will block by looping infinitely.
@@ -135,9 +123,6 @@ impl RunLoop {
         let pox_constants = burnchain.get_pox_constants();
 
         let is_miner = if self.config.node.miner {
-            // Initialize the wallet.
-            self.create_wallet_if_dne(&burnchain);
-
             let keychain = Keychain::default(self.config.node.seed.clone());
             let node_address = Keychain::address_from_burnchain_signer(
                 &keychain.get_burnchain_signer(),

--- a/testnet/stacks-node/src/run_loop/neon.rs
+++ b/testnet/stacks-node/src/run_loop/neon.rs
@@ -121,6 +121,8 @@ impl RunLoop {
             Some(should_keep_running.clone()),
         );
         let pox_constants = burnchain.get_pox_constants();
+        // Initialize the wallet.
+        burnchain.create_wallet("test");
 
         let is_miner = if self.config.node.miner {
             let keychain = Keychain::default(self.config.node.seed.clone());


### PR DESCRIPTION
## Description
Makes tests in `neon_integrations.rs` compatible with both old/newest version of bitcoind. This change was needed because the newest version of `bitcoind` does not automatically create a default wallet anymore. 
Fixes #2559.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] API reference/documentation update
- [ ] Other


## Testing information
Ran tests in `neon_integrations.rs` using versions 0.20.1 & 0.21.0 of bitcoind.