### PR TITLE
fix: switched all occurrences of max_value/min_value to MAX/MIN

### DIFF
--- a/src/chainstate/coordinator/tests.rs
+++ b/src/chainstate/coordinator/tests.rs
@@ -368,8 +368,8 @@ fn make_reward_set_coordinator<'a>(
 
 pub fn get_burnchain(path: &str, pox_consts: Option<PoxConstants>) -> Burnchain {
     let mut b = Burnchain::regtest(&format!("{}/burnchain/db/", path));
-    b.pox_constants = pox_consts
-        .unwrap_or_else(|| PoxConstants::new(5, 3, 3, 25, 5, u64::max_value(), u64::max_value()));
+    b.pox_constants =
+        pox_consts.unwrap_or_else(|| PoxConstants::new(5, 3, 3, 25, 5, u64::MAX, u64::MAX));
     b
 }
 

--- a/src/chainstate/stacks/db/accounts.rs
+++ b/src/chainstate/stacks/db/accounts.rs
@@ -314,9 +314,9 @@ impl StacksChainState {
         block_reward: &MinerPaymentSchedule,
         user_burns: &Vec<StagingUserBurnSupport>,
     ) -> Result<(), Error> {
-        assert!(block_reward.burnchain_commit_burn < i64::max_value() as u64);
-        assert!(block_reward.burnchain_sortition_burn < i64::max_value() as u64);
-        assert!(block_reward.stacks_block_height < i64::max_value() as u64);
+        assert!(block_reward.burnchain_commit_burn < i64::MAX as u64);
+        assert!(block_reward.burnchain_sortition_burn < i64::MAX as u64);
+        assert!(block_reward.stacks_block_height < i64::MAX as u64);
 
         let index_block_hash = StacksBlockHeader::make_index_block_hash(
             &block_reward.consensus_hash,
@@ -364,7 +364,7 @@ impl StacksChainState {
         .map_err(|e| Error::DBError(db_error::SqliteError(e)))?;
 
         for user_support in user_burns.iter() {
-            assert!(user_support.burn_amount < i64::max_value() as u64);
+            assert!(user_support.burn_amount < i64::MAX as u64);
 
             let args: &[&dyn ToSql] = &[
                 &user_support.address.to_string(),

--- a/src/chainstate/stacks/db/blocks.rs
+++ b/src/chainstate/stacks/db/blocks.rs
@@ -1558,8 +1558,8 @@ impl StacksChainState {
             block.block_hash(),
             parent_consensus_hash
         );
-        assert!(commit_burn < i64::max_value() as u64);
-        assert!(sortition_burn < i64::max_value() as u64);
+        assert!(commit_burn < i64::MAX as u64);
+        assert!(sortition_burn < i64::MAX as u64);
 
         let block_hash = block.block_hash();
         let index_block_hash =
@@ -1729,7 +1729,7 @@ impl StacksChainState {
         burn_supports: &Vec<UserBurnSupportOp>,
     ) -> Result<(), Error> {
         for burn_support in burn_supports.iter() {
-            assert!(burn_support.burn_fee < i64::max_value() as u64);
+            assert!(burn_support.burn_fee < i64::MAX as u64);
         }
 
         for burn_support in burn_supports.iter() {
@@ -6536,7 +6536,7 @@ pub mod test {
                 &block.block_hash()
             ),
             0,
-            u16::max_value()
+            u16::MAX
         )
         .unwrap()
         .is_none());
@@ -6605,7 +6605,7 @@ pub mod test {
                     &block.block_hash()
                 ),
                 0,
-                u16::max_value()
+                u16::MAX
             )
             .unwrap()
             .unwrap(),
@@ -6704,7 +6704,7 @@ pub mod test {
                 &block.block_hash()
             ),
             0,
-            u16::max_value()
+            u16::MAX
         )
         .unwrap()
         .is_some());
@@ -6716,7 +6716,7 @@ pub mod test {
                     &block.block_hash()
                 ),
                 0,
-                u16::max_value()
+                u16::MAX
             )
             .unwrap()
             .unwrap(),
@@ -6760,7 +6760,7 @@ pub mod test {
                 &block.block_hash()
             ),
             0,
-            u16::max_value()
+            u16::MAX
         )
         .unwrap()
         .is_none());
@@ -6830,7 +6830,7 @@ pub mod test {
                     &block.block_hash()
                 ),
                 0,
-                u16::max_value()
+                u16::MAX
             )
             .unwrap()
             .unwrap(),
