### PR TITLE
Draft: Use fee rate estimation in block assembly

### DIFF
--- a/src/chainstate/coordinator/mod.rs
+++ b/src/chainstate/coordinator/mod.rs
@@ -148,8 +148,8 @@ pub struct ChainsCoordinator<
     T: BlockEventDispatcher,
     N: CoordinatorNotices,
     R: RewardSetProvider,
-    CE: CostEstimator,
-    FE: FeeEstimator,
+    CE: CostEstimator + ?Sized,
+    FE: FeeEstimator + ?Sized,
 > {
     canonical_sortition_tip: Option<SortitionId>,
     canonical_chain_tip: Option<StacksBlockId>,
@@ -160,8 +160,8 @@ pub struct ChainsCoordinator<
     burnchain: Burnchain,
     attachments_tx: SyncSender<HashSet<AttachmentInstance>>,
     dispatcher: Option<&'a T>,
-    cost_estimator: Option<CE>,
-    fee_estimator: Option<FE>,
+    cost_estimator: Option<&'a mut CE>,
+    fee_estimator: Option<&'a mut FE>,
     reward_set_provider: R,
     notifier: N,
     atlas_config: AtlasConfig,
@@ -256,7 +256,7 @@ impl RewardSetProvider for OnChainRewardSetProvider {
     }
 }
 
