### PR TITLE
Chore: remove tini dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,7 +263,6 @@ dependencies = [
  "slog-term",
  "stx-genesis",
  "time 0.2.23",
- "tini",
  "url",
 ]
 
@@ -2445,12 +2444,6 @@ dependencies = [
  "standback",
  "syn",
 ]
-
-[[package]]
-name = "tini"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11eeaa68267376df2aacbaaed9b0092544ebbc897cd59f61e81a1105fbaf102e"
 
 [[package]]
 name = "tinyvec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,6 @@ name = "block_limits"
 harness = false
 
 [dependencies]
-tini = "0.2"
 rand = "=0.7.2"
 rand_chacha = "=0.2.2"
 serde = "1"

--- a/src/burnchains/bitcoin/indexer.rs
+++ b/src/burnchains/bitcoin/indexer.rs
@@ -25,8 +25,6 @@ use std::path::PathBuf;
 use std::time;
 use std::time::Duration;
 
-use tini::Ini;
-
 use burnchains::bitcoin::blocks::BitcoinHeaderIPC;
 use burnchains::bitcoin::messages::BitcoinMessageHandler;
 use burnchains::bitcoin::spv::*;
@@ -137,165 +135,6 @@ impl BitcoinIndexerConfig {
             magic_bytes: BLOCKSTACK_MAGIC_MAINNET.clone(),
         }
     }
