### PR TITLE
2.05: use serialized_size() aggregation for cost inputs of linear methods

### DIFF
--- a/src/vm/callables.rs
+++ b/src/vm/callables.rs
@@ -32,9 +32,19 @@ use vm::types::{
 };
 use vm::{eval, Environment, LocalContext, Value};
 
+use super::costs::CostOverflowingMath;
+
 pub enum CallableType {
     UserFunction(DefinedFunction),
     NativeFunction(&'static str, NativeHandle, ClarityCostFunction),
+    /// These native functions have a new method for calculating input size in 2.05
+    /// If the global context's epoch is >= 2.05, then the NativeCostInputHandle field is applied
+    NativeFunction205(
+        &'static str,
+        NativeHandle,
+        ClarityCostFunction,
+        &'static dyn Fn(&[Value]) -> Result<u64>,
+    ),
     SpecialFunction(
         &'static str,
         &'static dyn Fn(&[SymbolicExpression], &mut Environment, &LocalContext) -> Result<Value>,
@@ -58,28 +68,47 @@ pub struct DefinedFunction {
     body: SymbolicExpression,
 }
 
+/// This enum handles the actual invocation of the method
+/// implementing a native function. Each variant handles
+/// different expected number of arguments.
 pub enum NativeHandle {
     SingleArg(&'static dyn Fn(Value) -> Result<Value>),
     DoubleArg(&'static dyn Fn(Value, Value) -> Result<Value>),
     MoreArg(&'static dyn Fn(Vec<Value>) -> Result<Value>),
 }
 
+/// Used to calculate the input uint to a cost function from the
+///  input arguments of the associated native function
+pub enum NativeCostInputHandle {
+    SingleArg(&'static dyn Fn(&Value) -> Result<u64>),
+    DoubleArg(&'static dyn Fn(&Value, &Value) -> Result<u64>),
+    MoreArg(&'static dyn Fn(&[Value]) -> Result<u64>),
+}
+
 impl NativeHandle {
     pub fn apply(&self, mut args: Vec<Value>) -> Result<Value> {
         match self {
-            NativeHandle::SingleArg(function) => {
+            Self::SingleArg(function) => {
                 check_argument_count(1, &args)?;
                 function(args.pop().unwrap())
             }
-            NativeHandle::DoubleArg(function) => {
+            Self::DoubleArg(function) => {
                 check_argument_count(2, &args)?;
                 let second = args.pop().unwrap();
                 let first = args.pop().unwrap();
                 function(first, second)
             }
-            NativeHandle::MoreArg(function) => function(args),
+            Self::MoreArg(function) => function(args),
         }
     }
+}
+
+pub fn cost_input_sized_vararg(args: &[Value]) -> Result<u64> {
+    args.iter()
+        .try_fold(0, |sum, value| {
+            (value.serialized_size() as u64).cost_overflow_add(sum)
+        })
+        .map_err(Error::from)
 }
 
 #[derive(Clone, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]
@@ -243,6 +272,9 @@ impl CallableType {
             CallableType::UserFunction(f) => f.get_identifier(),
             CallableType::NativeFunction(s, _, _) => FunctionIdentifier::new_native_function(s),
             CallableType::SpecialFunction(s, _) => FunctionIdentifier::new_native_function(s),
+            CallableType::NativeFunction205(s, _, _, _) => {
+                FunctionIdentifier::new_native_function(s)
+            }
         }
     }
 }

--- a/src/vm/contexts.rs
+++ b/src/vm/contexts.rs
@@ -941,6 +941,11 @@ impl<'a, 'b> Environment<'a, 'b> {
         result
     }
 
+    /// This is the epoch of the the block that this transaction is executing within.
+    /// Note: in the current plans for 2.10, there is also a contract-specific **Clarity version**
+    ///  which governs which native functions are available / defined. That is separate from this
+    ///  epoch identifier, and most Clarity VM changes should consult that value instead. This
+    ///  epoch identifier is used for determining how cost functions should be applied.
     pub fn epoch(&self) -> &StacksEpochId {
         &self.global_context.epoch_id
     }

--- a/src/vm/functions/assets.rs
+++ b/src/vm/functions/assets.rs
@@ -26,8 +26,7 @@ use vm::errors::{
 };
 use vm::representations::SymbolicExpression;
 use vm::types::{
-    byte_len_of_serialization, AssetIdentifier, BlockInfoProperty, BuffData, OptionalData,
-    PrincipalData, TypeSignature, Value,
+    AssetIdentifier, BlockInfoProperty, BuffData, OptionalData, PrincipalData, TypeSignature, Value,
 };
 use vm::{eval, Environment, LocalContext};
 
@@ -374,7 +373,7 @@ pub fn special_mint_asset_v205(
         .ok_or(CheckErrors::NoSuchNFT(asset_name.to_string()))?;
     let expected_asset_type = &nft_metadata.key_type;
 
-    let asset_size = byte_len_of_serialization(&asset.serialize());
+    let asset_size = asset.serialized_size() as u64;
     runtime_cost(ClarityCostFunction::NftMint, env, asset_size)?;
 
     if !expected_asset_type.admits(&asset) {
@@ -525,7 +524,7 @@ pub fn special_transfer_asset_v205(
         .ok_or(CheckErrors::NoSuchNFT(asset_name.to_string()))?;
     let expected_asset_type = &nft_metadata.key_type;
 
-    let asset_size = byte_len_of_serialization(&asset.serialize());
+    let asset_size = asset.serialized_size() as u64;
     runtime_cost(ClarityCostFunction::NftTransfer, env, asset_size)?;
 
     if !expected_asset_type.admits(&asset) {
@@ -785,7 +784,7 @@ pub fn special_get_owner_v205(
         .ok_or(CheckErrors::NoSuchNFT(asset_name.to_string()))?;
     let expected_asset_type = &nft_metadata.key_type;
 
-    let asset_size = byte_len_of_serialization(&asset.serialize());
+    let asset_size = asset.serialized_size() as u64;
     runtime_cost(ClarityCostFunction::NftOwner, env, asset_size)?;
 
     if !expected_asset_type.admits(&asset) {
@@ -993,7 +992,7 @@ pub fn special_burn_asset_v205(
         .ok_or(CheckErrors::NoSuchNFT(asset_name.to_string()))?;
     let expected_asset_type = &nft_metadata.key_type;
 
-    let asset_size = byte_len_of_serialization(&asset.serialize());
+    let asset_size = asset.serialized_size() as u64;
     runtime_cost(ClarityCostFunction::NftBurn, env, asset_size)?;
 
     if !expected_asset_type.admits(&asset) {

--- a/src/vm/functions/mod.rs
+++ b/src/vm/functions/mod.rs
@@ -37,6 +37,7 @@ use vm::types::{
 use vm::{eval, Environment, LocalContext};
 
 use crate::types::chainstate::StacksAddress;
+use crate::vm::callables::cost_input_sized_vararg;
 
 macro_rules! switch_on_global_epoch {
     ($Name:ident ($Epoch2Version:ident, $Epoch205Version:ident)) => {
@@ -153,7 +154,7 @@ define_named_enum!(NativeFunctions {
 });
 
 pub fn lookup_reserved_functions(name: &str) -> Option<CallableType> {
-    use vm::callables::CallableType::{NativeFunction, SpecialFunction};
+    use vm::callables::CallableType::{NativeFunction, NativeFunction205, SpecialFunction};
     use vm::functions::NativeFunctions::*;
     if let Some(native_function) = NativeFunctions::lookup_by_name(name) {
         let callable = match native_function {
@@ -239,10 +240,11 @@ pub fn lookup_reserved_functions(name: &str) -> Option<CallableType> {
                 NativeHandle::SingleArg(&boolean::native_not),
                 ClarityCostFunction::Not,
             ),
-            Equals => NativeFunction(
+            Equals => NativeFunction205(
                 "native_eq",
                 NativeHandle::MoreArg(&native_eq),
                 ClarityCostFunction::Eq,
+                &cost_input_sized_vararg,
             ),
             If => SpecialFunction("special_if", &special_if),
             Let => SpecialFunction("special_let", &special_let),
@@ -264,10 +266,11 @@ pub fn lookup_reserved_functions(name: &str) -> Option<CallableType> {
                 NativeHandle::DoubleArg(&sequences::native_element_at),
                 ClarityCostFunction::ElementAt,
             ),
-            IndexOf => NativeFunction(
+            IndexOf => NativeFunction205(
                 "native_index_of",
                 NativeHandle::DoubleArg(&sequences::native_index_of),
                 ClarityCostFunction::IndexOf,
+                &cost_input_sized_vararg,
             ),
             ListCons => SpecialFunction("special_list_cons", &sequences::list_cons),
             FetchEntry => SpecialFunction("special_map-get?", &database::special_fetch_entry),
@@ -276,40 +279,46 @@ pub fn lookup_reserved_functions(name: &str) -> Option<CallableType> {
             DeleteEntry => SpecialFunction("special_delete-entry", &database::special_delete_entry),
             TupleCons => SpecialFunction("special_tuple", &tuples::tuple_cons),
             TupleGet => SpecialFunction("special_get-tuple", &tuples::tuple_get),
-            TupleMerge => NativeFunction(
+            TupleMerge => NativeFunction205(
                 "native_merge-tuple",
                 NativeHandle::DoubleArg(&tuples::tuple_merge),
                 ClarityCostFunction::TupleMerge,
+                &cost_input_sized_vararg,
             ),
             Begin => NativeFunction(
                 "native_begin",
                 NativeHandle::MoreArg(&native_begin),
                 ClarityCostFunction::Begin,
             ),
-            Hash160 => NativeFunction(
+            Hash160 => NativeFunction205(
                 "native_hash160",
                 NativeHandle::SingleArg(&crypto::native_hash160),
                 ClarityCostFunction::Hash160,
+                &cost_input_sized_vararg,
             ),
-            Sha256 => NativeFunction(
+            Sha256 => NativeFunction205(
                 "native_sha256",
                 NativeHandle::SingleArg(&crypto::native_sha256),
                 ClarityCostFunction::Sha256,
+                &cost_input_sized_vararg,
             ),
-            Sha512 => NativeFunction(
+            Sha512 => NativeFunction205(
                 "native_sha512",
                 NativeHandle::SingleArg(&crypto::native_sha512),
                 ClarityCostFunction::Sha512,
+                &cost_input_sized_vararg,
             ),
-            Sha512Trunc256 => NativeFunction(
+            Sha512Trunc256 => NativeFunction205(
                 "native_sha512trunc256",
                 NativeHandle::SingleArg(&crypto::native_sha512trunc256),
                 ClarityCostFunction::Sha512t256,
+                &cost_input_sized_vararg,
             ),
-            Keccak256 => NativeFunction(
+            Keccak256 => NativeFunction205(
                 "native_keccak256",
                 NativeHandle::SingleArg(&crypto::native_keccak256),
                 ClarityCostFunction::Keccak256,
+                &cost_input_sized_vararg,
             ),
             Secp256k1Recover => SpecialFunction(
                 "native_secp256k1-recover",

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -190,6 +190,16 @@ pub fn apply(
                     .map_err(Error::from)
                     .and_then(|_| function.apply(evaluated_args))
             }
+            CallableType::NativeFunction205(_, function, cost_function, cost_input_handle) => {
+                let cost_input = if env.epoch() >= &StacksEpochId::Epoch2_05 {
+                    cost_input_handle(evaluated_args.as_slice())?
+                } else {
+                    evaluated_args.len() as u64
+                };
+                runtime_cost(*cost_function, env, cost_input)
+                    .map_err(Error::from)
+                    .and_then(|_| function.apply(evaluated_args))
+            }
             CallableType::UserFunction(function) => function.apply(&evaluated_args, env),
             _ => panic!("Should be unreachable."),
         };

--- a/src/vm/types/serialization.rs
+++ b/src/vm/types/serialization.rs
@@ -37,6 +37,7 @@ use vm::types::{
 };
 
 use crate::codec::{Error as codec_error, StacksMessageCodec};
+use crate::vm::types::byte_len_of_serialization;
 
 /// Errors that may occur in serialization or deserialization
 /// If deserialization failed because the described type is a bad type and
@@ -650,6 +651,40 @@ impl Value {
         Value::try_deserialize_hex(hex, expected)
             .expect("ERROR: Failed to parse Clarity hex string")
     }
+
+    pub fn serialized_size(&self) -> u32 {
+        let mut counter = WriteCounter { count: 0 };
+        self.serialize_write(&mut counter)
+            .expect("Error: Failed to count serialization length of Clarity value");
+        counter.count
+    }
+}
+
+/// A writer that just counts the bytes written
+struct WriteCounter {
+    count: u32,
+}
+
+impl Write for WriteCounter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        let input: u32 = buf.len().try_into().map_err(|_e| {
+            std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "Serialization size would overflow u32",
+            )
+        })?;
+        self.count = self.count.checked_add(input).ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "Serialization size would overflow u32",
+            )
+        })?;
+        Ok(input as usize)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
 }
 
 impl ClaritySerializable for Value {
@@ -712,6 +747,12 @@ mod tests {
         assert_eq!(
             &v,
             &Value::try_deserialize_hex_untyped(&v.serialize()).unwrap()
+        );
+        // test the serialized_size implementation
+        assert_eq!(
+            v.serialized_size(),
+            v.serialize().len() as u32 / 2,
+            "serialized_size() should return the byte length of the serialization (half the length of the hex encoding)",
         );
     }
 
@@ -1062,6 +1103,17 @@ mod tests {
                 expected,
                 &Value::try_deserialize_hex_untyped(&format!("0x{}", test))
             );
+        }
+
+        // test the serialized_size implementation
+        for (test, expected) in tests.iter() {
+            if let Ok(value) = expected {
+                assert_eq!(
+                    value.serialized_size(),
+                    test.len() as u32 / 2,
+                    "serialized_size() should return the byte length of the serialization (half the length of the hex encoding)",
+                );
+            }
         }
     }
 


### PR DESCRIPTION
This PR implements #2871 by adding a new `Callable` variant for methods whose cost _input_ calculation changes from 2.0 to 2.05. The methods changed are:

-     native_eq
-     index_of
-     tuple_merge
-     hash160
-     sha256
-     sha512
-     sha512trunc256
-     keccak256

This PR also adds a method to Clarity values `.serialized_size()` which returns the size in bytes of the consensus serialization of the Clarity value. This uses a non-recording writer to just count the number of bytes the serialize method would write. The runtime of this method is linear in the size of the Clarity value, but it doesn't involve creating a new buffer. While the runtime of this method is small, because it does depend on the input size, it should only be invoked for functions that already have a linear associated cost.
