### PR TITLE
Instantiate `costs-2.clar` with latest results from benchmarking

### DIFF
--- a/src/chainstate/stacks/boot/costs-2-testnet.clar
+++ b/src/chainstate/stacks/boot/costs-2-testnet.clar
@@ -1,0 +1,567 @@
+;; the .costs-2 contract
+
+;; Helper Functions
+
+;; Return a Cost Specification with just a runtime cost
+(define-private (runtime (r uint))
+    {
+        runtime: r,
+        write_length: u0,
+        write_count: u0,
+        read_count: u0,
+        read_length: u0,
+    })
+
+;; Linear cost-assessment function
+(define-private (linear (n uint) (a uint) (b uint))
+    (+ (* a n) b))
+
+;; LogN cost-assessment function
+(define-private (logn (n uint) (a uint) (b uint))
+    (+ (* a (log2 n)) b))
+
+;; NLogN cost-assessment function
+(define-private (nlogn (n uint) (a uint) (b uint))
+    (+ (* a (* n (log2 n))) b))
+
+
+;; Cost Functions
+(define-read-only (cost_analysis_type_annotate (n uint))
+    (runtime (linear n u1 u9)))
+
+(define-read-only (cost_analysis_type_check (n uint))
+    (runtime (linear n u113 u1)))
+
+(define-read-only (cost_analysis_type_lookup (n uint))
+    (runtime (linear n u1 u6)))
+
+(define-read-only (cost_analysis_visit (n uint))
+    (runtime u1))
+
+(define-read-only (cost_analysis_iterable_func (n uint))
+    (runtime (linear n u2 u14)))
+
+(define-read-only (cost_analysis_option_cons (n uint))
+    (runtime u6))
+
+(define-read-only (cost_analysis_option_check (n uint))
+    (runtime u3))
+
+(define-read-only (cost_analysis_bind_name (n uint))
+    (runtime (linear n u2 u176)))
+
+(define-read-only (cost_analysis_list_items_check (n uint))
+    (runtime (linear n u2 u4)))
+
+(define-read-only (cost_analysis_check_tuple_get (n uint))
+    (runtime (logn n u1 u2)))
+
+(define-read-only (cost_analysis_check_tuple_merge (n uint))
+    (runtime (linear n u1000 u1000)))
+
+(define-read-only (cost_analysis_check_tuple_cons (n uint))
+    (runtime (nlogn n u3 u5)))
+
+(define-read-only (cost_analysis_tuple_items_check (n uint))
+    (runtime (linear n u1 u59)))
+
+(define-read-only (cost_analysis_check_let (n uint))
+    (runtime (linear n u1 u12)))
+
+(define-read-only (cost_analysis_lookup_function (n uint))
+    (runtime u20))
+
+(define-read-only (cost_analysis_lookup_function_types (n uint))
+    (runtime (linear n u1 u28)))
+
+(define-read-only (cost_analysis_lookup_variable_const (n uint))
+    (runtime u15))
+
+(define-read-only (cost_analysis_lookup_variable_depth (n uint))
+    (runtime (nlogn n u1 u34)))
+
+(define-read-only (cost_ast_parse (n uint))
+    (runtime (linear n u172 u287441)))
+
+(define-read-only (cost_ast_cycle_detection (n uint))
+    (runtime (linear n u141 u72)))
+
+(define-read-only (cost_analysis_storage (n uint))
+    {
+        runtime: (linear n u2 u100),
+        write_length: (linear n u1 u1),
+        write_count: u1,
+        read_count: u1,
+        read_length: u1
+    })
+
+(define-read-only (cost_analysis_use_trait_entry (n uint))
+    {
+        runtime: (linear n u9 u723),
+        write_length: (linear n u1 u1),
+        write_count: u0,
+        read_count: u1,
+        read_length: (linear n u1 u1)
+    })
+
+
+(define-read-only (cost_analysis_get_function_entry (n uint))
+    {
+        runtime: (linear n u81 u1303),
+        write_length: u0,
+        write_count: u0,
+        read_count: u1,
+        read_length: (linear n u1 u1)
+    })
+
+
+(define-read-only (cost_analysis_fetch_contract_entry (n uint))
+    {
+        runtime: (linear n u1000 u1000),
+        write_length: u0,
+        write_count: u0,
+        read_count: u1,
+        read_length: (linear n u1 u1)
+    })
+
+(define-read-only (cost_lookup_variable_depth (n uint))
+    (runtime (linear n u2 u14)))
+
+(define-read-only (cost_lookup_variable_size (n uint))
+    (runtime (linear n u2 u1)))
+
+(define-read-only (cost_lookup_function (n uint))
+    (runtime u16))
+
+(define-read-only (cost_bind_name (n uint))
+    (runtime u256))
+
+(define-read-only (cost_inner_type_check_cost (n uint))
+    (runtime (linear n u2 u9)))
+
+(define-read-only (cost_user_function_application (n uint))
+    (runtime (linear n u26 u140)))
+
+(define-read-only (cost_let (n uint))
+    (runtime (linear n u146 u862)))
+
+(define-read-only (cost_if (n uint))
+    (runtime u200))
+
+(define-read-only (cost_asserts (n uint))
+    (runtime u158))
+
+(define-read-only (cost_map (n uint))
+    (runtime (linear n u1210 u3314)))
+
+(define-read-only (cost_filter (n uint))
+    (runtime u460))
+
+(define-read-only (cost_len (n uint))
+    (runtime u486))
+
+(define-read-only (cost_element_at (n uint))
+    (runtime u619))
+
+(define-read-only (cost_index_of (n uint))
+    (runtime (linear n u1 u243)))
+
+(define-read-only (cost_fold (n uint))
+    (runtime u483))
+
+(define-read-only (cost_list_cons (n uint))
+    (runtime (linear n u14 u198)))
+
+(define-read-only (cost_type_parse_step (n uint))
+    (runtime u5))
+
+(define-read-only (cost_tuple_get (n uint))
+    (runtime (nlogn n u4 u1780)))
+
+(define-read-only (cost_tuple_merge (n uint))
+    (runtime (linear n u4 u646)))
+
+(define-read-only (cost_tuple_cons (n uint))
+    (runtime (nlogn n u11 u1101)))
+
+(define-read-only (cost_add (n uint))
+    (runtime (linear n u12 u156)))
+
+(define-read-only (cost_sub (n uint))
+    (runtime (linear n u12 u156)))
+
+(define-read-only (cost_mul (n uint))
+    (runtime (linear n u14 u157)))
+
+(define-read-only (cost_div (n uint))
+    (runtime (linear n u14 u157)))
+
+(define-read-only (cost_geq (n uint))
+    (runtime u166))
+
+(define-read-only (cost_leq (n uint))
+    (runtime u166))
+
+(define-read-only (cost_le (n uint))
+    (runtime u166))
+
+(define-read-only (cost_ge (n uint))
+    (runtime u166))
+
+(define-read-only (cost_int_cast (n uint))
+    (runtime u164))
+
+(define-read-only (cost_mod (n uint))
+    (runtime u168))
+
+(define-read-only (cost_pow (n uint))
+    (runtime u170))
+
+(define-read-only (cost_sqrti (n uint))
+    (runtime u167))
+
+(define-read-only (cost_log2 (n uint))
+    (runtime u161))
+
+(define-read-only (cost_xor (n uint))
+    (runtime u167))
+
+(define-read-only (cost_not (n uint))
+    (runtime u162))
+
+(define-read-only (cost_eq (n uint))
+    (runtime (linear n u7 u172)))
+
+(define-read-only (cost_begin (n uint))
+    (runtime u202))
+
+(define-read-only (cost_hash160 (n uint))
+    (runtime (linear n u1 u201)))
+
+(define-read-only (cost_sha256 (n uint))
+    (runtime (linear n u1 u100)))
+
+(define-read-only (cost_sha512 (n uint))
+    (runtime (linear n u1 u176)))
+
+(define-read-only (cost_sha512t256 (n uint))
+    (runtime (linear n u1 u188)))
+
+(define-read-only (cost_keccak256 (n uint))
+    (runtime (linear n u1 u221)))
+
+(define-read-only (cost_secp256k1recover (n uint))
+    (runtime u14344))
+
+(define-read-only (cost_secp256k1verify (n uint))
+    (runtime u13540))
+
+(define-read-only (cost_print (n uint))
+    (runtime (linear n u3 u1413)))
+
+(define-read-only (cost_some_cons (n uint))
+    (runtime u230))
+
+(define-read-only (cost_ok_cons (n uint))
+    (runtime u230))
+
+(define-read-only (cost_err_cons (n uint))
+    (runtime u230))
+
+(define-read-only (cost_default_to (n uint))
+    (runtime u249))
+
+(define-read-only (cost_unwrap_ret (n uint))
+    (runtime u299))
+
+(define-read-only (cost_unwrap_err_or_ret (n uint))
+    (runtime u339))
+
+(define-read-only (cost_is_okay (n uint))
+    (runtime u287))
+
+(define-read-only (cost_is_none (n uint))
+    (runtime u287))
+
+(define-read-only (cost_is_err (n uint))
+    (runtime u287))
+
+(define-read-only (cost_is_some (n uint))
+    (runtime u287))
+
+(define-read-only (cost_unwrap (n uint))
+    (runtime u284))
+
+(define-read-only (cost_unwrap_err (n uint))
+    (runtime u264))
+
+(define-read-only (cost_try_ret (n uint))
+    (runtime u256))
+
+(define-read-only (cost_match (n uint))
+    (runtime u286))
+
+(define-read-only (cost_or (n uint))
+    (runtime (linear n u3 u149)))
+
+(define-read-only (cost_and (n uint))
+    (runtime (linear n u3 u149)))
+
+(define-read-only (cost_append (n uint))
+    (runtime (linear n u71 u176)))
+
+(define-read-only (cost_concat (n uint))
+    (runtime (linear n u75 u244)))
+
+(define-read-only (cost_as_max_len (n uint))
+    (runtime u475))
+
+(define-read-only (cost_contract_call (n uint))
+    (runtime u153))
+
+(define-read-only (cost_contract_of (n uint))
+    (runtime u13400))
+
+(define-read-only (cost_principal_of (n uint))
+    (runtime u39))
+
+
+(define-read-only (cost_at_block (n uint))
+    {
+        runtime: u210,
+        write_length: u0,
+        write_count: u0,
+        read_count: u1,
+        read_length: u1
+    })
+
+
+(define-read-only (cost_load_contract (n uint))
+    {
+        runtime: (linear n u1 u157),
+        write_length: u0,
+        write_count: u0,
+        ;; set to 3 because of the associated metadata loads
+        read_count: u3,
+        read_length: (linear n u1 u1)
+    })
+
+
+(define-read-only (cost_create_map (n uint))
+    {
+        runtime: (linear n u1 u1631),
+        write_length: (linear n u1 u1),
+        write_count: u1,
+        read_count: u0,
+        read_length: u0
+    })
+
+
+(define-read-only (cost_create_var (n uint))
+    {
+        runtime: (linear n u7 u2152),
+        write_length: (linear n u1 u1),
+        write_count: u2,
+        read_count: u0,
+        read_length: u0
+    })
+
+
+(define-read-only (cost_create_nft (n uint))
+    {
+        runtime: (linear n u1 u1610),
+        write_length: (linear n u1 u1),
+        write_count: u1,
+        read_count: u0,
+        read_length: u0
+    })
+
+
+(define-read-only (cost_create_ft (n uint))
+    {
+        runtime: u1972,
+        write_length: u1,
+        write_count: u2,
+        read_count: u0,
+        read_length: u0
+    })
+
+
+(define-read-only (cost_fetch_entry (n uint))
+    {
+        runtime: (linear n u1 u1539),
+        write_length: u0,
+        write_count: u0,
+        read_count: u1,
+        read_length: (linear n u1 u1)
+    })
+
+
+(define-read-only (cost_set_entry (n uint))
+    {
+        runtime: (linear n u4 u2204),
+        write_length: (linear n u1 u1),
+        write_count: u1,
+        read_count: u1,
+        read_length: u0
+    })
+
+
+(define-read-only (cost_fetch_var (n uint))
+    {
+        runtime: (linear n u1 u543),
+        write_length: u0,
+        write_count: u0,
+        read_count: u1,
+        read_length: (linear n u1 u1)
+    })
+
+
+(define-read-only (cost_set_var (n uint))
+    {
+        runtime: (linear n u5 u691),
+        write_length: (linear n u1 u1),
+        write_count: u1,
+        read_count: u1,
+        read_length: u0
+    })
+
+
+(define-read-only (cost_contract_storage (n uint))
+    {
+        runtime: (linear n u13 u7982),
+        write_length: (linear n u1 u1),
+        write_count: u1,
+        read_count: u0,
+        read_length: u0
+    })
+
+
+(define-read-only (cost_block_info (n uint))
+    {
+        runtime: u6321,
+        write_length: u0,
+        write_count: u0,
+        read_count: u1,
+        read_length: u1
+    })
+
+
+(define-read-only (cost_stx_balance (n uint))
+    {
+        runtime: u1385,
+        write_length: u0,
+        write_count: u0,
+        read_count: u1,
+        read_length: u1
+    })
+
+
+(define-read-only (cost_stx_transfer (n uint))
+    {
+        runtime: u1430,
+        write_length: u1,
+        write_count: u1,
+        read_count: u1,
+        read_length: u1
+    })
+
+
+(define-read-only (cost_ft_mint (n uint))
+    {
+        runtime: u1645,
+        write_length: u1,
+        write_count: u2,
+        read_count: u2,
+        read_length: u1
+    })
+
+
+(define-read-only (cost_ft_transfer (n uint))
+    {
+        runtime: u612,
+        write_length: u1,
+        write_count: u2,
+        read_count: u2,
+        read_length: u1
+    })
+
+
+(define-read-only (cost_ft_balance (n uint))
+    {
+        runtime: u547,
+        write_length: u0,
+        write_count: u0,
+        read_count: u1,
+        read_length: u1
+    })
+
+
+(define-read-only (cost_nft_mint (n uint))
+    {
+        runtime: (linear n u9 u795),
+        write_length: u1,
+        write_count: u1,
+        read_count: u1,
+        read_length: u1
+    })
+
+
+(define-read-only (cost_nft_transfer (n uint))
+    {
+        runtime: (linear n u9 u795),
+        write_length: u1,
+        write_count: u1,
+        read_count: u1,
+        read_length: u1
+    })
+
+
+(define-read-only (cost_nft_owner (n uint))
+    {
+        runtime: (linear n u9 u795),
+        write_length: u0,
+        write_count: u0,
+        read_count: u1,
+        read_length: u1
+    })
+
+
+(define-read-only (cost_ft_get_supply (n uint))
+    {
+        runtime: u483,
+        write_length: u0,
+        write_count: u0,
+        read_count: u1,
+        read_length: u1
+    })
+
+
+(define-read-only (cost_ft_burn (n uint))
+    {
+        runtime: u612,
+        write_length: u1,
+        write_count: u2,
+        read_count: u2,
+        read_length: u1
+    })
+
+
+(define-read-only (cost_nft_burn (n uint))
+    {
+        runtime: (linear n u9 u795),
+        write_length: u1,
+        write_count: u1,
+        read_count: u1,
+        read_length: u1
+    })
+
+
+(define-read-only (poison_microblock (n uint))
+    {
+        runtime: u29568,
+        write_length: u1,
+        write_count: u1,
+        read_count: u1,
+        read_length: u1
+    })