@@ -6966,7 +6966,7 @@ pub mod test {
                 &block.block_hash()
             ),
             0,
-            u16::max_value()
+            u16::MAX
         )
         .unwrap()
         .is_some());
@@ -6978,7 +6978,7 @@ pub mod test {
                     &block.block_hash()
                 ),
                 0,
-                u16::max_value()
+                u16::MAX
             )
             .unwrap()
             .unwrap(),
@@ -7022,7 +7022,7 @@ pub mod test {
                 &block.block_hash()
             ),
             0,
-            u16::max_value()
+            u16::MAX
         )
         .unwrap()
         .is_none());
@@ -7107,7 +7107,7 @@ pub mod test {
                 &block.block_hash()
             ),
             0,
-            u16::max_value()
+            u16::MAX
         )
         .unwrap()
         .is_none());
@@ -8284,7 +8284,7 @@ pub mod test {
                             &block.block_hash()
                         ),
                         0,
-                        u16::max_value()
+                        u16::MAX
                     )
                     .unwrap()
                     .unwrap()
@@ -8297,7 +8297,7 @@ pub mod test {
                     &chainstate.db(),
                     &StacksBlockHeader::make_index_block_hash(&consensus_hash, &block.block_hash()),
                     0,
-                    u16::max_value()
+                    u16::MAX
                 )
                 .unwrap()
                 .is_none());

--- a/src/chainstate/stacks/db/headers.rs
+++ b/src/chainstate/stacks/db/headers.rs
@@ -123,7 +123,7 @@ impl StacksChainState {
             tip_info.block_height,
             tip_info.anchored_header.total_work.work
         );
-        assert!(tip_info.burn_header_timestamp < i64::max_value() as u64);
+        assert!(tip_info.burn_header_timestamp < i64::MAX as u64);
 
         let header = &tip_info.anchored_header;
         let index_root = &tip_info.index_root;
