### PR TITLE
docs: remove redundant $ from terminal commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,13 +315,13 @@ properly formatted.
 You can check the formatting locally via:
 
 ```bash
-$ cargo fmt --all -- --check
+cargo fmt --all -- --check
 ```
 
 You can automatically reformat your commit via:
 
 ```bash
-$ cargo fmt --all
+cargo fmt --all
 ```
 
 ## Copyright and License


### PR DESCRIPTION
Removing the unnecessary $ from terminal commands.

Referring to : https://github.com/blockstack/docs/issues/1190 
