### PR TITLE
[clean-up] Fix build warnings in 'cargo build'

### DIFF
--- a/src/chainstate/coordinator/comm.rs
+++ b/src/chainstate/coordinator/comm.rs
@@ -167,7 +167,7 @@ impl CoordinatorChannels {
                 return false;
             }
             thread::sleep(Duration::from_millis(100));
-            std::sync::atomic::spin_loop_hint();
+            std::hint::spin_loop();
         }
         return true;
     }
@@ -179,7 +179,7 @@ impl CoordinatorChannels {
                 return false;
             }
             thread::sleep(Duration::from_millis(100));
-            std::sync::atomic::spin_loop_hint();
+            std::hint::spin_loop();
         }
         return true;
     }

--- a/src/net/download.rs
+++ b/src/net/download.rs
@@ -2254,7 +2254,8 @@ impl PeerNetwork {
                 for (height, requests) in downloader.blocks_to_try.iter() {
                     assert!(
                         requests.len() > 0,
-                        format!("Empty block requests at height {}", height)
+                        "Empty block requests at height {}",
+                        height
                     );
                     debug!(
                         "   Height {}: anchored block {} available from {} peers: {:?}",
@@ -2270,7 +2271,8 @@ impl PeerNetwork {
                 for (height, requests) in downloader.microblocks_to_try.iter() {
                     assert!(
                         requests.len() > 0,
-                        format!("Empty microblock requests at height {}", height)
+                        "Empty microblock requests at height {}",
+                        height
                     );
                     debug!(
                         "   Height {}: microblocks {} available from {} peers: {:?}",

--- a/src/net/poll.rs
+++ b/src/net/poll.rs
@@ -211,12 +211,10 @@ impl NetworkState {
 
         assert!(
             self.event_map.len() <= self.event_capacity + self.servers.len(),
-            format!(
-                "BUG: event map exceeded event capacity ({} > {} + {})",
-                self.event_map.len(),
-                self.event_capacity,
-                self.servers.len()
-            )
+            "BUG: event map exceeded event capacity ({} > {} + {})",
+            self.event_map.len(),
+            self.event_capacity,
+            self.servers.len()
         );
 
         self.poll

--- a/src/vm/database/sqlite.rs
+++ b/src/vm/database/sqlite.rs
@@ -44,7 +44,7 @@ fn sqlite_put(conn: &Connection, key: &str, value: &str) {
         Ok(_) => {}
         Err(e) => {
             error!("Failed to insert/replace ({},{}): {:?}", key, value, &e);
-            panic!(SQL_FAIL_MESSAGE);
+            panic!("{}", SQL_FAIL_MESSAGE);
         }
     };
 }
@@ -63,7 +63,7 @@ fn sqlite_get(conn: &Connection, key: &str) -> Option<String> {
         Ok(x) => x,
         Err(e) => {
             error!("Failed to query '{}': {:?}", key, &e);
-            panic!(SQL_FAIL_MESSAGE);
+            panic!("{}", SQL_FAIL_MESSAGE);
         }
     };
 
@@ -105,7 +105,7 @@ impl SqliteConnection {
                 &value.to_string(),
                 &e
             );
-            panic!(SQL_FAIL_MESSAGE);
+            panic!("{}", SQL_FAIL_MESSAGE);
         }
     }
 
@@ -116,14 +116,14 @@ impl SqliteConnection {
             &params,
         ) {
             error!("Failed to update {} to {}: {:?}", &from, &to, &e);
-            panic!(SQL_FAIL_MESSAGE);
+            panic!("{}", SQL_FAIL_MESSAGE);
         }
     }
 
     pub fn drop_metadata(conn: &Connection, from: &StacksBlockId) {
         if let Err(e) = conn.execute("DELETE FROM metadata_table WHERE blockhash = ?", &[from]) {
             error!("Failed to drop metadata from {}: {:?}", &from, &e);
-            panic!(SQL_FAIL_MESSAGE);
+            panic!("{}", SQL_FAIL_MESSAGE);
         }
     }
 
@@ -147,7 +147,7 @@ impl SqliteConnection {
             Ok(x) => x,
             Err(e) => {
                 error!("Failed to query ({},{}): {:?}", &bhh, &key, &e);
-                panic!(SQL_FAIL_MESSAGE);
+                panic!("{}", SQL_FAIL_MESSAGE);
             }
         }
     }


### PR DESCRIPTION
Fixes 2698

## The Change
This PR fixes 12 build warnings in the rust code that we get when we run 'cargo build'. This greatly simplifies the output.

## Testing
After this change the build compiles without warnings.

