### PR TITLE
feat: gate ast passes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2318,7 +2318,6 @@ dependencies = [
  "rand 0.7.2",
  "reqwest",
  "ring",
- "rstest",
  "rusqlite",
  "serde",
  "serde_derive",

--- a/src/clarity.rs
+++ b/src/clarity.rs
@@ -79,6 +79,7 @@ use crate::types::chainstate::StacksAddress;
 use crate::types::chainstate::StacksBlockId;
 use crate::types::chainstate::VRFSeed;
 use crate::types::proof::ClarityMarfTrieId;
+use std::str::FromStr;
 
 #[cfg(test)]
 macro_rules! panic_test {
@@ -141,8 +142,9 @@ struct EvalInput {
 fn parse(
     contract_identifier: &QualifiedContractIdentifier,
     source_code: &str,
+    version: ClarityVersion,
 ) -> Result<Vec<SymbolicExpression>, Error> {
-    let ast = build_ast(contract_identifier, source_code, &mut ())
+    let ast = build_ast(contract_identifier, source_code, &mut (), version)
         .map_err(|e| RuntimeErrorType::ASTError(e))?;
     Ok(ast.expressions)
 }
@@ -692,6 +694,7 @@ fn consume_arg(
     }
 }
 
+/// This function uses Clarity1 to parse the boot code.
 fn install_boot_code<C: ClarityStorage>(header_db: &CLIHeadersDB, marf: &mut C) {
     let mainnet = header_db.is_mainnet();
     let boot_code = if mainnet {
@@ -699,6 +702,8 @@ fn install_boot_code<C: ClarityStorage>(header_db: &CLIHeadersDB, marf: &mut C) 
     } else {
         *STACKS_BOOT_CODE_TESTNET
     };
+
+    let clarity_version = ClarityVersion::Clarity1;
 
     for (boot_code_name, boot_code_contract) in boot_code.iter() {
         let contract_identifier = QualifiedContractIdentifier::new(
@@ -714,7 +719,7 @@ fn install_boot_code<C: ClarityStorage>(header_db: &CLIHeadersDB, marf: &mut C) 
         );
 
         let mut ast = friendly_expect(
-            parse(&contract_identifier, &contract_content),
+            parse(&contract_identifier, &contract_content, clarity_version),
             "Failed to parse program.",
         );
 
@@ -966,7 +971,11 @@ pub fn invoke_command(invoked_by: &str, args: &[String]) -> (i32, Option<serde_j
                 )
             };
 
-            let mut ast = friendly_expect(parse(&contract_id, &content), "Failed to parse program");
+            // TODO: Add --clarity_version as command line argument
+            let mut ast = friendly_expect(
+                parse(&contract_id, &content, ClarityVersion::Clarity1),
+                "Failed to parse program",
+            );
 
             let contract_analysis_res = {
                 if argv.len() >= 3 {
@@ -1068,7 +1077,8 @@ pub fn invoke_command(invoked_by: &str, args: &[String]) -> (i32, Option<serde_j
                     }
                 };
 
-                let mut ast = match parse(&contract_id, &content) {
+                // TODO: Add --clarity_version as command line argument
+                let mut ast = match parse(&contract_id, &content, ClarityVersion::Clarity1) {
                     Ok(val) => val,
                     Err(error) => {
                         println!("Parse error:\n{}", error);
@@ -1111,8 +1121,11 @@ pub fn invoke_command(invoked_by: &str, args: &[String]) -> (i32, Option<serde_j
 
             let contract_id = QualifiedContractIdentifier::transient();
 
-            let mut ast =
-                friendly_expect(parse(&contract_id, &content), "Failed to parse program.");
+            // TODO: Add --clarity_version as command line argument
+            let mut ast = friendly_expect(
+                parse(&contract_id, &content, ClarityVersion::Clarity1),
+                "Failed to parse program.",
+            );
             match run_analysis_free(&contract_id, &mut ast, &mut analysis_marf, true) {
                 Ok(_) => {
                     let result = vm_env.get_exec_environment(None, None).eval_raw(&content);
@@ -1360,8 +1373,13 @@ pub fn invoke_command(invoked_by: &str, args: &[String]) -> (i32, Option<serde_j
                 &format!("Error reading file: {}", argv[2]),
             );
 
+            // TODO: Add --clarity_version as command line argument
             let mut ast = friendly_expect(
-                parse(&contract_identifier, &contract_content),
+                parse(
+                    &contract_identifier,
+                    &contract_content,
+                    ClarityVersion::Clarity1,
+                ),
                 "Failed to parse program.",
             );
             let header_db =

--- a/src/clarity_vm/clarity.rs
+++ b/src/clarity_vm/clarity.rs
@@ -906,7 +906,12 @@ impl<'a, 'b> ClarityTransactionConnection<'a, 'b> {
 
         using!(self.cost_track, "cost tracker", |mut cost_track| {
             self.inner_with_analysis_db(|db| {
-                let ast_result = ast::build_ast(identifier, contract_content, &mut cost_track);
+                let ast_result = ast::build_ast(
+                    identifier,
+                    contract_content,
+                    &mut cost_track,
+                    clarity_version,
+                );
 
                 let mut contract_ast = match ast_result {
                     Ok(x) => x,

--- a/src/vm/analysis/arithmetic_checker/tests.rs
+++ b/src/vm/analysis/arithmetic_checker/tests.rs
@@ -36,14 +36,14 @@ use vm::variables::NativeVariables;
 #[rstest]
 #[case(ClarityVersion::Clarity1)]
 #[case(ClarityVersion::Clarity2)]
-fn template_test_clarity_versions(#[case] version: ClarityVersion) {}
+fn test_clarity_versions_arith_checker(#[case] version: ClarityVersion) {}
 
 /// Checks whether or not a contract only contains arithmetic expressions (for example, defining a
 /// map would not pass this check).
 /// This check is useful in determining the validity of new potential cost functions.
 fn arithmetic_check(contract: &str, version: ClarityVersion) -> Result<(), Error> {
     let contract_identifier = QualifiedContractIdentifier::transient();
-    let expressions = parse(&contract_identifier, contract).unwrap();
+    let expressions = parse(&contract_identifier, contract, version).unwrap();
 
     let analysis = ContractAnalysis::new(
         contract_identifier,
@@ -65,7 +65,7 @@ fn test_boot_definitions() {
     check_good(BOOT_CODE_COSTS);
 }
 
-#[apply(template_test_clarity_versions)]
+#[apply(test_clarity_versions_arith_checker)]
 fn test_bad_defines(#[case] version: ClarityVersion) {
     let tests = [
         ("(define-public (foo) (ok 1))", DefineTypeForbidden(DefineFunctions::PublicFunction)),

--- a/src/vm/analysis/mod.rs
+++ b/src/vm/analysis/mod.rs
@@ -46,7 +46,7 @@ pub fn mem_type_check(
     use crate::clarity_vm::database::MemoryBackingStore;
     use vm::ast::parse;
     let contract_identifier = QualifiedContractIdentifier::transient();
-    let mut contract = parse(&contract_identifier, snippet).unwrap();
+    let mut contract = parse(&contract_identifier, snippet, version).unwrap();
     let mut marf = MemoryBackingStore::new();
     let mut analysis_db = marf.as_analysis_db();
     match run_analysis(

--- a/src/vm/analysis/read_only_checker/tests.rs
+++ b/src/vm/analysis/read_only_checker/tests.rs
@@ -19,6 +19,13 @@ use vm::analysis::type_checker::tests::{contracts::type_check, mem_type_check};
 use vm::analysis::{CheckError, CheckErrors};
 use vm::ast::parse;
 use vm::types::QualifiedContractIdentifier;
+use vm::ClarityVersion;
+
+#[template]
+#[rstest]
+#[case(ClarityVersion::Clarity1)]
+#[case(ClarityVersion::Clarity2)]
+fn test_clarity_versions_read_only_checker(#[case] version: ClarityVersion) {}
 
 #[test]
 fn test_argument_count_violations() {
@@ -174,8 +181,8 @@ fn test_nested_writing_closure() {
     }
 }
 
-#[test]
-fn test_contract_call_read_only_violations() {
+#[apply(test_clarity_versions_read_only_checker)]
+fn test_contract_call_read_only_violations(#[case] version: ClarityVersion) {
     let contract1 = "(define-map tokens { account: principal } { balance: int })
          (define-read-only (get-token-balance)
             (get balance (map-get? tokens (tuple (account tx-sender))) ))
@@ -193,9 +200,9 @@ fn test_contract_call_read_only_violations() {
     let contract_bad_caller_id = QualifiedContractIdentifier::local("bad_caller").unwrap();
     let contract_ok_caller_id = QualifiedContractIdentifier::local("ok_caller").unwrap();
 
-    let mut contract1 = parse(&contract_1_id, contract1).unwrap();
-    let mut bad_caller = parse(&contract_bad_caller_id, bad_caller).unwrap();
-    let mut ok_caller = parse(&contract_ok_caller_id, ok_caller).unwrap();
+    let mut contract1 = parse(&contract_1_id, contract1, version).unwrap();
+    let mut bad_caller = parse(&contract_bad_caller_id, bad_caller, version).unwrap();
+    let mut ok_caller = parse(&contract_ok_caller_id, ok_caller, version).unwrap();
 
     let mut marf = MemoryBackingStore::new();
 

--- a/src/vm/ast/definition_sorter/mod.rs
+++ b/src/vm/ast/definition_sorter/mod.rs
@@ -50,6 +50,7 @@ impl<'a> DefinitionSorter {
     pub fn run_pass<T: CostTracker>(
         contract_ast: &mut ContractAST,
         accounting: &mut T,
+        _version: ClarityVersion,
     ) -> ParseResult<()> {
         let mut pass = DefinitionSorter::new();
         pass.run(contract_ast, accounting)?;

--- a/src/vm/ast/definition_sorter/tests.rs
+++ b/src/vm/ast/definition_sorter/tests.rs
@@ -15,6 +15,10 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use crate::clarity_vm::database::MemoryBackingStore;
+#[cfg(test)]
+use rstest::rstest;
+#[cfg(test)]
+use rstest_reuse::{self, *};
 use vm::analysis::type_checker::tests::mem_type_check as run_analysis_helper;
 use vm::ast::definition_sorter::DefinitionSorter;
 use vm::ast::errors::ParseErrors;
@@ -23,21 +27,28 @@ use vm::ast::expression_identifier::ExpressionIdentifier;
 use vm::ast::parser;
 use vm::ast::types::{BuildASTPass, ContractAST};
 use vm::types::QualifiedContractIdentifier;
+use vm::ClarityVersion;
 
-fn run_scoped_parsing_helper(contract: &str) -> ParseResult<ContractAST> {
+#[template]
+#[rstest]
+#[case(ClarityVersion::Clarity1)]
+#[case(ClarityVersion::Clarity2)]
+fn test_clarity_versions_definition_sorter(#[case] version: ClarityVersion) {}
+
+fn run_scoped_parsing_helper(contract: &str, version: ClarityVersion) -> ParseResult<ContractAST> {
     let contract_identifier = QualifiedContractIdentifier::transient();
     let pre_expressions = parser::parse(contract)?;
     let mut contract_ast = ContractAST::new(contract_identifier.clone(), pre_expressions);
-    ExpressionIdentifier::run_pre_expression_pass(&mut contract_ast)?;
-    DefinitionSorter::run_pass(&mut contract_ast, &mut ())?;
+    ExpressionIdentifier::run_pre_expression_pass(&mut contract_ast, version)?;
+    DefinitionSorter::run_pass(&mut contract_ast, &mut (), version)?;
     Ok(contract_ast)
 }
 
-#[test]
-fn should_succeed_sorting_contract_call() {
+#[apply(test_clarity_versions_definition_sorter)]
+fn should_succeed_sorting_contract_call(#[case] version: ClarityVersion) {
     let contract = "(define-read-only (foo-function (a int))
            (contract-call? .contract-b foo-function a))";
-    run_scoped_parsing_helper(contract).unwrap();
+    run_scoped_parsing_helper(contract, version).unwrap();
 }
 
 #[test]
@@ -47,8 +58,8 @@ fn should_fix_2123() {
     run_analysis_helper(contract).unwrap();
 }
 
-#[test]
-fn should_succeed_sorting_contract_case_1() {
+#[apply(test_clarity_versions_definition_sorter)]
+fn should_succeed_sorting_contract_case_1(#[case] version: ClarityVersion) {
     let contract = r#"
         (define-private (wrapped-kv-del (key int))
             (kv-del key))
@@ -58,11 +69,11 @@ fn should_succeed_sorting_contract_case_1() {
                 key))
         (define-map kv-store { key: int } { value: int })
     "#;
-    run_scoped_parsing_helper(contract).unwrap();
+    run_scoped_parsing_helper(contract, version).unwrap();
 }
 
-#[test]
-fn should_succeed_sorting_contract_case_2() {
+#[apply(test_clarity_versions_definition_sorter)]
+fn should_succeed_sorting_contract_case_2(#[case] version: ClarityVersion) {
     let contract = r#"
         (define-private (a (x int)) (b x))
         (define-private (b (x int)) (+ x c))
@@ -74,26 +85,26 @@ fn should_succeed_sorting_contract_case_2() {
         (define-private (h (x int)) (a x))
         (+ (a 1) (b 1) c (d 1) e (f 1) g (h 1))
     "#;
-    run_scoped_parsing_helper(contract).unwrap();
+    run_scoped_parsing_helper(contract, version).unwrap();
 }
 
-#[test]
-fn should_raise_dependency_cycle_case_1() {
+#[apply(test_clarity_versions_definition_sorter)]
+fn should_raise_dependency_cycle_case_1(#[case] version: ClarityVersion) {
     let contract = r#"
         (define-private (a (x int)) (b x))
         (define-private (b (x int)) (c x))
         (define-private (c (x int)) (a x))
     "#;
 
-    let err = run_scoped_parsing_helper(contract).unwrap_err();
+    let err = run_scoped_parsing_helper(contract, version).unwrap_err();
     assert!(match err.err {
         ParseErrors::CircularReference(_) => true,
         _ => false,
     });
 }
 
-#[test]
-fn should_raise_dependency_cycle_case_2() {
+#[apply(test_clarity_versions_definition_sorter)]
+fn should_raise_dependency_cycle_case_2(#[case] version: ClarityVersion) {
     let contract = r#"
         (define-private (a (x int)) (b x))
         (define-private (b (x int)) (c x))
@@ -101,211 +112,211 @@ fn should_raise_dependency_cycle_case_2() {
         (a 0)
     "#;
 
-    let err = run_scoped_parsing_helper(contract).unwrap_err();
+    let err = run_scoped_parsing_helper(contract, version).unwrap_err();
     assert!(match err.err {
         ParseErrors::CircularReference(_) => true,
         _ => false,
     });
 }
 
-#[test]
-fn should_not_raise_dependency_cycle_case_let() {
+#[apply(test_clarity_versions_definition_sorter)]
+fn should_not_raise_dependency_cycle_case_let(#[case] version: ClarityVersion) {
     let contract = r#"
         (define-private (foo (x int)) (begin (bar 1) 1))
         (define-private (bar (x int)) (let ((foo 1)) (+ 1 x))) 
     "#;
 
-    run_scoped_parsing_helper(contract).unwrap();
+    run_scoped_parsing_helper(contract, version).unwrap();
     run_analysis_helper(contract).unwrap();
 }
 
-#[test]
-fn should_raise_dependency_cycle_case_let() {
+#[apply(test_clarity_versions_definition_sorter)]
+fn should_raise_dependency_cycle_case_let(#[case] version: ClarityVersion) {
     let contract = r#"
         (define-private (foo (x int)) (begin (bar 1) 1))
         (define-private (bar (x int)) (let ((baz (foo 1))) (+ 1 x))) 
     "#;
 
-    let err = run_scoped_parsing_helper(contract).unwrap_err();
+    let err = run_scoped_parsing_helper(contract, version).unwrap_err();
     assert!(match err.err {
         ParseErrors::CircularReference(_) => true,
         _ => false,
     })
 }
 
-#[test]
-fn should_not_raise_dependency_cycle_case_get() {
+#[apply(test_clarity_versions_definition_sorter)]
+fn should_not_raise_dependency_cycle_case_get(#[case] version: ClarityVersion) {
     let contract = r#"
         (define-private (foo (x int)) (begin (bar 1) 1))
         (define-private (bar (x int)) (get foo (tuple (foo 1) (bar 2))))
     "#;
 
-    run_scoped_parsing_helper(contract).unwrap();
+    run_scoped_parsing_helper(contract, version).unwrap();
     run_analysis_helper(contract).unwrap();
 }
 
-#[test]
-fn should_raise_dependency_cycle_case_get() {
+#[apply(test_clarity_versions_definition_sorter)]
+fn should_raise_dependency_cycle_case_get(#[case] version: ClarityVersion) {
     let contract = r#"
         (define-private (foo (x int)) (begin (bar 1) 1))
         (define-private (bar (x int)) (let ((res (foo 1))) (+ 1 x))) 
     "#;
 
-    let err = run_scoped_parsing_helper(contract).unwrap_err();
+    let err = run_scoped_parsing_helper(contract, version).unwrap_err();
     assert!(match err.err {
         ParseErrors::CircularReference(_) => true,
         _ => false,
     })
 }
 
-#[test]
-fn should_not_raise_dependency_cycle_case_fetch_entry() {
+#[apply(test_clarity_versions_definition_sorter)]
+fn should_not_raise_dependency_cycle_case_fetch_entry(#[case] version: ClarityVersion) {
     let contract = r#"
         (define-private (foo (x int)) (begin (bar 1) 1))
         (define-private (bar (x int)) (map-get? kv-store { foo: 1 })) 
         (define-map kv-store { foo: int } { bar: int })
     "#;
 
-    run_scoped_parsing_helper(contract).unwrap();
+    run_scoped_parsing_helper(contract, version).unwrap();
     run_analysis_helper(contract).unwrap();
 }
 
-#[test]
-fn should_raise_dependency_cycle_case_fetch_entry() {
+#[apply(test_clarity_versions_definition_sorter)]
+fn should_raise_dependency_cycle_case_fetch_entry(#[case] version: ClarityVersion) {
     let contract = r#"
         (define-private (foo (x int)) (+ (bar x) x))
         (define-private (bar (x int)) (map-get? kv-store { foo: (foo 1) })) 
         (define-map kv-store { foo: int } { bar: int })
     "#;
 
-    let err = run_scoped_parsing_helper(contract).unwrap_err();
+    let err = run_scoped_parsing_helper(contract, version).unwrap_err();
     assert!(match err.err {
         ParseErrors::CircularReference(_) => true,
         _ => false,
     })
 }
 
-#[test]
-fn should_not_raise_dependency_cycle_case_delete_entry() {
+#[apply(test_clarity_versions_definition_sorter)]
+fn should_not_raise_dependency_cycle_case_delete_entry(#[case] version: ClarityVersion) {
     let contract = r#"
         (define-private (foo (x int)) (begin (bar 1) 1))
         (define-private (bar (x int)) (map-delete kv-store (tuple (foo 1)))) 
         (define-map kv-store { foo: int } { bar: int })
     "#;
 
-    run_scoped_parsing_helper(contract).unwrap();
+    run_scoped_parsing_helper(contract, version).unwrap();
     run_analysis_helper(contract).unwrap();
 }
 
-#[test]
-fn should_raise_dependency_cycle_case_delete_entry() {
+#[apply(test_clarity_versions_definition_sorter)]
+fn should_raise_dependency_cycle_case_delete_entry(#[case] version: ClarityVersion) {
     let contract = r#"
         (define-private (foo (x int)) (+ (bar x) x))
         (define-private (bar (x int)) (map-delete kv-store (tuple (foo (foo 1))))) 
         (define-map kv-store { foo: int } { bar: int })
     "#;
 
-    let err = run_scoped_parsing_helper(contract).unwrap_err();
+    let err = run_scoped_parsing_helper(contract, version).unwrap_err();
     assert!(match err.err {
         ParseErrors::CircularReference(_) => true,
         _ => false,
     })
 }
 
-#[test]
-fn should_not_raise_dependency_cycle_case_set_entry() {
+#[apply(test_clarity_versions_definition_sorter)]
+fn should_not_raise_dependency_cycle_case_set_entry(#[case] version: ClarityVersion) {
     let contract = r#"
         (define-private (foo (x int)) (begin (bar 1) 1))
         (define-private (bar (x int)) (map-set kv-store { foo: 1 } { bar: 3 })) 
         (define-map kv-store { foo: int } { bar: int })
     "#;
 
-    run_scoped_parsing_helper(contract).unwrap();
+    run_scoped_parsing_helper(contract, version).unwrap();
     run_analysis_helper(contract).unwrap();
 }
 
-#[test]
-fn should_raise_dependency_cycle_case_set_entry() {
+#[apply(test_clarity_versions_definition_sorter)]
+fn should_raise_dependency_cycle_case_set_entry(#[case] version: ClarityVersion) {
     let contract = r#"
         (define-private (foo (x int)) (+ (bar x) x))
         (define-private (bar (x int)) (map-set kv-store { foo: 1 } { bar: (foo 1) })) 
         (define-map kv-store { foo: int } { bar: int })
     "#;
 
-    let err = run_scoped_parsing_helper(contract).unwrap_err();
+    let err = run_scoped_parsing_helper(contract, version).unwrap_err();
     assert!(match err.err {
         ParseErrors::CircularReference(_) => true,
         _ => false,
     })
 }
 
-#[test]
-fn should_not_raise_dependency_cycle_case_insert_entry() {
+#[apply(test_clarity_versions_definition_sorter)]
+fn should_not_raise_dependency_cycle_case_insert_entry(#[case] version: ClarityVersion) {
     let contract = r#"
         (define-private (foo (x int)) (begin (bar 1) 1))
         (define-private (bar (x int)) (map-insert kv-store { foo: 1 } { bar: 3 })) 
         (define-map kv-store { foo: int } { bar: int })
     "#;
 
-    run_scoped_parsing_helper(contract).unwrap();
+    run_scoped_parsing_helper(contract, version).unwrap();
     run_analysis_helper(contract).unwrap();
 }
 
-#[test]
-fn should_raise_dependency_cycle_case_insert_entry() {
+#[apply(test_clarity_versions_definition_sorter)]
+fn should_raise_dependency_cycle_case_insert_entry(#[case] version: ClarityVersion) {
     let contract = r#"
         (define-private (foo (x int)) (+ (bar x) x))
         (define-private (bar (x int)) (map-insert kv-store { foo: (foo 1) } { bar: 3 }))
         (define-map kv-store { foo: int } { bar: int })
     "#;
 
-    let err = run_scoped_parsing_helper(contract).unwrap_err();
+    let err = run_scoped_parsing_helper(contract, version).unwrap_err();
     assert!(match err.err {
         ParseErrors::CircularReference(_) => true,
         _ => false,
     })
 }
 
-#[test]
-fn should_raise_dependency_cycle_case_fetch_contract_entry() {
+#[apply(test_clarity_versions_definition_sorter)]
+fn should_raise_dependency_cycle_case_fetch_contract_entry(#[case] version: ClarityVersion) {
     let contract = r#"
         (define-private (foo (x int)) (+ (bar x) x))
         (define-private (bar (x int)) (map-get? kv-store { foo: (foo 1) })) 
     "#;
 
-    let err = run_scoped_parsing_helper(contract).unwrap_err();
+    let err = run_scoped_parsing_helper(contract, version).unwrap_err();
     assert!(match err.err {
         ParseErrors::CircularReference(_) => true,
         _ => false,
     })
 }
 
-#[test]
-fn should_not_build_cycle_within_defined_args_types() {
+#[apply(test_clarity_versions_definition_sorter)]
+fn should_not_build_cycle_within_defined_args_types(#[case] version: ClarityVersion) {
     let contract = r#"
         (define-private (function-1 (function-2 int)) (+ 1 2))
         (define-private (function-2 (function-1 int)) (+ 1 2))
     "#;
 
-    run_scoped_parsing_helper(contract).unwrap();
+    run_scoped_parsing_helper(contract, version).unwrap();
 }
 
-#[test]
-fn should_reorder_traits_references() {
+#[apply(test_clarity_versions_definition_sorter)]
+fn should_reorder_traits_references(#[case] version: ClarityVersion) {
     let contract = r#"
         (define-private (foo (function-2 <trait-a>)) (+ 1 2))
         (define-trait trait-a ((get-a () (response uint uint))))
     "#;
 
-    run_scoped_parsing_helper(contract).unwrap();
+    run_scoped_parsing_helper(contract, version).unwrap();
 }
 
-#[test]
-fn should_not_conflict_with_atoms_from_trait_definitions() {
+#[apply(test_clarity_versions_definition_sorter)]
+fn should_not_conflict_with_atoms_from_trait_definitions(#[case] version: ClarityVersion) {
     let contract = r#"
         (define-trait foo ((bar (int) (int))))
         (define-trait bar ((foo (int) (int))))
     "#;
 
-    run_scoped_parsing_helper(contract).unwrap();
+    run_scoped_parsing_helper(contract, version).unwrap();
 }

--- a/src/vm/ast/expression_identifier/mod.rs
+++ b/src/vm/ast/expression_identifier/mod.rs
@@ -18,6 +18,7 @@ use vm::ast::errors::{ParseError, ParseErrors, ParseResult};
 use vm::ast::types::{BuildASTPass, ContractAST};
 use vm::representations::PreSymbolicExpressionType::List;
 use vm::representations::SymbolicExpressionCommon;
+use vm::ClarityVersion;
 
 fn inner_relabel<T: SymbolicExpressionCommon>(args: &mut [T], index: u64) -> ParseResult<u64> {
     let mut current = index
@@ -44,11 +45,17 @@ pub fn update_expression_id<T: SymbolicExpressionCommon>(exprs: &mut [T]) -> Par
 pub struct ExpressionIdentifier;
 
 impl ExpressionIdentifier {
-    pub fn run_pre_expression_pass(contract_ast: &mut ContractAST) -> ParseResult<()> {
+    pub fn run_pre_expression_pass(
+        contract_ast: &mut ContractAST,
+        _version: ClarityVersion,
+    ) -> ParseResult<()> {
         update_expression_id(contract_ast.pre_expressions.as_mut_slice())?;
         Ok(())
     }
-    pub fn run_expression_pass(contract_ast: &mut ContractAST) -> ParseResult<()> {
+    pub fn run_expression_pass(
+        contract_ast: &mut ContractAST,
+        _version: ClarityVersion,
+    ) -> ParseResult<()> {
         update_expression_id(contract_ast.expressions.as_mut_slice())?;
         Ok(())
     }

--- a/src/vm/ast/stack_depth_checker.rs
+++ b/src/vm/ast/stack_depth_checker.rs
@@ -19,7 +19,7 @@ use vm::ast::types::{BuildASTPass, ContractAST};
 use vm::representations::PreSymbolicExpression;
 use vm::representations::PreSymbolicExpressionType::List;
 
-use vm::MAX_CALL_STACK_DEPTH;
+use vm::{ClarityVersion, MAX_CALL_STACK_DEPTH};
 
 // allow  the AST to get deeper than the max call stack depth,
 //    but not much deeper (things like tuples would increase the
@@ -46,7 +46,7 @@ fn check(args: &[PreSymbolicExpression], depth: u64) -> ParseResult<()> {
 pub struct StackDepthChecker;
 
 impl BuildASTPass for StackDepthChecker {
-    fn run_pass(contract_ast: &mut ContractAST) -> ParseResult<()> {
+    fn run_pass(contract_ast: &mut ContractAST, _version: ClarityVersion) -> ParseResult<()> {
         check(&contract_ast.pre_expressions, 0)
     }
 }

--- a/src/vm/ast/sugar_expander/mod.rs
+++ b/src/vm/ast/sugar_expander/mod.rs
@@ -27,6 +27,7 @@ use vm::representations::{
 use vm::types::{
     PrincipalData, QualifiedContractIdentifier, StandardPrincipalData, TraitIdentifier, Value,
 };
+use vm::ClarityVersion;
 
 pub struct SugarExpander {
     issuer: StandardPrincipalData,
@@ -35,7 +36,7 @@ pub struct SugarExpander {
 }
 
 impl BuildASTPass for SugarExpander {
-    fn run_pass(contract_ast: &mut ContractAST) -> ParseResult<()> {
+    fn run_pass(contract_ast: &mut ContractAST, _version: ClarityVersion) -> ParseResult<()> {
         let pass = SugarExpander::new(contract_ast.contract_identifier.issuer.clone());
         pass.run(contract_ast)?;
         Ok(())

--- a/src/vm/ast/traits_resolver/mod.rs
+++ b/src/vm/ast/traits_resolver/mod.rs
@@ -28,11 +28,12 @@ use vm::representations::{
     ClarityName, PreSymbolicExpression, SymbolicExpression, TraitDefinition,
 };
 use vm::types::{QualifiedContractIdentifier, TraitIdentifier, Value};
+use vm::ClarityVersion;
 
 pub struct TraitsResolver {}
 
 impl BuildASTPass for TraitsResolver {
-    fn run_pass(contract_ast: &mut ContractAST) -> ParseResult<()> {
+    fn run_pass(contract_ast: &mut ContractAST, _version: ClarityVersion) -> ParseResult<()> {
         let mut command = TraitsResolver::new();
         command.run(contract_ast)?;
         Ok(())

--- a/src/vm/ast/types.rs
+++ b/src/vm/ast/types.rs
@@ -20,10 +20,10 @@ use vm::ast::errors::ParseResult;
 use vm::representations::{PreSymbolicExpression, SymbolicExpression, TraitDefinition};
 use vm::types::signatures::FunctionSignature;
 use vm::types::{QualifiedContractIdentifier, TraitIdentifier};
-use vm::ClarityName;
+use vm::{ClarityName, ClarityVersion};
 
 pub trait BuildASTPass {
-    fn run_pass(contract_ast: &mut ContractAST) -> ParseResult<()>;
+    fn run_pass(contract_ast: &mut ContractAST, _version: ClarityVersion) -> ParseResult<()>;
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/vm/contexts.rs
+++ b/src/vm/contexts.rs
@@ -900,7 +900,10 @@ impl<'a, 'b> Environment<'a, 'b> {
         contract_identifier: &QualifiedContractIdentifier,
         program: &str,
     ) -> Result<Value> {
-        let parsed = ast::build_ast(contract_identifier, program, self)?.expressions;
+        let clarity_version = self.contract_context.clarity_version.clone();
+
+        let parsed =
+            ast::build_ast(contract_identifier, program, self, clarity_version)?.expressions;
 
         if parsed.len() < 1 {
             return Err(RuntimeErrorType::ParseError(
@@ -936,8 +939,9 @@ impl<'a, 'b> Environment<'a, 'b> {
 
     pub fn eval_raw(&mut self, program: &str) -> Result<Value> {
         let contract_id = QualifiedContractIdentifier::transient();
+        let clarity_version = self.contract_context.clarity_version.clone();
 
-        let parsed = ast::build_ast(&contract_id, program, self)?.expressions;
+        let parsed = ast::build_ast(&contract_id, program, self, clarity_version)?.expressions;
         if parsed.len() < 1 {
             return Err(RuntimeErrorType::ParseError(
                 "Expected a program of at least length 1".to_string(),
@@ -1091,7 +1095,14 @@ impl<'a, 'b> Environment<'a, 'b> {
         contract_identifier: QualifiedContractIdentifier,
         contract_content: &str,
     ) -> Result<()> {
-        let contract_ast = ast::build_ast(&contract_identifier, contract_content, self)?;
+        let clarity_version = self.contract_context.clarity_version.clone();
+
+        let contract_ast = ast::build_ast(
+            &contract_identifier,
+            contract_content,
+            self,
+            clarity_version,
+        )?;
         self.initialize_contract_from_ast(contract_identifier, &contract_ast, &contract_content)
     }
 

--- a/src/vm/docs/mod.rs
+++ b/src/vm/docs/mod.rs
@@ -2021,8 +2021,8 @@ mod test {
         database::{BurnStateDB, HeadersDB, STXBalance},
         eval_all, execute,
         types::PrincipalData,
-        ContractContext, Error, GlobalContext, LimitedCostTracker, QualifiedContractIdentifier,
-        Value,
+        ClarityVersion, ContractContext, Error, GlobalContext, LimitedCostTracker,
+        QualifiedContractIdentifier, Value,
     };
 
     use crate::types::chainstate::VRFSeed;
@@ -2127,6 +2127,7 @@ mod test {
         }
     }
 
+    /// Execute docs against the latest version of Clarity.
     fn docs_execute(marf: &mut MarfedKV, program: &str) {
         // start the next block,
         //  we never commit it so that we can reuse the initialization
@@ -2154,9 +2155,14 @@ mod test {
             let mut analysis_db = store.as_analysis_db();
             let whole_contract = segments.join("\n");
             eprintln!("{}", whole_contract);
-            let mut parsed = ast::build_ast(&contract_id, &whole_contract, &mut ())
-                .unwrap()
-                .expressions;
+            let mut parsed = ast::build_ast(
+                &contract_id,
+                &whole_contract,
+                &mut (),
+                ClarityVersion::latest(),
+            )
+            .unwrap()
+            .expressions;
 
             type_check(&contract_id, &mut parsed, &mut analysis_db, false)
                 .expect("Failed to type check");
@@ -2180,9 +2186,14 @@ mod test {
                     eprintln!("{}", segment);
 
                     let result = {
-                        let parsed = ast::build_ast(&contract_id, segment, &mut ())
-                            .unwrap()
-                            .expressions;
+                        let parsed = ast::build_ast(
+                            &contract_id,
+                            segment,
+                            &mut (),
+                            ClarityVersion::latest(),
+                        )
+                        .unwrap()
+                        .expressions;
                         eval_all(&parsed, &mut contract_context, g, None).unwrap()
                     };
 
@@ -2206,6 +2217,7 @@ mod test {
 
     #[test]
     fn test_examples() {
+        // Execute test examples against the latest version of Clarity
         let apis = make_all_api_reference();
         let mut marf = MarfedKV::temporary();
         // first, load the samples for contract-call
@@ -2222,9 +2234,14 @@ mod test {
                 let mut analysis_db = store.as_analysis_db();
                 let whole_contract =
                     std::fs::read_to_string("sample-contracts/tokens.clar").unwrap();
-                let mut parsed = ast::build_ast(&contract_id, &whole_contract, &mut ())
-                    .unwrap()
-                    .expressions;
+                let mut parsed = ast::build_ast(
+                    &contract_id,
+                    &whole_contract,
+                    &mut (),
+                    ClarityVersion::latest(),
+                )
+                .unwrap()
+                .expressions;
 
                 type_check(&contract_id, &mut parsed, &mut analysis_db, true)
                     .expect("Failed to type check sample-contracts/tokens");
@@ -2232,10 +2249,14 @@ mod test {
 
             {
                 let mut analysis_db = store.as_analysis_db();
-                let mut parsed =
-                    ast::build_ast(&trait_def_id, super::DEFINE_TRAIT_API.example, &mut ())
-                        .unwrap()
-                        .expressions;
+                let mut parsed = ast::build_ast(
+                    &trait_def_id,
+                    super::DEFINE_TRAIT_API.example,
+                    &mut (),
+                    ClarityVersion::latest(),
+                )
+                .unwrap()
+                .expressions;
 
                 type_check(&trait_def_id, &mut parsed, &mut analysis_db, true)
                     .expect("Failed to type check sample-contracts/tokens");

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -377,7 +377,7 @@ pub fn execute_against_version_and_network(
     let conn = marf.as_clarity_db();
     let mut global_context = GlobalContext::new(as_mainnet, conn, LimitedCostTracker::new_free());
     global_context.execute(|g| {
-        let parsed = ast::build_ast(&contract_id, program, &mut ())?.expressions;
+        let parsed = ast::build_ast(&contract_id, program, &mut (), version)?.expressions;
         eval_all(&parsed, &mut contract_context, g, None)
     })
 }

--- a/src/vm/tests/defines.rs
+++ b/src/vm/tests/defines.rs
@@ -14,11 +14,21 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+#[cfg(test)]
+use rstest::rstest;
+#[cfg(test)]
+use rstest_reuse::{self, *};
 use vm::ast::build_ast;
 use vm::ast::errors::ParseErrors;
 use vm::errors::{CheckErrors, Error, RuntimeErrorType};
-use vm::execute;
 use vm::types::{QualifiedContractIdentifier, TypeSignature, Value};
+use vm::{execute, ClarityVersion};
+
+#[template]
+#[rstest]
+#[case(ClarityVersion::Clarity1)]
+#[case(ClarityVersion::Clarity2)]
+fn test_clarity_versions_defines(#[case] version: ClarityVersion) {}
 
 fn assert_eq_err(e1: CheckErrors, e2: Error) {
     let e1: Error = e1.into();
@@ -47,8 +57,8 @@ fn test_defines() {
     assert_eq!(Ok(Some(Value::Int(1))), execute(&tests));
 }
 
-#[test]
-fn test_accept_options() {
+#[apply(test_clarity_versions_defines)]
+fn test_accept_options(#[case] version: ClarityVersion) {
     let defun = "(define-private (f (b (optional int))) (* 10 (default-to 0 b)))";
     let tests = [
         format!("{} {}", defun, "(f none)"),
@@ -59,7 +69,7 @@ fn test_accept_options() {
         Ok(Some(Value::Int(0))),
         Ok(Some(Value::Int(10))),
         Err(CheckErrors::TypeValueError(
-            TypeSignature::from("(optional int)"),
+            TypeSignature::from_string("(optional int)", version),
             Value::some(Value::Bool(true)).unwrap(),
         )
         .into()),
@@ -180,15 +190,21 @@ fn test_stack_depth() {
     })
 }
 
-#[test]
-fn test_recursive_panic() {
+#[apply(test_clarity_versions_defines)]
+fn test_recursive_panic(#[case] version: ClarityVersion) {
     let tests = "(define-private (factorial (a int))
           (if (is-eq a 0)
               1
               (* a (factorial (- a 1)))))
          (factorial 10)";
 
-    let err = build_ast(&QualifiedContractIdentifier::transient(), tests, &mut ()).unwrap_err();
+    let err = build_ast(
+        &QualifiedContractIdentifier::transient(),
+        tests,
+        &mut (),
+        version,
+    )
+    .unwrap_err();
     match err.err {
         ParseErrors::CircularReference(_) => {}
         _ => panic!("{:?}", err),

--- a/src/vm/tests/sequences.rs
+++ b/src/vm/tests/sequences.rs
@@ -14,6 +14,10 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+#[cfg(test)]
+use rstest::rstest;
+#[cfg(test)]
+use rstest_reuse::{self, *};
 use vm::types::signatures::{ListTypeData, SequenceSubtype};
 use vm::types::TypeSignature::{BoolType, IntType, SequenceType, UIntType};
 use vm::types::{TypeSignature, Value};
@@ -21,7 +25,13 @@ use vm::types::{TypeSignature, Value};
 use std::convert::TryInto;
 use vm::analysis::errors::CheckError;
 use vm::errors::{CheckErrors, Error, RuntimeErrorType};
-use vm::execute;
+use vm::{execute, ClarityVersion};
+
+#[template]
+#[rstest]
+#[case(ClarityVersion::Clarity1)]
+#[case(ClarityVersion::Clarity2)]
+fn test_clarity_versions_sequences(#[case] version: ClarityVersion) {}
 
 #[test]
 fn test_simple_list_admission() {
@@ -719,8 +729,8 @@ fn test_buff_len() {
     assert_eq!(expected, execute(test2).unwrap().unwrap());
 }
 
-#[test]
-fn test_construct_bad_list() {
+#[apply(test_clarity_versions_sequences)]
+fn test_construct_bad_list(#[case] version: ClarityVersion) {
     let test1 = "(list 1 2 3 true)";
     assert_eq!(
         execute(test1).unwrap_err(),
@@ -743,7 +753,7 @@ fn test_construct_bad_list() {
     );
     assert_eq!(
         execute(bad_high_order_list).unwrap_err(),
-        CheckErrors::TypeError(IntType, TypeSignature::from("(list 3 int)")).into()
+        CheckErrors::TypeError(IntType, TypeSignature::from_string("(list 3 int)", version)).into()
     );
 }
 

--- a/src/vm/types/serialization.rs
+++ b/src/vm/types/serialization.rs
@@ -665,6 +665,9 @@ impl ClarityDeserializable<Value> for Value {
 
 #[cfg(test)]
 mod tests {
+    use rstest::rstest;
+    use rstest_reuse::{self, *};
+
     use std::io::Write;
 
     use vm::database::ClaritySerializable;
@@ -673,6 +676,13 @@ mod tests {
 
     use super::super::*;
     use super::SerializationError;
+    use vm::ClarityVersion;
+
+    #[template]
+    #[rstest]
+    #[case(ClarityVersion::Clarity1)]
+    #[case(ClarityVersion::Clarity2)]
+    fn test_clarity_versions_serialization(#[case] version: ClarityVersion) {}
 
     fn buff_type(size: u32) -> TypeSignature {
         TypeSignature::SequenceType(SequenceSubtype::BufferType(size.try_into().unwrap())).into()
@@ -698,8 +708,8 @@ mod tests {
         )
     }
 
-    #[test]
-    fn test_lists() {
+    #[apply(test_clarity_versions_serialization)]
+    fn test_lists(#[case] version: ClarityVersion) {
         let list_list_int = Value::list_from(vec![Value::list_from(vec![
             Value::Int(1),
             Value::Int(2),
@@ -711,17 +721,17 @@ mod tests {
         // Should be legal!
         Value::try_deserialize_hex(
             &Value::list_from(vec![]).unwrap().serialize(),
-            &TypeSignature::from("(list 2 (list 3 int))"),
+            &TypeSignature::from_string("(list 2 (list 3 int))", version),
         )
         .unwrap();
         Value::try_deserialize_hex(
             &list_list_int.serialize(),
-            &TypeSignature::from("(list 2 (list 3 int))"),
+            &TypeSignature::from_string("(list 2 (list 3 int))", version),
         )
         .unwrap();
         Value::try_deserialize_hex(
             &list_list_int.serialize(),
-            &TypeSignature::from("(list 1 (list 4 int))"),
+            &TypeSignature::from_string("(list 1 (list 4 int))", version),
         )
         .unwrap();
 
@@ -731,17 +741,17 @@ mod tests {
         // inner type isn't expected
         test_bad_expectation(
             list_list_int.clone(),
-            TypeSignature::from("(list 1 (list 4 uint))"),
+            TypeSignature::from_string("(list 1 (list 4 uint))", version),
         );
         // child list longer than expected
         test_bad_expectation(
             list_list_int.clone(),
-            TypeSignature::from("(list 1 (list 2 uint))"),
+            TypeSignature::from_string("(list 1 (list 2 uint))", version),
         );
         // parent list longer than expected
         test_bad_expectation(
             list_list_int.clone(),
-            TypeSignature::from("(list 0 (list 2 uint))"),
+            TypeSignature::from_string("(list 0 (list 2 uint))", version),
         );
 
         // make a list too large for the type itself!
@@ -822,8 +832,8 @@ mod tests {
         test_bad_expectation(Value::UInt(1), TypeSignature::IntType);
     }
 
-    #[test]
-    fn test_opts() {
+    #[apply(test_clarity_versions_serialization)]
+    fn test_opts(#[case] version: ClarityVersion) {
         test_deser_ser(Value::none());
         test_deser_ser(Value::some(Value::Int(15)).unwrap());
 
@@ -832,12 +842,12 @@ mod tests {
         // bad expected _contained_ type
         test_bad_expectation(
             Value::some(Value::Int(15)).unwrap(),
-            TypeSignature::from("(optional uint)"),
+            TypeSignature::from_string("(optional uint)", version),
         );
     }
 
-    #[test]
-    fn test_resp() {
+    #[apply(test_clarity_versions_serialization)]
+    fn test_resp(#[case] version: ClarityVersion) {
         test_deser_ser(Value::okay(Value::Int(15)).unwrap());
         test_deser_ser(Value::error(Value::Int(15)).unwrap());
 
@@ -845,16 +855,16 @@ mod tests {
         test_bad_expectation(Value::okay(Value::Int(15)).unwrap(), TypeSignature::IntType);
         test_bad_expectation(
             Value::okay(Value::Int(15)).unwrap(),
-            TypeSignature::from("(response uint int)"),
+            TypeSignature::from_string("(response uint int)", version),
         );
         test_bad_expectation(
             Value::error(Value::Int(15)).unwrap(),
-            TypeSignature::from("(response int uint)"),
+            TypeSignature::from_string("(response int uint)", version),
         );
     }
 
-    #[test]
-    fn test_buffs() {
+    #[apply(test_clarity_versions_serialization)]
+    fn test_buffs(#[case] version: ClarityVersion) {
         test_deser_ser(Value::buff_from(vec![0, 0, 0, 0]).unwrap());
         test_deser_ser(Value::buff_from(vec![0xde, 0xad, 0xbe, 0xef]).unwrap());
         test_deser_ser(Value::buff_from(vec![0, 0xde, 0xad, 0xbe, 0xef, 0]).unwrap());
@@ -867,23 +877,23 @@ mod tests {
         // fail because we expect a shorter buffer
         test_bad_expectation(
             Value::buff_from(vec![0, 0xde, 0xad, 0xbe, 0xef, 0]).unwrap(),
-            TypeSignature::from("(buff 2)"),
+            TypeSignature::from_string("(buff 2)", version),
         );
     }
 
-    #[test]
-    fn test_string_ascii() {
+    #[apply(test_clarity_versions_serialization)]
+    fn test_string_ascii(#[case] version: ClarityVersion) {
         test_deser_ser(Value::string_ascii_from_bytes(vec![61, 62, 63, 64]).unwrap());
 
         // fail because we expect a shorter string
         test_bad_expectation(
             Value::string_ascii_from_bytes(vec![61, 62, 63, 64]).unwrap(),
-            TypeSignature::from("(string-ascii 3)"),
+            TypeSignature::from_string("(string-ascii 3)", version),
         );
     }
 
-    #[test]
-    fn test_string_utf8() {
+    #[apply(test_clarity_versions_serialization)]
+    fn test_string_utf8(#[case] version: ClarityVersion) {
         test_deser_ser(Value::string_utf8_from_bytes(vec![61, 62, 63, 64]).unwrap());
         test_deser_ser(
             Value::string_utf8_from_bytes(vec![61, 62, 63, 240, 159, 164, 151]).unwrap(),
@@ -892,12 +902,12 @@ mod tests {
         // fail because we expect a shorter string
         test_bad_expectation(
             Value::string_utf8_from_bytes(vec![61, 62, 63, 64]).unwrap(),
-            TypeSignature::from("(string-utf8 3)"),
+            TypeSignature::from_string("(string-utf8 3)", version),
         );
 
         test_bad_expectation(
             Value::string_utf8_from_bytes(vec![61, 62, 63, 240, 159, 164, 151]).unwrap(),
-            TypeSignature::from("(string-utf8 3)"),
+            TypeSignature::from_string("(string-utf8 3)", version),
         );
     }
 

--- a/src/vm/version.rs
+++ b/src/vm/version.rs
@@ -1,5 +1,7 @@
 use core::StacksEpochId;
 use std::fmt;
+use std::str::FromStr;
+use vm::errors::{Error, RuntimeErrorType};
 
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, PartialOrd)]
 pub enum ClarityVersion {
@@ -28,6 +30,24 @@ impl ClarityVersion {
             }
             StacksEpochId::Epoch20 => ClarityVersion::Clarity1,
             StacksEpochId::Epoch21 => ClarityVersion::Clarity2,
+        }
+    }
+}
+
+impl FromStr for ClarityVersion {
+    type Err = Error;
+
+    fn from_str(version: &str) -> Result<ClarityVersion, Error> {
+        let s = version.to_string().to_lowercase();
+        if s == "clarity1" {
+            Ok(ClarityVersion::Clarity1)
+        } else if s == "clarity2" {
+            Ok(ClarityVersion::Clarity1)
+        } else {
+            Err(RuntimeErrorType::ParseError(
+                "Invalid clarity version. Valid versions are: Clarity1, Clarity2.".to_string(),
+            )
+            .into())
         }
     }
 }


### PR DESCRIPTION
Fixes #2759 

I added clarity version as a parameter to all of the ast passes. For the time being, this parameter is unused.

For all tests that used functions related to the ast passes, such as `build_ast` or `parse`, I defined and used a macro that enabled me to test the same snippet of code across multiple clarity versions. 

## Notes 
- In `vm/docs/mod.rs`, the documentation examples are now tested against the latest version of clarity only 
- The way the clarity version is determined in different parts of the code could be worth scrutiny during review. In some places, the "default for epoch" is used to get the version, and in other places, the version is extracted from the contract context. 