### PR TITLE
ci: update clarity-js-sdk gh workflow

### DIFF
--- a/.github/workflows/clarity-js-sdk-pr.yml
+++ b/.github/workflows/clarity-js-sdk-pr.yml
@@ -11,7 +11,7 @@ env:
 on:
   release:
     types:
-      - published
+      - released
   workflow_dispatch:
 
 jobs:      
@@ -29,7 +29,6 @@ jobs:
         run: |
           RELEASE_VERSION=$(echo ${GITHUB_REF#refs/*/} | tr / -)
           echo "RELEASE_VERSION=$RELEASE_VERSION" >> $GITHUB_ENV
-          echo "UPDATE_BRANCH=auto/update-bin-$RELEASE_VERSION" >> $GITHUB_ENV
 
       - name: Update SDK Tag
         run: sed -i "s@CORE_SDK_TAG = \".*\"@CORE_SDK_TAG = \"$RELEASE_VERSION\"@g" packages/clarity-native-bin/src/index.ts
@@ -41,11 +40,14 @@ jobs:
           commit-message: 'chore: update clarity-native-bin tag'
           committer: ${{ env.COMMIT_USER }} <${{ env.COMMIT_EMAIL }}>
           author: ${{ env.COMMIT_USER }} <${{ env.COMMIT_EMAIL }}>
-          branch: ${{ env.UPDATE_BRANCH }}
+          branch: auto/update-bin-tag
+          delete-branch: true
           title: "clarity-native-bin tag update: ${{ env.RELEASE_VERSION }}"
+          labels: |
+            dependencies
           body: |
             :robot: This is an automated pull request created from a new release in [stacks-blockchain](https://github.com/blockstack/stacks-blockchain/releases).
 
             Updates the clarity-native-bin tag.
-          assignees: zone117x,hstove
-          reviewers: zone117x,hstove
+          assignees: zone117x
+          reviewers: zone117x

--- a/.github/workflows/clarity-js-sdk-pr.yml
+++ b/.github/workflows/clarity-js-sdk-pr.yml
@@ -17,6 +17,8 @@ on:
 jobs:
   run:
     runs-on: ubuntu-latest
+    # This condition can be removed once the main `stacks-blockchain` workflow creates pre-releases
+    # when appropriate, instead of full releases for every tag passed in.
     if: "!contains(github.ref, '-rc')"
     steps:
       - name: Checkout latest clarity js sdk

--- a/.github/workflows/clarity-js-sdk-pr.yml
+++ b/.github/workflows/clarity-js-sdk-pr.yml
@@ -14,9 +14,10 @@ on:
       - released
   workflow_dispatch:
 
-jobs:      
+jobs:
   run:
     runs-on: ubuntu-latest
+    if: "!contains(github.ref, '-rc')"
     steps:
       - name: Checkout latest clarity js sdk
         uses: actions/checkout@v2
@@ -37,7 +38,7 @@ jobs:
         uses: peter-evans/create-pull-request@v3
         with:
           token: ${{ secrets.GH_TOKEN }}
-          commit-message: 'chore: update clarity-native-bin tag'
+          commit-message: "chore: update clarity-native-bin tag"
           committer: ${{ env.COMMIT_USER }} <${{ env.COMMIT_EMAIL }}>
           author: ${{ env.COMMIT_USER }} <${{ env.COMMIT_EMAIL }}>
           branch: auto/update-bin-tag


### PR DESCRIPTION
## Description

Updates the clarity-js-sdk Github workflow to:
* Remove Hank as a reviewer of new PRs
* Update the same PR if it's still open instead of creating a new PR for each release
* Only run on releases and not pre-releases.
* Add a `dependencies` label to the PR

For details refer to issue https://github.com/hirosystems/devops/issues/750

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [x] Other

## Does this introduce a breaking change?
No

## Are documentation updates required?
No

## Checklist
- [x] Tag 1 of @person1 or @person2
