### PR TITLE
Feat: added mining-related prometheus stats

### DIFF
--- a/src/chainstate/burn/distribution.rs
+++ b/src/chainstate/burn/distribution.rs
@@ -288,7 +288,7 @@ impl BurnSamplePoint {
                        "all_burns" => %format!("{:?}", all_burns));
 
                 // prometheus: log miner commitment
-                if let Some(signer) = global_burnchain_signer {
+                if let Some(signer) = &global_burnchain_signer {
                     if candidate.apparent_sender == *signer {
                         monitoring::update_computed_miner_commitment(burns);
                         monitoring::update_miner_current_median_commitment(median_burn);
@@ -312,9 +312,9 @@ impl BurnSamplePoint {
             let mut range_total = Uint256::zero();
             let mut signer_seen = false;
             for burn in burn_sample.iter() {
-                if burn.candidate.apparent_sender == *signer {
+                if burn.candidate.apparent_sender == signer {
                     signer_seen = true;
-                    range_total = range_total + burn.range_end - burn.range_start;
+                    range_total = range_total + (burn.range_end - burn.range_start);
                 }
             }
             if signer_seen {

--- a/src/chainstate/burn/operations/leader_block_commit.rs
+++ b/src/chainstate/burn/operations/leader_block_commit.rs
@@ -561,7 +561,7 @@ impl LeaderBlockCommitOp {
                             .collect();
 
                         if check_recipients.len() == 1 {
-                            // If the number of recipients in the set was even, we need to pad
+                            // If the number of recipients in the set was odd, we need to pad
                             // with a burn address
                             check_recipients
                                 .push(StacksAddress::burn_address(burnchain.is_mainnet()))
@@ -598,14 +598,14 @@ impl LeaderBlockCommitOp {
                             error!("Failed to check whether parent (height={}) is descendent of anchor block={}: {}",
                                    parent_block_height, &reward_set_info.anchor_block, e);
                             op_error::BlockCommitAnchorCheck})?;
-                    if descended_from_anchor != expect_pox_descendant {
-                        if descended_from_anchor {
-                            warn!("Invalid block commit: descended from PoX anchor, but used burn outputs");
-                        } else {
-                            warn!(
+                    if descended_from_anchor && !expect_pox_descendant {
+                        warn!("Invalid block commit: descended from PoX anchor, but used burn outputs");
+                        return Err(op_error::BlockCommitBadOutputs);
+                    }
+                    if !descended_from_anchor && expect_pox_descendant {
+                        warn!(
                                 "Invalid block commit: not descended from PoX anchor, but used PoX outputs"
                             );
-                        }
                         return Err(op_error::BlockCommitBadOutputs);
                     }
                 }

--- a/src/chainstate/burn/operations/leader_block_commit.rs
+++ b/src/chainstate/burn/operations/leader_block_commit.rs
@@ -598,14 +598,13 @@ impl LeaderBlockCommitOp {
                             error!("Failed to check whether parent (height={}) is descendent of anchor block={}: {}",
                                    parent_block_height, &reward_set_info.anchor_block, e);
                             op_error::BlockCommitAnchorCheck})?;
-                    if descended_from_anchor && !expect_pox_descendant {
-                        warn!("Invalid block commit: descended from PoX anchor, but used burn outputs");
-                        return Err(op_error::BlockCommitBadOutputs);
-                    }
-                    if !descended_from_anchor && expect_pox_descendant {
-                        warn!(
-                                "Invalid block commit: not descended from PoX anchor, but used PoX outputs"
+                    if descended_from_anchor != expect_pox_descendant {
+                        if descended_from_anchor {
+                            warn!("Invalid block commit: descended from PoX anchor, but used burn outputs");
+                        } else {
+                            warn!("Invalid block commit: not descended from PoX anchor, but used PoX outputs"
                             );
+                        }
                         return Err(op_error::BlockCommitBadOutputs);
                     }
                 }

--- a/src/monitoring/prometheus.rs
+++ b/src/monitoring/prometheus.rs
@@ -14,7 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use prometheus::{Histogram, HistogramTimer, HistogramVec, IntCounter, IntCounterVec, IntGauge};
+use prometheus::{
+    Gauge, Histogram, HistogramTimer, HistogramVec, IntCounter, IntCounterVec, IntGauge,
+};
 
 lazy_static! {
     pub static ref RPC_CALL_COUNTER: IntCounter = register_int_counter!(opts!(
@@ -162,6 +164,31 @@ lazy_static! {
         "Time (seconds) between when a tx was received by this node's mempool and when a tx was first processed in a block",
         vec![300.0, 600.0, 900.0, 1200.0, 1500.0, 1800.0, 2100.0, 2400.0, 2700.0, 3000.0, 3600.0, 4200.0, 4800.0, 6000.0],
         labels! {"handler".to_string() => "all".to_string(),}
+    )).unwrap();
+
+    pub static ref COMPUTED_RELATIVE_MINER_SCORE: Gauge = register_gauge!(opts!(
+        "stacks_node_computed_relative_miner_score",
+        "Percentage of the u256 range that this miner is assigned in a particular round of sortition"
+    )).unwrap();
+
+    pub static ref COMPUTED_MINER_COMMITMENT_HIGH: IntGauge = register_int_gauge!(opts!(
+        "stacks_node_computed_miner_commitment_high",
+        "High 64 bits of a miner's effective commitment (min of the miner's previous commitment and their median commitment)"
+    )).unwrap();
+
+     pub static ref COMPUTED_MINER_COMMITMENT_LOW: IntGauge = register_int_gauge!(opts!(
+        "stacks_node_computed_miner_commitment_low",
+        "Low 64 bits of a miner's effective commitment (min of the miner's previous commitment and their median commitment)"
+    )).unwrap();
+
+    pub static ref MINER_CURRENT_MEDIAN_COMMITMENT_HIGH: IntGauge = register_int_gauge!(opts!(
+        "stacks_node_miner_current_median_commitment_high",
+        "High 64 bits of a miner's median commitment over the mining commitment window."
+    )).unwrap();
+
+    pub static ref MINER_CURRENT_MEDIAN_COMMITMENT_LOW: IntGauge = register_int_gauge!(opts!(
+        "stacks_node_miner_current_median_commitment_low",
+        "Low 64 bits of a miner's median commitment over the mining commitment window."
     )).unwrap();
 }
 

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -1233,7 +1233,12 @@ impl InitializedNeonNode {
         let (relay_send, relay_recv) = sync_channel(RELAYER_MAX_BUFFER);
 
         let burnchain_signer = keychain.get_burnchain_signer();
-        monitoring::set_burnchain_signer(burnchain_signer.clone());
+        match monitoring::set_burnchain_signer(burnchain_signer.clone()) {
+            Err(e) => {
+                warn!("Failed to set global burnchain signer: {:?}", &e);
+            }
+            _ => {}
+        }
 
         let relayer = Relayer::from_p2p(&mut p2p_net);
         let shared_unconfirmed_txs = Arc::new(Mutex::new(UnconfirmedTxMap::new()));

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -64,6 +64,7 @@ use crate::syncctl::PoxSyncWatchdogComms;
 use crate::ChainTip;
 
 use super::{BurnchainController, BurnchainTip, Config, EventDispatcher, Keychain};
+use stacks::monitoring;
 
 pub const RELAYER_MAX_BUFFER: usize = 100;
 
@@ -1232,6 +1233,8 @@ impl InitializedNeonNode {
         let (relay_send, relay_recv) = sync_channel(RELAYER_MAX_BUFFER);
 
         let burnchain_signer = keychain.get_burnchain_signer();
+        monitoring::set_burnchain_signer(burnchain_signer.clone());
+
         let relayer = Relayer::from_p2p(&mut p2p_net);
         let shared_unconfirmed_txs = Arc::new(Mutex::new(UnconfirmedTxMap::new()));
 

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -469,7 +469,6 @@ fn bitcoind_integration_test() {
             .unwrap()
             .text()
             .unwrap();
-        info!("result is: {:?}", res);
         assert!(res.contains("stacks_node_computed_miner_commitment_high 0"));
         assert!(res.contains("stacks_node_computed_miner_commitment_low 1"));
         assert!(res.contains("stacks_node_computed_relative_miner_score 100"));

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -414,7 +414,9 @@ fn bitcoind_integration_test() {
         return;
     }
 
-    let (conf, miner_account) = neon_integration_test_conf();
+    let (mut conf, miner_account) = neon_integration_test_conf();
+    let prom_bind = format!("{}:{}", "127.0.0.1", 6000);
+    conf.node.prometheus_bind = Some(prom_bind.clone());
 
     let mut btcd_controller = BitcoinCoreController::new(conf.clone());
     btcd_controller
@@ -455,6 +457,26 @@ fn bitcoind_integration_test() {
     let account = get_account(&http_origin, &miner_account);
     assert_eq!(account.balance, 0);
     assert_eq!(account.nonce, 1);
+
+    // query for prometheus metrics
+    #[cfg(feature = "monitoring_prom")]
+    {
+        let prom_http_origin = format!("http://{}", prom_bind);
+        let client = reqwest::blocking::Client::new();
+        let res = client
+            .get(&prom_http_origin)
+            .send()
+            .unwrap()
+            .text()
+            .unwrap();
+        info!("result is: {:?}", res);
+        assert!(res.contains("stacks_node_computed_miner_commitment_high 0"));
+        assert!(res.contains("stacks_node_computed_miner_commitment_low 1"));
+        assert!(res.contains("stacks_node_computed_relative_miner_score 100"));
+        assert!(res.contains("stacks_node_miner_current_median_commitment_high 0"));
+        assert!(res.contains("stacks_node_miner_current_median_commitment_low 1"));
+        assert!(res.contains("stacks_node_active_miners_total 1"));
+    }
 
     channel.stop_chains_coordinator();
 }


### PR DESCRIPTION
## Description

Fixes #2651 

Added the following metrics in prometheus: 
- Miner's computed relative miner score as a percentage (Gauge)
- Miner's computed commitment, the min of their previous commitment and their median commitment
- Miner's current median commitment

The latter two metrics are u128 values. Prometheus's IntGauge only captures 64 bit values, so I used two IntGauges for both of the metrics (one for the high 64 bits, and another for the low 64 bits). 

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Testing information
Ran `BITCOIND_TEST=1 cargo test --release --features monitoring_prom -- --test-threads 1 --ignored neon_integrations::bitcoind_integration_test` in the `testnet/stacks-node` directory.  Pinged the prometheus endpoint and got the value of all tracked metrics, which I then checked against expected value.
> Note: When running an integration test with a specific feature enabled, running the command above in the root directory of the repo doesn't work. If anyone understands why this is, let me know! 


Ran `cargo test`. 
