### PR TITLE
Chore: BufferLength code quality

### DIFF
--- a/src/burnchains/mod.rs
+++ b/src/burnchains/mod.rs
@@ -167,7 +167,7 @@ pub trait PrivateKey: Clone + fmt::Debug + serde::Serialize + serde::de::Deseria
 
 pub trait Address: Clone + fmt::Debug + fmt::Display {
     fn to_bytes(&self) -> Vec<u8>;
-    fn from_string(&str) -> Option<Self>
+    fn from_string(from: &str) -> Option<Self>
     where
         Self: Sized;
     fn is_burn(&self) -> bool;

--- a/src/types/proof.rs
+++ b/src/types/proof.rs
@@ -20,7 +20,7 @@ pub trait ClarityMarfTrieId:
 {
     fn as_bytes(&self) -> &[u8];
     fn to_bytes(self) -> [u8; 32];
-    fn from_bytes([u8; 32]) -> Self;
+    fn from_bytes(from: [u8; 32]) -> Self;
     fn sentinel() -> Self;
 }
 

--- a/src/vm/analysis/type_checker/natives/mod.rs
+++ b/src/vm/analysis/type_checker/natives/mod.rs
@@ -482,7 +482,7 @@ fn check_secp256k1_recover(
     check_argument_count(2, args)?;
     checker.type_check_expects(&args[0], context, &BUFF_32)?;
     checker.type_check_expects(&args[1], context, &BUFF_65)?;
-    Ok(TypeSignature::new_response(BUFF_33, TypeSignature::UIntType).unwrap())
+    Ok(TypeSignature::new_response(BUFF_33.clone(), TypeSignature::UIntType).unwrap())
 }
 
 fn check_secp256k1_verify(

--- a/src/vm/functions/crypto.rs
+++ b/src/vm/functions/crypto.rs
@@ -80,11 +80,11 @@ pub fn special_principal_of(
     let pub_key = match param0 {
         Value::Sequence(SequenceData::Buffer(BuffData { ref data })) => {
             if data.len() != 33 {
-                return Err(CheckErrors::TypeValueError(BUFF_33, param0).into());
+                return Err(CheckErrors::TypeValueError(BUFF_33.clone(), param0).into());
             }
             data
         }
-        _ => return Err(CheckErrors::TypeValueError(BUFF_33, param0).into()),
+        _ => return Err(CheckErrors::TypeValueError(BUFF_33.clone(), param0).into()),
     };
 
     if let Ok(pub_key) = Secp256k1PublicKey::from_slice(&pub_key) {
@@ -117,25 +117,25 @@ pub fn special_secp256k1_recover(
     let message = match param0 {
         Value::Sequence(SequenceData::Buffer(BuffData { ref data })) => {
             if data.len() != 32 {
-                return Err(CheckErrors::TypeValueError(BUFF_32, param0).into());
+                return Err(CheckErrors::TypeValueError(BUFF_32.clone(), param0).into());
             }
             data
         }
-        _ => return Err(CheckErrors::TypeValueError(BUFF_32, param0).into()),
+        _ => return Err(CheckErrors::TypeValueError(BUFF_32.clone(), param0).into()),
     };
 
     let param1 = eval(&args[1], env, context)?;
     let signature = match param1 {
         Value::Sequence(SequenceData::Buffer(BuffData { ref data })) => {
             if data.len() > 65 {
-                return Err(CheckErrors::TypeValueError(BUFF_65, param1).into());
+                return Err(CheckErrors::TypeValueError(BUFF_65.clone(), param1).into());
             }
             if data.len() < 65 || data[64] > 3 {
                 return Ok(Value::err_uint(2));
             }
             data
         }
-        _ => return Err(CheckErrors::TypeValueError(BUFF_65, param1).into()),
+        _ => return Err(CheckErrors::TypeValueError(BUFF_65.clone(), param1).into()),
     };
 
     match secp256k1_recover(&message, &signature).map_err(|_| CheckErrors::InvalidSecp65k1Signature)
@@ -160,18 +160,18 @@ pub fn special_secp256k1_verify(
     let message = match param0 {
         Value::Sequence(SequenceData::Buffer(BuffData { ref data })) => {
             if data.len() != 32 {
-                return Err(CheckErrors::TypeValueError(BUFF_32, param0).into());
+                return Err(CheckErrors::TypeValueError(BUFF_32.clone(), param0).into());
             }
             data
         }
-        _ => return Err(CheckErrors::TypeValueError(BUFF_32, param0).into()),
+        _ => return Err(CheckErrors::TypeValueError(BUFF_32.clone(), param0).into()),
     };
 
     let param1 = eval(&args[1], env, context)?;
     let signature = match param1 {
         Value::Sequence(SequenceData::Buffer(BuffData { ref data })) => {
             if data.len() > 65 {
-                return Err(CheckErrors::TypeValueError(BUFF_65, param1).into());
+                return Err(CheckErrors::TypeValueError(BUFF_65.clone(), param1).into());
             }
             if data.len() < 64 {
                 return Ok(Value::Bool(false));
@@ -181,18 +181,18 @@ pub fn special_secp256k1_verify(
             }
             data
         }
-        _ => return Err(CheckErrors::TypeValueError(BUFF_65, param1).into()),
+        _ => return Err(CheckErrors::TypeValueError(BUFF_65.clone(), param1).into()),
     };
 
     let param2 = eval(&args[2], env, context)?;
     let pubkey = match param2 {
         Value::Sequence(SequenceData::Buffer(BuffData { ref data })) => {
             if data.len() != 33 {
-                return Err(CheckErrors::TypeValueError(BUFF_33, param2).into());
+                return Err(CheckErrors::TypeValueError(BUFF_33.clone(), param2).into());
             }
             data
         }
-        _ => return Err(CheckErrors::TypeValueError(BUFF_33, param2).into()),
+        _ => return Err(CheckErrors::TypeValueError(BUFF_33.clone(), param2).into()),
     };
 
     Ok(Value::Bool(

--- a/src/vm/tests/simple_apply_eval.rs
+++ b/src/vm/tests/simple_apply_eval.rs
@@ -27,7 +27,7 @@ use vm::contexts::OwnedEnvironment;
 use vm::costs::LimitedCostTracker;
 use vm::errors::{CheckErrors, Error, RuntimeErrorType, ShortReturnType};
 use vm::tests::execute;
-use vm::types::signatures::BufferLength;
+use vm::types::signatures::*;
 use vm::types::{BuffData, QualifiedContractIdentifier, TypeSignature};
 use vm::types::{PrincipalData, ResponseData, SequenceData, SequenceSubtype};
 use vm::{eval, execute as vm_execute};
@@ -281,14 +281,14 @@ fn test_secp256k1_errors() {
     ];
 
     let expectations: &[Error] = &[
-        CheckErrors::TypeValueError(TypeSignature::SequenceType(SequenceSubtype::BufferType(BufferLength(32))), Value::Sequence(SequenceData::Buffer(BuffData { data: hex_bytes("de5b9eb9e7c5592930eb2e30a01369c36586d872082ed8181ee83d2a0ec20f").unwrap() }))).into(),
-        CheckErrors::TypeValueError(TypeSignature::SequenceType(SequenceSubtype::BufferType(BufferLength(65))), Value::Sequence(SequenceData::Buffer(BuffData { data: hex_bytes("8738487ebe69b93d8e51583be8eee50bb4213fc49c767d329632730cc193b873554428fc936ca3569afc15f1c9365f6591d6251a89fee9c9ac661116824d3a130100").unwrap() }))).into(),
+        CheckErrors::TypeValueError(BUFF_32.clone(), Value::Sequence(SequenceData::Buffer(BuffData { data: hex_bytes("de5b9eb9e7c5592930eb2e30a01369c36586d872082ed8181ee83d2a0ec20f").unwrap() }))).into(),
+        CheckErrors::TypeValueError(BUFF_65.clone(), Value::Sequence(SequenceData::Buffer(BuffData { data: hex_bytes("8738487ebe69b93d8e51583be8eee50bb4213fc49c767d329632730cc193b873554428fc936ca3569afc15f1c9365f6591d6251a89fee9c9ac661116824d3a130100").unwrap() }))).into(),
         CheckErrors::IncorrectArgumentCount(2, 1).into(),
         CheckErrors::IncorrectArgumentCount(2, 3).into(),
 
-        CheckErrors::TypeValueError(TypeSignature::SequenceType(SequenceSubtype::BufferType(BufferLength(32))), Value::Sequence(SequenceData::Buffer(BuffData { data: hex_bytes("de5b9eb9e7c5592930eb2e30a01369c36586d872082ed8181ee83d2a0ec20f").unwrap() }))).into(),
-        CheckErrors::TypeValueError(TypeSignature::SequenceType(SequenceSubtype::BufferType(BufferLength(65))), Value::Sequence(SequenceData::Buffer(BuffData { data: hex_bytes("8738487ebe69b93d8e51583be8eee50bb4213fc49c767d329632730cc193b873554428fc936ca3569afc15f1c9365f6591d6251a89fee9c9ac661116824d3a130111").unwrap() }))).into(),
-        CheckErrors::TypeValueError(TypeSignature::SequenceType(SequenceSubtype::BufferType(BufferLength(33))), Value::Sequence(SequenceData::Buffer(BuffData { data: hex_bytes("03adb8de4bfb65db2cfd6120d55c6526ae9c52e675db7e47308636534ba7").unwrap() }))).into(),
+        CheckErrors::TypeValueError(BUFF_32.clone(), Value::Sequence(SequenceData::Buffer(BuffData { data: hex_bytes("de5b9eb9e7c5592930eb2e30a01369c36586d872082ed8181ee83d2a0ec20f").unwrap() }))).into(),
+        CheckErrors::TypeValueError(BUFF_65.clone(), Value::Sequence(SequenceData::Buffer(BuffData { data: hex_bytes("8738487ebe69b93d8e51583be8eee50bb4213fc49c767d329632730cc193b873554428fc936ca3569afc15f1c9365f6591d6251a89fee9c9ac661116824d3a130111").unwrap() }))).into(),
+        CheckErrors::TypeValueError(BUFF_33.clone(), Value::Sequence(SequenceData::Buffer(BuffData { data: hex_bytes("03adb8de4bfb65db2cfd6120d55c6526ae9c52e675db7e47308636534ba7").unwrap() }))).into(),
         CheckErrors::IncorrectArgumentCount(3, 2).into(),
 
         CheckErrors::IncorrectArgumentCount(1, 2).into(),

--- a/src/vm/types/signatures.rs
+++ b/src/vm/types/signatures.rs
@@ -68,7 +68,7 @@ pub struct TupleTypeSignature {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct BufferLength(pub u32);
+pub struct BufferLength(u32);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct StringUTF8Length(u32);
@@ -125,12 +125,29 @@ use self::TypeSignature::{
     TraitReferenceType, TupleType, UIntType,
 };
 
-pub const BUFF_64: TypeSignature = SequenceType(SequenceSubtype::BufferType(BufferLength(64)));
-pub const BUFF_65: TypeSignature = SequenceType(SequenceSubtype::BufferType(BufferLength(65)));
-pub const BUFF_32: TypeSignature = SequenceType(SequenceSubtype::BufferType(BufferLength(32)));
-pub const BUFF_33: TypeSignature = SequenceType(SequenceSubtype::BufferType(BufferLength(33)));
-pub const BUFF_20: TypeSignature = SequenceType(SequenceSubtype::BufferType(BufferLength(20)));
-pub const BUFF_1: TypeSignature = SequenceType(SequenceSubtype::BufferType(BufferLength(1)));
+lazy_static! {
+    pub static ref BUFF_64: TypeSignature = SequenceType(SequenceSubtype::BufferType(
+        BufferLength::try_from(64u32).expect("BUG: Legal Clarity buffer length marked invalid")
+    ));
+    pub static ref BUFF_65: TypeSignature = SequenceType(SequenceSubtype::BufferType(
+        BufferLength::try_from(65u32).expect("BUG: Legal Clarity buffer length marked invalid")
+    ));
+    pub static ref BUFF_32: TypeSignature = SequenceType(SequenceSubtype::BufferType(
+        BufferLength::try_from(32u32).expect("BUG: Legal Clarity buffer length marked invalid")
+    ));
+    pub static ref BUFF_33: TypeSignature = SequenceType(SequenceSubtype::BufferType(
+        BufferLength::try_from(33u32).expect("BUG: Legal Clarity buffer length marked invalid")
+    ));
+    pub static ref BUFF_20: TypeSignature = SequenceType(SequenceSubtype::BufferType(
+        BufferLength::try_from(20u32).expect("BUG: Legal Clarity buffer length marked invalid")
+    ));
+    pub static ref BUFF_1: TypeSignature = SequenceType(SequenceSubtype::BufferType(
+        BufferLength::try_from(1u32).expect("BUG: Legal Clarity buffer length marked invalid")
+    ));
+    pub static ref BUFF_16: TypeSignature = SequenceType(SequenceSubtype::BufferType(
+        BufferLength::try_from(16u32).expect("BUG: Legal Clarity buffer length marked invalid")
+    ));
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ListTypeData {
@@ -638,10 +655,10 @@ impl TypeSignature {
     }
 
     pub fn max_buffer() -> TypeSignature {
-        SequenceType(SequenceSubtype::BufferType(BufferLength(
-            u32::try_from(MAX_VALUE_SIZE)
+        SequenceType(SequenceSubtype::BufferType(
+            BufferLength::try_from(MAX_VALUE_SIZE)
                 .expect("FAIL: Max Clarity Value Size is no longer realizable in Buffer Type"),
-        )))
+        ))
     }
 
     /// If one of the types is a NoType, return Ok(the other type), otherwise return least_supertype(a, b)


### PR DESCRIPTION
This PR makes the BufferLength instance variable private. The rationale for this is that the BufferLength constructor enforces the Clarity TypeSignature invariant that a TypeSignature fails to construct if the described type is too large.

As part of this, this also refactored the BufferLength constants to be lazy_statics, so that the length check is applied to the constants on first use.