### PR TITLE
2.05 integration testing: exact costs matching in miner and follower: #2913

### DIFF
--- a/.github/workflows/bitcoin-tests.yml
+++ b/.github/workflows/bitcoin-tests.yml
@@ -53,6 +53,7 @@ jobs:
           - tests::epoch_205::test_dynamic_db_method_costs
           - tests::epoch_205::transition_empty_blocks
           - tests::epoch_205::test_cost_limit_switch_version205
+          - tests::epoch_205::test_exact_block_costs
     steps:
       - uses: actions/checkout@v2
       - name: Download docker image

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to the versioning scheme outlined in the [README.md](README.md).
 
-## [Not yet released]
+## [2.0.11.4.0]
+
+This software update is a point-release to change the transaction
+selection logic in the default miner to prioritize by an estimated fee
+rate instead of raw fee. This release's chainstate directory is
+compatible with chainstate directories from 2.0.11.3.0.
 
 ## Added
 
@@ -18,6 +23,8 @@ and this project adheres to the versioning scheme outlined in the [README.md](RE
 ## Changed
 
 - Prioritize transaction inclusion in blocks by estimated fee rates (#2859).
+- MARF sqlite connections will now use `mmap`'ed connections with up to 256MB
+  space (#2869).
 
 ## [2.0.11.3.0]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -188,9 +188,9 @@ checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
 
 [[package]]
 name = "bitflags"
-version = "1.2.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "blake2b_simd"
@@ -245,6 +245,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "mio",
+ "nix",
  "percent-encoding",
  "prometheus",
  "rand 0.7.2",
@@ -266,6 +267,7 @@ dependencies = [
  "stx-genesis",
  "time 0.2.23",
  "url",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -369,6 +371,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "mio",
+ "nix",
  "percent-encoding",
  "prometheus",
  "rand 0.7.2",
@@ -391,6 +394,7 @@ dependencies = [
  "time 0.2.23",
  "tini",
  "url",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -495,7 +499,7 @@ dependencies = [
  "crossbeam-utils",
  "lazy_static",
  "maybe-uninit",
- "memoffset",
+ "memoffset 0.5.5",
  "scopeguard",
 ]
 
@@ -519,16 +523,6 @@ dependencies = [
  "autocfg 1.0.0",
  "cfg-if 0.1.10",
  "lazy_static",
-]
-
-[[package]]
-name = "ctrlc"
-version = "3.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b57a92e9749e10f25a171adcebfafe72991d45e7ec2dcb853e8f83d9dafaeb08"
-dependencies = [
- "nix",
- "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1076,9 +1070,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.82"
+version = "0.2.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89203f3fba0a3795506acaad8ebce3c80c0af93f994d5a1d7a0b1eeb23271929"
+checksum = "869d572136620d55835903746bcb5cdc54cb2851fd0aeec53220b4bb65ef3013"
 
 [[package]]
 name = "libflate"
@@ -1159,6 +1153,15 @@ name = "memoffset"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c198b026e1bbf08a937e94c6c60f9ec4a2267f5b0d2eec9c1b21b061ce2be55f"
+dependencies = [
+ "autocfg 1.0.0",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
 dependencies = [
  "autocfg 1.0.0",
 ]
@@ -1300,14 +1303,15 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.18.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83450fe6a6142ddd95fb064b746083fc4ef1705fe81f64a64e1d4b39f54a1055"
+checksum = "f305c2c2e4c39a82f7bf0bf65fb557f9070ce06781d4f2454295cc34b1c43188"
 dependencies = [
  "bitflags",
  "cc",
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "libc",
+ "memoffset 0.6.4",
 ]
 
 [[package]]
@@ -2269,7 +2273,6 @@ dependencies = [
  "backtrace",
  "base64 0.12.3",
  "blockstack-core",
- "ctrlc",
  "http-types",
  "lazy_static",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,15 @@ slog-json = { version = "2.3.0", optional = true }
 chrono = "0.4.19"
 libc = "0.2.82"
 
+[target.'cfg(unix)'.dependencies]
+nix = "0.23"
+
+[target.'cfg(windows)'.dependencies]
+winapi = { version = "0.3", features = ["consoleapi", "handleapi", "synchapi", "winbase"] }
+
+[target.'cfg(windows)'.dev-dependencies]
+winapi = { version = "0.3", features = ["fileapi", "processenv", "winnt"] }
+
 [dependencies.serde_json]
 version = "1.0"
 features = ["arbitrary_precision", "unbounded_depth"]

--- a/clarity/Cargo.toml
+++ b/clarity/Cargo.toml
@@ -41,6 +41,15 @@ slog-json = { version = "2.3.0", optional = true }
 chrono = "0.4.19"
 libc = "0.2.82"
 
+[target.'cfg(unix)'.dependencies]
+nix = "0.23"
+
+[target.'cfg(windows)'.dependencies]
+winapi = { version = "0.3", features = ["consoleapi", "handleapi", "synchapi", "winbase"] }
+
+[target.'cfg(windows)'.dev-dependencies]
+winapi = { version = "0.3", features = ["fileapi", "processenv", "winnt"] }
+
 [dependencies.serde_json]
 version = "1.0"
 features = ["arbitrary_precision", "unbounded_depth"]

--- a/docs/event-dispatcher.md
+++ b/docs/event-dispatcher.md
@@ -87,7 +87,21 @@ Example:
       "from_stacks_block_hash": "0xf5d4ce0efe1d42c963d615ce57f0d014f263a985175e4ece766eceff10e0a358",
       "from_index_block_hash": "0x329efcbcc6daf5ac3f264522e0df50eddb5be85df6ee8a9fc2384c54274d7afc",
     }
-   ]
+   ],
+   "anchored_cost": {
+    "runtime": 100,
+    "read_count": 10,
+    "write_count": 5,
+    "read_length": 150,
+    "write_length": 75
+   },
+   "confirmed_microblocks_cost": {
+    "runtime": 100,
+    "read_count": 10,
+    "write_count": 5,
+    "read_length": 150,
+    "write_length": 75
+   }
 }
 ```
 
@@ -216,3 +230,37 @@ Reason can be one of:
 * `ReplaceAcrossFork` - replaced by a transaction with the same nonce but in the canonical fork
 * `TooExpensive` - the transaction is too expensive to include in a block
 * `StaleGarbageCollect` - transaction was dropped because it became stale
+
+### `POST /mined_block`
+
+This payload includes data related to block mined by this Stacks node. This
+will never be invoked if the node is configured only as a follower. This is invoked
+when the miner **assembles** the block; this block may or may not win the sortition.
+
+This endpoint will only broadcast events to observers that explicitly register for
+`MinedBlocks` events, `AnyEvent` observers will not receive the events by default.
+
+Example:
+
+```json
+{
+  "block_hash": "0x4eaabcd105865e471f697eff5dd5bd85d47ecb5a26a3379d74fae0ae87c40904",
+  "staks_height": 3,
+  "target_burn_height": 745000,
+  "block_size": 145000,
+  "anchored_cost": {
+    "runtime": 100,
+    "read_count": 10,
+    "write_count": 5,
+    "read_length": 150,
+    "write_length": 75
+  },
+  "confirmed_microblocks_cost": {
+    "runtime": 100,
+    "read_count": 10,
+    "write_count": 5,
+    "read_length": 150,
+    "write_length": 75
+  }
+}
+```

--- a/src/chainstate/burn/db/sortdb.rs
+++ b/src/chainstate/burn/db/sortdb.rs
@@ -2154,13 +2154,12 @@ impl SortitionDB {
             Ok(_md) => false,
         };
 
-        let (db_path, index_path) = db_mkdirs(path)?;
+        let index_path = db_mkdirs(path)?;
         debug!(
-            "Connect/Open {} sortdb '{}' as '{}', with index as '{}'",
+            "Connect/Open {} sortdb '{}' as '{}'",
             if create_flag { "(create)" } else { "" },
-            db_path,
-            if readwrite { "readwrite" } else { "readonly" },
-            index_path
+            index_path,
+            if readwrite { "readwrite" } else { "readonly" }
         );
 
         let marf = SortitionDB::open_index(&index_path)?;
@@ -2314,7 +2313,8 @@ impl SortitionDB {
     ) -> Result<(), db_error> {
         debug!("Instantiate SortDB");
 
-        sql_pragma(self.conn(), "PRAGMA journal_mode = WAL;")?;
+        sql_pragma(self.conn(), "journal_mode", &"WAL")?;
+        sql_pragma(self.conn(), "foreign_keys", &true)?;
 
         let mut db_tx = SortitionHandleTx::begin(self, &SortitionId::sentinel())?;
 

--- a/src/chainstate/burn/db/sortdb.rs
+++ b/src/chainstate/burn/db/sortdb.rs
@@ -2011,17 +2011,18 @@ impl SortitionDB {
 
     fn open_index(index_path: &str) -> Result<MARF<SortitionId>, db_error> {
         test_debug!("Open index at {}", index_path);
-        MARF::from_path(index_path).map_err(|_e| db_error::Corruption)
+        let marf = MARF::from_path(index_path).map_err(|_e| db_error::Corruption)?;
+        sql_pragma(marf.sqlite_conn(), "foreign_keys", &true)?;
+        Ok(marf)
     }
 
     /// Open the database on disk.  It must already exist and be instantiated.
     /// It's best not to call this if you are able to call connect().  If you must call this, do so
     /// after you call connect() somewhere else, since connect() performs additional validations.
     pub fn open(path: &str, readwrite: bool) -> Result<SortitionDB, db_error> {
-        let (db_path, index_path) = db_mkdirs(path)?;
+        let index_path = db_mkdirs(path)?;
         debug!(
-            "Open sortdb '{}' as '{}', with index as '{}'",
-            db_path,
+            "Open sortdb as '{}', with index as '{}'",
             if readwrite { "readwrite" } else { "readonly" },
             index_path
         );
@@ -2066,11 +2067,10 @@ impl SortitionDB {
             Ok(_md) => false,
         };
 
-        let (db_path, index_path) = db_mkdirs(path)?;
+        let index_path = db_mkdirs(path)?;
         debug!(
-            "Connect/Open {} sortdb '{}' as '{}', with index as '{}'",
+            "Connect/Open {} sortdb as '{}', with index as '{}'",
             if create_flag { "(create)" } else { "" },
-            db_path,
             if readwrite { "readwrite" } else { "readonly" },
             index_path
         );
@@ -2242,7 +2242,8 @@ impl SortitionDB {
     ) -> Result<(), db_error> {
         debug!("Instantiate SortDB");
 
-        sql_pragma(self.conn(), "PRAGMA journal_mode = WAL;")?;
+        sql_pragma(self.conn(), "journal_mode", &"WAL")?;
+        sql_pragma(self.conn(), "foreign_keys", &true)?;
 
         let mut db_tx = SortitionHandleTx::begin(self, &SortitionId::sentinel())?;
 

--- a/src/chainstate/coordinator/mod.rs
+++ b/src/chainstate/coordinator/mod.rs
@@ -126,6 +126,8 @@ pub trait BlockEventDispatcher {
         parent_burn_block_hash: BurnchainHeaderHash,
         parent_burn_block_height: u32,
         parent_burn_block_timestamp: u64,
+        anchored_consumed: &ExecutionCost,
+        mblock_confirmed_consumed: &ExecutionCost,
     );
 
     /// called whenever a burn block is about to be
@@ -833,6 +835,8 @@ impl<
                             block_receipt.parent_burn_block_hash,
                             block_receipt.parent_burn_block_height,
                             block_receipt.parent_burn_block_timestamp,
+                            &block_receipt.anchored_block_cost,
+                            &block_receipt.parent_microblocks_cost,
                         );
                     }
 

--- a/src/chainstate/coordinator/tests.rs
+++ b/src/chainstate/coordinator/tests.rs
@@ -310,6 +310,8 @@ impl BlockEventDispatcher for NullEventDispatcher {
         _parent_burn_block_hash: BurnchainHeaderHash,
         _parent_burn_block_height: u32,
         _parent_burn_block_timestamp: u64,
+        _anchor_block_cost: &ExecutionCost,
+        _confirmed_mblock_cost: &ExecutionCost,
     ) {
         assert!(
             false,
@@ -463,7 +465,7 @@ fn make_genesis_block_with_recipients(
     .unwrap();
 
     let iconn = sort_db.index_conn();
-    let mut epoch_tx = builder.epoch_begin(state, &iconn).unwrap();
+    let mut epoch_tx = builder.epoch_begin(state, &iconn).unwrap().0;
     builder.try_mine_tx(&mut epoch_tx, &coinbase_op).unwrap();
 
     let block = builder.mine_anchored_block(&mut epoch_tx);
@@ -673,7 +675,7 @@ fn make_stacks_block_with_input(
         next_hash160(),
     )
     .unwrap();
-    let mut epoch_tx = builder.epoch_begin(state, &iconn).unwrap();
+    let mut epoch_tx = builder.epoch_begin(state, &iconn).unwrap().0;
     builder.try_mine_tx(&mut epoch_tx, &coinbase_op).unwrap();
 
     let block = builder.mine_anchored_block(&mut epoch_tx);

--- a/src/chainstate/stacks/index/storage.rs
+++ b/src/chainstate/stacks/index/storage.rs
@@ -45,9 +45,12 @@ use chainstate::stacks::index::node::{
 };
 use chainstate::stacks::index::Error;
 use chainstate::stacks::index::{trie_sql, BlockMap, MarfTrieId};
+use util::db::sql_pragma;
+use util::db::sqlite_open;
 use util::db::tx_begin_immediate;
 use util::db::tx_busy_handler;
 use util::db::Error as db_error;
+use util::db::SQLITE_MMAP_SIZE;
 use util::log;
 
 use crate::types::chainstate::BlockHeaderHash;
@@ -720,6 +723,16 @@ pub struct TrieFileStorage<T: MarfTrieId> {
     pub test_genesis_block: Option<T>,
 }
 
+fn marf_sqlite_open<P: AsRef<Path>>(
+    db_path: P,
+    open_flags: OpenFlags,
+    foreign_keys: bool,
+) -> Result<Connection, db_error> {
+    let db = sqlite_open(db_path, open_flags, foreign_keys)?;
+    sql_pragma(&db, "mmap_size", &SQLITE_MMAP_SIZE)?;
+    Ok(db)
+}
+
 impl<T: MarfTrieId> TrieFileStorage<T> {
     pub fn connection<'a>(&'a mut self) -> TrieStorageConnection<'a, T> {
         TrieStorageConnection {
@@ -795,9 +808,7 @@ impl<T: MarfTrieId> TrieFileStorage<T> {
             }
         };
 
-        let mut db = Connection::open_with_flags(db_path, open_flags)?;
-        db.busy_handler(Some(tx_busy_handler))?;
-
+        let mut db = marf_sqlite_open(db_path, open_flags, false)?;
         let db_path = db_path.to_string();
 
         if create_flag {
@@ -866,8 +877,7 @@ impl<T: MarfTrieId> TrieFileStorage<T> {
     }
 
     pub fn reopen_readonly(&self) -> Result<TrieFileStorage<T>, Error> {
-        let db = Connection::open_with_flags(&self.db_path, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
-        db.busy_handler(Some(tx_busy_handler))?;
+        let db = marf_sqlite_open(&self.db_path, OpenFlags::SQLITE_OPEN_READ_ONLY, false)?;
 
         trace!("Make read-only view of TrieFileStorage: {}", &self.db_path);
 
@@ -911,8 +921,7 @@ impl<'a, T: MarfTrieId> TrieStorageTransaction<'a, T> {
     /// reopen this transaction as a read-only marf.
     ///  _does not_ preserve the cur_block/open tip
     pub fn reopen_readonly(&self) -> Result<TrieFileStorage<T>, Error> {
-        let db = Connection::open_with_flags(&self.db_path, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
-        db.busy_handler(Some(tx_busy_handler))?;
+        let db = marf_sqlite_open(&self.db_path, OpenFlags::SQLITE_OPEN_READ_ONLY, false)?;
 
         trace!(
             "Make read-only view of TrieStorageTransaction: {}",
@@ -1286,9 +1295,7 @@ impl<'a, T: MarfTrieId> TrieStorageConnection<'a, T> {
     /// Recover from partially-written state -- i.e. blow it away.
     /// Doesn't get called automatically.
     pub fn recover(db_path: &String) -> Result<(), Error> {
-        let conn = Connection::open(db_path)?;
-        conn.busy_handler(Some(tx_busy_handler))?;
-
+        let conn = marf_sqlite_open(db_path, OpenFlags::SQLITE_OPEN_READ_WRITE, false)?;
         trie_sql::clear_lock_data(&conn)
     }
 

--- a/src/chainstate/stacks/index/trie_sql.rs
+++ b/src/chainstate/stacks/index/trie_sql.rs
@@ -83,8 +83,6 @@ CREATE TABLE IF NOT EXISTS block_extension_locks (block_hash TEXT PRIMARY KEY);
 ";
 
 pub fn create_tables_if_needed(conn: &mut Connection) -> Result<(), Error> {
-    sql_pragma(conn, "PRAGMA journal_mode = WAL;")?;
-
     let tx = tx_begin_immediate(conn)?;
 
     tx.execute_batch(SQL_MARF_DATA_TABLE)?;

--- a/src/chainstate/stacks/miner.rs
+++ b/src/chainstate/stacks/miner.rs
@@ -1663,6 +1663,15 @@ impl StacksBlockBuilder {
 
         let ts_end = get_epoch_time_ms();
 
+        if let Some(observer) = event_observer {
+            observer.mined_block_event(
+                SortitionDB::get_canonical_burn_chain_tip(burn_dbconn.conn())?.block_height + 1,
+                &block,
+                size,
+                &consumed,
+            );
+        }
+
         debug!(
             "Miner: mined anchored block";
             "block_hash" => %block.block_hash(),

--- a/src/clarity.rs
+++ b/src/clarity.rs
@@ -31,6 +31,7 @@ use rusqlite::{Connection, OpenFlags, NO_PARAMS};
 
 use address::c32::c32_address;
 use chainstate::stacks::index::{storage::TrieFileStorage, MarfTrieId};
+use util::db::sqlite_open;
 use util::db::FromColumn;
 use util::hash::{bytes_to_hex, Sha512Trunc256Sum};
 
@@ -259,7 +260,7 @@ fn create_or_open_db(path: &String) -> Connection {
     };
 
     let conn = friendly_expect(
-        Connection::open_with_flags(path, open_flags),
+        sqlite_open(path, open_flags, false),
         &format!("FATAL: failed to open '{}'", path),
     );
     conn

--- a/src/core/mempool.rs
+++ b/src/core/mempool.rs
@@ -151,6 +151,7 @@ pub trait MemPoolEventDispatcher {
         block: &StacksBlock,
         block_size_bytes: u64,
         consumed: &ExecutionCost,
+        confirmed_microblock_cost: &ExecutionCost,
     );
 }
 

--- a/src/core/mempool.rs
+++ b/src/core/mempool.rs
@@ -61,6 +61,7 @@ use vm::types::PrincipalData;
 use clarity_vm::clarity::ClarityConnection;
 
 use crate::chainstate::stacks::events::StacksTransactionReceipt;
+use crate::chainstate::stacks::StacksBlock;
 use crate::codec::StacksMessageCodec;
 use crate::cost_estimates;
 use crate::cost_estimates::metrics::CostMetric;
@@ -144,6 +145,13 @@ impl std::fmt::Display for MemPoolDropReason {
 
 pub trait MemPoolEventDispatcher {
     fn mempool_txs_dropped(&self, txids: Vec<Txid>, reason: MemPoolDropReason);
+    fn mined_block_event(
+        &self,
+        target_burn_height: u64,
+        block: &StacksBlock,
+        block_size_bytes: u64,
+        consumed: &ExecutionCost,
+    );
 }
 
 #[derive(Debug, PartialEq, Clone)]

--- a/src/cost_estimates/fee_scalar.rs
+++ b/src/cost_estimates/fee_scalar.rs
@@ -10,6 +10,7 @@ use rusqlite::{
 use serde_json::Value as JsonValue;
 
 use chainstate::stacks::TransactionPayload;
+use util::db::sqlite_open;
 use util::db::tx_begin_immediate_sqlite;
 use util::db::u64_to_sql;
 
@@ -18,7 +19,6 @@ use vm::costs::ExecutionCost;
 use chainstate::stacks::db::StacksEpochReceipt;
 use chainstate::stacks::events::TransactionOrigin;
 
-use crate::util::db::set_wal_mode;
 use crate::util::db::sql_pragma;
 use crate::util::db::table_exists;
 
@@ -52,16 +52,16 @@ pub struct ScalarFeeRateEstimator<M: CostMetric> {
 impl<M: CostMetric> ScalarFeeRateEstimator<M> {
     /// Open a fee rate estimator at the given db path. Creates if not existent.
     pub fn open(p: &Path, metric: M) -> Result<Self, SqliteError> {
-        let db = match Connection::open_with_flags(p, rusqlite::OpenFlags::SQLITE_OPEN_READ_WRITE) {
-            Ok(db) => {
-                set_wal_mode(&db)?;
-                Ok(db)
-            }
-            Err(e) => {
+        let db =
+            sqlite_open(p, rusqlite::OpenFlags::SQLITE_OPEN_READ_WRITE, false).or_else(|e| {
                 if let SqliteError::SqliteFailure(ref internal, _) = e {
                     if let rusqlite::ErrorCode::CannotOpen = internal.code {
-                        let mut db = Connection::open(p)?;
-                        set_wal_mode(&db)?;
+                        let mut db = sqlite_open(
+                            p,
+                            rusqlite::OpenFlags::SQLITE_OPEN_CREATE
+                                | rusqlite::OpenFlags::SQLITE_OPEN_READ_WRITE,
+                            false,
+                        )?;
                         let tx = tx_begin_immediate_sqlite(&mut db)?;
                         Self::instantiate_db(&tx)?;
                         tx.commit()?;
@@ -72,8 +72,7 @@ impl<M: CostMetric> ScalarFeeRateEstimator<M> {
                 } else {
                     Err(e)
                 }
-            }
-        }?;
+            })?;
 
         Ok(Self {
             db,

--- a/src/cost_estimates/pessimistic.rs
+++ b/src/cost_estimates/pessimistic.rs
@@ -14,7 +14,6 @@ use util::db::sqlite_open;
 use util::db::u64_to_sql;
 use vm::costs::ExecutionCost;
 
-use crate::util::db::set_wal_mode;
 use crate::util::db::sql_pragma;
 use crate::util::db::table_exists;
 use crate::util::db::tx_begin_immediate_sqlite;

--- a/src/deps/README.md
+++ b/src/deps/README.md
@@ -10,3 +10,5 @@ snapshots of important libraries this codebase depends on.
 * The `bitcoin` package was produced by Andrew Poelstra (https://github.com/rust-bitcoin/rust-bitcoin).  License is CC0.
 * The `httparse` package was produced by Sean McArthur
   (https://github.com/seanmonstar/httparse).  License is MIT.
+* The `ctrlc` package was produced by Antti Keräne
+  (https://github.com/Detegr/rust-ctrlc).  License is MIT.

--- a/src/deps/ctrlc/error.rs
+++ b/src/deps/ctrlc/error.rs
@@ -1,0 +1,46 @@
+use deps::ctrlc::platform;
+use std::fmt;
+
+/// Ctrl-C error.
+#[derive(Debug)]
+pub enum Error {
+    /// Ctrl-C signal handler already registered.
+    MultipleHandlers,
+    /// Unexpected system error.
+    System(std::io::Error),
+}
+
+impl Error {
+    fn describe(&self) -> &str {
+        match *self {
+            Error::MultipleHandlers => "Ctrl-C signal handler already registered",
+            Error::System(_) => "Unexpected system error",
+        }
+    }
+}
+
+impl From<platform::Error> for Error {
+    fn from(e: platform::Error) -> Error {
+        let system_error = std::io::Error::new(std::io::ErrorKind::Other, e);
+        Error::System(system_error)
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Ctrl-C error: {}", self.describe())
+    }
+}
+
+impl std::error::Error for Error {
+    fn description(&self) -> &str {
+        self.describe()
+    }
+
+    fn cause(&self) -> Option<&dyn std::error::Error> {
+        match *self {
+            Error::System(ref e) => Some(e),
+            _ => None,
+        }
+    }
+}

--- a/src/deps/ctrlc/mod.rs
+++ b/src/deps/ctrlc/mod.rs
@@ -1,0 +1,97 @@
+// Copyright (c) 2017 CtrlC developers
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>,
+// at your option. All files in the project carrying such
+// notice may not be copied, modified, or distributed except
+// according to those terms.
+
+#[macro_use]
+
+mod error;
+mod platform;
+pub use self::error::Error;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::thread;
+
+#[cfg(test)]
+mod tests;
+
+#[derive(PartialEq, Clone)]
+#[repr(u8)]
+pub enum SignalId {
+    CtrlC = 0x00,
+    Termination = 0x01,
+    Bus = 0x02,
+    Other = 0xff,
+}
+
+impl std::fmt::Display for SignalId {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+        match *self {
+            SignalId::CtrlC => write!(f, "CtrlC"),
+            SignalId::Termination => write!(f, "Termination"),
+            SignalId::Bus => write!(f, "Bus"),
+            SignalId::Other => write!(f, "Other"),
+        }
+    }
+}
+
+static INIT: AtomicBool = AtomicBool::new(false);
+
+/// Register signal handler for Ctrl-C.
+///
+/// Starts a new dedicated signal handling thread. Should only be called once,
+/// typically at the start of your program.
+///
+/// # Warning
+/// On Unix, any existing `SIGINT`, `SIGTERM`, `SIGHUP`, `SIGBUS`, or `SA_SIGINFO`
+/// posix signal handlers will be overwritten. On Windows, multiple handler routines are allowed,
+/// but they are called on a last-registered, first-called basis until the signal is handled.
+///
+/// On Unix, signal dispositions and signal handlers are inherited by child processes created via
+/// `fork(2)` on, but not by child processes created via `execve(2)`.
+/// Signal handlers are not inherited on Windows.
+///
+/// # Errors
+/// Will return an error if another `ctrlc::set_handler()` handler exists or if a
+/// system error occurred while setting the handler.
+///
+/// # Panics
+/// Any panic in the handler will not be caught and will cause the signal handler thread to stop.
+///
+pub fn set_handler<F>(mut user_handler: F) -> Result<(), Error>
+where
+    F: FnMut(SignalId) -> () + 'static + Send,
+{
+    if INIT
+        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+        .is_err()
+    {
+        return Err(Error::MultipleHandlers);
+    }
+
+    unsafe {
+        match platform::init_os_handler() {
+            Ok(_) => {}
+            Err(err) => {
+                INIT.store(false, Ordering::SeqCst);
+                return Err(err.into());
+            }
+        }
+    }
+
+    thread::Builder::new()
+        .name("signal-handler".into())
+        .spawn(move || loop {
+            let received_signal = unsafe {
+                platform::block_ctrl_c()
+                    .expect("Critical system error while waiting for terminating signal")
+            };
+            user_handler(received_signal);
+        })
+        .expect("failed to spawn thread");
+
+    Ok(())
+}

--- a/src/deps/ctrlc/platform/mod.rs
+++ b/src/deps/ctrlc/platform/mod.rs
@@ -1,0 +1,20 @@
+// Copyright (c) 2017 CtrlC developers
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>,
+// at your option. All files in the project carrying such
+// notice may not be copied, modified, or distributed except
+// according to those terms.
+
+#[cfg(unix)]
+mod unix;
+
+#[cfg(windows)]
+mod windows;
+
+#[cfg(unix)]
+pub use self::unix::*;
+
+#[cfg(windows)]
+pub use self::windows::*;

--- a/src/deps/ctrlc/platform/unix/mod.rs
+++ b/src/deps/ctrlc/platform/unix/mod.rs
@@ -1,0 +1,191 @@
+// Copyright (c) 2017 CtrlC developers
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>,
+// at your option. All files in the project carrying such
+// notice may not be copied, modified, or distributed except
+// according to those terms.
+
+use deps::ctrlc::error::Error as CtrlcError;
+use deps::ctrlc::SignalId;
+use nix::unistd;
+use std::os::unix::io::RawFd;
+
+static mut PIPE: (RawFd, RawFd) = (-1, -1);
+
+/// Platform specific error type
+pub type Error = nix::Error;
+
+/// Platform specific signal type
+pub type Signal = nix::sys::signal::Signal;
+
+impl SignalId {
+    pub fn from_c_signal(c_sig_id: nix::libc::c_int) -> SignalId {
+        match c_sig_id {
+            x if x == Signal::SIGTERM as nix::libc::c_int
+                || x == Signal::SIGHUP as nix::libc::c_int =>
+            {
+                SignalId::Termination
+            }
+            x if x == Signal::SIGINT as nix::libc::c_int => SignalId::CtrlC,
+            x if x == Signal::SIGBUS as nix::libc::c_int => SignalId::Bus,
+            _ => SignalId::Other,
+        }
+    }
+
+    pub fn from_u8(sig_id: u8) -> SignalId {
+        match sig_id {
+            x if x == SignalId::CtrlC as u8 => SignalId::CtrlC,
+            x if x == SignalId::Termination as u8 => SignalId::Termination,
+            x if x == SignalId::Bus as u8 => SignalId::Bus,
+            _ => SignalId::Other,
+        }
+    }
+}
+
+extern "C" fn os_handler(c_sig_id: nix::libc::c_int) {
+    let sig_id = SignalId::from_c_signal(c_sig_id) as u8;
+    // Assuming this always succeeds. Can't really handle errors in any meaningful way.
+    unsafe {
+        let _ = unistd::write(PIPE.1, &[sig_id]);
+    }
+}
+
+// pipe2(2) is not available on macOS or iOS, so we need to use pipe(2) and fcntl(2)
+#[inline]
+#[cfg(any(target_os = "ios", target_os = "macos"))]
+fn pipe2(flags: nix::fcntl::OFlag) -> nix::Result<(RawFd, RawFd)> {
+    use nix::fcntl::{fcntl, FcntlArg, FdFlag, OFlag};
+
+    let pipe = unistd::pipe()?;
+
+    let mut res = Ok(0);
+
+    if flags.contains(OFlag::O_CLOEXEC) {
+        res = res
+            .and_then(|_| fcntl(pipe.0, FcntlArg::F_SETFD(FdFlag::FD_CLOEXEC)))
+            .and_then(|_| fcntl(pipe.1, FcntlArg::F_SETFD(FdFlag::FD_CLOEXEC)));
+    }
+
+    if flags.contains(OFlag::O_NONBLOCK) {
+        res = res
+            .and_then(|_| fcntl(pipe.0, FcntlArg::F_SETFL(OFlag::O_NONBLOCK)))
+            .and_then(|_| fcntl(pipe.1, FcntlArg::F_SETFL(OFlag::O_NONBLOCK)));
+    }
+
+    match res {
+        Ok(_) => Ok(pipe),
+        Err(e) => {
+            let _ = unistd::close(pipe.0);
+            let _ = unistd::close(pipe.1);
+            Err(e)
+        }
+    }
+}
+
+#[inline]
+#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+fn pipe2(flags: nix::fcntl::OFlag) -> nix::Result<(RawFd, RawFd)> {
+    unistd::pipe2(flags)
+}
+
+/// Register os signal handler.
+///
+/// Must be called before calling [`block_ctrl_c()`](fn.block_ctrl_c.html)
+/// and should only be called once.
+///
+/// # Errors
+/// Will return an error if a system error occurred.
+///
+#[inline]
+pub unsafe fn init_os_handler() -> Result<(), Error> {
+    use nix::fcntl;
+    use nix::sys::signal;
+
+    PIPE = pipe2(fcntl::OFlag::O_CLOEXEC)?;
+
+    let close_pipe = |e: nix::Error| -> Error {
+        // Try to close the pipes. close() should not fail,
+        // but if it does, there isn't much we can do
+        let _ = unistd::close(PIPE.1);
+        let _ = unistd::close(PIPE.0);
+        e
+    };
+
+    // Make sure we never block on write in the os handler.
+    if let Err(e) = fcntl::fcntl(PIPE.1, fcntl::FcntlArg::F_SETFL(fcntl::OFlag::O_NONBLOCK)) {
+        return Err(close_pipe(e));
+    }
+
+    let handler = signal::SigHandler::Handler(os_handler);
+    let new_action = signal::SigAction::new(
+        handler,
+        signal::SaFlags::SA_RESTART,
+        signal::SigSet::empty(),
+    );
+
+    let sigint_old = match signal::sigaction(signal::Signal::SIGINT, &new_action) {
+        Ok(old) => old,
+        Err(e) => return Err(close_pipe(e)),
+    };
+
+    let sigterm_old = match signal::sigaction(signal::Signal::SIGTERM, &new_action) {
+        Ok(old) => old,
+        Err(e) => {
+            signal::sigaction(signal::Signal::SIGINT, &sigint_old).unwrap();
+            return Err(close_pipe(e));
+        }
+    };
+
+    // new with stacks-blockchain: build-in "termination" feature, and handle SIGBUS
+    let sigbus_old = match signal::sigaction(signal::Signal::SIGBUS, &new_action) {
+        Ok(old) => old,
+        Err(e) => {
+            signal::sigaction(signal::Signal::SIGINT, &sigint_old).unwrap();
+            signal::sigaction(signal::Signal::SIGTERM, &sigterm_old).unwrap();
+            return Err(close_pipe(e));
+        }
+    };
+
+    match signal::sigaction(signal::Signal::SIGHUP, &new_action) {
+        Ok(_) => {}
+        Err(e) => {
+            signal::sigaction(signal::Signal::SIGINT, &sigint_old).unwrap();
+            signal::sigaction(signal::Signal::SIGTERM, &sigterm_old).unwrap();
+            signal::sigaction(signal::Signal::SIGBUS, &sigbus_old).unwrap();
+            return Err(close_pipe(e));
+        }
+    }
+
+    // TODO: Maybe throw an error if old action is not SigDfl.
+
+    Ok(())
+}
+
+/// Blocks until a Ctrl-C signal is received.
+///
+/// Must be called after calling [`init_os_handler()`](fn.init_os_handler.html).
+///
+/// # Errors
+/// Will return an error if a system error occurred.
+///
+#[inline]
+pub unsafe fn block_ctrl_c() -> Result<SignalId, CtrlcError> {
+    use std::io;
+    let mut buf = [0u8];
+
+    // TODO: Can we safely convert the pipe fd into a std::io::Read
+    // with std::os::unix::io::FromRawFd, this would handle EINTR
+    // and everything for us.
+    loop {
+        match unistd::read(PIPE.0, &mut buf[..]) {
+            Ok(1) => break,
+            Ok(_) => return Err(CtrlcError::System(io::ErrorKind::UnexpectedEof.into())),
+            Err(nix::errno::Errno::EINTR) => {}
+            Err(e) => return Err(e.into()),
+        }
+    }
+
+    Ok(SignalId::from_u8(buf[0]))
+}

--- a/src/deps/ctrlc/platform/windows/mod.rs
+++ b/src/deps/ctrlc/platform/windows/mod.rs
@@ -1,0 +1,82 @@
+// Copyright (c) 2017 CtrlC developers
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>,
+// at your option. All files in the project carrying such
+// notice may not be copied, modified, or distributed except
+// according to those terms.
+
+use std::io;
+use std::ptr;
+use winapi::ctypes::c_long;
+use winapi::shared::minwindef::{BOOL, DWORD, FALSE, TRUE};
+use winapi::shared::ntdef::HANDLE;
+use winapi::um::consoleapi::SetConsoleCtrlHandler;
+use winapi::um::handleapi::CloseHandle;
+use winapi::um::synchapi::{ReleaseSemaphore, WaitForSingleObject};
+use winapi::um::winbase::{CreateSemaphoreA, INFINITE, WAIT_FAILED, WAIT_OBJECT_0};
+
+use deps::ctrlc::SignalId;
+
+/// Platform specific error type
+pub type Error = io::Error;
+
+/// Platform specific signal type
+pub type Signal = DWORD;
+
+const MAX_SEM_COUNT: c_long = 255;
+static mut SEMAPHORE: HANDLE = 0 as HANDLE;
+
+unsafe extern "system" fn os_handler(_: DWORD) -> BOOL {
+    // Assuming this always succeeds. Can't really handle errors in any meaningful way.
+    ReleaseSemaphore(SEMAPHORE, 1, ptr::null_mut());
+    TRUE
+}
+
+/// Register os signal handler.
+///
+/// Must be called before calling [`block_ctrl_c()`](fn.block_ctrl_c.html)
+/// and should only be called once.
+///
+/// # Errors
+/// Will return an error if a system error occurred.
+///
+#[inline]
+pub unsafe fn init_os_handler() -> Result<(), Error> {
+    SEMAPHORE = CreateSemaphoreA(ptr::null_mut(), 0, MAX_SEM_COUNT, ptr::null());
+    if SEMAPHORE.is_null() {
+        return Err(io::Error::last_os_error());
+    }
+
+    if SetConsoleCtrlHandler(Some(os_handler), TRUE) == FALSE {
+        let e = io::Error::last_os_error();
+        CloseHandle(SEMAPHORE);
+        SEMAPHORE = 0 as HANDLE;
+        return Err(e);
+    }
+
+    Ok(())
+}
+
+/// Blocks until a Ctrl-C signal is received.
+///
+/// Must be called after calling [`init_os_handler()`](fn.init_os_handler.html).
+///
+/// # Errors
+/// Will return an error if a system error occurred.
+///
+#[inline]
+pub unsafe fn block_ctrl_c() -> Result<SignalId, Error> {
+    match WaitForSingleObject(SEMAPHORE, INFINITE) {
+        WAIT_OBJECT_0 => Ok(SignalId::CtrlC),
+        WAIT_FAILED => Err(io::Error::last_os_error()),
+        ret => Err(io::Error::new(
+            io::ErrorKind::Other,
+            format!(
+                "WaitForSingleObject(), unexpected return value \"{:x}\"",
+                ret
+            ),
+        )),
+    }
+}

--- a/src/deps/ctrlc/tests.rs
+++ b/src/deps/ctrlc/tests.rs
@@ -1,0 +1,278 @@
+// Copyright (c) 2017 CtrlC developers
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>,
+// at your option. All files in the project carrying such
+// notice may not be copied, modified, or distributed except
+// according to those terms.
+
+use deps::ctrlc;
+
+#[cfg(unix)]
+mod platform {
+    use std::io;
+
+    pub unsafe fn setup() -> io::Result<()> {
+        Ok(())
+    }
+
+    pub unsafe fn cleanup() -> io::Result<()> {
+        Ok(())
+    }
+
+    pub unsafe fn raise_ctrl_c() {
+        nix::sys::signal::raise(nix::sys::signal::SIGBUS).unwrap();
+    }
+
+    pub unsafe fn print(fmt: ::std::fmt::Arguments) {
+        use self::io::Write;
+        let stdout = ::std::io::stdout();
+        stdout.lock().write_fmt(fmt).unwrap();
+    }
+}
+
+#[cfg(windows)]
+mod platform {
+    use std::io;
+    use std::ptr;
+
+    use winapi::shared::minwindef::DWORD;
+    use winapi::shared::ntdef::{CHAR, HANDLE};
+    use winapi::um::consoleapi::{AllocConsole, GetConsoleMode};
+    use winapi::um::fileapi::WriteFile;
+    use winapi::um::handleapi::INVALID_HANDLE_VALUE;
+    use winapi::um::processenv::{GetStdHandle, SetStdHandle};
+    use winapi::um::winbase::{STD_ERROR_HANDLE, STD_OUTPUT_HANDLE};
+    use winapi::um::wincon::{AttachConsole, FreeConsole, GenerateConsoleCtrlEvent};
+
+    /// Stores a piped stdout handle or a cache that gets
+    /// flushed when we reattached to the old console.
+    enum Output {
+        Pipe(HANDLE),
+        Cached(Vec<u8>),
+    }
+
+    static mut OLD_OUT: *mut Output = 0 as *mut Output;
+
+    impl io::Write for Output {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            match *self {
+                Output::Pipe(handle) => unsafe {
+                    use winapi::shared::ntdef::VOID;
+
+                    let mut n = 0u32;
+                    if WriteFile(
+                        handle,
+                        buf.as_ptr() as *const VOID,
+                        buf.len() as DWORD,
+                        &mut n as *mut DWORD,
+                        ptr::null_mut(),
+                    ) == 0
+                    {
+                        Err(io::Error::last_os_error())
+                    } else {
+                        Ok(n as usize)
+                    }
+                },
+                Output::Cached(ref mut s) => s.write(buf),
+            }
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl Output {
+        /// Stores current piped stdout or creates a new output cache that will
+        /// be written to stdout at a later time.
+        fn new() -> io::Result<Output> {
+            unsafe {
+                let stdout = GetStdHandle(STD_OUTPUT_HANDLE);
+                if stdout.is_null() || stdout == INVALID_HANDLE_VALUE {
+                    return Err(io::Error::last_os_error());
+                }
+
+                let mut out = 0u32;
+                match GetConsoleMode(stdout, &mut out as *mut DWORD) {
+                    0 => Ok(Output::Pipe(stdout)),
+                    _ => Ok(Output::Cached(Vec::new())),
+                }
+            }
+        }
+
+        /// Set stdout/stderr and flush cache.
+        unsafe fn set_as_std(self) -> io::Result<()> {
+            let stdout = match self {
+                Output::Pipe(h) => h,
+                Output::Cached(_) => get_stdout()?,
+            };
+
+            if SetStdHandle(STD_OUTPUT_HANDLE, stdout) == 0 {
+                return Err(io::Error::last_os_error());
+            }
+
+            if SetStdHandle(STD_ERROR_HANDLE, stdout) == 0 {
+                return Err(io::Error::last_os_error());
+            }
+
+            match self {
+                Output::Pipe(_) => Ok(()),
+                Output::Cached(ref s) => {
+                    // Write cached output
+                    use self::io::Write;
+                    let out = io::stdout();
+                    out.lock().write_all(&s[..])?;
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    unsafe fn get_stdout() -> io::Result<HANDLE> {
+        use winapi::um::fileapi::{CreateFileA, OPEN_EXISTING};
+        use winapi::um::handleapi::INVALID_HANDLE_VALUE;
+        use winapi::um::winnt::{FILE_SHARE_WRITE, GENERIC_READ, GENERIC_WRITE};
+
+        let stdout = CreateFileA(
+            "CONOUT$\0".as_ptr() as *const CHAR,
+            GENERIC_READ | GENERIC_WRITE,
+            FILE_SHARE_WRITE,
+            ptr::null_mut(),
+            OPEN_EXISTING,
+            0,
+            ptr::null_mut(),
+        );
+
+        if stdout.is_null() || stdout == INVALID_HANDLE_VALUE {
+            Err(io::Error::last_os_error())
+        } else {
+            Ok(stdout)
+        }
+    }
+
+    /// Detach from the current console and create a new one,
+    /// We do this because GenerateConsoleCtrlEvent() sends ctrl-c events
+    /// to all processes on the same console. We want events to be received
+    /// only by our process.
+    ///
+    /// This breaks rust's stdout pre 1.18.0. Rust used to
+    /// [cache the std handles](https://github.com/rust-lang/rust/pull/40516)
+    ///
+    pub unsafe fn setup() -> io::Result<()> {
+        let old_out = Output::new()?;
+
+        if FreeConsole() == 0 {
+            return Err(io::Error::last_os_error());
+        }
+
+        if AllocConsole() == 0 {
+            return Err(io::Error::last_os_error());
+        }
+
+        // AllocConsole will not always set stdout/stderr to the to the console buffer
+        // of the new terminal.
+
+        let stdout = get_stdout()?;
+        if SetStdHandle(STD_OUTPUT_HANDLE, stdout) == 0 {
+            return Err(io::Error::last_os_error());
+        }
+
+        if SetStdHandle(STD_ERROR_HANDLE, stdout) == 0 {
+            return Err(io::Error::last_os_error());
+        }
+
+        OLD_OUT = Box::into_raw(Box::new(old_out));
+
+        Ok(())
+    }
+
+    /// Reattach to the old console.
+    pub unsafe fn cleanup() -> io::Result<()> {
+        if FreeConsole() == 0 {
+            return Err(io::Error::last_os_error());
+        }
+
+        if AttachConsole(winapi::um::wincon::ATTACH_PARENT_PROCESS) == 0 {
+            return Err(io::Error::last_os_error());
+        }
+
+        Box::from_raw(OLD_OUT).set_as_std()?;
+
+        Ok(())
+    }
+
+    /// This will signal the whole process group.
+    pub unsafe fn raise_ctrl_c() {
+        assert!(GenerateConsoleCtrlEvent(winapi::um::wincon::CTRL_C_EVENT, 0) != 0);
+    }
+
+    /// Print to both consoles, this is not thread safe.
+    pub unsafe fn print(fmt: ::std::fmt::Arguments) {
+        use self::io::Write;
+        {
+            let stdout = io::stdout();
+            stdout.lock().write_fmt(fmt).unwrap();
+        }
+        {
+            assert!(!OLD_OUT.is_null());
+            (*OLD_OUT).write_fmt(fmt).unwrap();
+        }
+    }
+}
+
+macro_rules! run_tests {
+    ( $($test_fn:ident),* ) => {
+        unsafe {
+            platform::print(format_args!("\n"));
+            $(
+                platform::print(format_args!("test deps::ctrlc::tests::{} ... ", stringify!($test_fn)));
+                $test_fn();
+                platform::print(format_args!("ok\n"));
+            )*
+            platform::print(format_args!("\n"));
+        }
+    }
+}
+
+fn test_set_handler() {
+    let (tx, rx) = ::std::sync::mpsc::channel();
+    ctrlc::set_handler(move |sig_id| {
+        tx.send(true).unwrap();
+    })
+    .unwrap();
+
+    unsafe {
+        platform::raise_ctrl_c();
+    }
+
+    rx.recv_timeout(::std::time::Duration::from_secs(10))
+        .unwrap();
+
+    match ctrlc::set_handler(|sig_id| {}) {
+        Err(ctrlc::Error::MultipleHandlers) => {}
+        ret => panic!("{:?}", ret),
+    }
+}
+
+#[test]
+fn test_signal_handler() {
+    unsafe {
+        platform::setup().unwrap();
+    }
+
+    let default = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        unsafe {
+            platform::cleanup().unwrap();
+        }
+        (default)(info);
+    }));
+
+    run_tests!(test_set_handler);
+
+    unsafe {
+        platform::cleanup().unwrap();
+    }
+}

--- a/src/deps/mod.rs
+++ b/src/deps/mod.rs
@@ -15,6 +15,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 pub mod bitcoin;
+pub mod ctrlc;
 pub mod httparse;
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,12 @@ extern crate slog_term;
 #[cfg(unix)]
 extern crate libc;
 
+#[cfg(unix)]
+extern crate nix;
+
+#[cfg(windows)]
+extern crate winapi;
+
 #[macro_use]
 extern crate serde_derive;
 #[macro_use]

--- a/src/libclarity.rs
+++ b/src/libclarity.rs
@@ -51,6 +51,12 @@ extern crate slog_term;
 #[cfg(unix)]
 extern crate libc;
 
+#[cfg(unix)]
+extern crate nix;
+
+#[cfg(windows)]
+extern crate winapi;
+
 #[macro_use]
 extern crate serde_derive;
 #[macro_use]

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,6 +65,7 @@ use blockstack_lib::{
         stacks::db::{StacksChainState, StacksHeaderInfo},
     },
     core::MemPoolDB,
+    util::db::sqlite_open,
     util::{hash::Hash160, vrf::VRFProof},
     vm::costs::ExecutionCost,
 };
@@ -610,7 +611,7 @@ simulating a miner.
         let value_opt = marf.get(&marf_bhh, marf_key).expect("Failed to read MARF");
 
         if let Some(value) = value_opt {
-            let conn = Connection::open_with_flags(&db_path, OpenFlags::SQLITE_OPEN_READ_ONLY)
+            let conn = sqlite_open(&db_path, OpenFlags::SQLITE_OPEN_READ_ONLY, false)
                 .expect("Failed to open DB");
             let args: &[&dyn ToSql] = &[&value.to_hex()];
             let res: Result<String, rusqlite::Error> = conn.query_row_and_then(

--- a/src/monitoring/mod.rs
+++ b/src/monitoring/mod.rs
@@ -31,6 +31,7 @@ use burnchains::BurnchainSigner;
 use std::error::Error;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Mutex;
+use util::db::sqlite_open;
 use util::db::Error as DatabaseError;
 use util::uint::{Uint256, Uint512};
 
@@ -144,9 +145,7 @@ fn txid_tracking_db(chainstate_root_path: &str) -> Result<DBConn, DatabaseError>
         OpenFlags::SQLITE_OPEN_READ_WRITE
     };
 
-    let conn = DBConn::open_with_flags(&db_path, open_flags)?;
-
-    conn.busy_handler(Some(tx_busy_handler))?;
+    let conn = sqlite_open(&db_path, open_flags, false)?;
 
     if create_flag {
         conn.execute(
@@ -195,8 +194,7 @@ pub fn log_transaction_processed(
     #[cfg(feature = "monitoring_prom")]
     {
         let mempool_db_path = MemPoolDB::db_path(chainstate_root_path)?;
-        let mempool_conn =
-            DBConn::open_with_flags(&mempool_db_path, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
+        let mempool_conn = sqlite_open(&mempool_db_path, OpenFlags::SQLITE_OPEN_READ_ONLY, false)?;
         let tracking_db = txid_tracking_db(chainstate_root_path)?;
 
         let tx = match MemPoolDB::get_tx(&mempool_conn, txid)? {

--- a/src/net/atlas/db.rs
+++ b/src/net/atlas/db.rs
@@ -24,6 +24,7 @@ use std::convert::From;
 use std::convert::TryFrom;
 use std::fs;
 
+use util::db::sqlite_open;
 use util::db::tx_begin_immediate;
 use util::db::DBConn;
 use util::db::Error as db_error;
@@ -197,9 +198,8 @@ impl AtlasDB {
                 OpenFlags::SQLITE_OPEN_READ_ONLY
             }
         };
-        let conn =
-            Connection::open_with_flags(path, open_flags).map_err(|e| db_error::SqliteError(e))?;
 
+        let conn = sqlite_open(path, open_flags, false)?;
         let mut db = AtlasDB {
             atlas_config,
             conn,

--- a/src/net/db.rs
+++ b/src/net/db.rs
@@ -25,6 +25,7 @@ use std::convert::From;
 use std::convert::TryFrom;
 use std::fs;
 
+use util::db::sqlite_open;
 use util::db::tx_begin_immediate;
 use util::db::DBConn;
 use util::db::Error as db_error;
@@ -526,10 +527,8 @@ impl PeerDB {
             }
         };
 
-        let conn =
-            Connection::open_with_flags(path, open_flags).map_err(|e| db_error::SqliteError(e))?;
+        let conn = sqlite_open(path, open_flags, false)?;
 
-        conn.busy_handler(Some(tx_busy_handler))?;
         let mut db = PeerDB {
             conn: conn,
             readwrite: readwrite,

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -2169,6 +2169,8 @@ pub mod test {
             parent_burn_block_hash: BurnchainHeaderHash,
             parent_burn_block_height: u32,
             parent_burn_block_timestamp: u64,
+            _anchor_block_cost: &ExecutionCost,
+            _confirmed_mblock_cost: &ExecutionCost,
         ) {
             self.blocks.lock().unwrap().push(TestEventObserverBlock {
                 block,
@@ -3356,7 +3358,8 @@ pub mod test {
                     let sort_iconn = sortdb.index_conn();
                     let mut epoch = builder
                         .epoch_begin(&mut miner_chainstate, &sort_iconn)
-                        .unwrap();
+                        .unwrap()
+                        .0;
 
                     let (stacks_block, microblocks) =
                         mine_smart_contract_block_contract_call_microblock(

--- a/src/util/db.rs
+++ b/src/util/db.rs
@@ -23,6 +23,7 @@ use std::io;
 use std::io::Error as IOError;
 use std::ops::Deref;
 use std::ops::DerefMut;
+use std::path::Path;
 use std::path::PathBuf;
 
 use util::hash::to_hex;
@@ -37,6 +38,7 @@ use rusqlite::types::{
 };
 use rusqlite::Connection;
 use rusqlite::Error as sqlite_error;
+use rusqlite::OpenFlags;
 use rusqlite::OptionalExtension;
 use rusqlite::Row;
 use rusqlite::Transaction;
@@ -60,6 +62,9 @@ use serde_json::Error as serde_error;
 
 pub type DBConn = rusqlite::Connection;
 pub type DBTx<'a> = rusqlite::Transaction<'a>;
+
+// 256MB
+pub const SQLITE_MMAP_SIZE: i64 = 256 * 1024 * 1024;
 
 #[derive(Debug)]
 pub enum Error {
@@ -400,14 +405,20 @@ where
 
 /// Run a PRAGMA statement.  This can't always be done via execute(), because it may return a result (and
 /// rusqlite does not like this).
-pub fn sql_pragma(conn: &Connection, pragma_stmt: &str) -> Result<(), Error> {
-    conn.query_row_and_then(pragma_stmt, NO_PARAMS, |_row| Ok(()))
+pub fn sql_pragma(
+    conn: &Connection,
+    pragma_name: &str,
+    pragma_value: &dyn ToSql,
+) -> Result<(), Error> {
+    inner_sql_pragma(conn, pragma_name, pragma_value).map_err(|e| Error::SqliteError(e))
 }
 
-pub fn set_wal_mode(conn: &Connection) -> Result<(), sqlite_error> {
-    conn.query_row("PRAGMA journal_mode = WAL;", rusqlite::NO_PARAMS, |_row| {
-        Ok(())
-    })
+fn inner_sql_pragma(
+    conn: &Connection,
+    pragma_name: &str,
+    pragma_value: &dyn ToSql,
+) -> Result<(), sqlite_error> {
+    conn.pragma_update(None, pragma_name, pragma_value)
 }
 
 /// Returns true if the database table `table_name` exists in the active
@@ -420,8 +431,8 @@ pub fn table_exists(conn: &Connection, table_name: &str) -> Result<bool, sqlite_
 }
 
 /// Set up an on-disk database with a MARF index if they don't exist yet.
-/// Either way, returns (db path, MARF path)
-pub fn db_mkdirs(path_str: &str) -> Result<(String, String), Error> {
+/// Either way, returns the MARF path
+pub fn db_mkdirs(path_str: &str) -> Result<String, Error> {
     let mut path = PathBuf::from(path_str);
     match fs::metadata(path_str) {
         Ok(md) => {
@@ -441,11 +452,7 @@ pub fn db_mkdirs(path_str: &str) -> Result<(String, String), Error> {
     path.push("marf.sqlite");
     let marf_path = path.to_str().ok_or_else(|| Error::ParseError)?.to_string();
 
-    path.pop();
-    path.push("data.sqlite");
-    let data_path = path.to_str().ok_or_else(|| Error::ParseError)?.to_string();
-
-    Ok((data_path, marf_path))
+    Ok(marf_path)
 }
 
 /// Read-only connection to a MARF-indexed DB
@@ -549,6 +556,21 @@ pub fn tx_begin_immediate_sqlite<'a>(conn: &'a mut Connection) -> Result<DBTx<'a
     conn.busy_handler(Some(tx_busy_handler))?;
     let tx = Transaction::new(conn, TransactionBehavior::Immediate)?;
     Ok(tx)
+}
+
+/// Open a database connection and set some typically-used pragmas
+pub fn sqlite_open<P: AsRef<Path>>(
+    path: P,
+    flags: OpenFlags,
+    foreign_keys: bool,
+) -> Result<Connection, sqlite_error> {
+    let db = Connection::open_with_flags(path, flags)?;
+    db.busy_handler(Some(tx_busy_handler))?;
+    inner_sql_pragma(&db, "journal_mode", &"WAL")?;
+    if foreign_keys {
+        inner_sql_pragma(&db, "foreign_keys", &true)?;
+    }
+    Ok(db)
 }
 
 /// Get the ancestor block hash of a block of a given height, given a descendent block hash.
@@ -783,5 +805,43 @@ impl<'a, C: Clone, T: MarfTrieId> Drop for IndexDBTx<'a, C, T> {
             debug!("Dropping MARF linkage ({},{})", parent, child);
             index_tx.drop_current();
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn test_pragma() {
+        let path = "/tmp/blockstack_db_test_pragma.db";
+        if fs::metadata(path).is_ok() {
+            fs::remove_file(path).unwrap();
+        }
+
+        // calls pragma_update with both journal_mode and foreign_keys
+        let db = sqlite_open(
+            path,
+            OpenFlags::SQLITE_OPEN_CREATE | OpenFlags::SQLITE_OPEN_READ_WRITE,
+            true,
+        )
+        .unwrap();
+
+        // journal mode must be WAL
+        db.pragma_query(None, "journal_mode", |row| {
+            let value: String = row.get(0)?;
+            assert_eq!(value, "wal");
+            Ok(())
+        })
+        .unwrap();
+
+        // foreign keys must be on
+        db.pragma_query(None, "foreign_keys", |row| {
+            let value: i64 = row.get(0)?;
+            assert_eq!(value, 1);
+            Ok(())
+        })
+        .unwrap();
     }
 }

--- a/testnet/stacks-node/Cargo.toml
+++ b/testnet/stacks-node/Cargo.toml
@@ -21,7 +21,6 @@ base64 = "0.12.0"
 backtrace = "0.3.50"
 libc = "0.2"
 slog = { version = "2.5.2", features = [ "max_level_trace" ] }
-ctrlc = { version = "3.1.7", features = [ "termination" ] }
 
 [dev-dependencies]
 ring = "0.16.19"

--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -1464,6 +1464,7 @@ pub enum EventKeyType {
     Microblocks,
     AnyEvent,
     BurnchainBlocks,
+    MinedBlocks,
 }
 
 impl EventKeyType {

--- a/testnet/stacks-node/src/event_dispatcher.rs
+++ b/testnet/stacks-node/src/event_dispatcher.rs
@@ -67,7 +67,7 @@ pub const PATH_ATTACHMENT_PROCESSED: &str = "attachments/new";
 
 #[derive(Clone, Serialize, Deserialize)]
 pub struct MinedBlockEvent {
-    pub target_burn_block: u64,
+    pub target_burn_height: u64,
     pub block_hash: String,
     pub stacks_height: u64,
     pub block_size: u64,
@@ -802,7 +802,7 @@ impl EventDispatcher {
         }
 
         let payload = serde_json::to_value(MinedBlockEvent {
-            target_burn_block: target_burn_height,
+            target_burn_height,
             block_hash: block.block_hash().to_string(),
             stacks_height: block.header.total_work.work,
             block_size: block_size_bytes,

--- a/testnet/stacks-node/src/event_dispatcher.rs
+++ b/testnet/stacks-node/src/event_dispatcher.rs
@@ -71,7 +71,8 @@ pub struct MinedBlockEvent {
     pub block_hash: String,
     pub stacks_height: u64,
     pub block_size: u64,
-    pub anchor_consumed: ExecutionCost,
+    pub anchored_cost: ExecutionCost,
+    pub confirmed_microblocks_cost: ExecutionCost,
 }
 
 impl EventObserver {
@@ -364,8 +365,8 @@ impl EventObserver {
             "parent_burn_block_hash":  format!("0x{}", parent_burn_block_hash),
             "parent_burn_block_height": parent_burn_block_height,
             "parent_burn_block_timestamp": parent_burn_block_timestamp,
-            "anchored_block_consumed_cost": anchored_consumed,
-            "microblocks_confirmed_consumed_cost": mblock_confirmed_consumed,
+            "anchored_cost": anchored_consumed,
+            "confirmed_microblocks_cost": mblock_confirmed_consumed,
         });
 
         // Send payload
@@ -400,8 +401,15 @@ impl MemPoolEventDispatcher for EventDispatcher {
         block: &StacksBlock,
         block_size_bytes: u64,
         consumed: &ExecutionCost,
+        confirmed_microblock_cost: &ExecutionCost,
     ) {
-        self.process_mined_block_event(target_burn_height, block, block_size_bytes, consumed)
+        self.process_mined_block_event(
+            target_burn_height,
+            block,
+            block_size_bytes,
+            consumed,
+            confirmed_microblock_cost,
+        )
     }
 }
 
@@ -781,6 +789,7 @@ impl EventDispatcher {
         block: &StacksBlock,
         block_size_bytes: u64,
         consumed: &ExecutionCost,
+        confirmed_microblock_cost: &ExecutionCost,
     ) {
         let interested_observers: Vec<_> = self
             .registered_observers
@@ -797,7 +806,8 @@ impl EventDispatcher {
             block_hash: block.block_hash().to_string(),
             stacks_height: block.header.total_work.work,
             block_size: block_size_bytes,
-            anchor_consumed: consumed.clone(),
+            anchored_cost: consumed.clone(),
+            confirmed_microblocks_cost: confirmed_microblock_cost.clone(),
         })
         .unwrap();
 

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -1857,7 +1857,7 @@ impl InitializedNeonNode {
             }
         }
 
-        let (anchored_block, consumed_cost, _) = match StacksBlockBuilder::build_anchored_block(
+        let (anchored_block, _, _) = match StacksBlockBuilder::build_anchored_block(
             chain_state,
             &burn_db.index_conn(),
             mem_pool,
@@ -1933,12 +1933,6 @@ impl InitializedNeonNode {
             anchored_block.block_hash(),
             anchored_block.txs.len(),
             attempt
-        );
-
-        eprintln!(
-            "Assembled block at burn height = {}, consumed.runtime = {}",
-            burn_block.block_height + 1,
-            consumed_cost.runtime
         );
 
         // let's figure out the recipient set!

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -1857,7 +1857,7 @@ impl InitializedNeonNode {
             }
         }
 
-        let (anchored_block, _, _) = match StacksBlockBuilder::build_anchored_block(
+        let (anchored_block, consumed_cost, _) = match StacksBlockBuilder::build_anchored_block(
             chain_state,
             &burn_db.index_conn(),
             mem_pool,
@@ -1933,6 +1933,12 @@ impl InitializedNeonNode {
             anchored_block.block_hash(),
             anchored_block.txs.len(),
             attempt
+        );
+
+        eprintln!(
+            "Assembled block at burn height = {}, consumed.runtime = {}",
+            burn_block.block_height + 1,
+            consumed_cost.runtime
         );
 
         // let's figure out the recipient set!

--- a/testnet/stacks-node/src/node.rs
+++ b/testnet/stacks-node/src/node.rs
@@ -929,6 +929,8 @@ impl Node {
             parent_burn_block_hash,
             parent_burn_block_height,
             parent_burn_block_timestamp,
+            &processed_block.anchored_block_cost,
+            &processed_block.parent_microblocks_cost,
         );
 
         self.chain_tip = Some(chain_tip.clone());

--- a/testnet/stacks-node/src/tests/epoch_205.rs
+++ b/testnet/stacks-node/src/tests/epoch_205.rs
@@ -189,7 +189,7 @@ fn test_exact_block_costs() {
     let mined_blocks = test_observer::get_mined_blocks();
     let mut mined_blocks_map = HashMap::new();
     for mined_block in mined_blocks.into_iter() {
-        mined_blocks_map.insert(mined_block.target_burn_block, mined_block);
+        mined_blocks_map.insert(mined_block.target_burn_height, mined_block);
     }
 
     let mut total_txs = 0;

--- a/testnet/stacks-node/src/tests/mod.rs
+++ b/testnet/stacks-node/src/tests/mod.rs
@@ -363,6 +363,34 @@ pub fn make_contract_call(
     serialize_sign_standard_single_sig_tx(payload.into(), sender, nonce, tx_fee)
 }
 
+pub fn make_contract_call_mblock_only(
+    sender: &StacksPrivateKey,
+    nonce: u64,
+    tx_fee: u64,
+    contract_addr: &StacksAddress,
+    contract_name: &str,
+    function_name: &str,
+    function_args: &[Value],
+) -> Vec<u8> {
+    let contract_name = ContractName::from(contract_name);
+    let function_name = ClarityName::from(function_name);
+
+    let payload = TransactionContractCall {
+        address: contract_addr.clone(),
+        contract_name,
+        function_name,
+        function_args: function_args.iter().map(|x| x.clone()).collect(),
+    };
+
+    serialize_sign_standard_single_sig_tx_anchor_mode(
+        payload.into(),
+        sender,
+        nonce,
+        tx_fee,
+        TransactionAnchorMode::OffChainOnly,
+    )
+}
+
 fn make_microblock(
     privk: &StacksPrivateKey,
     chainstate: &mut StacksChainState,


### PR DESCRIPTION
This PR does a few things:

1. Merges `develop` to `next-costs`
2. Adds the confirmed microblock cost and anchored block cost to `new_block` events
3. Adds a new `mined_block` event that relays information about mined, but not necessarily won blocks from a miner.
4. Adds an integration test that asserts exact cost consumption matching between the miner block assembly and the follower block validation paths (#2913)
5. Fixes a bug in the miner block assembly path that led miners to be overly pessimistic in their own block costs when confirming microblocks