### PR TITLE
Fix: 2771

### DIFF
--- a/.github/actions/bitcoin-int-tests/Dockerfile.bitcoin-tests
+++ b/.github/actions/bitcoin-int-tests/Dockerfile.bitcoin-tests
@@ -21,6 +21,7 @@ RUN cargo test -- --test-threads 1 --ignored tests::neon_integrations::bitcoind_
 RUN cargo test -- --test-threads 1 --ignored tests::neon_integrations::liquid_ustx_integration
 RUN cargo test -- --test-threads 1 --ignored tests::neon_integrations::stx_transfer_btc_integration_test
 RUN cargo test -- --test-threads 1 --ignored tests::neon_integrations::bitcoind_forking_test
+RUN cargo test -- --test-threads 1 --ignored tests::neon_integrations::should_fix_2771
 RUN cargo test -- --test-threads 1 --ignored tests::neon_integrations::pox_integration_test
 RUN cargo test -- --test-threads 1 --ignored tests::bitcoin_regtest::bitcoind_integration_test
 RUN cargo test -- --test-threads 1 --ignored tests::should_succeed_handling_malformed_and_valid_txs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,34 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to the versioning scheme outlined in the [README.md](README.md).
 
-## [Unreleased]
+## [2.0.11.2.0]
 
-## Added
+### Added
 
