### PR TITLE
Chore: fix all warns in `cargo check --tests --workspace`

### DIFF
--- a/src/chainstate/stacks/db/blocks.rs
+++ b/src/chainstate/stacks/db/blocks.rs
@@ -9000,21 +9000,17 @@ pub mod test {
             for j in 0..(i + 1) {
                 assert!(
                     block_inv_all.has_ith_block(j as u16),
-                    format!(
-                        "Missing block {} from bitvec {}",
-                        j,
-                        to_hex(&block_inv_all.block_bitvec)
-                    )
+                    "Missing block {} from bitvec {}",
+                    j,
+                    to_hex(&block_inv_all.block_bitvec)
                 );
 
                 // microblocks not stored yet, so they should be marked absent
                 assert!(
                     !block_inv_all.has_ith_microblock_stream(j as u16),
-                    format!(
-                        "Have microblock {} from bitvec {}",
-                        j,
-                        to_hex(&block_inv_all.microblocks_bitvec)
-                    )
+                    "Have microblock {} from bitvec {}",
+                    j,
+                    to_hex(&block_inv_all.microblocks_bitvec)
                 );
             }
             for j in i + 1..blocks.len() {
@@ -9094,19 +9090,15 @@ pub mod test {
                 test_debug!("Test bit {} ({})", j, i);
                 assert!(
                     !block_inv_all.has_ith_block(j as u16),
-                    format!(
-                        "Have orphaned block {} from bitvec {}",
-                        j,
-                        to_hex(&block_inv_all.block_bitvec)
-                    )
+                    "Have orphaned block {} from bitvec {}",
+                    j,
+                    to_hex(&block_inv_all.block_bitvec)
                 );
                 assert!(
                     !block_inv_all.has_ith_microblock_stream(j as u16),
-                    format!(
-                        "Still have microblock {} from bitvec {}",
-                        j,
-                        to_hex(&block_inv_all.microblocks_bitvec)
-                    )
+                    "Still have microblock {} from bitvec {}",
+                    j,
+                    to_hex(&block_inv_all.microblocks_bitvec)
                 );
             }
             for j in (i + 1)..blocks.len() {

--- a/src/chainstate/stacks/db/transactions.rs
+++ b/src/chainstate/stacks/db/transactions.rs
@@ -1474,7 +1474,7 @@ pub mod test {
 
             match res {
                 Err(Error::InvalidStacksTransaction(msg, false)) => {
-                    assert!(msg.contains(&err_frag), err_frag);
+                    assert!(msg.contains(&err_frag), "{}", err_frag);
                 }
                 _ => {
                     eprintln!("bad error: {:?}", &res);

--- a/src/deps/bitcoin/network/encodable.rs
+++ b/src/deps/bitcoin/network/encodable.rs
@@ -538,27 +538,27 @@ mod tests {
     fn deserialize_nonminimal_vec() {
         match deserialize::<Vec<u8>>(&[0xfd, 0x00, 0x00]) {
             Err(Error::ParseFailed("non-minimal varint")) => {}
-            x => panic!(x),
+            x => std::panic::panic_any(x),
         }
         match deserialize::<Vec<u8>>(&[0xfd, 0xfc, 0x00]) {
             Err(Error::ParseFailed("non-minimal varint")) => {}
-            x => panic!(x),
+            x => std::panic::panic_any(x),
         }
         match deserialize::<Vec<u8>>(&[0xfe, 0xff, 0x00, 0x00, 0x00]) {
             Err(Error::ParseFailed("non-minimal varint")) => {}
-            x => panic!(x),
+            x => std::panic::panic_any(x),
         }
         match deserialize::<Vec<u8>>(&[0xfe, 0xff, 0xff, 0x00, 0x00]) {
             Err(Error::ParseFailed("non-minimal varint")) => {}
-            x => panic!(x),
+            x => std::panic::panic_any(x),
         }
         match deserialize::<Vec<u8>>(&[0xff, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]) {
             Err(Error::ParseFailed("non-minimal varint")) => {}
-            x => panic!(x),
+            x => std::panic::panic_any(x),
         }
         match deserialize::<Vec<u8>>(&[0xff, 0xff, 0xff, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00]) {
             Err(Error::ParseFailed("non-minimal varint")) => {}
-            x => panic!(x),
+            x => std::panic::panic_any(x),
         }
 
         let mut vec_256 = vec![0; 259];

--- a/src/net/http.rs
+++ b/src/net/http.rs
@@ -4894,12 +4894,11 @@ mod test {
         for (data, errstr) in tests.iter() {
             let res = HttpRequestPreamble::consensus_deserialize(&mut data.as_bytes());
             test_debug!("Expect '{}'", errstr);
-            let expected_errstr = format!("{:?}", &res);
-            assert!(res.is_err(), "{}", expected_errstr);
+            assert!(res.is_err(), "{:?}", &res);
             assert!(
-                res.unwrap_err().to_string().find(errstr).is_some(),
-                "{}",
-                expected_errstr
+                res.as_ref().unwrap_err().to_string().find(errstr).is_some(),
+                "{:?}",
+                &res
             );
         }
     }
@@ -4947,13 +4946,16 @@ mod test {
 
         for (data, errstr) in tests.iter() {
             let sres = StacksHttpPreamble::consensus_deserialize(&mut data.as_bytes());
-            let expected_serrstr = format!("{:?}", &sres);
             test_debug!("Expect '{}'", errstr);
-            assert!(sres.is_err(), "{}", expected_serrstr);
+            assert!(sres.is_err(), "{:?}", &sres);
             assert!(
-                sres.unwrap_err().to_string().find(errstr).is_some(),
-                "{}",
-                expected_serrstr
+                sres.as_ref()
+                    .unwrap_err()
+                    .to_string()
+                    .find(errstr)
+                    .is_some(),
+                "{:?}",
+                &sres
             );
         }
     }
@@ -5213,13 +5215,16 @@ mod test {
 
         for (data, errstr) in tests.iter() {
             let sres = StacksHttpPreamble::consensus_deserialize(&mut data.as_bytes());
-            let expected_serrstr = format!("{:?}", &sres);
             test_debug!("Expect '{}', got: {:?}", errstr, &sres);
-            assert!(sres.is_err(), "{}", expected_serrstr);
+            assert!(sres.is_err(), "{:?}", &sres);
             assert!(
-                sres.unwrap_err().to_string().find(errstr).is_some(),
-                "{}",
-                expected_serrstr
+                sres.as_ref()
+                    .unwrap_err()
+                    .to_string()
+                    .find(errstr)
+                    .is_some(),
+                "{:?}",
+                &sres
             );
         }
     }
@@ -5465,16 +5470,16 @@ mod test {
             let mut http = StacksHttp::new("127.0.0.1:20443".parse().unwrap());
             let (preamble, offset) = http.read_preamble(bad_content_length.as_bytes()).unwrap();
             let e = http.read_payload(&preamble, &bad_content_length.as_bytes()[offset..]);
-            let estr = format!("{:?}", &e);
 
-            assert!(e.is_err(), "{}", estr);
+            assert!(e.is_err(), "{:?}", &e);
             assert!(
-                e.unwrap_err()
+                e.as_ref()
+                    .unwrap_err()
                     .to_string()
                     .find("-length body for")
                     .is_some(),
-                "{}",
-                estr
+                "{:?}",
+                &e
             );
         }
 

--- a/src/net/http.rs
+++ b/src/net/http.rs
@@ -4808,11 +4808,11 @@ mod test {
 
         for (data, request) in tests.iter() {
             let req = HttpRequestPreamble::consensus_deserialize(&mut data.as_bytes());
-            assert!(req.is_ok(), format!("{:?}", &req));
+            assert!(req.is_ok(), "{:?}", &req);
             assert_eq!(req.unwrap(), *request);
 
             let sreq = StacksHttpPreamble::consensus_deserialize(&mut data.as_bytes());
-            assert!(sreq.is_ok(), format!("{:?}", &sreq));
+            assert!(sreq.is_ok(), "{:?}", &sreq);
             assert_eq!(
                 sreq.unwrap(),
                 StacksHttpPreamble::Request((*request).clone())
@@ -4850,11 +4850,11 @@ mod test {
 
         for (data, request) in tests.iter() {
             let req = HttpRequestPreamble::consensus_deserialize(&mut data.as_bytes());
-            assert!(req.is_ok(), format!("{:?}", &req));
+            assert!(req.is_ok(), "{:?}", &req);
             assert_eq!(req.unwrap(), *request);
 
             let sreq = StacksHttpPreamble::consensus_deserialize(&mut data.as_bytes());
-            assert!(sreq.is_ok(), format!("{:?}", &sreq));
+            assert!(sreq.is_ok(), "{:?}", &sreq);
             assert_eq!(
                 sreq.unwrap(),
                 StacksHttpPreamble::Request((*request).clone())
@@ -4895,9 +4895,10 @@ mod test {
             let res = HttpRequestPreamble::consensus_deserialize(&mut data.as_bytes());
             test_debug!("Expect '{}'", errstr);
             let expected_errstr = format!("{:?}", &res);
-            assert!(res.is_err(), expected_errstr);
+            assert!(res.is_err(), "{}", expected_errstr);
             assert!(
                 res.unwrap_err().to_string().find(errstr).is_some(),
+                "{}",
                 expected_errstr
             );
         }
@@ -4948,9 +4949,10 @@ mod test {
             let sres = StacksHttpPreamble::consensus_deserialize(&mut data.as_bytes());
             let expected_serrstr = format!("{:?}", &sres);
             test_debug!("Expect '{}'", errstr);
-            assert!(sres.is_err(), expected_serrstr);
+            assert!(sres.is_err(), "{}", expected_serrstr);
             assert!(
                 sres.unwrap_err().to_string().find(errstr).is_some(),
+                "{}",
                 expected_serrstr
             );
         }
@@ -5059,11 +5061,11 @@ mod test {
         for (data, response) in tests.iter() {
             test_debug!("Try parsing:\n{}\n", data);
             let res = HttpResponsePreamble::consensus_deserialize(&mut data.as_bytes());
-            assert!(res.is_ok(), format!("{:?}", &res));
+            assert!(res.is_ok(), "{:?}", &res);
             assert_eq!(res.unwrap(), *response);
 
             let sres = StacksHttpPreamble::consensus_deserialize(&mut data.as_bytes());
-            assert!(sres.is_ok(), format!("{:?}", &sres));
+            assert!(sres.is_ok(), "{:?}", &sres);
             assert_eq!(
                 sres.unwrap(),
                 StacksHttpPreamble::Response((*response).clone())
@@ -5087,11 +5089,11 @@ mod test {
         for (data, response) in tests.iter() {
             test_debug!("Try parsing:\n{}\n", data);
             let res = HttpResponsePreamble::consensus_deserialize(&mut data.as_bytes());
-            assert!(res.is_ok(), format!("{:?}", &res));
+            assert!(res.is_ok(), "{:?}", &res);
             assert_eq!(res.unwrap(), *response);
 
             let sres = StacksHttpPreamble::consensus_deserialize(&mut data.as_bytes());
-            assert!(sres.is_ok(), format!("{:?}", &sres));
+            assert!(sres.is_ok(), "{:?}", &sres);
             assert_eq!(
                 sres.unwrap(),
                 StacksHttpPreamble::Response((*response).clone())
@@ -5181,7 +5183,7 @@ mod test {
         for (data, errstr) in tests.iter() {
             let res = HttpResponsePreamble::consensus_deserialize(&mut data.as_bytes());
             test_debug!("Expect '{}', got: {:?}", errstr, &res);
-            assert!(res.is_err(), format!("{:?}", &res));
+            assert!(res.is_err(), "{:?}", &res);
             assert!(res.unwrap_err().to_string().find(errstr).is_some());
         }
     }
@@ -5213,9 +5215,10 @@ mod test {
             let sres = StacksHttpPreamble::consensus_deserialize(&mut data.as_bytes());
             let expected_serrstr = format!("{:?}", &sres);
             test_debug!("Expect '{}', got: {:?}", errstr, &sres);
-            assert!(sres.is_err(), expected_serrstr);
+            assert!(sres.is_err(), "{}", expected_serrstr);
             assert!(
                 sres.unwrap_err().to_string().find(errstr).is_some(),
+                "{}",
                 expected_serrstr
             );
         }
@@ -5464,12 +5467,13 @@ mod test {
             let e = http.read_payload(&preamble, &bad_content_length.as_bytes()[offset..]);
             let estr = format!("{:?}", &e);
 
-            assert!(e.is_err(), estr);
+            assert!(e.is_err(), "{}", estr);
             assert!(
                 e.unwrap_err()
                     .to_string()
                     .find("-length body for")
                     .is_some(),
+                "{}",
                 estr
             );
         }
@@ -5977,6 +5981,7 @@ mod test {
             assert!(e.is_err());
             assert!(
                 e.unwrap_err().to_string().find(expected_error).is_some(),
+                "{}",
                 errstr
             );
         }
@@ -6351,17 +6356,15 @@ mod test {
 
         for live_header in live_headers {
             let res = HttpRequestPreamble::consensus_deserialize(&mut live_header.as_bytes());
-            assert!(
-                res.is_ok(),
-                format!("headers: {}\nerror: {:?}", live_header, &res)
-            );
+            assert!(res.is_ok(), "headers: {}\nerror: {:?}", live_header, &res);
         }
 
         for bad_live_header in bad_live_headers {
             let res = HttpRequestPreamble::consensus_deserialize(&mut bad_live_header.as_bytes());
             assert!(
                 res.is_err(),
-                format!("headers: {}\nshould not have parsed", bad_live_header)
+                "headers: {}\nshould not have parsed",
+                bad_live_header
             );
         }
     }

--- a/src/net/inv.rs
+++ b/src/net/inv.rs
@@ -3919,7 +3919,9 @@ mod test {
             for i in 0..num_blocks {
                 assert!(
                     peer_2_inv.has_ith_block(i + first_stacks_block_height),
-                    format!("Missing block {} (+ {})", i, first_stacks_block_height)
+                    "Missing block {} (+ {})",
+                    i,
+                    first_stacks_block_height
                 );
             }
 
@@ -3927,7 +3929,9 @@ mod test {
             for i in 1..(num_blocks - 1) {
                 assert!(
                     peer_2_inv.has_ith_microblock_stream(i + first_stacks_block_height),
-                    format!("Missing microblock {} (+ {})", i, first_stacks_block_height)
+                    "Missing microblock {} (+ {})",
+                    i,
+                    first_stacks_block_height
                 );
             }
 
@@ -3949,7 +3953,9 @@ mod test {
             for i in 0..num_blocks {
                 assert!(
                     peer_1_inv.has_ith_block(i + first_stacks_block_height),
-                    format!("Missing block {} (+ {})", i, first_stacks_block_height)
+                    "Missing block {} (+ {})",
+                    i,
+                    first_stacks_block_height
                 );
             }
         })
@@ -4128,7 +4134,9 @@ mod test {
             for i in 0..num_blocks {
                 assert!(
                     peer_2_inv.has_ith_block(i + first_stacks_block_height),
-                    format!("Missing block {} (+ {})", i, first_stacks_block_height)
+                    "Missing block {} (+ {})",
+                    i,
+                    first_stacks_block_height
                 );
             }
 
@@ -4136,7 +4144,9 @@ mod test {
             for i in 1..(num_blocks - 1) {
                 assert!(
                     peer_2_inv.has_ith_microblock_stream(i + first_stacks_block_height),
-                    format!("Missing microblock {} (+ {})", i, first_stacks_block_height)
+                    "Missing microblock {} (+ {})",
+                    i,
+                    first_stacks_block_height
                 );
             }
 
@@ -4158,7 +4168,9 @@ mod test {
             for i in 0..num_blocks {
                 assert!(
                     peer_1_inv.has_ith_block(i + first_stacks_block_height),
-                    format!("Missing block {} (+ {})", i, first_stacks_block_height)
+                    "Missing block {} (+ {})",
+                    i,
+                    first_stacks_block_height
                 );
             }
         })

--- a/src/util/retry.rs
+++ b/src/util/retry.rs
@@ -168,14 +168,13 @@ mod test {
 
         let mut tmp_buf = [0u8; 3];
         let e = retry_reader.read_exact(&mut tmp_buf);
-        let e_str = format!("{:?}", &e);
-        assert!(e.is_err(), "{}", e_str);
+        assert!(e.is_err(), "{:?}", &e);
         assert!(
-            format!("{:?}", &e.unwrap_err())
+            format!("{:?}", &e.as_ref().unwrap_err())
                 .find("failed to fill whole buffer")
                 .is_some(),
-            "{}",
-            e_str
+            "{:?}",
+            &e
         );
 
         let res = retry_reader.read(&mut tmp_buf);

--- a/src/util/retry.rs
+++ b/src/util/retry.rs
@@ -169,11 +169,12 @@ mod test {
         let mut tmp_buf = [0u8; 3];
         let e = retry_reader.read_exact(&mut tmp_buf);
         let e_str = format!("{:?}", &e);
-        assert!(e.is_err(), e_str);
+        assert!(e.is_err(), "{}", e_str);
         assert!(
             format!("{:?}", &e.unwrap_err())
                 .find("failed to fill whole buffer")
                 .is_some(),
+            "{}",
             e_str
         );
 

--- a/src/vm/types/serialization.rs
+++ b/src/vm/types/serialization.rs
@@ -785,9 +785,9 @@ mod tests {
             Err(eres) => match eres {
                 SerializationError::IOError(ioe) => match ioe.err.kind() {
                     std::io::ErrorKind::UnexpectedEof => {}
-                    _ => assert!(false, format!("Invalid I/O error: {:?}", &ioe)),
+                    _ => assert!(false, "Invalid I/O error: {:?}", &ioe),
                 },
-                _ => assert!(false, format!("Invalid deserialize error: {:?}", &eres)),
+                _ => assert!(false, "Invalid deserialize error: {:?}", &eres),
             },
         }
     }

--- a/testnet/stacks-node/src/syncctl.rs
+++ b/testnet/stacks-node/src/syncctl.rs
@@ -73,7 +73,7 @@ impl PoxSyncWatchdogComms {
                 return Ok(false);
             }
             self.interruptable_sleep(1)?;
-            std::sync::atomic::spin_loop_hint();
+            std::hint::spin_loop();
         }
         return Ok(true);
     }
@@ -99,7 +99,7 @@ impl PoxSyncWatchdogComms {
                 return Ok(false);
             }
             self.interruptable_sleep(1)?;
-            std::sync::atomic::spin_loop_hint();
+            std::hint::spin_loop();
         }
         return Ok(true);
     }

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -5361,10 +5361,9 @@ fn atlas_stress_integration_test() {
             // requests should take no more than 20ms
             assert!(
                 total_time < attempts * 50,
-                format!(
-                    "Atlas inventory request is too slow: {} >= {} * 50",
-                    total_time, attempts
-                )
+                "Atlas inventory request is too slow: {} >= {} * 50",
+                total_time,
+                attempts
             );
         }
 
@@ -5403,10 +5402,9 @@ fn atlas_stress_integration_test() {
             // requests should take no more than 40ms
             assert!(
                 total_time < attempts * 50,
-                format!(
-                    "Atlas chunk request is too slow: {} >= {} * 50",
-                    total_time, attempts
-                )
+                "Atlas chunk request is too slow: {} >= {} * 50",
+                total_time,
+                attempts
             );
         }
     }


### PR DESCRIPTION
This PR fixes all the warnings generated by current rust stable in `develop` when run with `cargo check --workspace --tests` (previously, warnings were only addressed in `cargo check`)