--- a/src/chainstate/stacks/boot/costs-2.clar
+++ b/src/chainstate/stacks/boot/costs-2.clar
@@ -1,1 +1,567 @@
 ;; the .costs-2 contract
+
+;; Helper Functions
+
+;; Return a Cost Specification with just a runtime cost
+(define-private (runtime (r uint))
+    {
+        runtime: r,
+        write_length: u0,
+        write_count: u0,
+        read_count: u0,
+        read_length: u0,
+    })
+
+;; Linear cost-assessment function
+(define-private (linear (n uint) (a uint) (b uint))
+    (+ (* a n) b))
+
+;; LogN cost-assessment function
+(define-private (logn (n uint) (a uint) (b uint))
+    (+ (* a (log2 n)) b))
+
+;; NLogN cost-assessment function
+(define-private (nlogn (n uint) (a uint) (b uint))
+    (+ (* a (* n (log2 n))) b))
+
+
+;; Cost Functions
+(define-read-only (cost_analysis_type_annotate (n uint))
+    (runtime (linear n u1 u9)))
+
+(define-read-only (cost_analysis_type_check (n uint))
+    (runtime (linear n u113 u1)))
+
+(define-read-only (cost_analysis_type_lookup (n uint))
+    (runtime (linear n u1 u6)))
+
+(define-read-only (cost_analysis_visit (n uint))
+    (runtime u1))
+
+(define-read-only (cost_analysis_iterable_func (n uint))
+    (runtime (linear n u2 u14)))
+
+(define-read-only (cost_analysis_option_cons (n uint))
+    (runtime u6))
+
+(define-read-only (cost_analysis_option_check (n uint))
+    (runtime u3))
+
+(define-read-only (cost_analysis_bind_name (n uint))
+    (runtime (linear n u2 u176)))
+
+(define-read-only (cost_analysis_list_items_check (n uint))
+    (runtime (linear n u2 u4)))
+
+(define-read-only (cost_analysis_check_tuple_get (n uint))
+    (runtime (logn n u1 u2)))
+
+(define-read-only (cost_analysis_check_tuple_merge (n uint))
+    (runtime (linear n u1000 u1000)))
+
+(define-read-only (cost_analysis_check_tuple_cons (n uint))
+    (runtime (nlogn n u3 u5)))
+
+(define-read-only (cost_analysis_tuple_items_check (n uint))
+    (runtime (linear n u1 u59)))
+
+(define-read-only (cost_analysis_check_let (n uint))
+    (runtime (linear n u1 u12)))
+
+(define-read-only (cost_analysis_lookup_function (n uint))
+    (runtime u20))
+
+(define-read-only (cost_analysis_lookup_function_types (n uint))
+    (runtime (linear n u1 u28)))
+
+(define-read-only (cost_analysis_lookup_variable_const (n uint))
+    (runtime u15))
+
+(define-read-only (cost_analysis_lookup_variable_depth (n uint))
+    (runtime (nlogn n u1 u34)))
+
+(define-read-only (cost_ast_parse (n uint))
+    (runtime (linear n u172 u287441)))
+
+(define-read-only (cost_ast_cycle_detection (n uint))
+    (runtime (linear n u141 u72)))
+
+(define-read-only (cost_analysis_storage (n uint))
+    {
+        runtime: (linear n u2 u100),
+        write_length: (linear n u1 u1),
+        write_count: u1,
+        read_count: u1,
+        read_length: u1
+    })
+
+(define-read-only (cost_analysis_use_trait_entry (n uint))
+    {
+        runtime: (linear n u9 u723),
+        write_length: (linear n u1 u1),
+        write_count: u0,
+        read_count: u1,
+        read_length: (linear n u1 u1)
+    })
+
+
+(define-read-only (cost_analysis_get_function_entry (n uint))
+    {
+        runtime: (linear n u81 u1303),
+        write_length: u0,
+        write_count: u0,
+        read_count: u1,
+        read_length: (linear n u1 u1)
+    })
+
+
+(define-read-only (cost_analysis_fetch_contract_entry (n uint))
+    {
+        runtime: (linear n u1000 u1000),
+        write_length: u0,
+        write_count: u0,
+        read_count: u1,
+        read_length: (linear n u1 u1)
+    })
+
+(define-read-only (cost_lookup_variable_depth (n uint))
+    (runtime (linear n u2 u14)))
+
+(define-read-only (cost_lookup_variable_size (n uint))
+    (runtime (linear n u2 u1)))
+
+(define-read-only (cost_lookup_function (n uint))
+    (runtime u16))
+
+(define-read-only (cost_bind_name (n uint))
+    (runtime u256))
+
+(define-read-only (cost_inner_type_check_cost (n uint))
+    (runtime (linear n u2 u9)))
+
+(define-read-only (cost_user_function_application (n uint))
+    (runtime (linear n u26 u140)))
+
+(define-read-only (cost_let (n uint))
+    (runtime (linear n u146 u862)))
+
+(define-read-only (cost_if (n uint))
+    (runtime u200))
+
+(define-read-only (cost_asserts (n uint))
+    (runtime u158))
+
+(define-read-only (cost_map (n uint))
+    (runtime (linear n u1210 u3314)))
+
+(define-read-only (cost_filter (n uint))
+    (runtime u460))
+
+(define-read-only (cost_len (n uint))
+    (runtime u486))
+
+(define-read-only (cost_element_at (n uint))
+    (runtime u619))
+
+(define-read-only (cost_index_of (n uint))
+    (runtime (linear n u1 u243)))
+
+(define-read-only (cost_fold (n uint))
+    (runtime u483))
+
+(define-read-only (cost_list_cons (n uint))
+    (runtime (linear n u14 u198)))
+
+(define-read-only (cost_type_parse_step (n uint))
+    (runtime u5))
+
+(define-read-only (cost_tuple_get (n uint))
+    (runtime (nlogn n u4 u1780)))
+
+(define-read-only (cost_tuple_merge (n uint))
+    (runtime (linear n u4 u646)))
+
+(define-read-only (cost_tuple_cons (n uint))
+    (runtime (nlogn n u11 u1101)))
+
+(define-read-only (cost_add (n uint))
+    (runtime (linear n u12 u156)))
+
+(define-read-only (cost_sub (n uint))
+    (runtime (linear n u12 u156)))
+
+(define-read-only (cost_mul (n uint))
+    (runtime (linear n u14 u157)))
+
+(define-read-only (cost_div (n uint))
+    (runtime (linear n u14 u157)))
+
+(define-read-only (cost_geq (n uint))
+    (runtime u166))
+
+(define-read-only (cost_leq (n uint))
+    (runtime u166))
+
+(define-read-only (cost_le (n uint))
+    (runtime u166))
+
+(define-read-only (cost_ge (n uint))
+    (runtime u166))
+
+(define-read-only (cost_int_cast (n uint))
+    (runtime u164))
+
+(define-read-only (cost_mod (n uint))
+    (runtime u168))
+
+(define-read-only (cost_pow (n uint))
+    (runtime u170))
+
+(define-read-only (cost_sqrti (n uint))
+    (runtime u167))
+
+(define-read-only (cost_log2 (n uint))
+    (runtime u161))
+
+(define-read-only (cost_xor (n uint))
+    (runtime u167))
+
+(define-read-only (cost_not (n uint))
+    (runtime u162))
+
+(define-read-only (cost_eq (n uint))
+    (runtime (linear n u7 u172)))
+
+(define-read-only (cost_begin (n uint))
+    (runtime u202))
+
+(define-read-only (cost_hash160 (n uint))
+    (runtime (linear n u1 u201)))
+
+(define-read-only (cost_sha256 (n uint))
+    (runtime (linear n u1 u100)))
+
+(define-read-only (cost_sha512 (n uint))
+    (runtime (linear n u1 u176)))
+
+(define-read-only (cost_sha512t256 (n uint))
+    (runtime (linear n u1 u188)))
+
+(define-read-only (cost_keccak256 (n uint))
+    (runtime (linear n u1 u221)))
+
+(define-read-only (cost_secp256k1recover (n uint))
+    (runtime u14344))
+
+(define-read-only (cost_secp256k1verify (n uint))
+    (runtime u13540))
+
+(define-read-only (cost_print (n uint))
+    (runtime (linear n u3 u1413)))
+
+(define-read-only (cost_some_cons (n uint))
+    (runtime u219))
+
+(define-read-only (cost_ok_cons (n uint))
+    (runtime u219))
+
+(define-read-only (cost_err_cons (n uint))
+    (runtime u219))
+
+(define-read-only (cost_default_to (n uint))
+    (runtime u249))
+
+(define-read-only (cost_unwrap_ret (n uint))
+    (runtime u299))
+
+(define-read-only (cost_unwrap_err_or_ret (n uint))
+    (runtime u339))
+
+(define-read-only (cost_is_okay (n uint))
+    (runtime u287))
+
+(define-read-only (cost_is_none (n uint))
+    (runtime u212))
+
+(define-read-only (cost_is_err (n uint))
+    (runtime u282))
+
+(define-read-only (cost_is_some (n uint))
+    (runtime u223))
+
+(define-read-only (cost_unwrap (n uint))
+    (runtime u284))
+
+(define-read-only (cost_unwrap_err (n uint))
+    (runtime u264))
+
+(define-read-only (cost_try_ret (n uint))
+    (runtime u256))
+
+(define-read-only (cost_match (n uint))
+    (runtime u286))
+
+(define-read-only (cost_or (n uint))
+    (runtime (linear n u3 u149)))
+
+(define-read-only (cost_and (n uint))
+    (runtime (linear n u3 u149)))
+
+(define-read-only (cost_append (n uint))
+    (runtime (linear n u71 u176)))
+
+(define-read-only (cost_concat (n uint))
+    (runtime (linear n u75 u244)))
+
+(define-read-only (cost_as_max_len (n uint))
+    (runtime u475))
+
+(define-read-only (cost_contract_call (n uint))
+    (runtime u153))
+
+(define-read-only (cost_contract_of (n uint))
+    (runtime u13400))
+
+(define-read-only (cost_principal_of (n uint))
+    (runtime u39))
+
+
+(define-read-only (cost_at_block (n uint))
+    {
+        runtime: u210,
+        write_length: u0,
+        write_count: u0,
+        read_count: u1,
+        read_length: u1
+    })
+
+
+(define-read-only (cost_load_contract (n uint))
+    {
+        runtime: (linear n u1 u157),
+        write_length: u0,
+        write_count: u0,
+        ;; set to 3 because of the associated metadata loads
+        read_count: u3,
+        read_length: (linear n u1 u1)
+    })
+
+
+(define-read-only (cost_create_map (n uint))
+    {
+        runtime: (linear n u1 u1631),
+        write_length: (linear n u1 u1),
+        write_count: u1,
+        read_count: u0,
+        read_length: u0
+    })
+
+
+(define-read-only (cost_create_var (n uint))
+    {
+        runtime: (linear n u7 u2152),
+        write_length: (linear n u1 u1),
+        write_count: u2,
+        read_count: u0,
+        read_length: u0
+    })
+
+
+(define-read-only (cost_create_nft (n uint))
+    {
+        runtime: (linear n u1 u1610),
+        write_length: (linear n u1 u1),
+        write_count: u1,
+        read_count: u0,
+        read_length: u0
+    })
+
+
+(define-read-only (cost_create_ft (n uint))
+    {
+        runtime: u1972,
+        write_length: u1,
+        write_count: u2,
+        read_count: u0,
+        read_length: u0
+    })
+
+
+(define-read-only (cost_fetch_entry (n uint))
+    {
+        runtime: (linear n u1 u1539),
+        write_length: u0,
+        write_count: u0,
+        read_count: u1,
+        read_length: (linear n u1 u1)
+    })
+
+
+(define-read-only (cost_set_entry (n uint))
+    {
+        runtime: (linear n u4 u2204),
+        write_length: (linear n u1 u1),
+        write_count: u1,
+        read_count: u1,
+        read_length: u0
+    })
+
+
+(define-read-only (cost_fetch_var (n uint))
+    {
+        runtime: (linear n u1 u543),
+        write_length: u0,
+        write_count: u0,
+        read_count: u1,
+        read_length: (linear n u1 u1)
+    })
+
+
+(define-read-only (cost_set_var (n uint))
+    {
+        runtime: (linear n u5 u691),
+        write_length: (linear n u1 u1),
+        write_count: u1,
+        read_count: u1,
+        read_length: u0
+    })
+
+
+(define-read-only (cost_contract_storage (n uint))
+    {
+        runtime: (linear n u13 u7982),
+        write_length: (linear n u1 u1),
+        write_count: u1,
+        read_count: u0,
+        read_length: u0
+    })
+
+
+(define-read-only (cost_block_info (n uint))
+    {
+        runtime: u6321,
+        write_length: u0,
+        write_count: u0,
+        read_count: u1,
+        read_length: u1
+    })
+
+
+(define-read-only (cost_stx_balance (n uint))
+    {
+        runtime: u1385,
+        write_length: u0,
+        write_count: u0,
+        read_count: u1,
+        read_length: u1
+    })
+
+
+(define-read-only (cost_stx_transfer (n uint))
+    {
+        runtime: u1430,
+        write_length: u1,
+        write_count: u1,
+        read_count: u1,
+        read_length: u1
+    })
+
+
+(define-read-only (cost_ft_mint (n uint))
+    {
+        runtime: u1645,
+        write_length: u1,
+        write_count: u2,
+        read_count: u2,
+        read_length: u1
+    })
+
+
+(define-read-only (cost_ft_transfer (n uint))
+    {
+        runtime: u612,
+        write_length: u1,
+        write_count: u2,
+        read_count: u2,
+        read_length: u1
+    })
+
+
+(define-read-only (cost_ft_balance (n uint))
+    {
+        runtime: u547,
+        write_length: u0,
+        write_count: u0,
+        read_count: u1,
+        read_length: u1
+    })
+
+
+(define-read-only (cost_nft_mint (n uint))
+    {
+        runtime: (linear n u9 u636),
+        write_length: u1,
+        write_count: u1,
+        read_count: u1,
+        read_length: u1
+    })
+
+
+(define-read-only (cost_nft_transfer (n uint))
+    {
+        runtime: (linear n u9 u647),
+        write_length: u1,
+        write_count: u1,
+        read_count: u1,
+        read_length: u1
+    })
+
+
+(define-read-only (cost_nft_owner (n uint))
+    {
+        runtime: (linear n u9 u795),
+        write_length: u0,
+        write_count: u0,
+        read_count: u1,
+        read_length: u1
+    })
+
+
+(define-read-only (cost_ft_get_supply (n uint))
+    {
+        runtime: u483,
+        write_length: u0,
+        write_count: u0,
+        read_count: u1,
+        read_length: u1
+    })
+
+
+(define-read-only (cost_ft_burn (n uint))
+    {
+        runtime: u612,
+        write_length: u1,
+        write_count: u2,
+        read_count: u2,
+        read_length: u1
+    })
+
+
+(define-read-only (cost_nft_burn (n uint))
+    {
+        runtime: (linear n u9 u647),
+        write_length: u1,
+        write_count: u1,
+        read_count: u1,
+        read_length: u1
+    })
+
+
+(define-read-only (poison_microblock (n uint))
+    {
+        runtime: u29568,
+        write_length: u1,
+        write_count: u1,
+        read_count: u1,
+        read_length: u1
+    })

