### PR TITLE
fix: logic bug in mocknet/helium miner #2710

### DIFF
--- a/testnet/stacks-node/src/node.rs
+++ b/testnet/stacks-node/src/node.rs
@@ -919,14 +919,7 @@ impl Node {
         burnchain_tip: &BurnchainTip,
         vrf_seed: VRFSeed,
     ) -> BlockstackOperationType {
-        let winning_tx_vtindex = match (
-            burnchain_tip.get_winning_tx_index(),
-            burnchain_tip.block_snapshot.total_burn,
-        ) {
-            (Some(winning_tx_id), _) => winning_tx_id,
-            (None, 0) => 0,
-            _ => unreachable!(),
-        };
+        let winning_tx_vtindex = burnchain_tip.get_winning_tx_index().unwrap_or(0);
 
         let (parent_block_ptr, parent_vtxindex) = match self.bootstraping_chain {
             true => (0, 0), // parent_block_ptr and parent_vtxindex should both be 0 on block #1

--- a/testnet/stacks-node/src/run_loop/neon.rs
+++ b/testnet/stacks-node/src/run_loop/neon.rs
@@ -14,9 +14,8 @@ use stacks::chainstate::coordinator::comm::{CoordinatorChannels, CoordinatorRece
 use stacks::chainstate::coordinator::{
     BlockEventDispatcher, ChainsCoordinator, CoordinatorCommunication,
 };
-use stacks::chainstate::stacks::db::{ChainStateBootData, ClarityTx, StacksChainState};
+use stacks::chainstate::stacks::db::{ChainStateBootData, StacksChainState};
 use stacks::net::atlas::{AtlasConfig, Attachment};
-use stacks::vm::types::{PrincipalData, Value};
 use stx_genesis::GenesisData;
 
 use crate::monitoring::start_serving_monitoring_metrics;
@@ -24,7 +23,7 @@ use crate::node::use_test_genesis_chainstate;
 use crate::syncctl::PoxSyncWatchdog;
 use crate::{
     node::{get_account_balances, get_account_lockups, get_names, get_namespaces},
-    util, BitcoinRegtestController, BurnchainController, Config, EventDispatcher, Keychain,
+    BitcoinRegtestController, BurnchainController, Config, EventDispatcher, Keychain,
     NeonGenesisNode,
 };
 


### PR DESCRIPTION
This fixes #2710 -- the mocknet/helium miner had a logic bug that would lead to a panic if a burn block occurred without a sortition in it. 