-- lcov compatible coverage reporting in `clarity-cli` for Clarity contract testing.
+- `clarity-cli` will now also print a serialized version of the resulting
+  output from `eval` and `execute` commands. This serialization is in
+  hexademical string format and supports integration with other tools. (#2684)
+- `lcov`-compatible coverage reporting has been added to `clarity-cli` for
+  Clarity contract testing. (#2592)
+- The `README.md` file has new documentation about the release process. (#2726)
+
+### Changed
+
+- This change resets the testnet. (#2742)
+- Caching has been added to speed up `/v2/info` responses. (#2746)
+
+### Fixed
+
+- PoX syncing will only look back to the reward cycle prior to divergence,
+  instead of looking back over all history. This will speed up running a
+  follower node. (#2746)
+- The UTXO staleness check is re-ordered so that it occurs before the RBF-limit
+  check. This way, if stale UTXOs reached the "RBF limit" a miner will recover
+  by resetting the UTXO cache. (#2694)
+- A bug is fixed in the mocknet/helium miner that would lead to a panic if a
+  burn block occurred without a sortition in it. (#2711)
+- Documentation is fixed in cases where string and buffer types are allowed
+  but not covered in the documentation.  (#2676)
 
 ## [2.0.11.1.0]
 

--- a/src/burnchains/burnchain.rs
+++ b/src/burnchains/burnchain.rs
@@ -1187,9 +1187,9 @@ impl Burnchain {
         // get latest headers.
         debug!("Sync headers from {}", sync_height);
 
+        // fetch all headers, no matter what
         let mut end_block = indexer.sync_headers(sync_height, end_height)?;
 
-        // fetch all headers, no matter what
         let mut start_block = sync_height;
         if db_height < start_block {
             start_block = db_height;

--- a/src/burnchains/burnchain.rs
+++ b/src/burnchains/burnchain.rs
@@ -1184,10 +1184,10 @@ impl Burnchain {
             None
         };
 
-        let mut end_block = indexer.sync_headers(sync_height, end_height)?;
-
         // get latest headers.
         debug!("Sync headers from {}", sync_height);
+
+        let mut end_block = indexer.sync_headers(sync_height, end_height)?;
 
         // fetch all headers, no matter what
         let mut start_block = sync_height;

--- a/src/burnchains/burnchain.rs
+++ b/src/burnchains/burnchain.rs
@@ -891,7 +891,7 @@ impl Burnchain {
     }
 
     /// Determine if there has been a chain reorg, given our current canonical burnchain tip.
-    /// Return the new chain tip and a boolen signaling the presence of a reorg
+    /// Return the new chain tip and a boolean signaling the presence of a reorg
     fn sync_reorg<I: BurnchainIndexer>(indexer: &mut I) -> Result<(u64, bool), burnchain_error> {
         let headers_path = indexer.get_headers_path();
 

--- a/src/burnchains/burnchain.rs
+++ b/src/burnchains/burnchain.rs
@@ -1349,14 +1349,14 @@ impl Burnchain {
                         }
 
                         if is_mainnet {
-                            if block_height == STACKS_2_0_LAST_BLOCK_TO_PROCESS {
+                            if last_processed.block_height == STACKS_2_0_LAST_BLOCK_TO_PROCESS {
                                 info!("Reached Stacks 2.0 last block to processed, ignoring subsequent burn blocks";
-                                      "block_height" => block_height);
+                                      "block_height" => last_processed.block_height);
                                 continue;
-                            } else if block_height > STACKS_2_0_LAST_BLOCK_TO_PROCESS {
+                            } else if last_processed.block_height > STACKS_2_0_LAST_BLOCK_TO_PROCESS {
                                 debug!("Reached Stacks 2.0 last block to processed, ignoring subsequent burn blocks";
                                        "last_block" => STACKS_2_0_LAST_BLOCK_TO_PROCESS,
-                                       "block_height" => block_height);
+                                       "block_height" => last_processed.block_height);
                                 continue;
                             }
                         }

--- a/src/burnchains/burnchain.rs
+++ b/src/burnchains/burnchain.rs
@@ -891,7 +891,7 @@ impl Burnchain {
     }
 
     /// Determine if there has been a chain reorg, given our current canonical burnchain tip.
-    /// Return the new chain tip
+    /// Return the new chain tip and a boolen signaling the presence of a reorg
     fn sync_reorg<I: BurnchainIndexer>(indexer: &mut I) -> Result<(u64, bool), burnchain_error> {
         let headers_path = indexer.get_headers_path();
 
@@ -1196,7 +1196,7 @@ impl Burnchain {
                     }
                 }
                 let end_height = target_block_height_opt.unwrap_or(0).max(db_height);
-                info!("Burnchain reorg happened at height {} invalidating chain tip {} but only {} headers presents on canonical chain. Retry in 1s", sync_height, db_height, end_block);
+                info!("Burnchain reorg happened at height {} invalidating chain tip {} but only {} headers presents on canonical chain. Retry in 2s", sync_height, db_height, end_block);
                 thread::sleep(Duration::from_millis(2000));
                 end_block = indexer.sync_headers(sync_height, Some(end_height))?;
             }

--- a/src/burnchains/burnchain.rs
+++ b/src/burnchains/burnchain.rs
@@ -25,7 +25,7 @@ use std::sync::{
     Arc,
 };
 use std::thread;
-use std::time::{Instant, Duration};
+use std::time::{Duration, Instant};
 
 use crate::types::chainstate::StacksAddress;
 use crate::types::proof::TrieHash;
@@ -1190,9 +1190,7 @@ impl Burnchain {
             // is on a smaller fork than the one we just
             // invalidated. Wait for more blocks.
             while end_block < db_height {
-                let end_height = target_block_height_opt
-                        .unwrap_or(0)
-                        .max(db_height);
+                let end_height = target_block_height_opt.unwrap_or(0).max(db_height);
                 info!("Burnchain reorg happened at height {} invalidating chain tip {} but only {} headers presents on canonical chain. Retry in 1s", sync_height, db_height, end_block);
                 thread::sleep(Duration::from_millis(1000));
                 end_block = indexer.sync_headers(sync_height, Some(end_height))?;

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -1307,6 +1307,25 @@ fn bitcoind_forking_test() {
     // but we're able to keep on mining
     assert_eq!(account.nonce, 3);
 
+    // Let's create another fork, deeper
+    let burn_header_hash_to_fork = btc_regtest_controller.get_block_hash(206);
+    btc_regtest_controller.invalidate_block(&burn_header_hash_to_fork);
+    btc_regtest_controller.build_next_block(10);
+
+    thread::sleep(Duration::from_secs(5));
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+
+    let account = get_account(&http_origin, &miner_account);
+    assert_eq!(account.balance, 0);
+    assert_eq!(account.nonce, 2);
+
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+
+    let account = get_account(&http_origin, &miner_account);
+    assert_eq!(account.balance, 0);
+    // but we're able to keep on mining
+    assert_eq!(account.nonce, 3);
+
     channel.stop_chains_coordinator();
 }
 
@@ -1355,19 +1374,24 @@ fn should_fix_2771() {
         sort_height = channel.get_sortitions_processed();
         eprintln!("Sort height: {}", sort_height);
     }
-    // let's query the miner's account nonce:
-
-    eprintln!("Miner account: {}", miner_account);
 
     // okay, let's figure out the burn block we want to fork away.
-    warn!("Will trigger re-org at block {}", 208);
-    let burn_header_hash_to_fork = btc_regtest_controller.get_block_hash(208);
+    let reorg_height = 208;
+    warn!("Will trigger re-org at block {}", reorg_height);
+    let burn_header_hash_to_fork = btc_regtest_controller.get_block_hash(reorg_height);
     btc_regtest_controller.invalidate_block(&burn_header_hash_to_fork);
     btc_regtest_controller.build_next_block(1);
     thread::sleep(Duration::from_secs(5));
 
-    // We invalidated a fork 210 long, and the new one is 207 blocks long.
-    // Let's dispatch the blocks one by one, instead of mining 210-207 blocks
+    // The test here consists in producing a canonical chain with 210 blocks. 
+    // Once done, we invalidate the block 208, and instead of rebuilding directly 
+    // a longer fork with N blocks (at done in the bitcoind_forking_test) 
+    // we slowly add some more blocks.
+    // Without the patch, this behavior ends up crashing the node with errors like:
+    // WARN [1626791307.078061] [src/chainstate/coordinator/mod.rs:535] [chains-coordinator] ChainsCoordinator: could not retrieve  block burnhash=40bdbf0dda349642bdf4dd30dd31af4f0c9979ce12a7c17485245d0a6ddd970b
+    // WARN [1626791307.078098] [src/chainstate/coordinator/mod.rs:308] [chains-coordinator] Error processing new burn block: NonContiguousBurnchainBlock(UnknownBlock(40bdbf0dda349642bdf4dd30dd31af4f0c9979ce12a7c17485245d0a6ddd970b))
+    // And the burnchain db end up in the same state we ended up while investing 2771.
+    // With this patch, the node is able to entirely register this new canonical fork, and then able to make some progress.
     while sort_height < 213 {
         next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
         sort_height = channel.get_sortitions_processed();

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -1383,9 +1383,9 @@ fn should_fix_2771() {
     btc_regtest_controller.build_next_block(1);
     thread::sleep(Duration::from_secs(5));
 
-    // The test here consists in producing a canonical chain with 210 blocks. 
-    // Once done, we invalidate the block 208, and instead of rebuilding directly 
-    // a longer fork with N blocks (at done in the bitcoind_forking_test) 
+    // The test here consists in producing a canonical chain with 210 blocks.
+    // Once done, we invalidate the block 208, and instead of rebuilding directly
+    // a longer fork with N blocks (at done in the bitcoind_forking_test)
     // we slowly add some more blocks.
     // Without the patch, this behavior ends up crashing the node with errors like:
     // WARN [1626791307.078061] [src/chainstate/coordinator/mod.rs:535] [chains-coordinator] ChainsCoordinator: could not retrieve  block burnhash=40bdbf0dda349642bdf4dd30dd31af4f0c9979ce12a7c17485245d0a6ddd970b

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -1324,7 +1324,7 @@ fn bitcoind_forking_test() {
     let account = get_account(&http_origin, &miner_account);
     assert_eq!(account.balance, 0);
     // but we're able to keep on mining
-    assert_eq!(account.nonce, 4);
+    assert_eq!(account.nonce, 3);
 
     channel.stop_chains_coordinator();
 }

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -270,7 +270,7 @@ mod test_observer {
     }
 }
 
-const PANIC_TIMEOUT_SECS: u64 = 30;
+const PANIC_TIMEOUT_SECS: u64 = 600;
 fn next_block_and_wait(
     btc_controller: &mut BitcoinRegtestController,
     blocks_processed: &Arc<AtomicU64>,
@@ -1326,7 +1326,6 @@ fn should_fix_2771() {
         .expect("Failed starting bitcoind");
 
     let mut btc_regtest_controller = BitcoinRegtestController::new(conf.clone(), None);
-    let http_origin = format!("http://{}", &conf.node.rpc_bind);
 
     btc_regtest_controller.bootstrap_chain(201);
 

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -1317,14 +1317,14 @@ fn bitcoind_forking_test() {
 
     let account = get_account(&http_origin, &miner_account);
     assert_eq!(account.balance, 0);
-    assert_eq!(account.nonce, 2);
+    assert_eq!(account.nonce, 3);
 
     next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
 
     let account = get_account(&http_origin, &miner_account);
     assert_eq!(account.balance, 0);
     // but we're able to keep on mining
-    assert_eq!(account.nonce, 3);
+    assert_eq!(account.nonce, 4);
 
     channel.stop_chains_coordinator();
 }


### PR DESCRIPTION
Address #2771.
The test added consists in producing a canonical chain with 210 blocks. Once done, we invalidate the block 208, and instead of rebuilding directly a longer fork with N blocks (at done in the `bitcoind_forking_test`) we slowly add some more blocks.
Without the patch, this behavior ends up crashing the node with errors like:

```
WARN [1626791307.078061] [src/chainstate/coordinator/mod.rs:535] [chains-coordinator] ChainsCoordinator: could not retrieve  block burnhash=40bdbf0dda349642bdf4dd30dd31af4f0c9979ce12a7c17485245d0a6ddd970b
WARN [1626791307.078098] [src/chainstate/coordinator/mod.rs:308] [chains-coordinator] Error processing new burn block: NonContiguousBurnchainBlock(UnknownBlock(40bdbf0dda349642bdf4dd30dd31af4f0c9979ce12a7c17485245d0a6ddd970b))
```

And the burnchain db end up in the same state we ended up while investing 2771.

With this patch, the node is able to entirely register this new canonical fork, and then able to make some progress.  