### PR TITLE
chore: tweak stale bot settings

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,11 +1,14 @@
 # Number of days of inactivity before an issue becomes stale
-daysUntilStale: 180
+daysUntilStale: 365
 # Number of days of inactivity before a stale issue is closed
-daysUntilClose: 7
+daysUntilClose: 30
 # Issues with these labels will never be considered stale
 exemptLabels:
   - pinned
   - security
+  - stacks-2.1
+  - consensus-critical
+  - clarity
 # Label to use when marking an issue as stale
 staleLabel: stale
 # Comment to post when marking an issue as stale. Set to `false` to disable


### PR DESCRIPTION
Changes:
- wait 1 yr before marking issues stale. Even at 180 days, many
  important issues keep going stale.
- add more labels to exempt list.
- wait 30 days before closing stale issues.
