### PR TITLE
Clarity 2: Add `Unimplemented` cost variant

### DIFF
--- a/src/vm/costs/cost_functions.rs
+++ b/src/vm/costs/cost_functions.rs
@@ -130,4 +130,5 @@ define_named_enum!(ClarityCostFunction {
     NftOwner("cost_nft_owner"),
     NftBurn("cost_nft_burn"),
     PoisonMicroblock("poison_microblock"),
+    Unimplemented("cost_unimplemented"),
 });

--- a/src/vm/costs/mod.rs
+++ b/src/vm/costs/mod.rs
@@ -506,6 +506,12 @@ fn load_cost_functions(
         if target_contract == boot_code_id("costs", mainnet) {
             // refering to one of the boot code cost functions
             let target = match ClarityCostFunction::lookup_by_name(&target_function) {
+                Some(ClarityCostFunction::Unimplemented) => {
+                    warn!("Attempted vote on unimplemented cost function";
+                              "confirmed_proposal_id" => confirmed_proposal,
+                              "cost_function" => %target_function);
+                    continue;
+                }
                 Some(cost_func) => cost_func,
                 None => {
                     warn!("Confirmed cost proposal invalid: function-name does not reference a Clarity cost function";
@@ -839,6 +845,11 @@ impl CostTracker for LimitedCostTracker {
         if self.free {
             return Ok(ExecutionCost::zero());
         }
+        if cost_function == ClarityCostFunction::Unimplemented {
+            info!("Used unimplemented cost function");
+            return Ok(ExecutionCost::zero());
+        }
+
         let cost_function_ref = self
             .cost_function_references
             .get(&cost_function)

--- a/src/vm/functions/assets.rs
+++ b/src/vm/functions/assets.rs
@@ -186,8 +186,7 @@ pub fn special_stx_account(
 ) -> Result<Value> {
     check_argument_count(1, args)?;
 
-    // TODO: Clarity2 Costs
-    runtime_cost(ClarityCostFunction::StxBalance, env, 0)?;
+    runtime_cost(ClarityCostFunction::Unimplemented, env, 0)?;
 
     let owner = eval(&args[0], env, context)?;
     let principal = if let Value::Principal(p) = owner {

--- a/src/vm/functions/mod.rs
+++ b/src/vm/functions/mod.rs
@@ -262,26 +262,22 @@ pub fn lookup_reserved_functions(name: &str, version: &ClarityVersion) -> Option
             BuffToIntLe => NativeFunction(
                 "native_buff_to_int_le",
                 NativeHandle::SingleArg(&conversions::native_buff_to_int_le),
-                // TODO: Create a dedicated cost function for this case.
-                ClarityCostFunction::Mul,
+                ClarityCostFunction::Unimplemented,
             ),
             BuffToUIntLe => NativeFunction(
                 "native_buff_to_uint_le",
                 NativeHandle::SingleArg(&conversions::native_buff_to_uint_le),
-                // TODO: Create a dedicated cost function for this case.
-                ClarityCostFunction::Mul,
+                ClarityCostFunction::Unimplemented,
             ),
             BuffToIntBe => NativeFunction(
                 "native_buff_to_int_be",
                 NativeHandle::SingleArg(&conversions::native_buff_to_int_be),
-                // TODO: Create a dedicated cost function for this case.
-                ClarityCostFunction::Mul,
+                ClarityCostFunction::Unimplemented,
             ),
             BuffToUIntBe => NativeFunction(
                 "native_buff_to_uint_be",
                 NativeHandle::SingleArg(&conversions::native_buff_to_uint_be),
-                // TODO: Create a dedicated cost function for this case.
-                ClarityCostFunction::Mul,
+                ClarityCostFunction::Unimplemented,
             ),
             Fold => SpecialFunction("special_fold", &sequences::special_fold),
             Concat => SpecialFunction("special_concat", &sequences::special_concat),


### PR DESCRIPTION
This PR adds an `Unimplemented` cost variant to the Clarity CostFunctions, which is useful while #2717 is still open.