### PR TITLE
Only consider target_block_height when relevant

### DIFF
--- a/src/burnchains/burnchain.rs
+++ b/src/burnchains/burnchain.rs
@@ -1213,7 +1213,10 @@ impl Burnchain {
         );
 
         if let Some(target_block_height) = target_block_height_opt {
-            if target_block_height < end_block {
+            // target_block_height is used as a hint, but could also be completely off
+            // in certain situations. The current function is directly reading the 
+            // headers and syncing with the bitcoin-node.
+            if target_block_height > start_block && target_block_height < end_block {
                 debug!(
                     "Will download up to max burn block height {}",
                     target_block_height

--- a/src/burnchains/burnchain.rs
+++ b/src/burnchains/burnchain.rs
@@ -1214,7 +1214,7 @@ impl Burnchain {
 
         if let Some(target_block_height) = target_block_height_opt {
             // target_block_height is used as a hint, but could also be completely off
-            // in certain situations. The current function is directly reading the 
+            // in certain situations. The current function is directly reading the
             // headers and syncing with the bitcoin-node.
             if target_block_height > start_block && target_block_height < end_block {
                 debug!(

--- a/src/burnchains/burnchain.rs
+++ b/src/burnchains/burnchain.rs
@@ -1215,13 +1215,19 @@ impl Burnchain {
         if let Some(target_block_height) = target_block_height_opt {
             // target_block_height is used as a hint, but could also be completely off
             // in certain situations. The current function is directly reading the
-            // headers and syncing with the bitcoin-node.
+            // headers and syncing with the bitcoin-node, and the interval of blocks
+            // to download computed here should be considered as our source of truth.
             if target_block_height > start_block && target_block_height < end_block {
                 debug!(
                     "Will download up to max burn block height {}",
                     target_block_height
                 );
                 end_block = target_block_height;
+            } else {
+                debug!(
+                    "Ignoring target block height {} considered as irrelevant",
+                    target_block_height
+                );
             }
         }
 

--- a/src/burnchains/burnchain.rs
+++ b/src/burnchains/burnchain.rs
@@ -1209,7 +1209,7 @@ impl Burnchain {
 
         debug!(
             "Sync'ed headers from {} to {}. DB at {}",
-            start_block, end_block, db_height
+            sync_height, end_block, db_height
         );
 
         if let Some(target_block_height) = target_block_height_opt {

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -1324,7 +1324,7 @@ fn bitcoind_forking_test() {
     let account = get_account(&http_origin, &miner_account);
     assert_eq!(account.balance, 0);
     // but we're able to keep on mining
-    assert_eq!(account.nonce, 4);
+    assert_eq!(account.nonce, 3);
 
     channel.stop_chains_coordinator();
 }


### PR DESCRIPTION
With this fix, we're only considering the `target_block_height` if this value is relevant.
The `sync_with_indexer` function is reading the burnchain state from the bitcoin-node and should be considered as the source of truth, and should ignore / correct the hint when it's determined as off.
Address #2783.
