### PR TITLE
Fix/atlas replication retry

### DIFF
--- a/.github/actions/bitcoin-int-tests/Dockerfile.bitcoin-tests
+++ b/.github/actions/bitcoin-int-tests/Dockerfile.bitcoin-tests
@@ -25,5 +25,7 @@ RUN cargo test -- --test-threads 1 --ignored tests::neon_integrations::pox_integ
 RUN cargo test -- --test-threads 1 --ignored tests::bitcoin_regtest::bitcoind_integration_test
 RUN cargo test -- --test-threads 1 --ignored tests::should_succeed_handling_malformed_and_valid_txs
 RUN cargo test -- --test-threads 1 --ignored tests::neon_integrations::size_overflow_unconfirmed_microblocks_integration_test
+RUN cargo test -- --test-threads 1 --ignored tests::neon_integrations::size_overflow_unconfirmed_stream_microblocks_integration_test
+RUN cargo test -- --test-threads 1 --ignored tests::neon_integrations::size_overflow_unconfirmed_invalid_stream_microblocks_integration_test
 RUN cargo test -- --test-threads 1 --ignored tests::neon_integrations::runtime_overflow_unconfirmed_microblocks_integration_test
 RUN cargo test -- --test-threads 1 --ignored tests::neon_integrations::antientropy_integration_test

--- a/src/chainstate/stacks/db/blocks.rs
+++ b/src/chainstate/stacks/db/blocks.rs
@@ -4540,7 +4540,9 @@ impl StacksChainState {
                 return Err(Error::InvalidStacksBlock(msg));
             }
 
-            debug!("Reached state root {}", root_hash);
+            debug!("Reached state root {}", root_hash;
+                   "microblock cost" => %microblock_cost,
+                   "block cost" => %block_cost);
 
             // good to go!
             clarity_tx.commit_to_block(chain_tip_consensus_hash, &block.block_hash());

--- a/src/chainstate/stacks/db/unconfirmed.rs
+++ b/src/chainstate/stacks/db/unconfirmed.rs
@@ -57,6 +57,10 @@ pub struct UnconfirmedState {
     readonly: bool,
     dirty: bool,
     num_mblocks_added: u64,
+
+    // fault injection for testing
+    pub disable_cost_check: bool,
+    pub disable_bytes_check: bool,
 }
 
 impl UnconfirmedState {
@@ -85,6 +89,9 @@ impl UnconfirmedState {
             readonly: false,
             dirty: false,
             num_mblocks_added: 0,
+
+            disable_cost_check: check_fault_injection(FAULT_DISABLE_MICROBLOCKS_COST_CHECK),
+            disable_bytes_check: check_fault_injection(FAULT_DISABLE_MICROBLOCKS_BYTES_CHECK),
         })
     }
 
@@ -115,6 +122,9 @@ impl UnconfirmedState {
             readonly: true,
             dirty: false,
             num_mblocks_added: 0,
+
+            disable_cost_check: check_fault_injection(FAULT_DISABLE_MICROBLOCKS_COST_CHECK),
+            disable_bytes_check: check_fault_injection(FAULT_DISABLE_MICROBLOCKS_BYTES_CHECK),
         })
     }
 
@@ -237,6 +247,16 @@ impl UnconfirmedState {
         self.bytes_so_far += new_bytes;
         self.num_mblocks_added += num_new_mblocks;
 
+        // apply injected faults
+        if self.disable_cost_check {
+            warn!("Fault injection: disabling microblock miner's cost tracking");
+            self.cost_so_far = ExecutionCost::zero();
+        }
+        if self.disable_bytes_check {
+            warn!("Fault injection: disabling microblock miner's size tracking");
+            self.bytes_so_far = 0;
+        }
+
         Ok((total_fees, total_burns, all_receipts))
     }
 
@@ -310,6 +330,14 @@ impl UnconfirmedState {
         txid: &Txid,
     ) -> Option<(StacksTransaction, BlockHeaderHash, u16)> {
         self.mined_txs.get(txid).map(|x| x.clone())
+    }
+
+    pub fn num_microblocks(&self) -> u64 {
+        if self.last_mblock.is_some() {
+            (self.last_mblock_seq as u64) + 1
+        } else {
+            0
+        }
     }
 }
 

