### PR TITLE
Fix/2645

### DIFF
--- a/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
+++ b/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
@@ -555,6 +555,7 @@ impl BitcoinRegtestController {
                             vout: parsed_utxo.vout,
                             script_pub_key,
                             amount,
+                            confirmations: parsed_utxo.confirmations,
                         });
                     }
                 }
@@ -1173,9 +1174,10 @@ impl BitcoinRegtestController {
         utxos_set: &mut UTXOSet,
         signer: &mut BurnchainOpSigner,
     ) -> Option<()> {
-        // spend UTXOs in decreasing order
-        utxos_set.utxos.sort_by(|u1, u2| u1.amount.cmp(&u2.amount));
-        utxos_set.utxos.reverse();
+        // spend UTXOs in order by confirmations.  Spend the least-confirmed UTXO first.
+        utxos_set
+            .utxos
+            .sort_by(|u1, u2| u1.confirmations.cmp(&u2.confirmations));
 
         let tx_size = {
             // We will be calling 2 times serialize_tx, the first time with an estimated size,
@@ -1611,12 +1613,13 @@ pub struct ParsedUTXO {
     safe: bool,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct UTXO {
     pub txid: Sha256dHash,
     pub vout: u32,
     pub script_pub_key: Script,
     pub amount: u64,
+    pub confirmations: u32,
 }
 
 impl ParsedUTXO {
@@ -1844,6 +1847,7 @@ impl BitcoinRPCRequest {
                             vout: parsed_utxo.vout,
                             script_pub_key,
                             amount,
+                            confirmations: parsed_utxo.confirmations,
                         });
                     }
                 }

--- a/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
+++ b/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
@@ -3,7 +3,6 @@ use async_std::io::ReadExt;
 use async_std::net::TcpStream;
 use base64::encode;
 use http_types::{Method, Request, Url};
-use std::cmp::Ordering as CmpOrdering;
 use std::io::Cursor;
 use std::sync::{
     atomic::{AtomicBool, Ordering},
@@ -1183,13 +1182,7 @@ impl BitcoinRegtestController {
                 // for block-commits, the smaller value is likely the UTXO-chained value, so
                 // continue to prioritize it as the first spend in order to avoid breaking the
                 // miner commit chain.
-                if u1.amount < u2.amount {
-                    CmpOrdering::Greater
-                } else if u1.amount > u2.amount {
-                    CmpOrdering::Less
-                } else {
-                    CmpOrdering::Equal
-                }
+                u1.amount.cmp(&u2.amount)
             }
         });
 

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -459,6 +459,122 @@ fn bitcoind_integration_test() {
     channel.stop_chains_coordinator();
 }
 
+#[test]
+#[ignore]
+fn most_recent_utxo_integration_test() {
+    if env::var("BITCOIND_TEST") != Ok("1".into()) {
+        return;
+    }
+
+    let (conf, _) = neon_integration_test_conf();
+
+    let mut btcd_controller = BitcoinCoreController::new(conf.clone());
+    btcd_controller
+        .start_bitcoind()
+        .map_err(|_e| ())
+        .expect("Failed starting bitcoind");
+
+    let mut btc_regtest_controller = BitcoinRegtestController::new(conf.clone(), None);
+
+    btc_regtest_controller.bootstrap_chain(201);
+
+    eprintln!("Chain bootstrapped...");
+
+    let mut run_loop = neon::RunLoop::new(conf.clone());
+    let blocks_processed = run_loop.get_blocks_processed_arc();
+
+    let channel = run_loop.get_coordinator_channel().unwrap();
+
+    thread::spawn(move || run_loop.start(None, 0));
+
+    // give the run loop some time to start up!
+    wait_for_runloop(&blocks_processed);
+
+    // first block wakes up the run loop
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+
+    // first block will hold our VRF registration
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+
+    // second block will be the first mined Stacks block
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+
+    let mut miner_signer = Keychain::default(conf.node.seed.clone()).generate_op_signer();
+    let pubkey = miner_signer.get_public_key();
+    let utxos_before = btc_regtest_controller.get_all_utxos(&pubkey);
+
+    let mut last_utxo: Option<UTXO> = None;
+    let mut smallest_utxo: Option<UTXO> = None; // smallest non-dust UTXO
+    let mut biggest_utxo: Option<UTXO> = None;
+    for utxo in utxos_before.iter() {
+        if let Some(last) = last_utxo {
+            if utxo.confirmations < last.confirmations {
+                last_utxo = Some(utxo.clone());
+            } else {
+                last_utxo = Some(last);
+            }
+        } else {
+            last_utxo = Some(utxo.clone());
+        }
+
+        if let Some(smallest) = smallest_utxo {
+            if utxo.amount > 5500 && utxo.amount < smallest.amount {
+                smallest_utxo = Some(utxo.clone());
+            } else {
+                smallest_utxo = Some(smallest);
+            }
+        } else {
+            smallest_utxo = Some(utxo.clone());
+        }
+
+        if let Some(biggest) = biggest_utxo {
+            if utxo.amount > biggest.amount {
+                biggest_utxo = Some(utxo.clone());
+            } else {
+                biggest_utxo = Some(biggest);
+            }
+        } else {
+            biggest_utxo = Some(utxo.clone());
+        }
+    }
+
+    let last_utxo = last_utxo.unwrap();
+    let smallest_utxo = smallest_utxo.unwrap();
+    let mut biggest_utxo = biggest_utxo.unwrap();
+
+    eprintln!("Last-spent UTXO is {:?}", &last_utxo);
+    eprintln!("Smallest UTXO is {:?}", &smallest_utxo);
+    eprintln!("Biggest UTXO is {:?}", &biggest_utxo);
+
+    assert_eq!(last_utxo, smallest_utxo);
+    assert_ne!(biggest_utxo, last_utxo);
+    assert_ne!(biggest_utxo, smallest_utxo);
+
+    // third block will be the second mined Stacks block, and mining it should *not* spend the
+    // biggest UTXO, but should spend the *smallest non-dust* UTXO
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+
+    let utxos_after = btc_regtest_controller.get_all_utxos(&pubkey);
+
+    // last UTXO was spent, which would also have been the smallest.
+    let mut has_biggest = false;
+    for utxo in utxos_after.into_iter() {
+        assert_ne!(utxo, last_utxo);
+        assert_ne!(utxo, smallest_utxo);
+
+        // don't care about confirmations here
+        biggest_utxo.confirmations = utxo.confirmations;
+        if utxo == biggest_utxo {
+            has_biggest = true;
+        }
+    }
+
+    // biggest UTXO is *not* spent
+    assert!(has_biggest);
+
+    channel.stop_chains_coordinator();
+}
+
 fn get_balance<F: std::fmt::Display>(http_origin: &str, account: &F) -> u128 {
     get_account(http_origin, account).balance
 }
@@ -927,6 +1043,7 @@ fn stx_transfer_btc_integration_test() {
         vout: 1,
         script_pub_key: pre_stx_tx.output[1].script_pubkey.clone(),
         amount: pre_stx_tx.output[1].value,
+        confirmations: 0,
     };
 
     // let's fire off our transfer op.


### PR DESCRIPTION
This fixes #2645 by altering the miner to prioritize spending the _most recent_ UTXO when building a transaction, instead of the _largest_ UTXO.  In the event of a tie, it uses the _smallest_ UTXO first.  This way, if you refill your miner, your block-commits will remain chained together -- your new, large UTXO will be consolidated with your outstanding small UTXO in the subsequent block-commit.