### PR TITLE
2.05: make it so a block whose anchored parent is in a different epoch cannot confirm a microblock stream

### DIFF
--- a/src/burnchains/mod.rs
+++ b/src/burnchains/mod.rs
@@ -1034,6 +1034,13 @@ pub mod test {
             txop.txid =
                 Txid::from_test_data(txop.block_height, txop.vtxindex, &txop.burn_header_hash, 0);
 
+            let epoch = SortitionDB::get_stacks_epoch(ic, txop.block_height)
+                .unwrap()
+                .expect(&format!("BUG: no epoch for height {}", &txop.block_height));
+            if epoch.epoch_id == StacksEpochId::Epoch2_05 {
+                txop.memo = vec![STACKS_EPOCH_2_05_MARKER];
+            }
+
             self.txs
                 .push(BlockstackOperationType::LeaderBlockCommit(txop.clone()));
 

--- a/src/chainstate/burn/db/sortdb.rs
+++ b/src/chainstate/burn/db/sortdb.rs
@@ -1604,7 +1604,10 @@ impl<'a> SortitionHandleConn<'a> {
         Ok(winning_user_burns)
     }
 
-    /// Get the block snapshot of the parent stacks block of the given stacks block
+    /// Get the block snapshot of the parent stacks block of the given stacks block.
+    /// The returned block-commit is for the given (consensus_hash, block_hash).
+    /// The returned BlockSnapshot is for the parent of the block identified by (consensus_hash,
+    /// block_hash).
     pub fn get_block_snapshot_of_parent_stacks_block(
         &self,
         consensus_hash: &ConsensusHash,

--- a/src/chainstate/stacks/block.rs
+++ b/src/chainstate/stacks/block.rs
@@ -339,6 +339,12 @@ impl StacksBlockHeader {
         // * state_index_root   (validated on process_block())
         Ok(())
     }
+
+    /// Does this header have a microblock parent?
+    pub fn has_microblock_parent(&self) -> bool {
+        self.parent_microblock != EMPTY_MICROBLOCK_PARENT_HASH
+            || self.parent_microblock_sequence != 0
+    }
 }
 
 impl StacksMessageCodec for StacksBlock {
@@ -627,6 +633,11 @@ impl StacksBlock {
             return false;
         }
         return true;
+    }
+
+    /// Does this block have a microblock parent?
+    pub fn has_microblock_parent(&self) -> bool {
+        self.header.has_microblock_parent()
     }
 }
 

--- a/src/chainstate/stacks/db/accounts.rs
+++ b/src/chainstate/stacks/db/accounts.rs
@@ -866,6 +866,7 @@ mod test {
             &user_burns,
             &ExecutionCost::zero(),
             123,
+            false,
         )
         .unwrap();
         tx.commit().unwrap();