-
-    pub fn to_file(&self, path: &String) -> Result<(), btc_error> {
-        let username = self.username.clone().unwrap_or("".to_string());
-        let password = self.password.clone().unwrap_or("".to_string());
-
-        let conf = Ini::new()
-            .section("bitcoin")
-            .item("server", self.peer_host.as_str())
-            .item("p2p_port", format!("{}", self.peer_port).as_str())
-            .item("rpc_port", format!("{}", self.rpc_port).as_str())
-            .item("rpc_ssl", format!("{}", self.rpc_ssl).as_str())
-            .item("username", username.as_str())
-            .item("password", password.as_str())
-            .item("timeout", format!("{}", self.timeout).as_str())
-            .item("spv_path", self.spv_headers_path.as_str())
-            .item("first_block", format!("{}", self.first_block).as_str())
-            .section("blockstack")
-            .item(
-                "network_id",
-                format!(
-                    "{}{}",
-                    self.magic_bytes.as_bytes()[0] as char,
-                    self.magic_bytes.as_bytes()[1] as char
-                )
-                .as_str(),
-            );
-
-        conf.to_file(&path).map_err(|e| btc_error::Io(e))
-    }
-
-    pub fn from_file(path: &String) -> Result<BitcoinIndexerConfig, btc_error> {
-        let conf_path = PathBuf::from(path);
-        if !conf_path.is_file() {
-            return Err(btc_error::ConfigError(
-                "Failed to load BitcoinIndexerConfig file: No such file or directory".to_string(),
-            ));
-        }
-
-        let default_config = BitcoinIndexerConfig::default(0);
-
-        match Ini::from_file(path) {
-            Ok(ini_file) => {
-                // [bitcoin]
-                let peer_host = ini_file
-                    .get("bitcoin", "server")
-                    .unwrap_or(default_config.peer_host);
-
-                let peer_port = ini_file
-                    .get("bitcoin", "p2p_port")
-                    .unwrap_or(format!("{}", default_config.peer_port))
-                    .trim()
-                    .parse()
-                    .map_err(|_e| {
-                        btc_error::ConfigError("Invalid bitcoin:p2p_port value".to_string())
-                    })?;
-
-                if peer_port <= 1024 || peer_port == 65535 {
-                    return Err(btc_error::ConfigError("Invalid p2p_port".to_string()));
-                }
-
-                let rpc_port = ini_file
-                    .get("bitcoin", "rpc_port")
-                    .unwrap_or(format!("{}", default_config.rpc_port))
-                    .trim()
-                    .parse()
-                    .map_err(|_e| {
-                        btc_error::ConfigError("Invalid bitcoin:port value".to_string())
-                    })?;
-
-                if rpc_port <= 1024 || rpc_port == 65535 {
-                    return Err(btc_error::ConfigError("Invalid rpc_port".to_string()));
-                }
-
-                let username: Option<String> =
-                    ini_file.get("bitcoin", "username").and_then(|s| Some(s));
-                let password: Option<String> =
-                    ini_file.get("bitcoin", "password").and_then(|s| Some(s));
-
-                let timeout = ini_file
-                    .get("bitcoin", "timeout")
-                    .unwrap_or(format!("{}", default_config.timeout))
-                    .trim()
-                    .parse()
-                    .map_err(|_e| {
-                        btc_error::ConfigError("Invalid bitcoin:timeout value".to_string())
-                    })?;
-
-                let spv_headers_path_cfg = ini_file
-                    .get("bitcoin", "spv_path")
-                    .unwrap_or(default_config.spv_headers_path);
-
-                let spv_headers_path =
-                    if path::is_separator(spv_headers_path_cfg.chars().next().ok_or(
-                        btc_error::ConfigError("Invalid bitcoin:spv_path value".to_string()),
-                    )?) {
-                        // absolute
-                        spv_headers_path_cfg
-                    } else {
-                        // relative to config file
-                        let mut p = PathBuf::from(path);
-                        p.pop();
-                        let s = p.join(&spv_headers_path_cfg);
-                        s.to_str().unwrap().to_string()
-                    };
-
-                let first_block = ini_file
-                    .get("bitcoin", "first_block")
-                    .unwrap_or(format!("{}", 0))
-                    .trim()
-                    .parse()
-                    .map_err(|_e| {
-                        btc_error::ConfigError("Invalid bitcoin:first_block value".to_string())
-                    })?;
-
-                let rpc_ssl_str = ini_file
-                    .get("bitcoin", "ssl")
-                    .unwrap_or(format!("{}", default_config.rpc_ssl));
-
-                let rpc_ssl = rpc_ssl_str == "1" || rpc_ssl_str == "true";
-
-                // [blockstack]
-                let blockstack_magic_str =
-                    ini_file.get("blockstack", "network_id").unwrap_or(format!(
-                        "{}{}",
-                        BLOCKSTACK_MAGIC_MAINNET.as_bytes()[0] as char,
-                        BLOCKSTACK_MAGIC_MAINNET.as_bytes()[1] as char
-                    ));
-
-                if blockstack_magic_str.len() != 2 {
-                    return Err(btc_error::ConfigError(
-                        "Invalid blockstack:network_id value: must be two bytes".to_string(),
-                    ));
-                }
-
-                let blockstack_magic = MagicBytes([
-                    blockstack_magic_str.as_bytes()[0] as u8,
-                    blockstack_magic_str.as_bytes()[1] as u8,
-                ]);
-
-                let cfg = BitcoinIndexerConfig {
-                    peer_host: peer_host,
-                    peer_port: peer_port,
-                    rpc_port: rpc_port,
-                    rpc_ssl: rpc_ssl,
-                    username: username,
-                    password: password,
-                    timeout: timeout,
-                    spv_headers_path: spv_headers_path,
-                    first_block: first_block,
-                    magic_bytes: blockstack_magic,
-                };
-
-                Ok(cfg)
-            }
-            Err(_) => Err(btc_error::ConfigError(
-                "Failed to parse BitcoinConfigIndexer config file".to_string(),
-            )),
-        }
-    }
 }
 
 impl BitcoinIndexerRuntime {
@@ -321,18 +160,6 @@ impl BitcoinIndexer {
             config: config,
             runtime: runtime,
         }
-    }
-
-    pub fn from_file(
-        network_id: BitcoinNetworkType,
-        config_file: &String,
-    ) -> Result<BitcoinIndexer, btc_error> {
-        let config = BitcoinIndexerConfig::from_file(config_file)?;
-        let runtime = BitcoinIndexerRuntime::new(network_id);
-        Ok(BitcoinIndexer {
-            config: config,
-            runtime: runtime,
-        })
     }
 
     pub fn dup(&self) -> BitcoinIndexer {
@@ -769,57 +596,6 @@ impl Drop for BitcoinIndexer {
 
 impl BurnchainIndexer for BitcoinIndexer {
     type P = BitcoinBlockParser;
-
-    /// Instantiate the Bitcoin indexer, and connect to the peer network.
-    /// Instead, load our configuration state and sanity-check it.
-    ///
-    /// Pass a directory (working_dir) that contains a "bitcoin.ini" file.
-    fn init(
-        working_dir: &String,
-        network_name: &String,
-        first_block_height: u64,
-    ) -> Result<BitcoinIndexer, burnchain_error> {
-        let conf_path_str =
-            Burnchain::get_chainstate_config_path(working_dir, &"bitcoin".to_string());
-
-        let network_id_opt = match network_name.as_ref() {
-            BITCOIN_MAINNET_NAME => Some(BitcoinNetworkType::Mainnet),
-            BITCOIN_TESTNET_NAME => Some(BitcoinNetworkType::Testnet),
-            BITCOIN_REGTEST_NAME => Some(BitcoinNetworkType::Regtest),
-            _ => None,
-        };
-
-        if network_id_opt.is_none() {
-            return Err(burnchain_error::Bitcoin(btc_error::ConfigError(format!(
-                "Unrecognized network name '{}'",
-                network_name
-            ))));
-        }
-        let bitcoin_network_id = network_id_opt.unwrap();
-
-        if !PathBuf::from(&conf_path_str).exists() {
-            let default_config = BitcoinIndexerConfig::default(first_block_height);
-            default_config
-                .to_file(&conf_path_str)
-                .map_err(burnchain_error::Bitcoin)?;
-        }
-
-        let mut indexer = BitcoinIndexer::from_file(bitcoin_network_id, &conf_path_str)
-            .map_err(burnchain_error::Bitcoin)?;
-
-        SpvClient::new(
-            &indexer.config.spv_headers_path,
-            0,
-            None,
-            indexer.runtime.network_id,
-            true,
-            false,
-        )
-        .map_err(burnchain_error::Bitcoin)?;
-
-        indexer.connect()?;
-        Ok(indexer)
-    }
 
     /// Connect to the Bitcoin peer network.
     /// Use the peer host and peer port given in the config file,

--- a/src/burnchains/burnchain.rs
+++ b/src/burnchains/burnchain.rs
@@ -577,17 +577,6 @@ impl Burnchain {
         Ok(())
     }
 
-    pub fn make_indexer<I: BurnchainIndexer>(&self) -> Result<I, burnchain_error> {
-        Burnchain::setup_chainstate_dirs(&self.working_dir)?;
-
-        let indexer: I = BurnchainIndexer::init(
-            &self.working_dir,
-            &self.network_name,
-            self.first_block_height,
-        )?;
-        Ok(indexer)
-    }
-
     fn setup_chainstate<I: BurnchainIndexer>(
         &self,
         indexer: &mut I,
@@ -629,15 +618,13 @@ impl Burnchain {
         db_path
     }
 
-    pub fn connect_db<I: BurnchainIndexer>(
+    pub fn connect_db(
         &self,
-        indexer: &I,
         readwrite: bool,
+        first_block_header_hash: BurnchainHeaderHash,
+        first_block_header_timestamp: u64,
     ) -> Result<(SortitionDB, BurnchainDB), burnchain_error> {
         Burnchain::setup_chainstate_dirs(&self.working_dir)?;
-
-        let first_block_header_hash = indexer.get_first_block_header_hash()?;
-        let first_block_header_timestamp = indexer.get_first_block_header_timestamp()?;
 
         let db_path = self.get_db_path();
         let burnchain_db_path = self.get_burnchaindb_path();
@@ -941,25 +928,6 @@ impl Burnchain {
         }
     }
 
-    /// Top-level burnchain sync.
-    /// Returns new latest block height.
-    pub fn sync<I: BurnchainIndexer + 'static>(
-        &mut self,
-        comms: &CoordinatorChannels,
-        target_block_height_opt: Option<u64>,
-        max_blocks_opt: Option<u64>,
-    ) -> Result<u64, burnchain_error> {
-        let mut indexer: I = self.make_indexer()?;
-        let chain_tip = self.sync_with_indexer(
-            &mut indexer,
-            comms.clone(),
-            target_block_height_opt,
-            max_blocks_opt,
-            None,
-        )?;
-        Ok(chain_tip.block_height)
-    }
-
     /// Deprecated top-level burnchain sync.
     /// Returns (snapshot of new burnchain tip, last state-transition processed if any)
     /// If this method returns Err(burnchain_error::TrySyncAgain), then call this method again.
@@ -968,7 +936,11 @@ impl Burnchain {
         indexer: &mut I,
     ) -> Result<(BlockSnapshot, Option<BurnchainStateTransition>), burnchain_error> {
         self.setup_chainstate(indexer)?;
-        let (mut sortdb, mut burnchain_db) = self.connect_db(indexer, true)?;
+        let (mut sortdb, mut burnchain_db) = self.connect_db(
+            true,
+            indexer.get_first_block_header_hash()?,
+            indexer.get_first_block_header_timestamp()?,
+        )?;
         let burn_chain_tip = burnchain_db.get_canonical_chain_tip().map_err(|e| {
             error!("Failed to query burn chain tip from burn DB: {}", e);
             e
@@ -1185,7 +1157,11 @@ impl Burnchain {
         I: BurnchainIndexer + 'static,
     {
         self.setup_chainstate(indexer)?;
-        let (_, mut burnchain_db) = self.connect_db(indexer, true)?;
+        let (_, mut burnchain_db) = self.connect_db(
+            true,
+            indexer.get_first_block_header_hash()?,
+            indexer.get_first_block_header_timestamp()?,
+        )?;
         let burn_chain_tip = burnchain_db.get_canonical_chain_tip().map_err(|e| {
             error!("Failed to query burn chain tip from burn DB: {}", e);
             e

--- a/src/burnchains/indexer.rs
+++ b/src/burnchains/indexer.rs
@@ -57,13 +57,6 @@ pub trait BurnchainBlockParser {
 pub trait BurnchainIndexer {
     type P: BurnchainBlockParser + Send + Sync;
 
-    fn init(
-        working_dir: &String,
-        network_name: &String,
-        first_block_height: u64,
-    ) -> Result<Self, burnchain_error>
-    where
-        Self: Sized;
     fn connect(&mut self) -> Result<(), burnchain_error>;
 
     fn get_first_block_height(&self) -> u64;

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -145,32 +145,3 @@ pub fn check_fault_injection(fault_name: &str) -> bool {
 
     env::var(fault_name) == Ok("1".to_string())
 }
-
-/// Synchronize burn transactions from the Bitcoin blockchain
-pub fn sync_burnchain_bitcoin(
-    working_dir: &String,
-    network_name: &String,
-) -> Result<u64, burnchain_error> {
-    use burnchains::bitcoin::indexer::BitcoinIndexer;
-    let channels = CoordinatorCommunication::instantiate();
-
-    let mut burnchain =
-        Burnchain::new(working_dir, &"bitcoin".to_string(), network_name).map_err(|e| {
-            error!(
-                "Failed to instantiate burn chain driver for {}: {:?}",
-                network_name, e
-            );
-            e
-        })?;
-
-    let new_height_res = burnchain.sync::<BitcoinIndexer>(&channels.1, None, None);
-    let new_height = new_height_res.map_err(|e| {
-        error!(
-            "Failed to synchronize Bitcoin chain state for {} in {}",
-            network_name, working_dir
-        );
-        e
-    })?;
-
-    Ok(new_height)
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,6 @@ extern crate rand_chacha;
 extern crate rusqlite;
 extern crate secp256k1;
 extern crate serde;
-extern crate tini;
 #[macro_use]
 extern crate lazy_static;
 extern crate integer_sqrt;

--- a/src/main.rs
+++ b/src/main.rs
@@ -755,8 +755,13 @@ simulating a miner.
         let burnchain = Burnchain::regtest(&burnchain_db_path);
         let first_burnchain_block_height = burnchain.first_block_height;
         let first_burnchain_block_hash = burnchain.first_block_hash;
-        let indexer: BitcoinIndexer = burnchain.make_indexer().unwrap();
-        let (mut new_sortition_db, _) = burnchain.connect_db(&indexer, true).unwrap();
+        let (mut new_sortition_db, _) = burnchain
+            .connect_db(
+                true,
+                first_burnchain_block_hash,
+                BITCOIN_REGTEST_FIRST_BLOCK_TIMESTAMP.into(),
+            )
+            .unwrap();
 
         let old_burnchaindb = BurnchainDB::connect(
             &old_burnchaindb_path,
@@ -839,7 +844,13 @@ simulating a miner.
         let mut known_stacks_blocks = HashSet::new();
         let mut next_arrival = 0;
 
-        let (p2p_new_sortition_db, _) = burnchain.connect_db(&indexer, true).unwrap();
+        let (p2p_new_sortition_db, _) = burnchain
+            .connect_db(
+                true,
+                first_burnchain_block_hash,
+                BITCOIN_REGTEST_FIRST_BLOCK_TIMESTAMP.into(),
+            )
+            .unwrap();
         let (mut p2p_chainstate, _) = StacksChainState::open_with_block_limit(
             false,
             0x80000000,


### PR DESCRIPTION
This removes the `tini` dependency.

The only codepath that actually used the tini reader was a CLI command for replaying chainstate (this CLI command may already have been defunct), but that codepath only needed the tini reader for determining the first burn block hash and first burn timestamp, both of which were otherwise available.