--- a/src/chainstate/stacks/db/unconfirmed.rs
+++ b/src/chainstate/stacks/db/unconfirmed.rs
@@ -207,7 +207,7 @@ impl UnconfirmedState {
 
                 last_mblock = Some(mblock_header);
                 last_mblock_seq = seq;
-                new_bytes = {
+                new_bytes += {
                     let mut total = 0;
                     for tx in mblock.txs.iter() {
                         let mut bytes = vec![];

--- a/src/chainstate/stacks/miner.rs
+++ b/src/chainstate/stacks/miner.rs
@@ -348,6 +348,7 @@ impl<'a> StacksMicroblockBuilder<'a> {
         return Ok(false);
     }
 
+    /// NOTE: this is only used in integration tests.
     pub fn mine_next_microblock_from_txs(
         &mut self,
         txs_and_lens: Vec<(StacksTransaction, u64)>,

--- a/src/chainstate/stacks/miner.rs
+++ b/src/chainstate/stacks/miner.rs
@@ -65,6 +65,10 @@ struct MicroblockMinerRuntime {
     considered: Option<HashSet<Txid>>,
     num_mined: u64,
     tip: StacksBlockId,
+
+    // fault injection, inherited from unconfirmed
+    disable_bytes_check: bool,
+    disable_cost_check: bool,
 }
 
 #[derive(PartialEq)]
@@ -87,6 +91,9 @@ impl From<&UnconfirmedState> for MicroblockMinerRuntime {
             considered: Some(considered),
             num_mined: 0,
             tip: unconfirmed.confirmed_chain_tip.clone(),
+
+            disable_bytes_check: unconfirmed.disable_bytes_check,
+            disable_cost_check: unconfirmed.disable_cost_check,
         }
     }
 }
@@ -386,6 +393,16 @@ impl<'a> StacksMicroblockBuilder<'a> {
             }
         }
 
+        // do fault injection
+        if self.runtime.disable_bytes_check {
+            warn!("Fault injection: disabling miner limit on microblock stream size");
+            bytes_so_far = 0;
+        }
+        if self.runtime.disable_cost_check {
+            warn!("Fault injection: disabling miner limit on microblock runtime cost");
+            clarity_tx.reset_cost(ExecutionCost::zero());
+        }
+
         self.runtime.bytes_so_far = bytes_so_far;
         self.clarity_tx.replace(clarity_tx);
         self.runtime.considered.replace(considered);
@@ -465,6 +482,16 @@ impl<'a> StacksMicroblockBuilder<'a> {
             },
         );
 
+        // do fault injection
+        if self.runtime.disable_bytes_check {
+            warn!("Fault injection: disabling miner limit on microblock stream size");
+            bytes_so_far = 0;
+        }
+        if self.runtime.disable_cost_check {
+            warn!("Fault injection: disabling miner limit on microblock runtime cost");
+            clarity_tx.reset_cost(ExecutionCost::zero());
+        }
+
         self.runtime.bytes_so_far = bytes_so_far;
         self.clarity_tx.replace(clarity_tx);
         self.runtime.considered.replace(considered);
@@ -498,8 +525,9 @@ impl<'a> Drop for StacksMicroblockBuilder<'a> {
         debug!(
             "Drop StacksMicroblockBuilder";
             "chain tip" => %&self.runtime.tip,
-            "txs considered" => &self.runtime.considered.as_ref().map(|x| x.len()).unwrap_or(0),
-            "txs mined" => self.runtime.num_mined,
+            "txs mined off tip" => &self.runtime.considered.as_ref().map(|x| x.len()).unwrap_or(0),
+            "txs added" => self.runtime.num_mined,
+            "bytes so far" => self.runtime.bytes_so_far,
             "cost so far" => &format!("{:?}", &self.get_cost_so_far())
         );
         self.clarity_tx
@@ -1363,8 +1391,8 @@ impl StacksBlockBuilder {
         );
 
         debug!(
-            "Build anchored block off of {}/{} height {}",
-            &tip_consensus_hash, &tip_block_hash, tip_height
+            "Build anchored block off of {}/{} height {} budget {:?}",
+            &tip_consensus_hash, &tip_block_hash, tip_height, execution_budget
         );
 
         let (mut header_reader_chainstate, _) = chainstate_handle.reopen()?; // used for reading block headers during an epoch

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -119,6 +119,20 @@ pub const BLOCK_LIMIT_MAINNET: ExecutionCost = ExecutionCost {
     runtime: 5_000_000_000,
 };
 
+pub const FAULT_DISABLE_MICROBLOCKS_COST_CHECK: &str = "MICROBLOCKS_DISABLE_COST_CHECK";
+pub const FAULT_DISABLE_MICROBLOCKS_BYTES_CHECK: &str = "MICROBLOCKS_DISABLE_BYTES_CHECK";
+
+pub fn check_fault_injection(fault_name: &str) -> bool {
+    use std::env;
+
+    // only activates if we're testing
+    if env::var("BITCOIND_TEST") != Ok("1".to_string()) {
+        return false;
+    }
+
+    env::var(fault_name) == Ok("1".to_string())
+}
+
 /// Synchronize burn transactions from the Bitcoin blockchain
 pub fn sync_burnchain_bitcoin(
     working_dir: &String,

--- a/src/net/atlas/db.rs
+++ b/src/net/atlas/db.rs
@@ -1,3 +1,19 @@
+// Copyright (C) 2013-2020 Blockstack PBC, a public benefit corporation
+// Copyright (C) 2020-2021 Stacks Open Internet Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 use rusqlite::types::ToSql;
 use rusqlite::Row;
 use rusqlite::Transaction;

--- a/src/net/atlas/download.rs
+++ b/src/net/atlas/download.rs
@@ -1,4 +1,22 @@
-use super::{AtlasDB, Attachment, AttachmentInstance, MAX_ATTACHMENT_INV_PAGES_PER_REQUEST};
+// Copyright (C) 2013-2020 Blockstack PBC, a public benefit corporation
+// Copyright (C) 2020-2021 Stacks Open Internet Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use super::{
+    AtlasDB, Attachment, AttachmentInstance, MAX_ATTACHMENT_INV_PAGES_PER_REQUEST, MAX_RETRY_DELAY,
+};
 use chainstate::burn::{BlockHeaderHash, ConsensusHash};
 use chainstate::stacks::db::StacksChainState;
 use chainstate::stacks::{StacksBlockHeader, StacksBlockId};
@@ -23,6 +41,10 @@ use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::net::{IpAddr, SocketAddr};
 
+use rand::thread_rng;
+use rand::Rng;
+use std::cmp;
+
 #[derive(Debug)]
 pub struct AttachmentsDownloader {
     priority_queue: BinaryHeap<AttachmentsBatch>,
@@ -40,6 +62,29 @@ impl AttachmentsDownloader {
             processed_batches: vec![],
             reliability_reports: HashMap::new(),
             initial_batch,
+        }
+    }
+
+    pub fn has_ready_batches(&self) -> bool {
+        for batch in self.priority_queue.iter() {
+            if batch.retry_deadline < get_epoch_time_secs() {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    pub fn pop_next_ready_batch(&mut self) -> Option<AttachmentsBatch> {
+        let next_is_ready = if let Some(ref next) = self.priority_queue.peek() {
+            next.retry_deadline < get_epoch_time_secs()
+        } else {
+            false
+        };
+
+        if next_is_ready {
+            self.priority_queue.pop()
+        } else {
+            None
         }
     }
 
@@ -66,7 +111,7 @@ impl AttachmentsDownloader {
         let ongoing_fsm = match self.ongoing_batch.take() {
             Some(batch) => batch,
             None => {
-                if self.priority_queue.is_empty() {
+                if self.priority_queue.is_empty() || !self.has_ready_batches() {
                     // Nothing to do!
                     return Ok((vec![], vec![]));
                 }
@@ -88,8 +133,7 @@ impl AttachmentsDownloader {
                 }
 
                 let attachments_batch = self
-                    .priority_queue
-                    .pop()
+                    .pop_next_ready_batch()
                     .expect("Unable to pop attachments bactch from queue");
                 let ctx = AttachmentsBatchStateContext::new(
                     attachments_batch,
@@ -1003,6 +1047,7 @@ pub struct AttachmentsBatch {
     pub index_block_hash: StacksBlockId,
     pub attachments_instances: HashMap<QualifiedContractIdentifier, HashMap<u32, Hash160>>,
     pub retry_count: u64,
+    pub retry_deadline: u64,
 }
 
 impl AttachmentsBatch {
@@ -1012,6 +1057,7 @@ impl AttachmentsBatch {
             index_block_hash: StacksBlockId([0u8; 32]),
             attachments_instances: HashMap::new(),
             retry_count: 0,
+            retry_deadline: 0,
         }
     }
 
@@ -1023,7 +1069,7 @@ impl AttachmentsBatch {
             if self.block_height != attachment.block_height
                 || self.index_block_hash != attachment.index_block_hash
             {
-                warn!("Atlas: attempt to add unrelated AttachmentInstance ({}, {}) to AttachmentBatch", attachment.attachment_index, attachment.index_block_hash);
+                warn!("Atlas: attempt to add unrelated AttachmentInstance ({}, {}) to AttachmentsBatch", attachment.attachment_index, attachment.index_block_hash);
                 return;
             }
         }
@@ -1048,6 +1094,14 @@ impl AttachmentsBatch {
 
     pub fn bump_retry_count(&mut self) {
         self.retry_count += 1;
+        let delay = cmp::min(
+            MAX_RETRY_DELAY,
+            2u64.saturating_pow(self.retry_count as u32)
+                + (thread_rng().gen::<u64>() % 2u64.saturating_pow((self.retry_count - 1) as u32)),
+        );
+
+        debug!("Atlas: Re-attempt download in {} seconds", delay);
+        self.retry_deadline = get_epoch_time_secs() + delay;
     }
 
     pub fn has_fully_succeed(&self) -> bool {
@@ -1105,8 +1159,8 @@ impl AttachmentsBatch {
 impl Ord for AttachmentsBatch {
     fn cmp(&self, other: &AttachmentsBatch) -> Ordering {
         other
-            .retry_count
-            .cmp(&self.retry_count)
+            .retry_deadline
+            .cmp(&self.retry_deadline)
             .then_with(|| {
                 self.attachments_instances_count()
                     .cmp(&other.attachments_instances_count())

--- a/src/net/atlas/mod.rs
+++ b/src/net/atlas/mod.rs
@@ -36,7 +36,7 @@ use std::convert::TryFrom;
 use std::hash::{Hash, Hasher};
 
 pub const MAX_ATTACHMENT_INV_PAGES_PER_REQUEST: usize = 8;
-pub const MAX_RETRY_DELAY: u64 = 600;
+pub const MAX_RETRY_DELAY: u64 = 600; // seconds
 
 lazy_static! {
     pub static ref BNS_CHARS_REGEX: Regex = Regex::new("^([a-z0-9]|[-_])*$").unwrap();

--- a/src/net/atlas/mod.rs
+++ b/src/net/atlas/mod.rs
@@ -1,3 +1,19 @@
+// Copyright (C) 2013-2020 Blockstack PBC, a public benefit corporation
+// Copyright (C) 2020-2021 Stacks Open Internet Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 pub mod db;
 pub mod download;
 
@@ -20,6 +36,7 @@ use std::convert::TryFrom;
 use std::hash::{Hash, Hasher};
 
 pub const MAX_ATTACHMENT_INV_PAGES_PER_REQUEST: usize = 8;
+pub const MAX_RETRY_DELAY: u64 = 600;
 
 lazy_static! {
     pub static ref BNS_CHARS_REGEX: Regex = Regex::new("^([a-z0-9]|[-_])*$").unwrap();

--- a/src/net/atlas/tests.rs
+++ b/src/net/atlas/tests.rs
@@ -1,3 +1,19 @@
+// Copyright (C) 2013-2020 Blockstack PBC, a public benefit corporation
+// Copyright (C) 2020-2021 Stacks Open Internet Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 use super::download::{
     AttachmentRequest, AttachmentsBatch, AttachmentsBatchStateContext, AttachmentsInventoryRequest,
     BatchedRequestsResult, ReliabilityReport,

--- a/src/net/inv.rs
+++ b/src/net/inv.rs
@@ -92,7 +92,7 @@ pub const FULL_INV_SYNC_INTERVAL: u64 = 12 * 3600;
 pub const FULL_INV_SYNC_INTERVAL: u64 = 120;
 
 #[cfg(not(test))]
-pub const INV_REWARD_CYCLES: u64 = 6;
+pub const INV_REWARD_CYCLES: u64 = 3;
 #[cfg(test)]
 pub const INV_REWARD_CYCLES: u64 = 1;
 

--- a/src/net/p2p.rs
+++ b/src/net/p2p.rs
@@ -352,7 +352,7 @@ impl PeerNetwork {
             debug!("{:?}: disable inbound neighbor walks", &local_peer);
         }
 
-        PeerNetwork {
+        let mut network = PeerNetwork {
             local_peer: local_peer,
             peer_version: peer_version,
             chain_view: chain_view,
@@ -428,7 +428,10 @@ impl PeerNetwork {
             pending_messages: HashMap::new(),
 
             fault_last_disconnect: 0,
-        }
+        };
+
+        network.init_attachments_downloader(vec![]);
+        network
     }
 
     /// start serving.
@@ -4434,7 +4437,7 @@ impl PeerNetwork {
         }) {
             Ok(_) => {}
             Err(e) => {
-                warn!("Atlas: updating attachment inventory failed {}", e);
+                warn!("Atlas: updating attachment inventory failed: {}", e);
             }
         }
 

--- a/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
+++ b/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
@@ -1032,9 +1032,14 @@ impl BitcoinRegtestController {
             }
         }
 
-        // Stop as soon as the fee_rate is 1.50 higher, stop RBF
-        if ongoing_op.fees.fee_rate > (self.config.burnchain.satoshis_per_byte * 150 / 100) {
-            warn!("RBF'd block commits reached 1.5x satoshi per byte fee rate, not resubmitting");
+        // Stop as soon as the fee_rate is ${self.config.burnchain.max_rbf} percent higher, stop RBF
+        if ongoing_op.fees.fee_rate
+            > (self.config.burnchain.satoshis_per_byte * self.config.burnchain.max_rbf / 100)
+        {
+            warn!(
+                "RBF'd block commits reached {}% satoshi per byte fee rate, not resubmitting",
+                self.config.burnchain.max_rbf
+            );
             self.ongoing_block_commit = Some(ongoing_op);
             return None;
         }

--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -21,6 +21,7 @@ use stacks::vm::costs::ExecutionCost;
 use stacks::vm::types::{AssetIdentifier, PrincipalData, QualifiedContractIdentifier};
 
 const DEFAULT_SATS_PER_VB: u64 = 50;
+const DEFAULT_MAX_RBF_RATE: u64 = 150; // 1.5x
 const DEFAULT_RBF_FEE_RATE_INCREMENT: u64 = 5;
 const LEADER_KEY_TX_ESTIM_SIZE: u64 = 290;
 const BLOCK_COMMIT_TX_ESTIM_SIZE: u64 = 350;
@@ -571,6 +572,9 @@ impl Config {
                     satoshis_per_byte: burnchain
                         .satoshis_per_byte
                         .unwrap_or(default_burnchain_config.satoshis_per_byte),
+                    max_rbf: burnchain
+                        .max_rbf
+                        .unwrap_or(default_burnchain_config.max_rbf),
                     leader_key_tx_estimated_size: burnchain
                         .leader_key_tx_estimated_size
                         .unwrap_or(default_burnchain_config.leader_key_tx_estimated_size),
@@ -984,6 +988,7 @@ pub struct BurnchainConfig {
     pub process_exit_at_block_height: Option<u64>,
     pub poll_time_secs: u64,
     pub satoshis_per_byte: u64,
+    pub max_rbf: u64,
     pub leader_key_tx_estimated_size: u64,
     pub block_commit_tx_estimated_size: u64,
     pub rbf_fee_increment: u64,
@@ -1010,6 +1015,7 @@ impl BurnchainConfig {
             process_exit_at_block_height: None,
             poll_time_secs: 10, // TODO: this is a testnet specific value.
             satoshis_per_byte: DEFAULT_SATS_PER_VB,
+            max_rbf: DEFAULT_MAX_RBF_RATE,
             leader_key_tx_estimated_size: LEADER_KEY_TX_ESTIM_SIZE,
             block_commit_tx_estimated_size: BLOCK_COMMIT_TX_ESTIM_SIZE,
             rbf_fee_increment: DEFAULT_RBF_FEE_RATE_INCREMENT,
@@ -1065,6 +1071,7 @@ pub struct BurnchainConfigFile {
     pub leader_key_tx_estimated_size: Option<u64>,
     pub block_commit_tx_estimated_size: Option<u64>,
     pub rbf_fee_increment: Option<u64>,
+    pub max_rbf: Option<u64>,
 }
 
 #[derive(Clone, Debug, Default)]

--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -398,6 +398,7 @@ lazy_static! {
         max_neighbors_of_neighbor: 10,  // maximum number of neighbors we'll handshake with when doing a neighbor walk (I/O for this can be expensive, so keep small-ish)
         walk_interval: 60,              // how often, in seconds, we do a neighbor walk
         inv_sync_interval: 45,          // how often, in seconds, we refresh block inventories
+        inv_reward_cycles: 3,           // how many reward cycles to look back on, for mainnet
         download_interval: 10,          // how often, in seconds, we do a block download scan (should be less than inv_sync_interval)
         dns_timeout: 15_000,
         max_inflight_blocks: 6,

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -88,9 +88,9 @@ struct MicroblockMinerState {
 enum RelayerDirective {
     HandleNetResult(NetworkResult),
     ProcessTenure(ConsensusHash, BurnchainHeaderHash, BlockHeaderHash),
-    RunTenure(RegisteredKey, BlockSnapshot, u128),
+    RunTenure(RegisteredKey, BlockSnapshot, u128), // (vrf key, chain tip, time of issuance in ms)
     RegisterKey(BlockSnapshot),
-    RunMicroblockTenure(u128),
+    RunMicroblockTenure(u128), // time of issuance in ms
     Exit,
 }
 

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -47,6 +47,7 @@ use stacks::util::get_epoch_time_ms;
 use stacks::util::get_epoch_time_secs;
 use stacks::util::hash::{to_hex, Hash160, Sha256Sum};
 use stacks::util::secp256k1::Secp256k1PrivateKey;
+use stacks::util::sleep_ms;
 use stacks::util::strings::{UrlString, VecDisplay};
 use stacks::util::vrf::VRFPublicKey;
 use std::sync::mpsc::{sync_channel, Receiver, SyncSender, TrySendError};
@@ -87,9 +88,9 @@ struct MicroblockMinerState {
 enum RelayerDirective {
     HandleNetResult(NetworkResult),
     ProcessTenure(ConsensusHash, BurnchainHeaderHash, BlockHeaderHash),
-    RunTenure(RegisteredKey, BlockSnapshot),
+    RunTenure(RegisteredKey, BlockSnapshot, u128),
     RegisterKey(BlockSnapshot),
-    RunMicroblockTenure,
+    RunMicroblockTenure(u128),
     Exit,
 }
 
@@ -126,6 +127,14 @@ fn bump_processed_counter(blocks_processed: &BlocksProcessedCounter) {
 
 #[cfg(not(test))]
 fn bump_processed_counter(_blocks_processed: &BlocksProcessedCounter) {}
+
+#[cfg(test)]
+fn set_processed_counter(blocks_processed: &BlocksProcessedCounter, value: u64) {
+    blocks_processed.store(value, std::sync::atomic::Ordering::SeqCst);
+}
+
+#[cfg(not(test))]
+fn set_processed_counter(_blocks_processed: &BlocksProcessedCounter) {}
 
 /// Process artifacts from the tenure.
 /// At this point, we're modifying the chainstate, and merging the artifacts from the previous tenure.
@@ -302,13 +311,13 @@ fn mine_one_microblock(
     mempool: &MemPoolDB,
 ) -> Result<StacksMicroblock, ChainstateError> {
     debug!(
-        "Try to mine one microblock off of {}/{} (at seq {})",
+        "Try to mine one microblock off of {}/{} (total: {})",
         &microblock_state.parent_consensus_hash,
         &microblock_state.parent_block_hash,
         chainstate
             .unconfirmed_state
             .as_ref()
-            .map(|us| us.last_mblock_seq)
+            .map(|us| us.num_microblocks())
             .unwrap_or(0)
     );
 
@@ -375,91 +384,82 @@ fn try_mine_microblock(
     chainstate: &mut StacksChainState,
     sortdb: &SortitionDB,
     mem_pool: &MemPoolDB,
-    winning_tip_opt: Option<&(ConsensusHash, BlockHeaderHash, Secp256k1PrivateKey)>,
+    winning_tip: (ConsensusHash, BlockHeaderHash, Secp256k1PrivateKey),
 ) -> Result<Option<StacksMicroblock>, NetError> {
+    let ch = winning_tip.0;
+    let bhh = winning_tip.1;
+    let microblock_privkey = winning_tip.2;
+
     let mut next_microblock = None;
     if microblock_miner_state.is_none() {
-        // are we the current sortition winner?  Do we need to instantiate?
-        if let Some((ch, bhh, microblock_privkey)) = winning_tip_opt.as_ref() {
-            debug!(
-                "Instantiate microblock mining state off of {}/{}",
-                &ch, &bhh
-            );
-            // we won a block! proceed to build a microblock tail if we've stored it
-            match StacksChainState::get_anchored_block_header_info(chainstate.db(), ch, bhh) {
-                Ok(Some(_)) => {
-                    let parent_index_hash = StacksBlockHeader::make_index_block_hash(&ch, &bhh);
-                    let cost_so_far = StacksChainState::get_stacks_block_anchored_cost(
-                        chainstate.db(),
-                        &parent_index_hash,
-                    )?
-                    .ok_or(NetError::NotFoundError)?;
-                    microblock_miner_state.replace(MicroblockMinerState {
-                        parent_consensus_hash: ch.clone(),
-                        parent_block_hash: bhh.clone(),
-                        miner_key: microblock_privkey.clone(),
-                        frequency: config.node.microblock_frequency,
-                        last_mined: 0,
-                        quantity: 0,
-                        cost_so_far: cost_so_far,
-                    });
-                }
-                Ok(None) => {
-                    warn!(
-                        "No such anchored block: {}/{}.  Cannot mine microblocks",
-                        ch, bhh
-                    );
-                }
-                Err(e) => {
-                    warn!(
-                        "Failed to get anchored block cost for {}/{}: {:?}",
-                        ch, bhh, &e
-                    );
-                }
+        debug!(
+            "Instantiate microblock mining state off of {}/{}",
+            &ch, &bhh
+        );
+        // we won a block! proceed to build a microblock tail if we've stored it
+        match StacksChainState::get_anchored_block_header_info(chainstate.db(), &ch, &bhh) {
+            Ok(Some(_)) => {
+                let parent_index_hash = StacksBlockHeader::make_index_block_hash(&ch, &bhh);
+                let cost_so_far = StacksChainState::get_stacks_block_anchored_cost(
+                    chainstate.db(),
+                    &parent_index_hash,
+                )?
+                .ok_or(NetError::NotFoundError)?;
+                microblock_miner_state.replace(MicroblockMinerState {
+                    parent_consensus_hash: ch.clone(),
+                    parent_block_hash: bhh.clone(),
+                    miner_key: microblock_privkey.clone(),
+                    frequency: config.node.microblock_frequency,
+                    last_mined: 0,
+                    quantity: 0,
+                    cost_so_far: cost_so_far,
+                });
+            }
+            Ok(None) => {
+                warn!(
+                    "No such anchored block: {}/{}.  Cannot mine microblocks",
+                    ch, bhh
+                );
+            }
+            Err(e) => {
+                warn!(
+                    "Failed to get anchored block cost for {}/{}: {:?}",
+                    ch, bhh, &e
+                );
             }
         }
     }
 
-    if let Some((ch, bhh, ..)) = winning_tip_opt.as_ref() {
-        if let Some(mut microblock_miner) = microblock_miner_state.take() {
-            if microblock_miner.parent_consensus_hash == *ch
-                && microblock_miner.parent_block_hash == *bhh
+    if let Some(mut microblock_miner) = microblock_miner_state.take() {
+        if microblock_miner.parent_consensus_hash == ch && microblock_miner.parent_block_hash == bhh
+        {
+            if microblock_miner.last_mined + (microblock_miner.frequency as u128)
+                < get_epoch_time_ms()
             {
-                if microblock_miner.last_mined + (microblock_miner.frequency as u128)
-                    < get_epoch_time_ms()
-                {
-                    // opportunistically try and mine, but only if there's no attachable blocks
-                    let num_attachable =
-                        StacksChainState::count_attachable_staging_blocks(chainstate.db(), 1, 0)?;
-                    if num_attachable == 0 {
-                        match mine_one_microblock(
-                            &mut microblock_miner,
-                            sortdb,
-                            chainstate,
-                            &mem_pool,
-                        ) {
-                            Ok(microblock) => {
-                                // will need to relay this
-                                next_microblock = Some(microblock);
-                            }
-                            Err(ChainstateError::NoTransactionsToMine) => {
-                                info!("Will keep polling mempool for transactions to include in a microblock");
-                            }
-                            Err(e) => {
-                                warn!("Failed to mine one microblock: {:?}", &e);
-                            }
+                // opportunistically try and mine, but only if there's no attachable blocks
+                let num_attachable =
+                    StacksChainState::count_attachable_staging_blocks(chainstate.db(), 1, 0)?;
+                if num_attachable == 0 {
+                    match mine_one_microblock(&mut microblock_miner, sortdb, chainstate, &mem_pool)
+                    {
+                        Ok(microblock) => {
+                            // will need to relay this
+                            next_microblock = Some(microblock);
+                        }
+                        Err(ChainstateError::NoTransactionsToMine) => {
+                            info!("Will keep polling mempool for transactions to include in a microblock");
+                        }
+                        Err(e) => {
+                            warn!("Failed to mine one microblock: {:?}", &e);
                         }
                     }
                 }
-                microblock_miner.last_mined = get_epoch_time_ms();
-                microblock_miner_state.replace(microblock_miner);
             }
-            // otherwise, we're not the sortition winner, and the microblock miner state can be
-            // discarded.
+            microblock_miner.last_mined = get_epoch_time_ms();
+            microblock_miner_state.replace(microblock_miner);
         }
-    } else {
-        // no longer a winning tip
-        let _ = microblock_miner_state.take();
+        // otherwise, we're not the sortition winner, and the microblock miner state can be
+        // discarded.
     }
 
     Ok(next_microblock)
@@ -472,49 +472,61 @@ fn run_microblock_tenure(
     sortdb: &mut SortitionDB,
     mem_pool: &MemPoolDB,
     relayer: &mut Relayer,
-    miner_tip: Option<&(ConsensusHash, BlockHeaderHash, Secp256k1PrivateKey)>,
+    miner_tip: (ConsensusHash, BlockHeaderHash, Secp256k1PrivateKey),
+    microblocks_processed: BlocksProcessedCounter,
 ) {
     // TODO: this is sensitive to poll latency -- can we call this on a fixed
     // schedule, regardless of network activity?
-    if let Some((ref parent_consensus_hash, ref parent_block_hash, _)) = miner_tip.as_ref() {
+    let parent_consensus_hash = &miner_tip.0;
+    let parent_block_hash = &miner_tip.1;
+
+    debug!(
+        "Run microblock tenure for {}/{}",
+        parent_consensus_hash, parent_block_hash
+    );
+
+    // Mine microblocks, if we're active
+    let next_microblock_opt = match try_mine_microblock(
+        &config,
+        microblock_miner_state,
+        chainstate,
+        sortdb,
+        mem_pool,
+        miner_tip.clone(),
+    ) {
+        Ok(x) => x,
+        Err(e) => {
+            warn!("Failed to mine next microblock: {:?}", &e);
+            None
+        }
+    };
+
+    // did we mine anything?
+    if let Some(next_microblock) = next_microblock_opt {
+        // apply it
+        let microblock_hash = next_microblock.block_hash();
+
+        Relayer::refresh_unconfirmed(chainstate, sortdb);
+        let num_mblocks = chainstate
+            .unconfirmed_state
+            .as_ref()
+            .map(|ref unconfirmed| unconfirmed.num_microblocks())
+            .unwrap_or(0);
+
         debug!(
-            "Run microblock tenure for {}/{}",
-            parent_consensus_hash, parent_block_hash
+            "Relayer: mined one microblock: {} (total: {})",
+            &microblock_hash, num_mblocks
         );
+        set_processed_counter(&microblocks_processed, num_mblocks);
 
-        // Mine microblocks, if we're active
-        let next_microblock_opt = match try_mine_microblock(
-            &config,
-            microblock_miner_state,
-            chainstate,
-            sortdb,
-            mem_pool,
-            miner_tip.clone(),
-        ) {
-            Ok(x) => x,
-            Err(e) => {
-                warn!("Failed to mine next microblock: {:?}", &e);
-                None
-            }
-        };
-
-        // did we mine anything?
-        if let Some(next_microblock) = next_microblock_opt {
-            // apply it
-            Relayer::refresh_unconfirmed(chainstate, sortdb);
-
-            // send it off
-            let microblock_hash = next_microblock.block_hash();
-            if let Err(e) = relayer.broadcast_microblock(
-                parent_consensus_hash,
-                parent_block_hash,
-                next_microblock,
-            ) {
-                error!(
-                    "Failure trying to broadcast microblock {}: {}",
-                    microblock_hash, e
-                );
-            }
+        // send it off
+        if let Err(e) =
+            relayer.broadcast_microblock(parent_consensus_hash, parent_block_hash, next_microblock)
+        {
+            error!(
+                "Failure trying to broadcast microblock {}: {}",
+                microblock_hash, e
+            );
         }
     }
 }
@@ -683,7 +695,10 @@ fn spawn_peer(
                         // only do this on the Ok() path, even if we're mining, because an error in
                         // network dispatching is likely due to resource exhaustion
                         if mblock_deadline < get_epoch_time_ms() {
-                            results_with_data.push_back(RelayerDirective::RunMicroblockTenure);
+                            debug!("P2P: schedule microblock tenure");
+                            results_with_data.push_back(RelayerDirective::RunMicroblockTenure(
+                                get_epoch_time_ms(),
+                            ));
                             mblock_deadline =
                                 get_epoch_time_ms() + (config.node.microblock_frequency as u128);
                         }
@@ -706,7 +721,7 @@ fn spawn_peer(
                         );
                         match e {
                             TrySendError::Full(directive) => {
-                                if let RelayerDirective::RunMicroblockTenure = directive {
+                                if let RelayerDirective::RunMicroblockTenure(_) = directive {
                                     // can drop this
                                 } else {
                                     // don't lose this data -- just try it again
@@ -753,6 +768,7 @@ fn spawn_miner_relayer(
     relay_channel: Receiver<RelayerDirective>,
     event_dispatcher: EventDispatcher,
     blocks_processed: BlocksProcessedCounter,
+    microblocks_processed: BlocksProcessedCounter,
     burnchain: Burnchain,
     coord_comms: CoordinatorChannels,
     unconfirmed_txs: Arc<Mutex<UnconfirmedTxMap>>,
@@ -785,9 +801,10 @@ fn spawn_miner_relayer(
     let mut failed_to_mine_in_block: Option<BurnchainHeaderHash> = None;
 
     let mut bitcoin_controller = BitcoinRegtestController::new_dummy(config.clone());
-    let mut microblock_miner_state = None;
+    let mut microblock_miner_state: Option<MicroblockMinerState> = None;
     let mut miner_tip = None;
     let mut last_microblock_tenure_time = 0;
+    let mut last_tenure_issue_time = 0;
 
     let relayer_handle = thread::Builder::new().name("relayer".to_string()).spawn(move || {
         while let Ok(mut directive) = relay_channel.recv() {
@@ -913,10 +930,13 @@ fn spawn_miner_relayer(
 
                                     // proceed to mine microblocks
                                     debug!(
-                                        "Microblock miner tip is now {}/{}",
-                                        &consensus_hash, &block_header_hash
+                                        "Microblock miner tip is now {}/{} ({})",
+                                        &consensus_hash, &block_header_hash, StacksBlockHeader::make_index_block_hash(&consensus_hash, &block_header_hash)
                                     );
                                     miner_tip = Some((ch, bh, microblock_privkey));
+
+                                    Relayer::refresh_unconfirmed(&mut chainstate, &mut sortdb);
+                                    send_unconfirmed_txs(&chainstate, unconfirmed_txs.clone());
                                 }
                             } else {
                                 debug!("Did not win sortition, my blocks [burn_hash= {}, block_hash= {}], their blocks [parent_consenus_hash= {}, burn_hash= {}, block_hash ={}]",
@@ -927,7 +947,11 @@ fn spawn_miner_relayer(
                         }
                     }
                 }
-                RelayerDirective::RunTenure(registered_key, last_burn_block) => {
+                RelayerDirective::RunTenure(registered_key, last_burn_block, issue_timestamp_ms) => {
+                    if last_tenure_issue_time > issue_timestamp_ms {
+                        continue;
+                    }
+
                     let burn_header_hash = last_burn_block.burn_header_hash.clone();
                     debug!(
                         "Relayer: Run tenure";
@@ -974,6 +998,8 @@ fn spawn_miner_relayer(
                         failed_to_mine_in_block = Some(burn_chain_tip);
                     }
                     last_mined_blocks.insert(burn_header_hash, last_mined_blocks_vec);
+
+                    last_tenure_issue_time = get_epoch_time_ms();
                 }
                 RelayerDirective::RegisterKey(ref last_burn_block) => {
                     rotate_vrf_and_register(
@@ -984,32 +1010,48 @@ fn spawn_miner_relayer(
                     );
                     bump_processed_counter(&blocks_processed);
                 }
-                RelayerDirective::RunMicroblockTenure => {
-                    if last_microblock_tenure_time + (config.node.microblock_frequency as u128) > get_epoch_time_ms() {
-                        // only mine when necessary -- the deadline to begin hasn't passed yet
+                RelayerDirective::RunMicroblockTenure(tenure_issue_ms) => {
+                    if last_microblock_tenure_time > tenure_issue_ms {
+                        // stale request
                         continue;
                     }
-                    last_microblock_tenure_time = get_epoch_time_ms();
 
                     debug!("Relayer: run microblock tenure");
 
-                    // unconfirmed state must be consistent with the chain tip
-                    if miner_tip.is_some() {
-                        Relayer::refresh_unconfirmed(&mut chainstate, &mut sortdb);
+                    // unconfirmed state must be consistent with the chain tip, as must the
+                    // microblock mining state.
+                    if let Some((ch, bh, mblock_pkey)) = miner_tip.clone() {
+                        if let Some(miner_state) = microblock_miner_state.take() {
+                            if miner_state.parent_consensus_hash == ch || miner_state.parent_block_hash == bh {
+                                // preserve -- chaintip is unchanged
+                                microblock_miner_state = Some(miner_state);
+                            }
+                            else {
+                                debug!("Relayer: reset microblock miner state");
+                                microblock_miner_state = None;
+                            }
+                        }
+
+                        run_microblock_tenure(
+                            &config,
+                            &mut microblock_miner_state,
+                            &mut chainstate,
+                            &mut sortdb,
+                            &mem_pool,
+                            &mut relayer,
+                            (ch, bh, mblock_pkey),
+                            microblocks_processed.clone()
+                        );
+
+                        // synchronize unconfirmed tx index to p2p thread
+                        send_unconfirmed_txs(&chainstate, unconfirmed_txs.clone());
+                        last_microblock_tenure_time = get_epoch_time_ms();
                     }
-
-                    run_microblock_tenure(
-                        &config,
-                        &mut microblock_miner_state,
-                        &mut chainstate,
-                        &mut sortdb,
-                        &mem_pool,
-                        &mut relayer,
-                        miner_tip.as_ref(),
-                    );
-
-                    // synchronize unconfirmed tx index to p2p thread
-                    send_unconfirmed_txs(&chainstate, unconfirmed_txs.clone());
+                    else {
+                        debug!("Relayer: reset unconfirmed state to 0 microblocks");
+                        set_processed_counter(&microblocks_processed, 0);
+                        microblock_miner_state = None;
+                    }
                 }
                 RelayerDirective::Exit => break
             }
@@ -1034,6 +1076,7 @@ impl InitializedNeonNode {
         last_burn_block: Option<BurnchainTip>,
         miner: bool,
         blocks_processed: BlocksProcessedCounter,
+        microblocks_processed: BlocksProcessedCounter,
         coord_comms: CoordinatorChannels,
         sync_comms: PoxSyncWatchdogComms,
         burnchain: Burnchain,
@@ -1207,6 +1250,7 @@ impl InitializedNeonNode {
             relay_recv,
             event_dispatcher.clone(),
             blocks_processed.clone(),
+            microblocks_processed.clone(),
             burnchain,
             coord_comms,
             shared_unconfirmed_txs.clone(),
@@ -1227,7 +1271,7 @@ impl InitializedNeonNode {
             event_dispatcher,
             should_keep_running,
         )
-        .expect("Failed to initialize mine/relay thread");
+        .expect("Failed to initialize p2p thread");
 
         info!("Start HTTP server on: {}", &config.node.rpc_bind);
         info!("Start P2P server on: {}", &config.node.p2p_bind);
@@ -1251,7 +1295,8 @@ impl InitializedNeonNode {
         }
     }
 
-    /// Tell the relayer to fire off a tenure and a block commit op.
+    /// Tell the relayer to fire off a tenure and a block commit op,
+    /// if it is time to do so.
     pub fn relayer_issue_tenure(&mut self) -> bool {
         if !self.is_miner {
             // node is a follower, don't try to issue a tenure
@@ -1261,16 +1306,29 @@ impl InitializedNeonNode {
         if let Some(burnchain_tip) = self.last_burn_block.clone() {
             match self.leader_key_registration_state {
                 LeaderKeyRegistrationState::Active(ref key) => {
-                    debug!("Using key {:?}", &key.vrf_public_key);
-                    // sleep a little before building the anchor block, to give any broadcasted
-                    //   microblocks time to propagate.
-                    thread::sleep(std::time::Duration::from_millis(self.sleep_before_tenure));
+                    debug!(
+                        "Tenure: will wait for {}s before running tenure off of {}",
+                        self.sleep_before_tenure / 1000,
+                        &burnchain_tip.burn_header_hash
+                    );
+                    sleep_ms(self.sleep_before_tenure);
+                    debug!(
+                        "Tenure: Using key {:?} off of {}",
+                        &key.vrf_public_key, &burnchain_tip.burn_header_hash
+                    );
+
                     self.relay_channel
-                        .send(RelayerDirective::RunTenure(key.clone(), burnchain_tip))
+                        .send(RelayerDirective::RunTenure(
+                            key.clone(),
+                            burnchain_tip,
+                            get_epoch_time_ms(),
+                        ))
                         .is_ok()
                 }
                 LeaderKeyRegistrationState::Inactive => {
-                    warn!("Skipped tenure because no active VRF key. Trying to register one.");
+                    warn!(
+                        "Tenure: skipped tenure because no active VRF key. Trying to register one."
+                    );
                     self.leader_key_registration_state = LeaderKeyRegistrationState::Pending;
                     self.relay_channel
                         .send(RelayerDirective::RegisterKey(burnchain_tip))
@@ -1279,7 +1337,7 @@ impl InitializedNeonNode {
                 LeaderKeyRegistrationState::Pending => true,
             }
         } else {
-            warn!("Do not know the last burn block. As a miner, this is bad.");
+            warn!("Tenure: Do not know the last burn block. As a miner, this is bad.");
             true
         }
     }
@@ -1295,7 +1353,7 @@ impl InitializedNeonNode {
 
         if let Some(ref snapshot) = &self.last_burn_block {
             debug!(
-                "Notify sortition! Last snapshot is {}/{} ({})",
+                "Tenure: Notify sortition! Last snapshot is {}/{} ({})",
                 &snapshot.consensus_hash,
                 &snapshot.burn_header_hash,
                 &snapshot.winning_stacks_block_hash
@@ -1311,7 +1369,7 @@ impl InitializedNeonNode {
                     .is_ok();
             }
         } else {
-            debug!("Notify sortition! No last burn block");
+            debug!("Tenure: Notify sortition! No last burn block");
         }
         true
     }
@@ -1627,7 +1685,7 @@ impl InitializedNeonNode {
                 }
             };
 
-        if let Some((microblocks, poison_opt)) = microblock_info_opt {
+        if let Some((ref microblocks, ref poison_opt)) = &microblock_info_opt {
             if let Some(ref tail) = microblocks.last() {
                 debug!(
                     "Confirm microblock stream tailed at {} (seq {})",
@@ -1636,6 +1694,8 @@ impl InitializedNeonNode {
                 );
             }
 
+            // try and confirm as many microblocks as we can (but note that the stream itself may
+            // be too long; we'll try again if that happens).
             stacks_parent_header.microblock_tail =
                 microblocks.last().clone().map(|blk| blk.header.clone());
 
@@ -1643,7 +1703,7 @@ impl InitializedNeonNode {
                 let poison_microblock_tx = inner_generate_poison_microblock_tx(
                     keychain,
                     coinbase_nonce + 1,
-                    poison_payload,
+                    poison_payload.clone(),
                     config.is_mainnet(),
                     config.burnchain.chain_id,
                 );
@@ -1678,6 +1738,52 @@ impl InitializedNeonNode {
             Some(event_observer),
         ) {
             Ok(block) => block,
+            Err(ChainstateError::InvalidStacksMicroblock(msg, mblock_header_hash)) => {
+                // part of the parent microblock stream is invalid, so try again
+                info!("Parent microblock stream is invalid; trying again without the offender {} (msg: {})", &mblock_header_hash, &msg);
+
+                // truncate the stream
+                stacks_parent_header.microblock_tail = match microblock_info_opt {
+                    Some((microblocks, _)) => {
+                        let mut tail = None;
+                        for mblock in microblocks.into_iter() {
+                            if mblock.block_hash() == mblock_header_hash {
+                                break;
+                            }
+                            tail = Some(mblock);
+                        }
+                        if let Some(ref t) = &tail {
+                            debug!(
+                                "New parent microblock stream tail is {} (seq {})",
+                                t.block_hash(),
+                                t.header.sequence
+                            );
+                        }
+                        tail.map(|t| t.header)
+                    }
+                    None => None,
+                };
+
+                // try again
+                match StacksBlockBuilder::build_anchored_block(
+                    chain_state,
+                    &burn_db.index_conn(),
+                    mem_pool,
+                    &stacks_parent_header,
+                    parent_block_total_burn,
+                    vrf_proof.clone(),
+                    mblock_pubkey_hash,
+                    &coinbase_tx,
+                    config.block_limit.clone(),
+                    Some(event_observer),
+                ) {
+                    Ok(block) => block,
+                    Err(e) => {
+                        error!("Failure mining anchor block even after removing offending microblock {}: {}", &mblock_header_hash, &e);
+                        return None;
+                    }
+                }
+            }
             Err(e) => {
                 error!("Failure mining anchored block: {}", e);
                 return None;
@@ -1740,11 +1846,13 @@ impl InitializedNeonNode {
         );
         let mut op_signer = keychain.generate_op_signer();
         debug!(
-            "Submit block-commit for block {} off of {}/{} with microblock parent {}",
+            "Submit block-commit for block {} height {} off of {}/{} with microblock parent {} (seq {})",
             &anchored_block.block_hash(),
+            anchored_block.header.total_work.work,
             &parent_consensus_hash,
             &anchored_block.header.parent_block,
-            &anchored_block.header.parent_microblock
+            &anchored_block.header.parent_microblock,
+            &anchored_block.header.parent_microblock_sequence
         );
 
         let res = bitcoin_controller.submit_operation(op, &mut op_signer, attempt);
@@ -1845,6 +1953,7 @@ impl InitializedNeonNode {
         }
 
         // no-op on UserBurnSupport ops are not supported / produced at this point.
+
         self.last_burn_block = Some(block_snapshot);
 
         last_sortitioned_block.map(|x| x.0)
@@ -1899,6 +2008,7 @@ impl NeonGenesisNode {
         self,
         burnchain_tip: BurnchainTip,
         blocks_processed: BlocksProcessedCounter,
+        microblocks_processed: BlocksProcessedCounter,
         coord_comms: CoordinatorChannels,
         sync_comms: PoxSyncWatchdogComms,
         attachments_rx: Receiver<HashSet<AttachmentInstance>>,
@@ -1916,6 +2026,7 @@ impl NeonGenesisNode {
             Some(burnchain_tip),
             true,
             blocks_processed,
+            microblocks_processed,
             coord_comms,
             sync_comms,
             self.burnchain,
@@ -1929,6 +2040,7 @@ impl NeonGenesisNode {
         self,
         burnchain_tip: BurnchainTip,
         blocks_processed: BlocksProcessedCounter,
+        microblocks_processed: BlocksProcessedCounter,
         coord_comms: CoordinatorChannels,
         sync_comms: PoxSyncWatchdogComms,
         attachments_rx: Receiver<HashSet<AttachmentInstance>>,
@@ -1946,6 +2058,7 @@ impl NeonGenesisNode {
             Some(burnchain_tip),
             false,
             blocks_processed,
+            microblocks_processed,
             coord_comms,
             sync_comms,
             self.burnchain,

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -134,7 +134,7 @@ fn set_processed_counter(blocks_processed: &BlocksProcessedCounter, value: u64) 
 }
 
 #[cfg(not(test))]
-fn set_processed_counter(_blocks_processed: &BlocksProcessedCounter) {}
+fn set_processed_counter(_blocks_processed: &BlocksProcessedCounter, value: u64) {}
 
 /// Process artifacts from the tenure.
 /// At this point, we're modifying the chainstate, and merging the artifacts from the previous tenure.

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -1655,7 +1655,7 @@ fn size_overflow_unconfirmed_microblocks_integration_test() {
 
     // small-sized contracts for microblocks
     let mut small_contract = "(define-public (f) (ok 1))".to_string();
-    for _i in 0..((1024 * 1024 + 500) / 2) {
+    for _i in 0..(1024 * 1024 + 500) {
         small_contract.push_str(" ");
     }
 
@@ -1684,7 +1684,7 @@ fn size_overflow_unconfirmed_microblocks_integration_test() {
                     let tx = make_contract_publish_microblock_only(
                         spender_sk,
                         i as u64,
-                        600000,
+                        1100000,
                         &format!("small-{}", i),
                         &small_contract,
                     );
@@ -1765,7 +1765,7 @@ fn size_overflow_unconfirmed_microblocks_integration_test() {
         }
     }
 
-    sleep_ms(75_000);
+    sleep_ms(150_000);
 
     // now let's mine a couple blocks, and then check the sender's nonce.
     //  at the end of mining three blocks, there should be _two_ transactions from the microblock
@@ -1777,7 +1777,7 @@ fn size_overflow_unconfirmed_microblocks_integration_test() {
     next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
     // this one will contain the sortition from above anchor block,
     //    which *should* have also confirmed the microblock.
-    sleep_ms(75_000);
+    sleep_ms(150_000);
 
     next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
 

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -280,6 +280,35 @@ fn wait_for_runloop(blocks_processed: &Arc<AtomicU64>) {
     }
 }
 
+fn wait_for_microblocks(microblocks_processed: &Arc<AtomicU64>, timeout: u64) -> bool {
+    let mut current = microblocks_processed.load(Ordering::SeqCst);
+    let start = Instant::now();
+
+    loop {
+        let now = microblocks_processed.load(Ordering::SeqCst);
+        if now == 0 && current != 0 {
+            // wrapped around -- a new epoch started
+            debug!(
+                "New microblock epoch started while waiting (originally {})",
+                current
+            );
+            current = 0;
+        }
+
+        if now > current {
+            break;
+        }
+
+        if start.elapsed() > Duration::from_secs(timeout) {
+            warn!("Timed out waiting for microblocks to process");
+            return false;
+        }
+
+        thread::sleep(Duration::from_millis(100));
+    }
+    return true;
+}
+
 /// returns Txid string
 fn submit_tx(http_origin: &str, tx: &Vec<u8>) -> String {
     let client = reqwest::blocking::Client::new();
@@ -1609,6 +1638,8 @@ fn size_check_integration_test() {
     channel.stop_chains_coordinator();
 }
 
+// if a microblock consumes the majority of the block budget, then _only_ a microblock will be
+// mined for an epoch.
 #[test]
 #[ignore]
 fn size_overflow_unconfirmed_microblocks_integration_test() {
@@ -1808,6 +1839,372 @@ fn size_overflow_unconfirmed_microblocks_integration_test() {
     // NOTE: last-mined blocks aren't counted by the observer
     assert!(total_big_txs_per_block <= 2);
     assert!(total_big_txs_per_microblock <= 3);
+
+    test_observer::clear();
+    channel.stop_chains_coordinator();
+}
+
+// mine a stream of microblocks, and verify that the miner won't let us overflow the size
+#[test]
+#[ignore]
+fn size_overflow_unconfirmed_stream_microblocks_integration_test() {
+    if env::var("BITCOIND_TEST") != Ok("1".into()) {
+        return;
+    }
+
+    let mut small_contract = "(define-public (f) (ok 1))".to_string();
+    for _i in 0..((1024 * 1024 + 500) / 3) {
+        small_contract.push_str(" ");
+    }
+
+    let spender_sks: Vec<_> = (0..25)
+        .into_iter()
+        .map(|_| StacksPrivateKey::new())
+        .collect();
+    let spender_addrs: Vec<PrincipalData> = spender_sks.iter().map(|x| to_addr(x).into()).collect();
+
+    let txs: Vec<Vec<_>> = spender_sks
+        .iter()
+        .map(|spender_sk| {
+            let mut ret = vec![];
+            for i in 0..1 {
+                let tx = make_contract_publish_microblock_only(
+                    spender_sk,
+                    i as u64,
+                    600000,
+                    &format!("small-{}", i),
+                    &small_contract,
+                );
+                ret.push(tx);
+            }
+            ret
+        })
+        .collect();
+
+    let flat_txs: Vec<_> = txs.iter().fold(vec![], |mut acc, a| {
+        acc.append(&mut a.clone());
+        acc
+    });
+
+    let (mut conf, miner_account) = neon_integration_test_conf();
+
+    for spender_addr in spender_addrs.iter() {
+        conf.initial_balances.push(InitialBalance {
+            address: spender_addr.clone(),
+            amount: 10492300000,
+        });
+    }
+
+    conf.node.mine_microblocks = true;
+    conf.node.wait_time_for_microblocks = 1000;
+    conf.node.microblock_frequency = 1000;
+    conf.node.max_microblocks = 65536;
+    conf.burnchain.max_rbf = 1000000;
+
+    test_observer::spawn();
+    conf.events_observers.push(EventObserverConfig {
+        endpoint: format!("localhost:{}", test_observer::EVENT_OBSERVER_PORT),
+        events_keys: vec![EventKeyType::AnyEvent],
+    });
+
+    let mut btcd_controller = BitcoinCoreController::new(conf.clone());
+    btcd_controller
+        .start_bitcoind()
+        .map_err(|_e| ())
+        .expect("Failed starting bitcoind");
+
+    let mut btc_regtest_controller = BitcoinRegtestController::new(conf.clone(), None);
+    let http_origin = format!("http://{}", &conf.node.rpc_bind);
+
+    btc_regtest_controller.bootstrap_chain(201);
+
+    eprintln!("Chain bootstrapped...");
+
+    let mut run_loop = neon::RunLoop::new(conf);
+    let blocks_processed = run_loop.get_blocks_processed_arc();
+    let microblocks_processed = run_loop.get_microblocks_processed_arc();
+
+    let channel = run_loop.get_coordinator_channel().unwrap();
+
+    thread::spawn(move || run_loop.start(None, 0));
+
+    // give the run loop some time to start up!
+    wait_for_runloop(&blocks_processed);
+
+    // first block wakes up the run loop
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+
+    // first block will hold our VRF registration
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+
+    // second block will be the first mined Stacks block
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+
+    // let's query the miner's account nonce:
+    let account = get_account(&http_origin, &miner_account);
+    assert_eq!(account.nonce, 1);
+    assert_eq!(account.balance, 0);
+
+    for spender_addr in spender_addrs.iter() {
+        let account = get_account(&http_origin, &spender_addr);
+        assert_eq!(account.nonce, 0);
+        assert_eq!(account.balance, 10492300000);
+    }
+
+    let mut ctr = 0;
+    while ctr < flat_txs.len() {
+        submit_tx(&http_origin, &flat_txs[ctr]);
+        if !wait_for_microblocks(&microblocks_processed, 240) {
+            break;
+        }
+        ctr += 1;
+    }
+
+    // should be able to fit 5 transactions in, in 5 microblocks
+    assert_eq!(ctr, 5);
+    sleep_ms(5_000);
+
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+
+    eprintln!("First confirmed microblock stream!");
+
+    microblocks_processed.store(0, Ordering::SeqCst);
+
+    while ctr < flat_txs.len() {
+        submit_tx(&http_origin, &flat_txs[ctr]);
+        if !wait_for_microblocks(&microblocks_processed, 240) {
+            break;
+        }
+        ctr += 1;
+    }
+
+    // should be able to fit 5 more transactions in, in 5 microblocks
+    assert_eq!(ctr, 10);
+    sleep_ms(5_000);
+
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+
+    eprintln!("Second confirmed microblock stream!");
+
+    // confirm it
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+
+    let blocks = test_observer::get_blocks();
+    assert_eq!(blocks.len(), 4);
+
+    let mut max_big_txs_per_microblock = 0;
+    let mut total_big_txs_per_microblock = 0;
+
+    // NOTE: this only counts the number of txs per stream, not in each microblock
+    for block in blocks {
+        let transactions = block.get("transactions").unwrap().as_array().unwrap();
+        eprintln!("{}", transactions.len());
+
+        let mut num_big_microblock_txs = 0;
+
+        for tx in transactions.iter() {
+            let raw_tx = tx.get("raw_tx").unwrap().as_str().unwrap();
+            if raw_tx == "0x00" {
+                continue;
+            }
+            let tx_bytes = hex_bytes(&raw_tx[2..]).unwrap();
+            let parsed = StacksTransaction::consensus_deserialize(&mut &tx_bytes[..]).unwrap();
+            if let TransactionPayload::SmartContract(tsc) = parsed.payload {
+                if tsc.name.to_string().find("small-").is_some() {
+                    num_big_microblock_txs += 1;
+                    total_big_txs_per_microblock += 1;
+                }
+            }
+        }
+        if num_big_microblock_txs > max_big_txs_per_microblock {
+            max_big_txs_per_microblock = num_big_microblock_txs;
+        }
+    }
+
+    eprintln!(
+        "max_big_txs_per_microblock: {}, total_big_txs_per_microblock: {}",
+        max_big_txs_per_microblock, total_big_txs_per_microblock
+    );
+
+    assert_eq!(max_big_txs_per_microblock, 5);
+    assert!(total_big_txs_per_microblock >= 10);
+
+    test_observer::clear();
+    channel.stop_chains_coordinator();
+}
+
+// Mine a too-long microblock stream, and verify that the anchored block miner truncates it down to
+// the longest prefix of the stream that can be mined.
+#[test]
+#[ignore]
+fn size_overflow_unconfirmed_invalid_stream_microblocks_integration_test() {
+    if env::var("BITCOIND_TEST") != Ok("1".into()) {
+        return;
+    }
+
+    // create microblock streams that are too big
+    env::set_var(core::FAULT_DISABLE_MICROBLOCKS_BYTES_CHECK, "1");
+    env::set_var(core::FAULT_DISABLE_MICROBLOCKS_COST_CHECK, "1");
+
+    let mut small_contract = "(define-public (f) (ok 1))".to_string();
+    for _i in 0..((1024 * 1024 + 500) / 8) {
+        small_contract.push_str(" ");
+    }
+
+    let spender_sks: Vec<_> = (0..25)
+        .into_iter()
+        .map(|_| StacksPrivateKey::new())
+        .collect();
+    let spender_addrs: Vec<PrincipalData> = spender_sks.iter().map(|x| to_addr(x).into()).collect();
+
+    let txs: Vec<Vec<_>> = spender_sks
+        .iter()
+        .map(|spender_sk| {
+            let mut ret = vec![];
+            for i in 0..1 {
+                let tx = make_contract_publish_microblock_only(
+                    spender_sk,
+                    i as u64,
+                    1149230,
+                    &format!("small-{}", i),
+                    &small_contract,
+                );
+                ret.push(tx);
+            }
+            ret
+        })
+        .collect();
+
+    let flat_txs: Vec<_> = txs.iter().fold(vec![], |mut acc, a| {
+        acc.append(&mut a.clone());
+        acc
+    });
+
+    let (mut conf, miner_account) = neon_integration_test_conf();
+
+    for spender_addr in spender_addrs.iter() {
+        conf.initial_balances.push(InitialBalance {
+            address: spender_addr.clone(),
+            amount: 10492300000,
+        });
+    }
+
+    conf.node.mine_microblocks = true;
+    conf.node.wait_time_for_microblocks = 15000;
+    conf.node.microblock_frequency = 1000;
+    conf.node.max_microblocks = 65536;
+    conf.burnchain.max_rbf = 1000000;
+    conf.block_limit = BLOCK_LIMIT_MAINNET.clone();
+
+    test_observer::spawn();
+    conf.events_observers.push(EventObserverConfig {
+        endpoint: format!("localhost:{}", test_observer::EVENT_OBSERVER_PORT),
+        events_keys: vec![EventKeyType::AnyEvent],
+    });
+
+    let mut btcd_controller = BitcoinCoreController::new(conf.clone());
+    btcd_controller
+        .start_bitcoind()
+        .map_err(|_e| ())
+        .expect("Failed starting bitcoind");
+
+    let mut btc_regtest_controller = BitcoinRegtestController::new(conf.clone(), None);
+    let http_origin = format!("http://{}", &conf.node.rpc_bind);
+
+    btc_regtest_controller.bootstrap_chain(201);
+
+    eprintln!("Chain bootstrapped...");
+
+    let mut run_loop = neon::RunLoop::new(conf);
+    let blocks_processed = run_loop.get_blocks_processed_arc();
+    let microblocks_processed = run_loop.get_microblocks_processed_arc();
+
+    let channel = run_loop.get_coordinator_channel().unwrap();
+
+    thread::spawn(move || run_loop.start(None, 0));
+
+    // give the run loop some time to start up!
+    wait_for_runloop(&blocks_processed);
+
+    // first block wakes up the run loop
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+
+    // first block will hold our VRF registration
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+
+    // second block will be the first mined Stacks block
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+
+    // let's query the miner's account nonce:
+    let account = get_account(&http_origin, &miner_account);
+    assert_eq!(account.nonce, 1);
+    assert_eq!(account.balance, 0);
+
+    for spender_addr in spender_addrs.iter() {
+        let account = get_account(&http_origin, &spender_addr);
+        assert_eq!(account.nonce, 0);
+        assert_eq!(account.balance, 10492300000);
+    }
+
+    let mut ctr = 0;
+    for i in 0..6 {
+        submit_tx(&http_origin, &flat_txs[ctr]);
+        if !wait_for_microblocks(&microblocks_processed, 240) {
+            break;
+        }
+        ctr += 1;
+    }
+
+    // confirm that we were able to use the fault-injection to *mine* 6 microblocks
+    assert_eq!(ctr, 6);
+    sleep_ms(5_000);
+
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+
+    eprintln!("First confirmed microblock stream!");
+
+    // confirm it
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+
+    let blocks = test_observer::get_blocks();
+    assert_eq!(blocks.len(), 3);
+
+    let mut max_big_txs_per_microblock = 0;
+    let mut total_big_txs_per_microblock = 0;
+
+    // NOTE: this only counts the number of txs per stream, not in each microblock
+    for block in blocks {
+        let transactions = block.get("transactions").unwrap().as_array().unwrap();
+        eprintln!("{}", transactions.len());
+
+        let mut num_big_microblock_txs = 0;
+
+        for tx in transactions.iter() {
+            let raw_tx = tx.get("raw_tx").unwrap().as_str().unwrap();
+            if raw_tx == "0x00" {
+                continue;
+            }
+            let tx_bytes = hex_bytes(&raw_tx[2..]).unwrap();
+            let parsed = StacksTransaction::consensus_deserialize(&mut &tx_bytes[..]).unwrap();
+            if let TransactionPayload::SmartContract(tsc) = parsed.payload {
+                if tsc.name.to_string().find("small-").is_some() {
+                    num_big_microblock_txs += 1;
+                    total_big_txs_per_microblock += 1;
+                }
+            }
+        }
+        if num_big_microblock_txs > max_big_txs_per_microblock {
+            max_big_txs_per_microblock = num_big_microblock_txs;
+        }
+    }
+
+    eprintln!(
+        "max_big_txs_per_microblock: {}, total_big_txs_per_microblock: {}",
+        max_big_txs_per_microblock, total_big_txs_per_microblock
+    );
+
+    assert_eq!(max_big_txs_per_microblock, 3);
+    assert!(total_big_txs_per_microblock <= 6);
 
     test_observer::clear();
     channel.stop_chains_coordinator();

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -1881,10 +1881,7 @@ fn size_overflow_unconfirmed_stream_microblocks_integration_test() {
         })
         .collect();
 
-    let flat_txs: Vec<_> = txs.iter().fold(vec![], |mut acc, a| {
-        acc.append(&mut a.clone());
-        acc
-    });
+    let flat_txs: Vec<_> = txs.iter().flat_map(|a| a.clone()).collect();
 
     let (mut conf, miner_account) = neon_integration_test_conf();
 


### PR DESCRIPTION
Make it so Atlas chunks are re-tried in an exponential back-off fashion with random jitters.  Also, reduce the inv reward cycle sync to 3 reward cycles by default on mainnet (you can get away with just 1 in practice -- I've tried it several times), and fix the `new_bytes` calculation in microblock mining.