-impl<'a, T: BlockEventDispatcher, CE: CostEstimator, FE: FeeEstimator>
+impl<'a, T: BlockEventDispatcher, CE: CostEstimator + ?Sized, FE: FeeEstimator + ?Sized>
     ChainsCoordinator<'a, T, ArcCounterCoordinatorNotices, OnChainRewardSetProvider, CE, FE>
 {
     pub fn run(
@@ -266,8 +266,8 @@ impl<'a, T: BlockEventDispatcher, CE: CostEstimator, FE: FeeEstimator>
         dispatcher: &'a mut T,
         comms: CoordinatorReceivers,
         atlas_config: AtlasConfig,
-        cost_estimator: Option<CE>,
-        fee_estimator: Option<FE>,
+        cost_estimator: Option<&mut CE>,
+        fee_estimator: Option<&mut FE>,
     ) where
         T: BlockEventDispatcher,
     {
@@ -517,8 +517,8 @@ impl<
         T: BlockEventDispatcher,
         N: CoordinatorNotices,
         U: RewardSetProvider,
-        CE: CostEstimator,
-        FE: FeeEstimator,
+        CE: CostEstimator + ?Sized,
+        FE: FeeEstimator + ?Sized,
     > ChainsCoordinator<'a, T, N, U, CE, FE>
 {
     pub fn handle_new_stacks_block(&mut self) -> Result<(), Error> {

--- a/src/chainstate/stacks/db/blocks.rs
+++ b/src/chainstate/stacks/db/blocks.rs
@@ -5545,6 +5545,8 @@ pub mod test {
     use util::hash::*;
     use util::retry::*;
 
+    use crate::cost_estimates::metrics::UnitMetric;
+    use crate::cost_estimates::UnitEstimator;
     use crate::types::chainstate::{BlockHeaderHash, StacksWorkScore};
 
     use super::*;
@@ -9169,6 +9171,9 @@ pub mod test {
                     let mut mempool = MemPoolDB::open(false, 0x80000000, &chainstate_path).unwrap();
                     let coinbase_tx = make_coinbase(miner, tenure_id);
 
+                    let mut estimator = UnitEstimator;
+                    let metric = UnitMetric;
+
                     let anchored_block = StacksBlockBuilder::build_anchored_block(
                         chainstate,
                         &sortdb.index_conn(),
@@ -9180,6 +9185,8 @@ pub mod test {
                         &coinbase_tx,
                         BlockBuilderSettings::max_value(),
                         None,
+                        &mut estimator,
+                        &metric,
                     )
                     .unwrap();
                     (anchored_block.0, vec![])

--- a/src/chainstate/stacks/db/mod.rs
+++ b/src/chainstate/stacks/db/mod.rs
@@ -237,11 +237,11 @@ impl FromRow<DBConfig> for DBConfig {
 
 impl FromRow<StacksHeaderInfo> for StacksHeaderInfo {
     fn from_row<'a>(row: &'a Row) -> Result<StacksHeaderInfo, db_error> {
-        let block_height = u64::from_column(row, "block_height")?;
+        let block_height: u64 = u64::from_column(row, "block_height")?;
         let index_root = TrieHash::from_column(row, "index_root")?;
         let consensus_hash = ConsensusHash::from_column(row, "consensus_hash")?;
         let burn_header_hash = BurnchainHeaderHash::from_column(row, "burn_header_hash")?;
-        let burn_header_height = u64::from_column(row, "burn_header_height")? as u32;
+        let burn_header_height: u64 = u64::from_column(row, "burn_header_height")?;
         let burn_header_timestamp = u64::from_column(row, "burn_header_timestamp")?;
         let stacks_header = StacksBlockHeader::from_row(row)?;
         let anchored_block_size_str: String = row.get_unwrap("block_size");
@@ -256,13 +256,13 @@ impl FromRow<StacksHeaderInfo> for StacksHeaderInfo {
         Ok(StacksHeaderInfo {
             anchored_header: stacks_header,
             microblock_tail: None,
-            block_height: block_height,
-            index_root: index_root,
-            consensus_hash: consensus_hash,
-            burn_header_hash: burn_header_hash,
-            burn_header_height: burn_header_height,
-            burn_header_timestamp: burn_header_timestamp,
-            anchored_block_size: anchored_block_size,
+            block_height,
+            index_root,
+            consensus_hash,
+            burn_header_hash,
+            burn_header_height: burn_header_height as u32,
+            burn_header_timestamp,
+            anchored_block_size,
         })
     }
 }

--- a/src/chainstate/stacks/miner.rs
+++ b/src/chainstate/stacks/miner.rs
@@ -1496,7 +1496,7 @@ impl StacksBlockBuilder {
         builder.try_mine_tx(&mut epoch_tx, coinbase_tx)?;
 
         mempool.reset_last_known_nonces()?;
-        mempool.estimate_tx_rates(estimator, metric, 100);
+        mempool.estimate_tx_rates(estimator, metric, 100)?;
 
         let mut considered = HashSet::new(); // txids of all transactions we looked at
         let mut mined_origin_nonces: HashMap<StacksAddress, u64> = HashMap::new(); // map addrs of mined transaction origins to the nonces we used

--- a/src/chainstate/stacks/miner.rs
+++ b/src/chainstate/stacks/miner.rs
@@ -448,7 +448,7 @@ impl<'a> StacksMicroblockBuilder<'a> {
         return self.make_next_microblock(txs_included, miner_key);
     }
 
-    pub fn mine_next_microblock<CE: CostEstimator, CM: CostMetric>(
+    pub fn mine_next_microblock<CE: CostEstimator + ?Sized, CM: CostMetric + ?Sized>(
         &mut self,
         mem_pool: &mut MemPoolDB,
         miner_key: &Secp256k1PrivateKey,
@@ -1444,7 +1444,7 @@ impl StacksBlockBuilder {
 
     /// Given access to the mempool, mine an anchored block with no more than the given execution cost.
     ///   returns the assembled block, and the consumed execution budget.
-    pub fn build_anchored_block<CE: CostEstimator, CM: CostMetric>(
+    pub fn build_anchored_block<CE: CostEstimator + ?Sized, CM: CostMetric + ?Sized>(
         chainstate_handle: &StacksChainState, // not directly used; used as a handle to open other chainstates
         burn_dbconn: &SortitionDBConn,
         mempool: &mut MemPoolDB,

--- a/src/chainstate/stacks/miner.rs
+++ b/src/chainstate/stacks/miner.rs
@@ -475,7 +475,7 @@ impl<'a> StacksMicroblockBuilder<'a> {
         let deadline = get_epoch_time_ms() + (self.settings.max_miner_time_ms as u128);
 
         mem_pool.reset_last_known_nonces()?;
-        mem_pool.estimate_tx_rates(estimator, metric, 100);
+        mem_pool.estimate_tx_rates(estimator, metric, 100)?;
 
         debug!(
             "Microblock transaction selection begins (child of {}), bytes so far: {}",

--- a/src/chainstate/stacks/mod.rs
+++ b/src/chainstate/stacks/mod.rs
@@ -145,6 +145,11 @@ pub enum Error {
     InvalidStacksBlock(String),
     InvalidStacksMicroblock(String, BlockHeaderHash),
     InvalidStacksTransaction(String, bool),
+    /// This error indicates that the considered transaction was skipped
+    /// because of the current state of the block assembly algorithm,
+    /// but the transaction otherwise may be valid (e.g., block assembly is
+    /// only considering STX transfers and this tx isn't a transfer).
+    StacksTransactionSkipped,
     PostConditionFailed(String),
     NoSuchBlockError,
     InvalidChainstateDB,
@@ -229,6 +234,9 @@ impl fmt::Display for Error {
             Error::PoxAlreadyLocked => write!(f, "Account has already locked STX for PoX"),
             Error::PoxInsufficientBalance => write!(f, "Not enough STX to lock"),
             Error::PoxNoRewardCycle => write!(f, "No such reward cycle"),
+            Error::StacksTransactionSkipped => {
+                write!(f, "Stacks transaction skipped during assembly")
+            }
         }
     }
 }
@@ -261,6 +269,7 @@ impl error::Error for Error {
             Error::PoxAlreadyLocked => None,
             Error::PoxInsufficientBalance => None,
             Error::PoxNoRewardCycle => None,
+            Error::StacksTransactionSkipped => None,
         }
     }
 }
@@ -293,6 +302,7 @@ impl Error {
             Error::PoxAlreadyLocked => "PoxAlreadyLocked",
             Error::PoxInsufficientBalance => "PoxInsufficientBalance",
             Error::PoxNoRewardCycle => "PoxNoRewardCycle",
+            Error::StacksTransactionSkipped => "StacksTransactionSkipped",
         }
     }
 

--- a/src/core/mempool.rs
+++ b/src/core/mempool.rs
@@ -550,7 +550,7 @@ impl MemPoolDB {
     /// at most `max_updates` entries in the database before returning.
     ///
     /// Returns `Ok(number_updated)` on success
-    pub fn estimate_tx_rates<CE: CostEstimator, CM: CostMetric>(
+    pub fn estimate_tx_rates<CE: CostEstimator + ?Sized, CM: CostMetric + ?Sized>(
         &mut self,
         estimator: &CE,
         metric: &CM,

--- a/src/core/mempool.rs
+++ b/src/core/mempool.rs
@@ -812,7 +812,9 @@ impl MemPoolDB {
                           consensus_hash,
                           block_header_hash,
                           height,
-                          accept_time
+                          accept_time,
+                          last_known_sponsor_nonce,
+                          last_known_origin_nonce
                           FROM mempool WHERE {0}_address = ?1 AND {0}_nonce = ?2",
             if is_origin { "origin" } else { "sponsor" }
         );

--- a/src/cost_estimates/metrics.rs
+++ b/src/cost_estimates/metrics.rs
@@ -22,6 +22,11 @@ pub struct ProportionalDotProduct {
     block_size_limit: u64,
 }
 
+/// This metric always returns a unit value for all execution costs and tx lengths.
+/// When used, this metric will cause block assembly to consider transactions based
+/// solely on their raw transaction fee, not any kind of rate estimation.
+pub struct UnitMetric;
+
 impl ProportionalDotProduct {
     pub fn new(
         block_size_limit: u64,
@@ -52,5 +57,15 @@ impl CostMetric for ProportionalDotProduct {
 
     fn from_len(&self, tx_len: u64) -> u64 {
         self.calculate_len_proportion(tx_len)
+    }
+}
+
+impl CostMetric for UnitMetric {
+    fn from_cost_and_len(&self, _cost: &ExecutionCost, _tx_len: u64) -> u64 {
+        1
+    }
+
+    fn from_len(&self, _tx_len: u64) -> u64 {
+        1
     }
 }

--- a/src/cost_estimates/metrics.rs
+++ b/src/cost_estimates/metrics.rs
@@ -9,6 +9,16 @@ pub trait CostMetric {
     fn from_len(&self, tx_len: u64) -> u64;
 }
 
+impl CostMetric for Box<dyn CostMetric> {
+    fn from_cost_and_len(&self, cost: &ExecutionCost, tx_len: u64) -> u64 {
+        self.as_ref().from_cost_and_len(cost, tx_len)
+    }
+
+    fn from_len(&self, tx_len: u64) -> u64 {
+        self.as_ref().from_len(tx_len)
+    }
+}
+
 pub const PROPORTION_RESOLUTION: u64 = 10_000;
 
 /// This metric calculates a single dimensional value for a transaction's

--- a/src/cost_estimates/mod.rs
+++ b/src/cost_estimates/mod.rs
@@ -178,3 +178,28 @@ impl FeeEstimator for () {
         Err(EstimatorError::NoEstimateAvailable)
     }
 }
+
+/// This estimator always returns a unit estimate in all dimensions.
+/// This can be paired with the UnitMetric to cause block assembly to consider
+/// *only* transaction fees, not performing any kind of rate estimation.
+pub struct UnitEstimator;
+
+impl CostEstimator for UnitEstimator {
+    fn notify_event(
+        &mut self,
+        _tx: &TransactionPayload,
+        _actual_cost: &ExecutionCost,
+    ) -> Result<(), EstimatorError> {
+        Ok(())
+    }
+
+    fn estimate_cost(&self, _tx: &TransactionPayload) -> Result<ExecutionCost, EstimatorError> {
+        Ok(ExecutionCost {
+            write_length: 1,
+            write_count: 1,
+            read_length: 1,
+            read_count: 1,
+            runtime: 1,
+        })
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,8 @@ use std::process;
 use std::{collections::HashMap, env};
 use std::{convert::TryFrom, fs};
 
+use blockstack_lib::cost_estimates::UnitEstimator;
+use cost_estimates::metrics::UnitMetric;
 use rusqlite::types::ToSql;
 use rusqlite::Connection;
 use rusqlite::OpenFlags;
@@ -486,6 +488,9 @@ simulating a miner.
         settings.max_miner_time_ms = max_time;
         settings.mempool_settings.min_tx_fee = min_fee;
 
+        let mut estimator = UnitEstimator;
+        let metric = UnitMetric;
+
         let result = StacksBlockBuilder::build_anchored_block(
             &chain_state,
             &sort_db.index_conn(),
@@ -497,6 +502,8 @@ simulating a miner.
             &coinbase_tx,
             settings,
             None,
+            &mut estimator,
+            &metric,
         );
 
         let stop = get_epoch_time_ms();

--- a/src/net/download.rs
+++ b/src/net/download.rs
@@ -2554,6 +2554,9 @@ pub mod test {
     use vm::costs::ExecutionCost;
     use vm::representations::*;
 
+    use crate::cost_estimates::metrics::UnitMetric;
+    use crate::cost_estimates::UnitEstimator;
+
     use super::*;
 
     fn get_peer_availability(
@@ -3670,6 +3673,9 @@ pub mod test {
                                     let coinbase_tx =
                                         make_coinbase_with_nonce(miner, i, (i + 2) as u64);
 
+                                    let mut estimator = UnitEstimator;
+                                    let metric = UnitMetric;
+
                                     let (anchored_block, block_size, block_execution_cost) =
                                         StacksBlockBuilder::build_anchored_block(
                                             chainstate,
@@ -3682,6 +3688,8 @@ pub mod test {
                                             &coinbase_tx,
                                             BlockBuilderSettings::max_value(),
                                             None,
+                                            &mut estimator,
+                                            &metric,
                                         )
                                         .unwrap();
                                     (anchored_block, vec![])

--- a/src/util/db.rs
+++ b/src/util/db.rs
@@ -179,6 +179,21 @@ impl FromColumn<u64> for u64 {
     }
 }
 
+impl FromColumn<Option<u64>> for u64 {
+    fn from_column<'a>(row: &'a Row, column_name: &str) -> Result<Option<u64>, Error> {
+        let x: Option<i64> = row.get_unwrap(column_name);
+        match x {
+            Some(x) => {
+                if x < 0 {
+                    return Err(Error::ParseError);
+                }
+                Ok(Some(x as u64))
+            }
+            None => Ok(None),
+        }
+    }
+}
+
 impl FromRow<i64> for i64 {
     fn from_row<'a>(row: &'a Row) -> Result<i64, Error> {
         let x: i64 = row.get_unwrap(0);

--- a/testnet/stacks-node/src/run_loop/neon.rs
+++ b/testnet/stacks-node/src/run_loop/neon.rs
@@ -15,12 +15,9 @@ use stacks::chainstate::coordinator::{
     BlockEventDispatcher, ChainsCoordinator, CoordinatorCommunication,
 };
 use stacks::chainstate::stacks::db::{ChainStateBootData, StacksChainState};
-use stacks::chainstate::stacks::MAX_BLOCK_LEN;
-use stacks::cost_estimates::metrics::ProportionalDotProduct;
 use stacks::net::atlas::{AtlasConfig, Attachment};
 use stx_genesis::GenesisData;
 
-use crate::config::{CostEstimatorName, CostMetricName, FeeEstimatorName};
 use crate::monitoring::start_serving_monitoring_metrics;
 use crate::node::use_test_genesis_chainstate;
 use crate::syncctl::PoxSyncWatchdog;
@@ -248,39 +245,13 @@ impl RunLoop {
 
         let atlas_config = AtlasConfig::default(mainnet);
         let moved_atlas_config = atlas_config.clone();
-        let moved_estimator_config = self.config.estimation.clone();
-        let moved_chainstate_path = self.config.get_chainstate_path();
-        let moved_block_limit = self.config.block_limit.clone();
+        let moved_config = self.config.clone();
 
         let coordinator_thread_handle = thread::Builder::new()
             .name("chains-coordinator".to_string())
             .spawn(move || {
-                let cost_estimator = match moved_estimator_config.cost_estimator {
-                    Some(CostEstimatorName::NaivePessimistic) => Some(
-                        moved_estimator_config
-                            .make_pessimistic_cost_estimator(moved_chainstate_path.clone()),
-                    ),
-                    None => None,
-                };
-
-                let metric = match moved_estimator_config.cost_metric {
-                    Some(CostMetricName::ProportionDotProduct) => Some(
-                        ProportionalDotProduct::new(MAX_BLOCK_LEN as u64, moved_block_limit),
-                    ),
-                    None => None,
-                };
-
-                let fee_estimator = match moved_estimator_config.fee_estimator {
-                    Some(FeeEstimatorName::ScalarFeeRate) => {
-                        let metric = metric
-                            .expect("Configured a fee rate estimator without a configure metric.");
-                        Some(
-                            moved_estimator_config
-                                .make_scalar_fee_estimator(moved_chainstate_path, metric),
-                        )
-                    }
-                    None => None,
-                };
+                let mut cost_estimator = moved_config.make_cost_estimator();
+                let mut fee_estimator = moved_config.make_fee_estimator();
 
                 ChainsCoordinator::run(
                     chain_state_db,
@@ -289,8 +260,8 @@ impl RunLoop {
                     &mut coordinator_dispatcher,
                     coordinator_receivers,
                     moved_atlas_config,
-                    cost_estimator,
-                    fee_estimator,
+                    cost_estimator.as_deref_mut(),
+                    fee_estimator.as_deref_mut(),
                 );
             })
             .unwrap();

--- a/testnet/stacks-node/src/tenure.rs
+++ b/testnet/stacks-node/src/tenure.rs
@@ -11,6 +11,8 @@ use stacks::chainstate::stacks::{
     StacksPrivateKey, StacksPublicKey, StacksTransaction,
 };
 use stacks::core::mempool::MemPoolDB;
+use stacks::cost_estimates::metrics::UnitMetric;
+use stacks::cost_estimates::UnitEstimator;
 use stacks::types::chainstate::VRFSeed;
 use stacks::util::hash::Hash160;
 use stacks::util::vrf::VRFProof;
@@ -84,6 +86,8 @@ impl<'a> Tenure {
         )
         .unwrap();
 
+        let mut estimator = UnitEstimator;
+        let metric = UnitMetric;
         let (anchored_block, _, _) = StacksBlockBuilder::build_anchored_block(
             &mut chain_state,
             burn_dbconn,
@@ -95,6 +99,8 @@ impl<'a> Tenure {
             &self.coinbase_tx,
             BlockBuilderSettings::limited(self.config.block_limit.clone()),
             None,
+            &mut estimator,
+            &metric,
         )
         .unwrap();
 

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -2001,13 +2001,14 @@ fn filter_low_fee_tx_integration_test() {
     next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
     next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
 
-    // first five accounts are blank
+    // First five accounts have a transaction. The miner will consider low fee transactions,
+    //  but rank by estimated fee rate.
     for i in 0..5 {
         let account = get_account(&http_origin, &spender_addrs[i]);
-        assert_eq!(account.nonce, 0);
+        assert_eq!(account.nonce, 1);
     }
 
-    // last five accounts have traction
+    // last five accounts have transaction
     for i in 5..10 {
         let account = get_account(&http_origin, &spender_addrs[i]);
         assert_eq!(account.nonce, 1);
@@ -2134,8 +2135,8 @@ fn mining_transactions_is_fair() {
         txs.push(tx);
     }
 
-    // spender 1 sends 1 tx
-    let tx = make_stacks_transfer(&spender_sks[1], 0, 1000, &recipient.into(), 1000);
+    // spender 1 sends 1 tx, that is roughly the middle rate among the spender[0] transactions
+    let tx = make_stacks_transfer(&spender_sks[1], 0, 20_000, &recipient.into(), 1000);
     txs.push(tx);
 
     let (mut conf, _) = neon_integration_test_conf();


### PR DESCRIPTION
This **draft** PR alters the miner block assembly logic to use configured cost estimation and cost metrics to produce fee rate estimations for candidate transactions in the mempool. This fee rate estimation is used as the sort order for transaction consideration.

This PR also implements the expected nonce calculation proposed in #2834.

There isn't a new end to end test case yet for the block assembly -- I'm still trying to understand the best way to test the end to end changes here (many of the existing e2e tests cover these code paths, but they don't specifically test for the desired behavior here).