@@ -142,7 +142,7 @@ impl StacksChainState {
         let index_block_hash =
             StacksBlockHeader::make_index_block_hash(&consensus_hash, &block_hash);
 
-        assert!(block_height < (i64::max_value() as u64));
+        assert!(block_height < (i64::MAX as u64));
 
         let args: &[&dyn ToSql] = &[
             &header.version,

--- a/src/chainstate/stacks/db/unconfirmed.rs
+++ b/src/chainstate/stacks/db/unconfirmed.rs
@@ -164,7 +164,7 @@ impl UnconfirmedState {
         burn_dbconn: &dyn BurnStateDB,
         mblocks: Vec<StacksMicroblock>,
     ) -> Result<ProcessedUnconfirmedState, Error> {
-        if self.last_mblock_seq == u16::max_value() {
+        if self.last_mblock_seq == u16::MAX {
             // drop them -- nothing to do
             return Ok(Default::default());
         }
@@ -317,7 +317,7 @@ impl UnconfirmedState {
             &chainstate.db(),
             &StacksBlockHeader::make_index_block_hash(&consensus_hash, &anchored_block_hash),
             0,
-            u16::max_value(),
+            u16::MAX,
         )
     }
 
@@ -333,7 +333,7 @@ impl UnconfirmedState {
             "BUG: code tried to write unconfirmed state to a read-only instance"
         );
 
-        if self.last_mblock_seq == u16::max_value() {
+        if self.last_mblock_seq == u16::MAX {
             // no-op
             return Ok(Default::default());
         }

--- a/src/chainstate/stacks/miner.rs
+++ b/src/chainstate/stacks/miner.rs
@@ -4870,7 +4870,7 @@ pub mod test {
                     &all_microblocks_1[i].1,
                 ),
                 0,
-                u16::max_value(),
+                u16::MAX,
             )
             .unwrap();
             let chunk_2_opt = StacksChainState::load_descendant_staging_microblock_stream(
@@ -4880,7 +4880,7 @@ pub mod test {
                     &all_microblocks_2[i].1,
                 ),
                 0,
-                u16::max_value(),
+                u16::MAX,
             )
             .unwrap();
 

--- a/src/clarity_vm/clarity.rs
+++ b/src/clarity_vm/clarity.rs
@@ -1725,10 +1725,10 @@ mod tests {
         }
 
         clarity_instance.block_limit = ExecutionCost {
-            write_length: u64::max_value(),
-            write_count: u64::max_value(),
-            read_count: u64::max_value(),
-            read_length: u64::max_value(),
+            write_length: u64::MAX,
+            write_count: u64::MAX,
+            read_count: u64::MAX,
+            read_length: u64::MAX,
             runtime: 100,
         };
 

--- a/src/codec/mod.rs
+++ b/src/codec/mod.rs
@@ -156,7 +156,7 @@ where
     }
 
     fn consensus_deserialize<R: Read>(fd: &mut R) -> Result<Vec<T>, Error> {
-        read_next_at_most::<R, T>(fd, u32::max_value())
+        read_next_at_most::<R, T>(fd, u32::MAX)
     }
 }
 

--- a/src/core/mempool.rs
+++ b/src/core/mempool.rs
@@ -816,7 +816,7 @@ impl MemPoolDB {
             consensus_hash,
             block_hash,
             0,
-            (i64::max_value() - 1) as u64,
+            (i64::MAX - 1) as u64,
         )
         .unwrap_or(vec![])
         .into_iter()

--- a/src/net/db.rs
+++ b/src/net/db.rs
@@ -478,7 +478,7 @@ impl PeerDB {
         let deny_cidrs = PeerDB::get_denied_cidrs(tx)?;
         for (prefix, mask) in deny_cidrs.into_iter() {
             debug!("Refresh deny {}/{}", &prefix, mask);
-            PeerDB::apply_cidr_filter(tx, &prefix, mask, "denied", i64::max_value())?;
+            PeerDB::apply_cidr_filter(tx, &prefix, mask, "denied", i64::MAX)?;
         }
         Ok(())
     }
@@ -488,7 +488,7 @@ impl PeerDB {
         let allow_cidrs = PeerDB::get_allowed_cidrs(tx)?;
         for (prefix, mask) in allow_cidrs.into_iter() {
             debug!("Refresh allow {}/{}", &prefix, mask);
-            PeerDB::apply_cidr_filter(tx, &prefix, mask, "allowed", i64::max_value())?;
+            PeerDB::apply_cidr_filter(tx, &prefix, mask, "allowed", i64::MAX)?;
         }
         Ok(())
     }
@@ -1235,7 +1235,7 @@ impl PeerDB {
         PeerDB::add_cidr_prefix(tx, "denied_prefixes", prefix, mask)?;
 
         debug!("Apply deny {}/{}", &prefix, mask);
-        PeerDB::apply_cidr_filter(tx, prefix, mask, "denied", i64::max_value())?;
+        PeerDB::apply_cidr_filter(tx, prefix, mask, "denied", i64::MAX)?;
         Ok(())
     }
 
@@ -2011,7 +2011,7 @@ mod test {
         .unwrap()
         .unwrap();
         assert_eq!(n1.allowed, 12345);
-        assert_eq!(n1.denied, i64::max_value());
+        assert_eq!(n1.denied, i64::MAX);
         assert_eq!(n2.allowed, 12345);
         assert_eq!(n2.denied, 67890);
 
@@ -2048,7 +2048,7 @@ mod test {
         .unwrap();
 
         assert_eq!(n1.allowed, -1);
-        assert_eq!(n1.denied, i64::max_value());
+        assert_eq!(n1.denied, i64::MAX);
         assert_eq!(n2.allowed, 12345);
         assert_eq!(n2.denied, 67890);
     }
@@ -2168,7 +2168,7 @@ mod test {
         .unwrap()
         .unwrap();
 
-        assert_eq!(n1.denied, i64::max_value());
+        assert_eq!(n1.denied, i64::MAX);
         assert_eq!(n2.denied, 0); // refreshed; no longer denied
 
         assert_eq!(n1.allowed, -1);

--- a/src/net/http.rs
+++ b/src/net/http.rs
@@ -296,7 +296,7 @@ impl HttpChunkedTransferReaderState {
             chunk_read: 0,
             max_size: max_size,
             total_size: 0,
-            last_chunk_size: u64::max_value(), // if this ever becomes 0, then we should expect chunk boundary '0\r\n\r\n' and EOF
+            last_chunk_size: u64::MAX, // if this ever becomes 0, then we should expect chunk boundary '0\r\n\r\n' and EOF
             chunk_buffer: [0u8; 18],
             i: 0,
         }

--- a/src/net/inv.rs
+++ b/src/net/inv.rs
@@ -747,7 +747,7 @@ impl NeighborBlockStats {
         let mut bit = target_pox_reward_cycle;
         while bit < (network.pox_id.len() as u64) - 1
             && (bit - target_pox_reward_cycle) < poxinv_data.bitlen as u64
-            && (bit - target_pox_reward_cycle) < u16::max_value() as u64
+            && (bit - target_pox_reward_cycle) < u16::MAX as u64
         {
             if network.pox_id.has_ith_anchor_block(bit as usize)
                 && !poxinv_data.has_ith_reward_cycle((bit - target_pox_reward_cycle) as u16)
@@ -771,7 +771,7 @@ impl NeighborBlockStats {
         let mut bit = target_pox_reward_cycle;
         while bit < (network.pox_id.len() as u64) - 1
             && (bit - target_pox_reward_cycle) < poxinv_data.bitlen as u64
-            && (bit - target_pox_reward_cycle) < u16::max_value() as u64
+            && (bit - target_pox_reward_cycle) < u16::MAX as u64
         {
             if !network.pox_id.has_ith_anchor_block(bit as usize)
                 && poxinv_data.has_ith_reward_cycle((bit - target_pox_reward_cycle) as u16)
@@ -3121,8 +3121,7 @@ mod test {
     #[test]
     fn test_inv_merge_pox_inv() {
         let mut burnchain = Burnchain::regtest("unused");
-        burnchain.pox_constants =
-            PoxConstants::new(5, 3, 3, 25, 5, u64::max_value(), u64::max_value());
+        burnchain.pox_constants = PoxConstants::new(5, 3, 3, 25, 5, u64::MAX, u64::MAX);
 
         let mut peer_inv = PeerBlocksInv::new(vec![0x01], vec![0x01], vec![0x01], 1, 1, 0);
         for i in 0..32 {
@@ -3140,8 +3139,7 @@ mod test {
     #[test]
     fn test_inv_truncate_pox_inv() {
         let mut burnchain = Burnchain::regtest("unused");
-        burnchain.pox_constants =
-            PoxConstants::new(5, 3, 3, 25, 5, u64::max_value(), u64::max_value());
+        burnchain.pox_constants = PoxConstants::new(5, 3, 3, 25, 5, u64::MAX, u64::MAX);
 
         let mut peer_inv = PeerBlocksInv::new(vec![0x01], vec![0x01], vec![0x01], 1, 1, 0);
         for i in 0..5 {

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -1496,7 +1496,7 @@ pub trait ProtocolFamily {
 pub struct StacksP2P {}
 
 // an array in our protocol can't exceed this many items
-pub const ARRAY_MAX_LEN: u32 = u32::max_value();
+pub const ARRAY_MAX_LEN: u32 = u32::MAX;
 
 // maximum number of neighbors in a NeighborsData
 pub const MAX_NEIGHBORS_DATA_LEN: u32 = 128;
@@ -2113,8 +2113,7 @@ pub mod test {
                 )
                 .unwrap(),
             );
-            burnchain.pox_constants =
-                PoxConstants::new(5, 3, 3, 25, 5, u64::max_value(), u64::max_value());
+            burnchain.pox_constants = PoxConstants::new(5, 3, 3, 25, 5, u64::MAX, u64::MAX);
 
             let mut spending_account = TestMinerFactory::new().next_miner(
                 &burnchain,

--- a/src/util/db.rs
+++ b/src/util/db.rs
@@ -204,7 +204,7 @@ impl FromColumn<QualifiedContractIdentifier> for QualifiedContractIdentifier {
 }
 
 pub fn u64_to_sql(x: u64) -> Result<i64, Error> {
-    if x > (i64::max_value() as u64) {
+    if x > (i64::MAX as u64) {
         return Err(Error::ParseError);
     }
     Ok(x as i64)
@@ -518,7 +518,7 @@ pub fn get_ancestor_block_hash<T: MarfTrieId>(
     block_height: u64,
     tip_block_hash: &T,
 ) -> Result<Option<T>, Error> {
-    assert!(block_height < u32::max_value() as u64);
+    assert!(block_height < u32::MAX as u64);
     let mut read_only = index.reopen_readonly()?;
     let bh = read_only.get_block_at_height(block_height as u32, tip_block_hash)?;
     Ok(bh)

--- a/src/util/uint.rs
+++ b/src/util/uint.rs
@@ -487,7 +487,7 @@ mod tests {
             "0x00000000000000000000000000000000000000000000000000000000deadbeef"
         );
         assert_eq!(
-            format!("{}", Uint256::from_u64(u64::max_value())),
+            format!("{}", Uint256::from_u64(u64::MAX)),
             "0x000000000000000000000000000000000000000000000000ffffffffffffffff"
         );
 

--- a/src/vm/analysis/errors.rs
+++ b/src/vm/analysis/errors.rs
@@ -370,7 +370,7 @@ impl DiagnosableError for CheckErrors {
             CheckErrors::NonFunctionApplication => format!("expecting expression of type function"),
             CheckErrors::ExpectedListApplication => format!("expecting expression of type list"),
             CheckErrors::ExpectedSequence(found_type) => format!("expecting expression of type 'list', 'buff', 'string-ascii' or 'string-utf8' - found '{}'", found_type),
-            CheckErrors::MaxLengthOverflow => format!("expecting a value <= {}", u32::max_value()),
+            CheckErrors::MaxLengthOverflow => format!("expecting a value <= {}", u32::MAX),
             CheckErrors::BadLetSyntax => format!("invalid syntax of 'let'"),
             CheckErrors::CircularReference(function_names) => format!("detected interdependent functions ({})", function_names.join(", ")),
             CheckErrors::BadSyntaxBinding => format!("invalid syntax binding"),

--- a/src/vm/contexts.rs
+++ b/src/vm/contexts.rs
@@ -1711,8 +1711,7 @@ mod test {
         let mut am2 = AssetMap::new();
 
         am1.add_token_transfer(&p1, t1.clone(), 1).unwrap();
-        am1.add_token_transfer(&p2, t1.clone(), u128::max_value())
-            .unwrap();
+        am1.add_token_transfer(&p2, t1.clone(), u128::MAX).unwrap();
         am2.add_token_transfer(&p1, t1.clone(), 1).unwrap();
         am2.add_token_transfer(&p2, t1.clone(), 1).unwrap();
 
@@ -1720,7 +1719,7 @@ mod test {
 
         let table = am1.to_table();
 
-        assert_eq!(table[&p2][&t1], AssetMapEntry::Token(u128::max_value()));
+        assert_eq!(table[&p2][&t1], AssetMapEntry::Token(u128::MAX));
         assert_eq!(table[&p1][&t1], AssetMapEntry::Token(1));
     }
 

--- a/src/vm/costs/mod.rs
+++ b/src/vm/costs/mod.rs
@@ -999,11 +999,11 @@ impl ExecutionCost {
 
     pub fn max_value() -> ExecutionCost {
         Self {
-            runtime: u64::max_value(),
-            write_length: u64::max_value(),
-            read_count: u64::max_value(),
-            write_count: u64::max_value(),
-            read_length: u64::max_value(),
+            runtime: u64::MAX,
+            write_length: u64::MAX,
+            read_count: u64::MAX,
+            write_count: u64::MAX,
+            read_length: u64::MAX,
         }
     }
 
@@ -1087,14 +1087,8 @@ mod unit_tests {
 
     #[test]
     fn test_simple_overflows() {
-        assert_eq!(
-            u64::max_value().cost_overflow_add(1),
-            Err(CostErrors::CostOverflow)
-        );
-        assert_eq!(
-            u64::max_value().cost_overflow_mul(2),
-            Err(CostErrors::CostOverflow)
-        );
+        assert_eq!(u64::MAX.cost_overflow_add(1), Err(CostErrors::CostOverflow));
+        assert_eq!(u64::MAX.cost_overflow_mul(2), Err(CostErrors::CostOverflow));
     }
 
     #[test]
@@ -1117,7 +1111,7 @@ mod unit_tests {
             64,
             128,
             2_u64.pow(63),
-            u64::max_value(),
+            u64::MAX,
         ];
         let expected = [0, 1, 2, 3, 4, 5, 5, 6, 6, 6, 7, 63, 64];
         for (input, expected) in inputs.iter().zip(expected.iter()) {

--- a/src/vm/functions/arithmetic.rs
+++ b/src/vm/functions/arithmetic.rs
@@ -201,7 +201,7 @@ macro_rules! make_arithmetic_ops {
                     return Self::make_value(base);
                 }
 
-                if power < 0 || power > (u32::max_value() as $type) {
+                if power < 0 || power > (u32::MAX as $type) {
                     return Err(RuntimeErrorType::Arithmetic(
                         "Power argument to (pow ...) must be a u32 integer".to_string(),
                     )

--- a/src/vm/tests/assets.rs
+++ b/src/vm/tests/assets.rs
@@ -183,7 +183,7 @@ fn test_native_stx_ops(owned_env: &mut OwnedEnvironment) {
         .initialize_contract(second_contract_id.clone(), contract_second)
         .unwrap();
 
-    owned_env.stx_faucet(&(p1_principal), u128::max_value() - 1500);
+    owned_env.stx_faucet(&(p1_principal), u128::MAX - 1500);
     owned_env.stx_faucet(&p2_principal, 1000);
 
     // test 1: send 0

--- a/src/vm/tests/simple_apply_eval.rs
+++ b/src/vm/tests/simple_apply_eval.rs
@@ -507,7 +507,7 @@ fn test_simple_arithmetic_functions() {
         Value::Bool(true),
         Value::Bool(true),
         Value::Int(65536),
-        Value::Int(u32::max_value() as i128 + 1),
+        Value::Int(u32::MAX as i128 + 1),
         Value::Int(1),
         Value::Int(170_141_183_460_469_231_731_687_303_715_884_105_727),
         Value::UInt(340_282_366_920_938_463_463_374_607_431_768_211_455),
@@ -525,10 +525,10 @@ fn test_simple_arithmetic_functions() {
         Value::Int(3),
         Value::Int(126),
         Value::UInt(127),
-        Value::UInt(u128::max_value()),
+        Value::UInt(u128::MAX),
         Value::UInt(137),
-        Value::Int(i128::max_value()),
-        Value::Int(-1 * (u32::max_value() as i128 + 1)),
+        Value::Int(i128::MAX),
+        Value::Int(-1 * (u32::MAX as i128 + 1)),
     ];
 
     tests

--- a/src/vm/types/mod.rs
+++ b/src/vm/types/mod.rs
@@ -1356,9 +1356,9 @@ mod test {
         }
 
         // on 32-bit archs, this error cannot even happen, so don't test (and cause an overflow panic)
-        if (u32::max_value() as usize) < usize::max_value() {
+        if (u32::MAX as usize) < usize::MAX {
             assert_eq!(
-                Value::buff_from(vec![0; (u32::max_value() as usize) + 10]),
+                Value::buff_from(vec![0; (u32::MAX as usize) + 10]),
                 Err(CheckErrors::ValueTooLarge.into())
             );
         }

--- a/src/vm/types/serialization.rs
+++ b/src/vm/types/serialization.rs
@@ -806,8 +806,8 @@ mod tests {
         test_deser_ser(Value::Int(0));
         test_deser_ser(Value::Int(1));
         test_deser_ser(Value::Int(-1));
-        test_deser_ser(Value::Int(i128::max_value()));
-        test_deser_ser(Value::Int(i128::min_value()));
+        test_deser_ser(Value::Int(i128::MAX));
+        test_deser_ser(Value::Int(i128::MIN));
 
         test_bad_expectation(Value::Int(1), TypeSignature::UIntType);
     }
@@ -816,8 +816,8 @@ mod tests {
     fn test_uints() {
         test_deser_ser(Value::UInt(0));
         test_deser_ser(Value::UInt(1));
-        test_deser_ser(Value::UInt(u128::max_value()));
-        test_deser_ser(Value::UInt(u128::min_value()));
+        test_deser_ser(Value::UInt(u128::MAX));
+        test_deser_ser(Value::UInt(u128::MIN));
 
         test_bad_expectation(Value::UInt(1), TypeSignature::IntType);
     }

--- a/testnet/stacks-node/src/syncctl.rs
+++ b/testnet/stacks-node/src/syncctl.rs
@@ -298,8 +298,8 @@ impl PoxSyncWatchdog {
     /// low and high pass filter average -- take average without the smallest and largest values
     fn hilo_filter_avg(samples: &Vec<i64>) -> f64 {
         // take average with low and high pass
-        let mut min = i64::max_value();
-        let mut max = i64::min_value();
+        let mut min = i64::MAX;
+        let mut max = i64::MIN;
         for s in samples.iter() {
             if *s < 0 {
                 // nonsensical result (e.g. due to clock drift?)


### PR DESCRIPTION
## Description
Switched all occurrences of {i, u}{8, 16, 32, 64, 128}::max_value() to {i, u}{8, 16, 32, 64, 128}::MAX. Did the same for the function min_value. I did this by searching for occurrences of max_value/min_value and replacing them one by one (since `ExecutionCost` also has a method named max_value).

These functions are set to be deprecated in a future rust version: https://doc.rust-lang.org/std/primitive.i64.html#method.min_value

## Testing Information 
Ran `cargo test`.