### PR TITLE
docs: added text on the return value of var-set

### DIFF
--- a/src/vm/docs/mod.rs
+++ b/src/vm/docs/mod.rs
@@ -454,7 +454,7 @@ const SET_VAR_API: SpecialAPI = SpecialAPI {
     output_type: "bool",
     signature: "(var-set var-name expr1)",
     description: "The `var-set` function sets the value associated with the input variable to the
-inputted value.",
+inputted value. The function always returns `true`.",
     example: "
 (define-data-var cursor int 6)
 (var-get cursor) ;; Returns 6


### PR DESCRIPTION
## Description

This PR adds text about the return value of the `var-set` Clarity function. This clarification came from discussion that I had with @reedrosenbluth regarding the usage of `asserts!` with the `var-set` function, where we discovered that it was not possible for `var-set` to return any other value than `true`.

## Type of Change

- [ ] New feature
- [ ] Bug fix
- [x] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?

No

## Are documentation updates required?

No

## Testing information

No tests are required for this PR.

## Checklist
- [x] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [x] Changelog is updated
- [x] Tag 1 of @person1 or @person2