--- a/src/chainstate/stacks/miner.rs
+++ b/src/chainstate/stacks/miner.rs
@@ -402,11 +402,13 @@ impl<'a> StacksMicroblockBuilder<'a> {
                 bytes_so_far,
             ) {
                 Ok(Some(_)) => {
+                    test_debug!("Include tx {} in microblock", tx.txid());
                     bytes_so_far += tx_len;
                     num_txs += 1;
                     txs_included.push(tx);
                 }
                 Ok(None) => {
+                    test_debug!("Exclude tx {} from microblock", tx.txid());
                     continue;
                 }
                 Err(e) => {
@@ -1183,24 +1185,40 @@ impl StacksBlockBuilder {
         let parent_index_hash =
             StacksBlockHeader::make_index_block_hash(&parent_consensus_hash, &parent_header_hash);
 
-        let parent_microblocks = match self.load_parent_microblocks(
-            chainstate,
-            &parent_consensus_hash,
-            &parent_header_hash,
-            &parent_index_hash,
-        ) {
-            Ok(x) => x,
-            Err(e) => {
-                warn!("Miner failed to load parent microblock, mining without parent microblock tail";
-                      "parent_block_hash" => %parent_header_hash,
-                      "parent_index_hash" => %parent_header_hash,
-                      "parent_consensus_hash" => %parent_header_hash,
-                      "parent_microblock_hash" => match self.parent_microblock_hash.as_ref() {
-                          Some(x) => format!("Some({})", x.to_string()),
-                          None => "None".to_string(),
-                      },
-                      "error" => ?e);
-                vec![]
+        let parent_sn =
+            SortitionDB::get_block_snapshot_consensus(burn_dbconn.conn(), &parent_consensus_hash)?
+                .ok_or(Error::NoSuchBlockError)?;
+        let burn_tip = SortitionDB::get_canonical_chain_tip_bhh(burn_dbconn.conn())?;
+        let burn_tip_height =
+            SortitionDB::get_canonical_burn_chain_tip(burn_dbconn.conn())?.block_height as u32;
+
+        let parent_microblocks = if StacksChainState::block_crosses_epoch_boundary(
+            burn_dbconn,
+            parent_sn.block_height,
+            (burn_tip_height + 1).into(),
+        )? {
+            info!("Descendant of {}/{} will NOT confirm any microblocks, since it will cross an epoch boundary", &parent_consensus_hash, &parent_header_hash);
+            vec![]
+        } else {
+            match self.load_parent_microblocks(
+                chainstate,
+                &parent_consensus_hash,
+                &parent_header_hash,
+                &parent_index_hash,
+            ) {
+                Ok(x) => x,
+                Err(e) => {
+                    warn!("Miner failed to load parent microblock, mining without parent microblock tail";
+                              "parent_block_hash" => %parent_header_hash,
+                              "parent_index_hash" => %parent_header_hash,
+                              "parent_consensus_hash" => %parent_header_hash,
+                              "parent_microblock_hash" => match self.parent_microblock_hash.as_ref() {
+                                  Some(x) => format!("Some({})", x.to_string()),
+                                  None => "None".to_string(),
+                              },
+                              "error" => ?e);
+                    vec![]
+                }
             }
         };
 
@@ -1211,9 +1229,6 @@ impl StacksBlockBuilder {
             parent_microblocks.len()
         );
 
-        let burn_tip = SortitionDB::get_canonical_chain_tip_bhh(burn_dbconn.conn())?;
-        let burn_tip_height =
-            SortitionDB::get_canonical_burn_chain_tip(burn_dbconn.conn())?.block_height as u32;
         let stacking_burn_ops = SortitionDB::get_stack_stx_ops(burn_dbconn.conn(), &burn_tip)?;
         let transfer_burn_ops = SortitionDB::get_transfer_stx_ops(burn_dbconn.conn(), &burn_tip)?;
 
@@ -6933,6 +6948,505 @@ pub mod test {
                 }
             }
         }
+    }
+
+    #[test]
+    fn test_build_anchored_blocks_connected_by_microblocks_across_epoch() {
+        let privk = StacksPrivateKey::from_hex(
+            "42faca653724860da7a41bfcef7e6ba78db55146f6900de8cb2a9f760ffac70c01",
+        )
+        .unwrap();
+        let addr = StacksAddress::from_public_keys(
+            C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
+            &AddressHashMode::SerializeP2PKH,
+            1,
+            &vec![StacksPublicKey::from_private(&privk)],
+        )
+        .unwrap();
+
+        let mut peer_config = TestPeerConfig::new(
+            "test_build_anchored_blocks_connected_by_microblocks_across_epoch",
+            2016,
+            2017,
+        );
+        peer_config.initial_balances = vec![(addr.to_account_principal(), 1000000000)];
+
+        let epochs = vec![
+            StacksEpoch {
+                epoch_id: StacksEpochId::Epoch10,
+                start_height: 0,
+                end_height: 0,
+                block_limit: ExecutionCost::max_value(),
+            },
+            StacksEpoch {
+                epoch_id: StacksEpochId::Epoch20,
+                start_height: 0,
+                end_height: 30, // NOTE: the first 25 burnchain blocks have no sortition
+                block_limit: ExecutionCost::max_value(),
+            },
+            StacksEpoch {
+                epoch_id: StacksEpochId::Epoch2_05,
+                start_height: 30,
+                end_height: STACKS_EPOCH_MAX,
+                block_limit: ExecutionCost {
+                    write_length: 205205,
+                    write_count: 205205,
+                    read_length: 205205,
+                    read_count: 205205,
+                    runtime: 205205,
+                },
+            },
+        ];
+        peer_config.epochs = Some(epochs);
+
+        let num_blocks = 10;
+
+        let mut mblock_privks = vec![];
+        for _ in 0..num_blocks {
+            let mblock_privk = StacksPrivateKey::new();
+            mblock_privks.push(mblock_privk);
+        }
+
+        let mut peer = TestPeer::new(peer_config);
+
+        let chainstate_path = peer.chainstate_path.clone();
+
+        let first_stacks_block_height = {
+            let sn =
+                SortitionDB::get_canonical_burn_chain_tip(&peer.sortdb.as_ref().unwrap().conn())
+                    .unwrap();
+            sn.block_height
+        };
+
+        let recipient_addr_str = "ST1RFD5Q2QPK3E0F08HG9XDX7SSC7CNRS0QR0SGEV";
+        let recipient = StacksAddress::from_string(recipient_addr_str).unwrap();
+        let mut sender_nonce = 0;
+
+        let mut last_block = None;
+        for tenure_id in 0..num_blocks {
+            // send transactions to the mempool
+            let tip =
+                SortitionDB::get_canonical_burn_chain_tip(&peer.sortdb.as_ref().unwrap().conn())
+                    .unwrap();
+
+            let acct = get_stacks_account(&mut peer, &addr.to_account_principal());
+
+            let (burn_ops, stacks_block, microblocks) = peer.make_tenure(
+                |ref mut miner,
+                 ref mut sortdb,
+                 ref mut chainstate,
+                 vrf_proof,
+                 ref parent_opt,
+                 ref parent_microblock_header_opt| {
+                    let parent_tip = match parent_opt {
+                        None => StacksChainState::get_genesis_header_info(chainstate.db()).unwrap(),
+                        Some(block) => {
+                            let ic = sortdb.index_conn();
+                            let snapshot =
+                                SortitionDB::get_block_snapshot_for_winning_stacks_block(
+                                    &ic,
+                                    &tip.sortition_id,
+                                    &block.block_hash(),
+                                )
+                                .unwrap()
+                                .unwrap(); // succeeds because we don't fork
+                            StacksChainState::get_anchored_block_header_info(
+                                chainstate.db(),
+                                &snapshot.consensus_hash,
+                                &snapshot.winning_stacks_block_hash,
+                            )
+                            .unwrap()
+                            .unwrap()
+                        }
+                    };
+
+                    let parent_header_hash = parent_tip.anchored_header.block_hash();
+                    let parent_consensus_hash = parent_tip.consensus_hash.clone();
+                    let parent_index_hash = StacksBlockHeader::make_index_block_hash(
+                        &parent_consensus_hash,
+                        &parent_header_hash,
+                    );
+
+                    let mut mempool =
+                        MemPoolDB::open_test(false, 0x80000000, &chainstate_path).unwrap();
+
+                    let coinbase_tx = make_coinbase(miner, tenure_id);
+                    let sort_ic = sortdb.index_conn();
+                    let (parent_mblock_stream, mblock_pubkey_hash) = {
+                        if tenure_id > 0 {
+                            chainstate
+                                .reload_unconfirmed_state(&sort_ic, parent_index_hash.clone())
+                                .unwrap();
+
+                            let parent_microblock_privkey = mblock_privks[tenure_id - 1].clone();
+                            // produce the microblock stream for the parent, which this tenure's anchor
+                            // block will confirm.
+                            let mut microblock_builder = StacksMicroblockBuilder::new(
+                                parent_header_hash.clone(),
+                                parent_consensus_hash.clone(),
+                                chainstate,
+                                &sort_ic,
+                                BlockBuilderSettings::max_value(),
+                            )
+                            .unwrap();
+
+                            let mut microblocks = vec![];
+
+                            let mblock_tx = make_user_stacks_transfer(
+                                &privk,
+                                acct.nonce,
+                                200,
+                                &recipient.to_account_principal(),
+                                1,
+                            );
+
+                            let mblock_tx_len = {
+                                let mut bytes = vec![];
+                                mblock_tx.consensus_serialize(&mut bytes).unwrap();
+                                bytes.len() as u64
+                            };
+
+                            test_debug!(
+                                "Make microblock parent stream for block in tenure {}",
+                                tenure_id
+                            );
+                            let mblock = microblock_builder
+                                .mine_next_microblock_from_txs(
+                                    vec![(mblock_tx, mblock_tx_len)],
+                                    &parent_microblock_privkey,
+                                )
+                                .unwrap();
+                            microblocks.push(mblock);
+
+                            let microblock_privkey = mblock_privks[tenure_id].clone();
+                            let mblock_pubkey_hash = Hash160::from_node_public_key(
+                                &StacksPublicKey::from_private(&microblock_privkey),
+                            );
+                            (microblocks, mblock_pubkey_hash)
+                        } else {
+                            let parent_microblock_privkey = mblock_privks[tenure_id].clone();
+                            let mblock_pubkey_hash = Hash160::from_node_public_key(
+                                &StacksPublicKey::from_private(&parent_microblock_privkey),
+                            );
+                            (vec![], mblock_pubkey_hash)
+                        }
+                    };
+
+                    test_debug!("Store parent microblocks for tenure {}", tenure_id);
+                    for mblock in parent_mblock_stream.iter() {
+                        let stored = chainstate
+                            .preprocess_streamed_microblock(
+                                &parent_consensus_hash,
+                                &parent_header_hash,
+                                mblock,
+                            )
+                            .unwrap();
+                        assert!(stored);
+                    }
+
+                    let anchored_block = StacksBlockBuilder::build_anchored_block(
+                        chainstate,
+                        &sort_ic,
+                        &mut mempool,
+                        &parent_tip,
+                        tip.total_burn,
+                        vrf_proof,
+                        mblock_pubkey_hash,
+                        &coinbase_tx,
+                        BlockBuilderSettings::max_value(),
+                        None,
+                    )
+                    .unwrap();
+
+                    if parent_mblock_stream.len() > 0 {
+                        if tenure_id != 4 {
+                            assert_eq!(
+                                anchored_block.0.header.parent_microblock,
+                                parent_mblock_stream.last().unwrap().block_hash()
+                            );
+                        } else {
+                            // epoch change happened, so miner didn't confirm any microblocks
+                            assert!(!anchored_block.0.has_microblock_parent());
+                        }
+                    }
+
+                    (anchored_block.0, parent_mblock_stream)
+                },
+            );
+
+            last_block = Some(stacks_block.clone());
+
+            peer.next_burnchain_block(burn_ops.clone());
+            peer.process_stacks_epoch_at_tip(&stacks_block, &vec![]);
+        }
+
+        let last_block = last_block.unwrap();
+        assert_eq!(last_block.header.total_work.work, 10); // mined a chain successfully across the epoch boundary
+    }
+
+    #[test]
+    #[should_panic(expected = "success")]
+    fn test_build_anchored_blocks_connected_by_microblocks_across_epoch_invalid() {
+        let privk = StacksPrivateKey::from_hex(
+            "42faca653724860da7a41bfcef7e6ba78db55146f6900de8cb2a9f760ffac70c01",
+        )
+        .unwrap();
+        let addr = StacksAddress::from_public_keys(
+            C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
+            &AddressHashMode::SerializeP2PKH,
+            1,
+            &vec![StacksPublicKey::from_private(&privk)],
+        )
+        .unwrap();
+
+        let mut peer_config = TestPeerConfig::new(
+            "test_build_anchored_blocks_connected_by_microblocks_across_epoch_invalid",
+            2018,
+            2019,
+        );
+        peer_config.initial_balances = vec![(addr.to_account_principal(), 1000000000)];
+
+        let epochs = vec![
+            StacksEpoch {
+                epoch_id: StacksEpochId::Epoch10,
+                start_height: 0,
+                end_height: 0,
+                block_limit: ExecutionCost::max_value(),
+            },
+            StacksEpoch {
+                epoch_id: StacksEpochId::Epoch20,
+                start_height: 0,
+                end_height: 30, // NOTE: the first 25 burnchain blocks have no sortition
+                block_limit: ExecutionCost::max_value(),
+            },
+            StacksEpoch {
+                epoch_id: StacksEpochId::Epoch2_05,
+                start_height: 30,
+                end_height: STACKS_EPOCH_MAX,
+                block_limit: ExecutionCost {
+                    write_length: 205205,
+                    write_count: 205205,
+                    read_length: 205205,
+                    read_count: 205205,
+                    runtime: 205205,
+                },
+            },
+        ];
+        peer_config.epochs = Some(epochs);
+
+        let num_blocks = 10;
+
+        let mut mblock_privks = vec![];
+        for _ in 0..num_blocks {
+            let mblock_privk = StacksPrivateKey::new();
+            mblock_privks.push(mblock_privk);
+        }
+
+        let mut peer = TestPeer::new(peer_config);
+
+        let chainstate_path = peer.chainstate_path.clone();
+
+        let first_stacks_block_height = {
+            let sn =
+                SortitionDB::get_canonical_burn_chain_tip(&peer.sortdb.as_ref().unwrap().conn())
+                    .unwrap();
+            sn.block_height
+        };
+
+        let recipient_addr_str = "ST1RFD5Q2QPK3E0F08HG9XDX7SSC7CNRS0QR0SGEV";
+        let recipient = StacksAddress::from_string(recipient_addr_str).unwrap();
+        let mut sender_nonce = 0;
+
+        let mut last_block: Option<StacksBlock> = None;
+        let mut last_block_ch: Option<ConsensusHash> = None;
+
+        for tenure_id in 0..num_blocks {
+            // send transactions to the mempool
+            let tip =
+                SortitionDB::get_canonical_burn_chain_tip(&peer.sortdb.as_ref().unwrap().conn())
+                    .unwrap();
+
+            let acct = get_stacks_account(&mut peer, &addr.to_account_principal());
+
+            let (burn_ops, stacks_block, microblocks) = peer.make_tenure(
+                |ref mut miner,
+                 ref mut sortdb,
+                 ref mut chainstate,
+                 vrf_proof,
+                 ref parent_opt,
+                 ref parent_microblock_header_opt| {
+                    let parent_tip = match parent_opt {
+                        None => StacksChainState::get_genesis_header_info(chainstate.db()).unwrap(),
+                        Some(block) => {
+                            let ic = sortdb.index_conn();
+
+                            if tenure_id < 5 {
+                                let snapshot =
+                                    SortitionDB::get_block_snapshot_for_winning_stacks_block(
+                                        &ic,
+                                        &tip.sortition_id,
+                                        &block.block_hash(),
+                                    )
+                                    .unwrap()
+                                    .unwrap();
+
+                                StacksChainState::get_anchored_block_header_info(
+                                    chainstate.db(),
+                                    &snapshot.consensus_hash,
+                                    &snapshot.winning_stacks_block_hash,
+                                )
+                                .unwrap()
+                                .unwrap()
+                            } else {
+                                // first block after the invalid block that had a microblock parent
+                                // while straddling the epoch boundary.
+                                // Verify that the last block was indeed marked as invalid, and abort.
+                                let bhh = last_block.as_ref().unwrap().block_hash();
+                                let ch = last_block_ch.as_ref().unwrap().clone();
+                                assert!(StacksChainState::is_block_orphaned(
+                                    chainstate.db(),
+                                    &ch,
+                                    &bhh
+                                )
+                                .unwrap());
+                                panic!("success");
+                            }
+                        }
+                    };
+
+                    let parent_header_hash = parent_tip.anchored_header.block_hash();
+                    let parent_consensus_hash = parent_tip.consensus_hash.clone();
+                    let parent_index_hash = StacksBlockHeader::make_index_block_hash(
+                        &parent_consensus_hash,
+                        &parent_header_hash,
+                    );
+
+                    let mut mempool =
+                        MemPoolDB::open_test(false, 0x80000000, &chainstate_path).unwrap();
+
+                    let coinbase_tx = make_coinbase(miner, tenure_id);
+                    let sort_ic = sortdb.index_conn();
+                    let (parent_mblock_stream, mblock_pubkey_hash) = {
+                        if tenure_id > 0 {
+                            chainstate
+                                .reload_unconfirmed_state(&sort_ic, parent_index_hash.clone())
+                                .unwrap();
+
+                            let parent_microblock_privkey = mblock_privks[tenure_id - 1].clone();
+
+                            // produce the microblock stream for the parent, which this tenure's anchor
+                            // block will confirm.
+                            let mut microblock_builder = StacksMicroblockBuilder::new(
+                                parent_header_hash.clone(),
+                                parent_consensus_hash.clone(),
+                                chainstate,
+                                &sort_ic,
+                                BlockBuilderSettings::max_value(),
+                            )
+                            .unwrap();
+
+                            let mut microblocks = vec![];
+
+                            let mblock_tx = make_user_stacks_transfer(
+                                &privk,
+                                acct.nonce,
+                                (200 + tenure_id) as u64,
+                                &recipient.to_account_principal(),
+                                1,
+                            );
+
+                            let mblock_tx_len = {
+                                let mut bytes = vec![];
+                                mblock_tx.consensus_serialize(&mut bytes).unwrap();
+                                bytes.len() as u64
+                            };
+
+                            test_debug!(
+                                "Make microblock parent stream for block in tenure {}",
+                                tenure_id
+                            );
+                            let mblock = microblock_builder
+                                .mine_next_microblock_from_txs(
+                                    vec![(mblock_tx, mblock_tx_len)],
+                                    &parent_microblock_privkey,
+                                )
+                                .unwrap();
+                            microblocks.push(mblock);
+
+                            let microblock_privkey = mblock_privks[tenure_id].clone();
+                            let mblock_pubkey_hash = Hash160::from_node_public_key(
+                                &StacksPublicKey::from_private(&microblock_privkey),
+                            );
+                            (microblocks, mblock_pubkey_hash)
+                        } else {
+                            let parent_microblock_privkey = mblock_privks[tenure_id].clone();
+                            let mblock_pubkey_hash = Hash160::from_node_public_key(
+                                &StacksPublicKey::from_private(&parent_microblock_privkey),
+                            );
+                            (vec![], mblock_pubkey_hash)
+                        }
+                    };
+
+                    test_debug!("Store parent microblocks for tenure {}", tenure_id);
+                    for mblock in parent_mblock_stream.iter() {
+                        let stored = chainstate
+                            .preprocess_streamed_microblock(
+                                &parent_consensus_hash,
+                                &parent_header_hash,
+                                mblock,
+                            )
+                            .unwrap();
+                        assert!(stored);
+                    }
+
+                    let mut anchored_block = StacksBlockBuilder::build_anchored_block(
+                        chainstate,
+                        &sort_ic,
+                        &mut mempool,
+                        &parent_tip,
+                        tip.total_burn,
+                        vrf_proof,
+                        mblock_pubkey_hash,
+                        &coinbase_tx,
+                        BlockBuilderSettings::max_value(),
+                        None,
+                    )
+                    .unwrap();
+
+                    if parent_mblock_stream.len() > 0 {
+                        // force the block to confirm a microblock stream, even if it would result in
+                        // an invalid block.
+                        anchored_block.0.header.parent_microblock =
+                            parent_mblock_stream.last().unwrap().block_hash();
+                        anchored_block.0.header.parent_microblock_sequence =
+                            (parent_mblock_stream.len() as u16).saturating_sub(1);
+                        assert_eq!(
+                            anchored_block.0.header.parent_microblock,
+                            parent_mblock_stream.last().unwrap().block_hash()
+                        );
+                    } else {
+                        assert_eq!(tenure_id, 0);
+                    }
+
+                    (anchored_block.0, parent_mblock_stream)
+                },
+            );
+
+            last_block = Some(stacks_block.clone());
+
+            peer.next_burnchain_block(burn_ops.clone());
+            peer.process_stacks_epoch_at_tip_checked(&stacks_block, &vec![])
+                .unwrap();
+
+            last_block_ch = Some(
+                SortitionDB::get_canonical_burn_chain_tip(&peer.sortdb.as_ref().unwrap().conn())
+                    .unwrap()
+                    .consensus_hash,
+            );
+        }
+
+        let last_block = last_block.unwrap();
+        assert_eq!(last_block.header.total_work.work, 10); // mined a chain successfully across the epoch boundary
     }
 
     #[test]

--- a/src/chainstate/stacks/miner.rs
+++ b/src/chainstate/stacks/miner.rs
@@ -1209,8 +1209,8 @@ impl StacksBlockBuilder {
                 Err(e) => {
                     warn!("Miner failed to load parent microblock, mining without parent microblock tail";
                               "parent_block_hash" => %parent_header_hash,
-                              "parent_index_hash" => %parent_header_hash,
-                              "parent_consensus_hash" => %parent_header_hash,
+                              "parent_index_hash" => %parent_index_hash,
+                              "parent_consensus_hash" => %parent_consensus_hash,
                               "parent_microblock_hash" => match self.parent_microblock_hash.as_ref() {
                                   Some(x) => format!("Some({})", x.to_string()),
                                   None => "None".to_string(),

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -2993,13 +2993,13 @@ pub mod test {
             self.stacks_node = Some(node);
         }
 
-        pub fn process_stacks_epoch_at_tip_checked(
+        fn inner_process_stacks_epoch_at_tip(
             &mut self,
+            sortdb: &SortitionDB,
+            node: &mut TestStacksNode,
             block: &StacksBlock,
             microblocks: &Vec<StacksMicroblock>,
         ) -> Result<(), coordinator_error> {
-            let sortdb = self.sortdb.take().unwrap();
-            let mut node = self.stacks_node.take().unwrap();
             {
                 let ic = sortdb.index_conn();
                 let tip = SortitionDB::get_canonical_burn_chain_tip(&ic)?;
@@ -3020,10 +3020,21 @@ pub mod test {
                 &block.block_hash(),
                 &pox_id
             );
+            Ok(())
+        }
 
+        pub fn process_stacks_epoch_at_tip_checked(
+            &mut self,
+            block: &StacksBlock,
+            microblocks: &Vec<StacksMicroblock>,
+        ) -> Result<(), coordinator_error> {
+            let sortdb = self.sortdb.take().unwrap();
+            let mut node = self.stacks_node.take().unwrap();
+            let res =
+                self.inner_process_stacks_epoch_at_tip(&sortdb, &mut node, block, microblocks);
             self.sortdb = Some(sortdb);
             self.stacks_node = Some(node);
-            Ok(())
+            res
         }
 
         pub fn process_stacks_epoch(

--- a/testnet/stacks-node/src/tests/epoch_205.rs
+++ b/testnet/stacks-node/src/tests/epoch_205.rs
@@ -8,6 +8,7 @@ use std::thread;
 use stacks::burnchains::Burnchain;
 use stacks::burnchains::Txid;
 use stacks::chainstate::burn::operations::BlockstackOperationType;
+use stacks::chainstate::stacks::db::StacksChainState;
 use stacks::chainstate::stacks::StacksPrivateKey;
 use stacks::chainstate::stacks::StacksTransaction;
 use stacks::chainstate::stacks::TransactionPayload;
@@ -17,6 +18,7 @@ use stacks::core::StacksEpochId;
 use stacks::types::chainstate::BlockHeaderHash;
 use stacks::types::chainstate::BurnchainHeaderHash;
 use stacks::types::chainstate::StacksAddress;
+use stacks::types::chainstate::StacksBlockHeader;
 use stacks::util::hash::hex_bytes;
 use stacks::vm::types::PrincipalData;
 use stacks::vm::ContractName;
@@ -235,6 +237,7 @@ fn test_exact_block_costs() {
     // check that we processed at least 32 transactions...
     // the reason not to do an exact check here is that there *is* some variability in microblock production,
     // so sometimes the miner doesn't produce a microblock
+    eprintln!("Got {} total txs", total_txs);
     assert!(total_txs >= 32);
 
     test_observer::clear();
@@ -520,6 +523,38 @@ fn transition_empty_blocks() {
         // also, make *huge* block-commits with invalid marker bytes once we reach the new
         // epoch, and verify that it fails.
         let tip_info = get_chain_info(&conf);
+
+        // this block is the epoch transition?
+        let (chainstate, _) = StacksChainState::open(
+            false,
+            conf.burnchain.chain_id,
+            &conf.get_chainstate_path_str(),
+        )
+        .unwrap();
+        let res = StacksChainState::block_crosses_epoch_boundary(
+            &chainstate.db(),
+            &tip_info.stacks_tip_consensus_hash,
+            &tip_info.stacks_tip,
+        )
+        .unwrap();
+        debug!(
+            "Epoch transition at {} ({}/{}) height {}: {}",
+            &StacksBlockHeader::make_index_block_hash(
+                &tip_info.stacks_tip_consensus_hash,
+                &tip_info.stacks_tip
+            ),
+            &tip_info.stacks_tip_consensus_hash,
+            &tip_info.stacks_tip,
+            tip_info.burn_block_height,
+            res
+        );
+
+        if tip_info.burn_block_height == epoch_2_05 {
+            assert!(res);
+        } else {
+            assert!(!res);
+        }
+
         if tip_info.burn_block_height + 1 >= epoch_2_05 {
             let burn_fee_cap = 100000000; // 1 BTC
             let sunset_burn =


### PR DESCRIPTION
This PR implements #2904.  It adds the following three changes:

* It makes it so that when pre-processing an anchored block (such as one downloaded or pushed to the node), the node will not store it if its parent is in a different epoch and it confirms a microblock stream.

* It makes it so the block-processing logic in `append_block()` will reject a block whose parent is in a different epoch and who has a parent microblock.

* It makes it so the anchored block miner will not confirm a microblock stream if the anchored block it produces builds on a parent in a different epoch.

The test coverage here is only in `miner.rs` -- there is no neon integration test.  This is because in order to test this new consensus behavior, we need fine-grained control over how the blocks and microblocks get produced.  Namely, we need to *force* the system to produce an anchored block in epoch 2.05 whose parent is in epoch 2.0 and who confirms a microblock stream in order to test that the consensus rules reject the block.  The neon integration test framework cannot (easily) test this, because it only passes anchored blocks to the relayer, which would simply never store the invalid block per the first change.