### PR TITLE
Build: buster -> bullseye in rust testing dockerfiles

### DIFF
--- a/.github/actions/bitcoin-int-tests/Dockerfile.atlas-test
+++ b/.github/actions/bitcoin-int-tests/Dockerfile.atlas-test
@@ -1,4 +1,4 @@
-FROM rust:buster
+FROM rust:bullseye
 
 WORKDIR /src
 

--- a/.github/actions/bitcoin-int-tests/Dockerfile.bitcoin-tests
+++ b/.github/actions/bitcoin-int-tests/Dockerfile.bitcoin-tests
@@ -1,4 +1,4 @@
-FROM rust:buster
+FROM rust:bullseye
 
 WORKDIR /src/
 

--- a/.github/actions/bitcoin-int-tests/Dockerfile.code-cov
+++ b/.github/actions/bitcoin-int-tests/Dockerfile.code-cov
@@ -1,4 +1,4 @@
-FROM rust:buster AS build
+FROM rust:bullseye AS build
 
 WORKDIR /build
 

--- a/.github/actions/bitcoin-int-tests/Dockerfile.large-genesis
+++ b/.github/actions/bitcoin-int-tests/Dockerfile.large-genesis
@@ -1,4 +1,4 @@
-FROM rust:buster
+FROM rust:bullseye
 
 WORKDIR /src
 

--- a/.github/actions/bitcoin-int-tests/Dockerfile.net-tests
+++ b/.github/actions/bitcoin-int-tests/Dockerfile.net-tests
@@ -1,4 +1,4 @@
-FROM rust:buster
+FROM rust:bullseye
 
 WORKDIR /src
 

--- a/.github/actions/bitcoin-int-tests/Dockerfile.rustfmt
+++ b/.github/actions/bitcoin-int-tests/Dockerfile.rustfmt
@@ -1,4 +1,4 @@
-FROM rust:buster
+FROM rust:bullseye
 
 WORKDIR /src
 

--- a/migration-verification/Dockerfile
+++ b/migration-verification/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:buster
+FROM rust:bullseye
 
 ### Install Node.js
 RUN apt-get update


### PR DESCRIPTION
This PR upgrades the rust containers in our testing dockerfiles from `buster` to `bullseye` (the new Debian stable).

This fixes an issue with the recent rust nightly in our code-coverage tests -- one of the packages interacting poorly with profiling builds in `buster`.