--- a/src/chainstate/stacks/boot/costs-2.clar
+++ b/src/chainstate/stacks/boot/costs-2.clar
@@ -260,13 +260,13 @@
     (runtime (linear n u3 u1413)))
 
 (define-read-only (cost_some_cons (n uint))
-    (runtime u219))
+    (runtime u230))
 
 (define-read-only (cost_ok_cons (n uint))
-    (runtime u219))
+    (runtime u230))
 
 (define-read-only (cost_err_cons (n uint))
-    (runtime u219))
+    (runtime u230))
 
 (define-read-only (cost_default_to (n uint))
     (runtime u249))
@@ -281,13 +281,13 @@
     (runtime u287))
 
 (define-read-only (cost_is_none (n uint))
-    (runtime u212))
+    (runtime u287))
 
 (define-read-only (cost_is_err (n uint))
-    (runtime u282))
+    (runtime u287))
 
 (define-read-only (cost_is_some (n uint))
-    (runtime u223))
+    (runtime u287))
 
 (define-read-only (cost_unwrap (n uint))
     (runtime u284))

--- a/src/chainstate/stacks/boot/costs-2.clar
+++ b/src/chainstate/stacks/boot/costs-2.clar
@@ -499,7 +499,7 @@
 
 (define-read-only (cost_nft_mint (n uint))
     {
-        runtime: (linear n u9 u636),
+        runtime: (linear n u9 u795),
         write_length: u1,
         write_count: u1,
         read_count: u1,
@@ -509,7 +509,7 @@
 
 (define-read-only (cost_nft_transfer (n uint))
     {
-        runtime: (linear n u9 u647),
+        runtime: (linear n u9 u795),
         write_length: u1,
         write_count: u1,
         read_count: u1,
@@ -549,7 +549,7 @@
 
 (define-read-only (cost_nft_burn (n uint))
     {
-        runtime: (linear n u9 u647),
+        runtime: (linear n u9 u795),
         write_length: u1,
         write_count: u1,
         read_count: u1,

--- a/src/chainstate/stacks/boot/costs-2.clar
+++ b/src/chainstate/stacks/boot/costs-2.clar
@@ -149,7 +149,7 @@
     (runtime u200))
 
 (define-read-only (cost_asserts (n uint))
-    (runtime u158))
+    (runtime u170))
 
 (define-read-only (cost_map (n uint))
     (runtime (linear n u1210 u3314)))
@@ -185,10 +185,10 @@
     (runtime (nlogn n u11 u1101)))
 
 (define-read-only (cost_add (n uint))
-    (runtime (linear n u12 u156)))
+    (runtime (linear n u14 u157)))
 
 (define-read-only (cost_sub (n uint))
-    (runtime (linear n u12 u156)))
+    (runtime (linear n u14 u157)))
 
 (define-read-only (cost_mul (n uint))
     (runtime (linear n u14 u157)))
@@ -197,37 +197,37 @@
     (runtime (linear n u14 u157)))
 
 (define-read-only (cost_geq (n uint))
-    (runtime u166))
+    (runtime u170))
 
 (define-read-only (cost_leq (n uint))
-    (runtime u166))
+    (runtime u170))
 
 (define-read-only (cost_le (n uint))
-    (runtime u166))
+    (runtime u170))
 
 (define-read-only (cost_ge (n uint))
-    (runtime u166))
+    (runtime u170))
 
 (define-read-only (cost_int_cast (n uint))
-    (runtime u164))
+    (runtime u170))
 
 (define-read-only (cost_mod (n uint))
-    (runtime u168))
+    (runtime u170))
 
 (define-read-only (cost_pow (n uint))
     (runtime u170))
 
 (define-read-only (cost_sqrti (n uint))
-    (runtime u167))
+    (runtime u170))
 
 (define-read-only (cost_log2 (n uint))
-    (runtime u161))
+    (runtime u170))
 
 (define-read-only (cost_xor (n uint))
-    (runtime u167))
+    (runtime u170))
 
 (define-read-only (cost_not (n uint))
-    (runtime u162))
+    (runtime u170))
 
 (define-read-only (cost_eq (n uint))
     (runtime (linear n u7 u172)))
