### PR TITLE
Feat: Add seed -> secret key output commands

### DIFF
--- a/testnet/stacks-node/src/main.rs
+++ b/testnet/stacks-node/src/main.rs
@@ -233,9 +233,9 @@ start\t\tStart a node with a config of your own. Can be used for joining a netwo
 
 version\t\tDisplay information about the current version and our release cycle.
 
-key-for-seed\t\tOutput the associated secret key for a burnchain signer created with a given seed.
-Can be passed a config file for the seed via the `--config=<file>` option *or* by supplying the hex seed on
-the command line directly.
+key-for-seed\tOutput the associated secret key for a burnchain signer created with a given seed.
+\t\tCan be passed a config file for the seed via the `--config=<file>` option *or* by supplying the hex seed on
+\t\tthe command line directly.
 
 help\t\tDisplay this help.
 

--- a/testnet/stacks-node/src/main.rs
+++ b/testnet/stacks-node/src/main.rs
@@ -16,6 +16,7 @@ extern crate stacks;
 extern crate slog;
 
 pub use stacks::util;
+use stacks::util::hash::hex_bytes;
 
 pub mod monitoring;
 
@@ -129,6 +130,32 @@ fn main() {
             println!("{}", &version());
             return;
         }
+        "key-for-seed" => {
+            let seed = {
+                let config_path: Option<String> = args.opt_value_from_str("--config").unwrap();
+                if let Some(config_path) = config_path {
+                    let conf = Config::from_config_file(ConfigFile::from_path(&config_path));
+                    args.finish().unwrap();
+                    conf.node.seed
+                } else {
+                    let free_args = args.free().unwrap();
+                    let seed_hex = free_args
+                        .first()
+                        .expect("`wif-for-seed` must be passed either a config file via the `--config` flag or a hex seed string");
+                    hex_bytes(seed_hex).expect("Seed should be a hex encoded string")
+                }
+            };
+            let keychain = Keychain::default(seed);
+            println!(
+                "Hex formatted secret key: {}",
+                keychain.generate_op_signer().get_sk_as_hex()
+            );
+            println!(
+                "WIF formatted secret key: {}",
+                keychain.generate_op_signer().get_sk_as_wif()
+            );
+            return;
+        }
         _ => {
             print_help();
             return;
@@ -205,6 +232,10 @@ start\t\tStart a node with a config of your own. Can be used for joining a netwo
 \t\t  stacks-node start --config=/path/to/config.toml
 
 version\t\tDisplay information about the current version and our release cycle.
+
+key-for-seed\t\tOutput the associated secret key for a burnchain signer created with a given seed.
+Can be passed a config file for the seed via the `--config=<file>` option *or* by supplying the hex seed on
+the command line directly.
 
 help\t\tDisplay this help.
 

--- a/testnet/stacks-node/src/operations.rs
+++ b/testnet/stacks-node/src/operations.rs
@@ -1,5 +1,5 @@
-use stacks::burnchains::PrivateKey;
 use stacks::util::secp256k1::{MessageSignature, Secp256k1PrivateKey, Secp256k1PublicKey};
+use stacks::{burnchains::PrivateKey, util::hash::hex_bytes};
 
 pub struct BurnchainOpSigner {
     secret_key: Secp256k1PrivateKey,
@@ -11,11 +11,22 @@ pub struct BurnchainOpSigner {
 impl BurnchainOpSigner {
     pub fn new(secret_key: Secp256k1PrivateKey, is_one_off: bool) -> BurnchainOpSigner {
         BurnchainOpSigner {
-            secret_key: secret_key,
+            secret_key,
             usages: 0,
             is_one_off,
             is_disposed: false,
         }
+    }
+
+    pub fn get_sk_as_wif(&self) -> String {
+        let hex_encoded = self.secret_key.to_hex();
+        let mut as_bytes = hex_bytes(&hex_encoded).unwrap();
+        as_bytes.insert(0, 0x80);
+        stacks::address::b58::check_encode_slice(&as_bytes)
+    }
+
+    pub fn get_sk_as_hex(&self) -> String {
+        self.secret_key.to_hex()
     }
 
     pub fn get_public_key(&mut self) -> Secp256k1PublicKey {
@@ -43,5 +54,25 @@ impl BurnchainOpSigner {
 
     pub fn dispose(&mut self) {
         self.is_disposed = true;
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use stacks::util::secp256k1::Secp256k1PrivateKey;
+
+    use super::BurnchainOpSigner;
+
+    #[test]
+    fn test_wif() {
+        let examples = [(
+            "0C28FCA386C7A227600B2FE50B7CAE11EC86D3BF1FBE471BE89827E19D72AA1D",
+            "5HueCGU8rMjxEXxiPuD5BDku4MkFqeZyd4dZ1jvhTVqvbTLvyTJ",
+        )];
+        for (secret_key, expected_wif) in examples.iter() {
+            let secp_k = Secp256k1PrivateKey::from_hex(secret_key).unwrap();
+            let op_signer = BurnchainOpSigner::new(secp_k, false);
+            assert_eq!(expected_wif, &op_signer.get_sk_as_wif());
+        }
     }
 }


### PR DESCRIPTION
This PR adds the `key-for-seed` command to the `stacks-node` binary. It outputs the associated secret key hex string and WIF formatted secret key for a given "seed" value:

The seed value can either be read from a config file, or supplied as a free CLI arg.

```
$ ./target/debug/stacks-node key-for-seed --config=./testnet/stacks-node/conf/local-leader-conf.toml 
INFO [1621344961.200296] [testnet/stacks-node/src/main.rs:81] [main] stacks-node 0.1.0 (develop:5f6c1fd68+, debug build, macos [aarch64])
Hex formatted secret key: 66687aadf862bd776c8fc18b8e9f8e20089714856ee233b3902a591d0d5f2925
WIF formatted secret key: 5JbPTc935MFttEwiXUMnC5EBwmaGH3TZYE22a72J2bQREjxJseN
```

```
$ ./target/debug/stacks-node key-for-seed 0000000000000000000000000000000000000000000000000000000000000000
INFO [1621344995.269964] [testnet/stacks-node/src/main.rs:81] [main] stacks-node 0.1.0 (develop:5f6c1fd68+, debug build, macos [aarch64])
Hex formatted secret key: 66687aadf862bd776c8fc18b8e9f8e20089714856ee233b3902a591d0d5f2925
WIF formatted secret key: 5JbPTc935MFttEwiXUMnC5EBwmaGH3TZYE22a72J2bQREjxJseN
```

This is useful for miners attempting to remediate #2646 -- obtaining the secret key allows someone to import the key into a wallet of their choosing to perform the UTXO consolidation.