### PR TITLE
fix: launch testnet via stacks-node

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,8 @@ cargo run --bin blockstack-cli publish b8d99fd45da58038d630d9855d3ca2466e8e0f89d
 You can observe the state machine in action locally by running:
 
 ```bash
-cargo testnet start --config=./testnet/stacks-node/Stacks.toml
+cargo build --workspace --bin stacks-node
+./target/debug/stacks-node start --config=./testnet/stacks-node/Stacks.toml
 ```
 
 `Stacks.toml` is a configuration file that you can use for setting genesis balances or configuring Event observers.  You can grant an address an initial account balance by adding the following entries:


### PR DESCRIPTION
This minor change explains how to use `stacks-node` to launch a testnet with a custom config.
The current README cmd `cargo testnet start` fails to launch: `error: no such subcommand: 'testnet'`