@@ -269,10 +269,10 @@
     (runtime u230))
 
 (define-read-only (cost_default_to (n uint))
-    (runtime u249))
+    (runtime u287))
 
 (define-read-only (cost_unwrap_ret (n uint))
-    (runtime u299))
+    (runtime u339))
 
 (define-read-only (cost_unwrap_err_or_ret (n uint))
     (runtime u339))
@@ -290,16 +290,16 @@
     (runtime u287))
 
 (define-read-only (cost_unwrap (n uint))
-    (runtime u284))
+    (runtime u287))
 
 (define-read-only (cost_unwrap_err (n uint))
-    (runtime u264))
+    (runtime u287))
 
 (define-read-only (cost_try_ret (n uint))
-    (runtime u256))
+    (runtime u287))
 
 (define-read-only (cost_match (n uint))
-    (runtime u286))
+    (runtime u287))
 
 (define-read-only (cost_or (n uint))
     (runtime (linear n u3 u149)))
@@ -323,7 +323,7 @@
     (runtime u13400))
 
 (define-read-only (cost_principal_of (n uint))
-    (runtime u39))
+    (runtime u235))
 
 
 (define-read-only (cost_at_block (n uint))

--- a/src/chainstate/stacks/boot/mod.rs
+++ b/src/chainstate/stacks/boot/mod.rs
@@ -56,6 +56,7 @@ const BOOT_CODE_POX_MAINNET_CONSTS: &'static str = std::include_str!("pox-mainne
 const BOOT_CODE_LOCKUP: &'static str = std::include_str!("lockup.clar");
 pub const BOOT_CODE_COSTS: &'static str = std::include_str!("costs.clar");
 pub const BOOT_CODE_COSTS_2: &'static str = std::include_str!("costs-2.clar");
+pub const BOOT_CODE_COSTS_2_TESTNET: &'static str = std::include_str!("costs-2-testnet.clar");
 const BOOT_CODE_COST_VOTING_MAINNET: &'static str = std::include_str!("cost-voting.clar");
 const BOOT_CODE_BNS: &'static str = std::include_str!("bns.clar");
 const BOOT_CODE_GENESIS: &'static str = std::include_str!("genesis.clar");

--- a/src/clarity_vm/clarity.rs
+++ b/src/clarity_vm/clarity.rs
@@ -20,8 +20,8 @@ use std::fmt;
 use std::thread;
 
 use chainstate::stacks::boot::{
-    BOOT_CODE_COSTS, BOOT_CODE_COST_VOTING_TESTNET as BOOT_CODE_COST_VOTING, BOOT_CODE_POX_TESTNET,
-    COSTS_2_NAME,
+    BOOT_CODE_COSTS, BOOT_CODE_COSTS_2, BOOT_CODE_COST_VOTING_TESTNET as BOOT_CODE_COST_VOTING,
+    BOOT_CODE_POX_TESTNET, COSTS_2_NAME,
 };
 use chainstate::stacks::db::StacksAccount;
 use chainstate::stacks::events::{StacksTransactionEvent, StacksTransactionReceipt};
@@ -747,12 +747,7 @@ impl<'a> ClarityBlockConnection<'a> {
             let boot_code_account = boot_code_acc(boot_code_address, boot_code_nonce);
 
             // instantiate costs 2 contract...
-            // TODO - replace once costs-2 contract is updated with new costs
-            let cost_2_code = if mainnet {
-                &*BOOT_CODE_COSTS
-            } else {
-                &*BOOT_CODE_COSTS
-            };
+            let cost_2_code = &*BOOT_CODE_COSTS_2;
 
             let payload = TransactionPayload::SmartContract(TransactionSmartContract {
                 name: ContractName::try_from(COSTS_2_NAME)

--- a/src/clarity_vm/clarity.rs
+++ b/src/clarity_vm/clarity.rs
@@ -48,6 +48,7 @@ use vm::types::{
 };
 use vm::ContractName;
 
+use crate::chainstate::stacks::boot::BOOT_CODE_COSTS_2_TESTNET;
 use crate::chainstate::stacks::db::StacksChainState;
 use crate::chainstate::stacks::TransactionAuth;
 use crate::chainstate::stacks::TransactionPayload;
@@ -747,7 +748,11 @@ impl<'a> ClarityBlockConnection<'a> {
             let boot_code_account = boot_code_acc(boot_code_address, boot_code_nonce);
 
             // instantiate costs 2 contract...
-            let cost_2_code = &*BOOT_CODE_COSTS_2;
+            let cost_2_code = if mainnet {
+                &*BOOT_CODE_COSTS_2
+            } else {
+                &*BOOT_CODE_COSTS_2_TESTNET
+            };
 
             let payload = TransactionPayload::SmartContract(TransactionSmartContract {
                 name: ContractName::try_from(COSTS_2_NAME)

--- a/src/vm/analysis/tests/costs.rs
+++ b/src/vm/analysis/tests/costs.rs
@@ -33,6 +33,7 @@ use vm::tests::{
 };
 use vm::types::{AssetIdentifier, PrincipalData, QualifiedContractIdentifier, ResponseData, Value};
 
+use crate::clarity_vm::clarity::ClarityConnection;
 use crate::clarity_vm::database::marf::MarfedKV;
 use crate::core::StacksEpochId;
 use crate::types::chainstate::{BlockHeaderHash, StacksBlockId};
@@ -106,6 +107,12 @@ pub fn test_tracked_costs(prog: &str, epoch: StacksEpochId) -> ExecutionCost {
             &TEST_HEADER_DB,
             &TEST_BURN_STATE_DB,
         );
+
+        assert_eq!(
+            conn.with_clarity_db_readonly(|db| db.get_clarity_epoch_version()),
+            epoch
+        );
+
         conn.as_transaction(|conn| {
             let (ct_ast, ct_analysis) = conn
                 .analyze_smart_contract(&trait_contract_id, contract_trait)

--- a/src/vm/analysis/tests/costs.rs
+++ b/src/vm/analysis/tests/costs.rs
@@ -34,10 +34,11 @@ use vm::tests::{
 use vm::types::{AssetIdentifier, PrincipalData, QualifiedContractIdentifier, ResponseData, Value};
 
 use crate::clarity_vm::database::marf::MarfedKV;
+use crate::core::StacksEpochId;
 use crate::types::chainstate::{BlockHeaderHash, StacksBlockId};
 use crate::types::proof::ClarityMarfTrieId;
 
-pub fn test_tracked_costs(prog: &str) -> ExecutionCost {
+pub fn test_tracked_costs(prog: &str, epoch: StacksEpochId) -> ExecutionCost {
     let marf = MarfedKV::temporary();
     let mut clarity_instance = ClarityInstance::new(false, marf);
 
@@ -90,6 +91,21 @@ pub fn test_tracked_costs(prog: &str) -> ExecutionCost {
             &TEST_HEADER_DB,
             &TEST_BURN_STATE_DB,
         );
+
+        if epoch == StacksEpochId::Epoch2_05 {
+            conn.initialize_epoch_2_05().unwrap();
+        }
+
+        conn.commit_block();
+    }
+
+    {
+        let mut conn = clarity_instance.begin_block(
+            &StacksBlockId([1 as u8; 32]),
+            &StacksBlockId([2 as u8; 32]),
+            &TEST_HEADER_DB,
+            &TEST_BURN_STATE_DB,
+        );
         conn.as_transaction(|conn| {
             let (ct_ast, ct_analysis) = conn
                 .analyze_smart_contract(&trait_contract_id, contract_trait)
@@ -107,8 +123,8 @@ pub fn test_tracked_costs(prog: &str) -> ExecutionCost {
 
     {
         let mut conn = clarity_instance.begin_block(
-            &StacksBlockId([1 as u8; 32]),
             &StacksBlockId([2 as u8; 32]),
+            &StacksBlockId([3 as u8; 32]),
             &TEST_HEADER_DB,
             &TEST_BURN_STATE_DB,
         );
@@ -129,8 +145,8 @@ pub fn test_tracked_costs(prog: &str) -> ExecutionCost {
 
     {
         let mut conn = clarity_instance.begin_block(
-            &StacksBlockId([2 as u8; 32]),
             &StacksBlockId([3 as u8; 32]),
+            &StacksBlockId([4 as u8; 32]),
             &TEST_HEADER_DB,
             &TEST_BURN_STATE_DB,
         );
@@ -152,11 +168,22 @@ pub fn test_tracked_costs(prog: &str) -> ExecutionCost {
 
 #[test]
 fn test_all() {
-    let baseline = test_tracked_costs("1");
+    let baseline = test_tracked_costs("1", StacksEpochId::Epoch20);
 
     for f in NativeFunctions::ALL.iter() {
         let test = get_simple_test(f);
-        let cost = test_tracked_costs(test);
+        let cost = test_tracked_costs(test, StacksEpochId::Epoch20);
+        assert!(cost.exceeds(&baseline));
+    }
+}
+
+#[test]
+fn epoch_205_test_all() {
+    let baseline = test_tracked_costs("1", StacksEpochId::Epoch2_05);
+
+    for f in NativeFunctions::ALL.iter() {
+        let test = get_simple_test(f);
+        let cost = test_tracked_costs(test, StacksEpochId::Epoch2_05);
         assert!(cost.exceeds(&baseline));
     }
 }

--- a/src/vm/tests/costs.rs
+++ b/src/vm/tests/costs.rs
@@ -695,6 +695,8 @@ fn test_tracked_costs(prog: &str, epoch: StacksEpochId) -> ExecutionCost {
 }
 
 #[test]
+// test each individual cost function can be correctly invoked as
+//  Clarity code executes in Epoch 2.00
 fn test_all() {
     let baseline = test_tracked_costs("1", StacksEpochId::Epoch20);
 
@@ -706,6 +708,8 @@ fn test_all() {
 }
 
 #[test]
+// test each individual cost function can be correctly invoked as
+//  Clarity code executes in Epoch 2.05
 fn epoch_205_test_all() {
     let baseline = test_tracked_costs("1", StacksEpochId::Epoch2_05);
 

--- a/src/vm/tests/costs.rs
+++ b/src/vm/tests/costs.rs
@@ -149,36 +149,49 @@ fn execute_transaction(
     env.execute_transaction(issuer, contract_identifier.clone(), tx, args)
 }
 
-fn exec_cost(contract: &str, epoch: StacksEpochId) -> ExecutionCost {
+fn with_owned_env<F, R>(epoch: StacksEpochId, to_do: F) -> R
+where
+    F: Fn(OwnedEnvironment) -> R,
+{
     let marf_kv = MarfedKV::temporary();
     let mut clarity_instance = ClarityInstance::new(false, marf_kv);
+
+    let first_block = StacksBlockId::new(&FIRST_BURNCHAIN_CONSENSUS_HASH, &FIRST_STACKS_BLOCK_HASH);
     clarity_instance
         .begin_test_genesis_block(
             &StacksBlockId::sentinel(),
-            &StacksBlockHeader::make_index_block_hash(
-                &FIRST_BURNCHAIN_CONSENSUS_HASH,
-                &FIRST_STACKS_BLOCK_HASH,
-            ),
+            &first_block,
             &TEST_HEADER_DB,
             &TEST_BURN_STATE_DB,
         )
         .commit_block();
 
+    let tip = if epoch == StacksEpochId::Epoch2_05 {
+        let next_block = StacksBlockId([1 as u8; 32]);
+        let mut clarity_conn = clarity_instance.begin_block(
+            &first_block,
+            &next_block,
+            &TEST_HEADER_DB,
+            &TEST_BURN_STATE_DB,
+        );
+        clarity_conn.initialize_epoch_2_05().unwrap();
+        clarity_conn.commit_block();
+        next_block
+    } else {
+        first_block.clone()
+    };
+
     let mut marf_kv = clarity_instance.destroy();
 
-    let mut store = marf_kv.begin(
-        &StacksBlockHeader::make_index_block_hash(
-            &FIRST_BURNCHAIN_CONSENSUS_HASH,
-            &FIRST_STACKS_BLOCK_HASH,
-        ),
-        &StacksBlockId([1 as u8; 32]),
-    );
+    let mut store = marf_kv.begin(&tip, &StacksBlockId([2 as u8; 32]));
 
-    let mut owned_env = OwnedEnvironment::new_max_limit(
+    to_do(OwnedEnvironment::new_max_limit(
         store.as_clarity_db(&TEST_HEADER_DB, &TEST_BURN_STATE_DB),
         epoch,
-    );
+    ))
+}
 
+fn exec_cost(contract: &str, epoch: StacksEpochId) -> ExecutionCost {
     let p1 = execute("'SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR");
     let p1_principal = match p1 {
         Value::Principal(PrincipalData::Standard(ref data)) => data.clone(),
@@ -186,26 +199,28 @@ fn exec_cost(contract: &str, epoch: StacksEpochId) -> ExecutionCost {
     };
     let contract_id = QualifiedContractIdentifier::new(p1_principal.clone(), "self".into());
 
-    owned_env
-        .initialize_contract(contract_id.clone(), contract)
+    with_owned_env(epoch, |mut owned_env| {
+        owned_env
+            .initialize_contract(contract_id.clone(), contract)
+            .unwrap();
+
+        let cost_before = owned_env.get_cost_total();
+
+        eprintln!("{}", &contract);
+        execute_transaction(
+            &mut owned_env,
+            p1_principal.clone().into(),
+            &contract_id,
+            "execute",
+            &[],
+        )
         .unwrap();
 
-    let cost_before = owned_env.get_cost_total();
-
-    eprintln!("{}", &contract);
-    execute_transaction(
-        &mut owned_env,
-        p1_principal.into(),
-        &contract_id,
-        "execute",
-        &[],
-    )
-    .unwrap();
-
-    let (_db, tracker) = owned_env.destruct().unwrap();
-    let mut cost_after = tracker.get_total();
-    cost_after.sub(&cost_before).unwrap();
-    cost_after
+        let (_db, tracker) = owned_env.destruct().unwrap();
+        let mut cost_after = tracker.get_total();
+        cost_after.sub(&cost_before).unwrap();
+        cost_after
+    })
 }
 
 /// Assert that the relative difference between `cost_small` and `cost_large`
@@ -612,7 +627,7 @@ fn epoch205_nfts() {
     );
 }
 
-fn test_tracked_costs(prog: &str) -> ExecutionCost {
+fn test_tracked_costs(prog: &str, epoch: StacksEpochId) -> ExecutionCost {
     let contract_trait = "(define-trait trait-1 (
                             (foo-exec (int) (response int int))
                           ))";
@@ -651,68 +666,52 @@ fn test_tracked_costs(prog: &str) -> ExecutionCost {
     let trait_contract_id =
         QualifiedContractIdentifier::new(p1_principal.clone(), "contract-trait".into());
 
-    let marf_kv = MarfedKV::temporary();
-    let mut clarity_instance = ClarityInstance::new(false, marf_kv);
-    clarity_instance
-        .begin_test_genesis_block(
-            &StacksBlockId::sentinel(),
-            &StacksBlockHeader::make_index_block_hash(
-                &FIRST_BURNCHAIN_CONSENSUS_HASH,
-                &FIRST_STACKS_BLOCK_HASH,
-            ),
-            &TEST_HEADER_DB,
-            &TEST_BURN_STATE_DB,
+    with_owned_env(epoch, |mut owned_env| {
+        owned_env
+            .initialize_contract(trait_contract_id.clone(), contract_trait)
+            .unwrap();
+        owned_env
+            .initialize_contract(other_contract_id.clone(), contract_other)
+            .unwrap();
+        owned_env
+            .initialize_contract(self_contract_id.clone(), &contract_self)
+            .unwrap();
+
+        let target_contract = Value::from(PrincipalData::Contract(other_contract_id.clone()));
+
+        eprintln!("{}", &contract_self);
+        execute_transaction(
+            &mut owned_env,
+            p2_principal.clone(),
+            &self_contract_id,
+            "execute",
+            &symbols_from_values(vec![target_contract]),
         )
-        .commit_block();
-
-    let mut marf_kv = clarity_instance.destroy();
-
-    let mut store = marf_kv.begin(
-        &StacksBlockHeader::make_index_block_hash(
-            &FIRST_BURNCHAIN_CONSENSUS_HASH,
-            &FIRST_STACKS_BLOCK_HASH,
-        ),
-        &StacksBlockId([1 as u8; 32]),
-    );
-
-    let mut owned_env = OwnedEnvironment::new_max_limit(
-        store.as_clarity_db(&TEST_HEADER_DB, &TEST_BURN_STATE_DB),
-        StacksEpochId::Epoch2_05,
-    );
-
-    owned_env
-        .initialize_contract(trait_contract_id.clone(), contract_trait)
-        .unwrap();
-    owned_env
-        .initialize_contract(other_contract_id.clone(), contract_other)
-        .unwrap();
-    owned_env
-        .initialize_contract(self_contract_id.clone(), &contract_self)
         .unwrap();
 
-    let target_contract = Value::from(PrincipalData::Contract(other_contract_id));
-
-    eprintln!("{}", &contract_self);
-    execute_transaction(
-        &mut owned_env,
-        p2_principal,
-        &self_contract_id,
-        "execute",
-        &symbols_from_values(vec![target_contract]),
-    )
-    .unwrap();
-
-    let (_db, tracker) = owned_env.destruct().unwrap();
-    tracker.get_total()
+        let (_db, tracker) = owned_env.destruct().unwrap();
+        tracker.get_total()
+    })
 }
 
 #[test]
 fn test_all() {
-    let baseline = test_tracked_costs("1");
+    let baseline = test_tracked_costs("1", StacksEpochId::Epoch20);
 
     for f in NativeFunctions::ALL.iter() {
         let test = get_simple_test(f);
-        let cost = test_tracked_costs(test);
+        let cost = test_tracked_costs(test, StacksEpochId::Epoch20);
+        assert!(cost.exceeds(&baseline));
+    }
+}
+
+#[test]
+fn epoch_205_test_all() {
+    let baseline = test_tracked_costs("1", StacksEpochId::Epoch2_05);
+
+    for f in NativeFunctions::ALL.iter() {
+        let test = get_simple_test(f);
+        let cost = test_tracked_costs(test, StacksEpochId::Epoch2_05);
         assert!(cost.exceeds(&baseline));
     }
 }

--- a/src/vm/tests/mod.rs
+++ b/src/vm/tests/mod.rs
@@ -103,6 +103,9 @@ impl HeadersDB for UnitTestHeaderDB {
         {
             Some(BITCOIN_REGTEST_FIRST_BLOCK_TIMESTAMP as u64)
         } else {
+            // for non-genesis blocks, just pick a u64 value that will increment in most
+            // unit tests as blocks are built (most unit tests construct blocks using
+            // incrementing high order bytes)
             Some(1 + 10 * (id_bhh.as_bytes()[0] as u64))
         }
     }

--- a/src/vm/tests/mod.rs
+++ b/src/vm/tests/mod.rs
@@ -103,7 +103,7 @@ impl HeadersDB for UnitTestHeaderDB {
         {
             Some(BITCOIN_REGTEST_FIRST_BLOCK_TIMESTAMP as u64)
         } else {
-            None
+            Some(1 + 10 * (id_bhh.as_bytes()[0] as u64))
         }
     }
     fn get_burn_block_height_for_block(&self, id_bhh: &StacksBlockId) -> Option<u32> {


### PR DESCRIPTION
This PR implements #2894 and #2890 -- using the cost contract from the latest results in the `clarity-benchmarking` repository.

SIP-012 hasn't been updated with these costs yet, but will be.

This PR expands the costs unit tests to instantiate and use the costs-2 contract for cost tracking.