### PR TITLE
Stacks 2.05: make p2p network reject connections from 2.0 peers after the epoch switch

### DIFF
--- a/src/chainstate/burn/operations/leader_block_commit.rs
+++ b/src/chainstate/burn/operations/leader_block_commit.rs
@@ -872,7 +872,10 @@ mod tests {
     use chainstate::burn::ConsensusHash;
     use chainstate::burn::*;
     use chainstate::stacks::StacksPublicKey;
-    use core::{StacksEpoch, StacksEpochId, STACKS_EPOCH_MAX};
+    use core::{
+        StacksEpoch, StacksEpochId, PEER_VERSION_EPOCH_1_0, PEER_VERSION_EPOCH_2_0,
+        PEER_VERSION_EPOCH_2_05, STACKS_EPOCH_MAX,
+    };
     use deps::bitcoin::blockdata::transaction::Transaction;
     use deps::bitcoin::network::serialize::{deserialize, serialize_hex};
     use util::get_epoch_time_secs;
@@ -2273,18 +2276,21 @@ mod tests {
                     start_height: 0,
                     end_height: first_block_height,
                     block_limit: ExecutionCost::max_value(),
+                    network_epoch: PEER_VERSION_EPOCH_1_0,
                 },
                 StacksEpoch {
                     epoch_id: StacksEpochId::Epoch20,
                     start_height: first_block_height,
                     end_height: epoch_2_05_start,
                     block_limit: ExecutionCost::max_value(),
+                    network_epoch: PEER_VERSION_EPOCH_2_0,
                 },
                 StacksEpoch {
                     epoch_id: StacksEpochId::Epoch2_05,
                     start_height: epoch_2_05_start,
                     end_height: STACKS_EPOCH_MAX,
                     block_limit: ExecutionCost::max_value(),
+                    network_epoch: PEER_VERSION_EPOCH_2_05,
                 },
             ],
             true,

--- a/src/chainstate/stacks/miner.rs
+++ b/src/chainstate/stacks/miner.rs
@@ -7034,12 +7034,14 @@ pub mod test {
                 start_height: 0,
                 end_height: 0,
                 block_limit: ExecutionCost::max_value(),
+                network_epoch: PEER_VERSION_EPOCH_1_0,
             },
             StacksEpoch {
                 epoch_id: StacksEpochId::Epoch20,
                 start_height: 0,
                 end_height: 30, // NOTE: the first 25 burnchain blocks have no sortition
                 block_limit: ExecutionCost::max_value(),
+                network_epoch: PEER_VERSION_EPOCH_2_0,
             },
             StacksEpoch {
                 epoch_id: StacksEpochId::Epoch2_05,
@@ -7052,6 +7054,7 @@ pub mod test {
                     read_count: 205205,
                     runtime: 205205,
                 },
+                network_epoch: PEER_VERSION_EPOCH_2_05,
             },
         ];
         peer_config.epochs = Some(epochs);
@@ -7272,12 +7275,14 @@ pub mod test {
                 start_height: 0,
                 end_height: 0,
                 block_limit: ExecutionCost::max_value(),
+                network_epoch: PEER_VERSION_EPOCH_1_0,
             },
             StacksEpoch {
                 epoch_id: StacksEpochId::Epoch20,
                 start_height: 0,
                 end_height: 30, // NOTE: the first 25 burnchain blocks have no sortition
                 block_limit: ExecutionCost::max_value(),
+                network_epoch: PEER_VERSION_EPOCH_2_0,
             },
             StacksEpoch {
                 epoch_id: StacksEpochId::Epoch2_05,
@@ -7290,6 +7295,7 @@ pub mod test {
                     read_count: 205205,
                     runtime: 205205,
                 },
+                network_epoch: PEER_VERSION_EPOCH_2_05,
             },
         ];
         peer_config.epochs = Some(epochs);

--- a/src/chainstate/stacks/miner.rs
+++ b/src/chainstate/stacks/miner.rs
@@ -7148,6 +7148,7 @@ pub mod test {
                 read_count: 100,
                 runtime: 3350,
             },
+            network_epoch: PEER_VERSION_EPOCH_2_0,
         }]);
 
         let mut peer = TestPeer::new(peer_config);
@@ -9151,6 +9152,7 @@ pub mod test {
                     read_count: 7_750,
                     runtime: 5_000_000_000,
                 },
+                network_epoch: PEER_VERSION_EPOCH_2_0,
             }],
             true,
         )

--- a/src/clarity_vm/clarity.rs
+++ b/src/clarity_vm/clarity.rs
@@ -1212,6 +1212,7 @@ mod tests {
     use vm::database::{ClarityBackingStore, STXBalance};
     use vm::types::{StandardPrincipalData, Value};
 
+    use core::{PEER_VERSION_EPOCH_1_0, PEER_VERSION_EPOCH_2_0, PEER_VERSION_EPOCH_2_05};
     use vm::tests::{TEST_BURN_STATE_DB, TEST_HEADER_DB};
 
     use crate::clarity_vm::database::marf::MarfedKV;
@@ -1919,6 +1920,7 @@ mod tests {
                         read_length: u64::MAX,
                         runtime: 100,
                     },
+                    network_epoch: PEER_VERSION_EPOCH_2_0,
                 })
             }
 

--- a/src/clarity_vm/tests/epoch_switch.rs
+++ b/src/clarity_vm/tests/epoch_switch.rs
@@ -35,6 +35,7 @@ use crate::types::chainstate::{StacksAddress, VRFSeed};
 use crate::types::proof::{ClarityMarfTrieId, TrieMerkleProof};
 
 use core::{StacksEpoch, StacksEpochId, STACKS_EPOCH_MAX};
+use core::{PEER_VERSION_EPOCH_1_0, PEER_VERSION_EPOCH_2_0, PEER_VERSION_EPOCH_2_05};
 
 use rand::thread_rng;
 use rand::RngCore;
@@ -83,18 +84,21 @@ fn test_vm_epoch_switch() {
                 start_height: 0,
                 end_height: 8,
                 block_limit: ExecutionCost::max_value(),
+                network_epoch: PEER_VERSION_EPOCH_1_0,
             },
             StacksEpoch {
                 epoch_id: StacksEpochId::Epoch20,
                 start_height: 8,
                 end_height: 12,
                 block_limit: ExecutionCost::max_value(),
+                network_epoch: PEER_VERSION_EPOCH_2_0,
             },
             StacksEpoch {
                 epoch_id: StacksEpochId::Epoch2_05,
                 start_height: 12,
                 end_height: STACKS_EPOCH_MAX,
                 block_limit: ExecutionCost::max_value(),
+                network_epoch: PEER_VERSION_EPOCH_2_05,
             },
         ],
         true,

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -375,6 +375,7 @@ lazy_static! {
             start_height: BITCOIN_TESTNET_STACKS_2_05_BURN_HEIGHT,
             end_height: STACKS_EPOCH_MAX,
             block_limit: BLOCK_LIMIT_MAINNET_205.clone(),
+            network_epoch: PEER_VERSION_EPOCH_2_05
         },
     ];
 }

--- a/src/net/chat.rs
+++ b/src/net/chat.rs
@@ -658,10 +658,11 @@ impl ConversationP2P {
 
         if my_epoch <= remote_epoch {
             // remote node supports same epochs we do
+            test_debug!("Remote peer has epoch {}, which is newer than our epoch {}", remote_epoch, my_epoch);
             return true;
         }
 
-        test_debug!("Remote peer has old network version {}", remote_peer_version);
+        test_debug!("Remote peer has old network version {} (epoch {})", remote_peer_version, remote_epoch);
 
         // what epoch are we in?
         // note that it might not be my_epoch -- for example, my_epoch can be 0x05 for a 2.05 node,
@@ -675,6 +676,7 @@ impl ConversationP2P {
 
         if cur_epoch <= remote_epoch {
             // epoch shift hasn't happened yet, and this peer supports the current epoch
+            test_debug!("Remote peer has epoch {} and current epoch is {}, so still valid", remote_epoch, cur_epoch);
             return true;
         }
 

--- a/src/net/chat.rs
+++ b/src/net/chat.rs
@@ -658,11 +658,19 @@ impl ConversationP2P {
 
         if my_epoch <= remote_epoch {
             // remote node supports same epochs we do
-            test_debug!("Remote peer has epoch {}, which is newer than our epoch {}", remote_epoch, my_epoch);
+            test_debug!(
+                "Remote peer has epoch {}, which is newer than our epoch {}",
+                remote_epoch,
+                my_epoch
+            );
             return true;
         }
 
-        test_debug!("Remote peer has old network version {} (epoch {})", remote_peer_version, remote_epoch);
+        test_debug!(
+            "Remote peer has old network version {} (epoch {})",
+            remote_peer_version,
+            remote_epoch
+        );
 
         // what epoch are we in?
         // note that it might not be my_epoch -- for example, my_epoch can be 0x05 for a 2.05 node,
@@ -676,7 +684,11 @@ impl ConversationP2P {
 
         if cur_epoch <= remote_epoch {
             // epoch shift hasn't happened yet, and this peer supports the current epoch
-            test_debug!("Remote peer has epoch {} and current epoch is {}, so still valid", remote_epoch, cur_epoch);
+            test_debug!(
+                "Remote peer has epoch {} and current epoch is {}, so still valid",
+                remote_epoch,
+                cur_epoch
+            );
             return true;
         }
 
@@ -4334,7 +4346,7 @@ mod test {
                 )
                 .unwrap();
             assert_eq!(convo_bad.is_preamble_valid(&ping_good, &chain_view), Ok(()));
-            
+
             // give ping a newer epoch than we support
             convo_bad.version = 0x18000006;
             let ping_good = convo_bad
@@ -4366,7 +4378,10 @@ mod test {
                 old_chain_view.burn_stable_block_height,
                 BurnchainHeaderHash([0xff; 32]),
             );
-            assert_eq!(convo_bad.is_preamble_valid(&ping_old, &old_chain_view), Ok(()));
+            assert_eq!(
+                convo_bad.is_preamble_valid(&ping_old, &old_chain_view),
+                Ok(())
+            );
         }
     }
 

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -2599,6 +2599,7 @@ pub mod test {
                 config.burnchain.clone(),
                 burnchain_view,
                 config.connection_opts.clone(),
+                epochs.clone(),
             );
 
             peer_network.bind(&local_addr, &http_local_addr).unwrap();

--- a/src/net/neighbors.rs
+++ b/src/net/neighbors.rs
@@ -3076,6 +3076,10 @@ impl PeerNetwork {
 #[cfg(test)]
 mod test {
     use super::*;
+    use core::{
+        StacksEpoch, StacksEpochId, PEER_VERSION_EPOCH_2_0, PEER_VERSION_EPOCH_2_05,
+        STACKS_EPOCH_MAX,
+    };
     use net::asn::*;
     use net::chat::*;
     use net::db::*;
@@ -3083,7 +3087,6 @@ mod test {
     use util::hash::*;
     use util::sleep_ms;
     use util::test::*;
-    use core::{StacksEpoch, StacksEpochId, PEER_VERSION_EPOCH_2_0, PEER_VERSION_EPOCH_2_05, STACKS_EPOCH_MAX};
 
     const TEST_IN_OUT_DEGREES: u64 = 0x1;
 
@@ -3390,7 +3393,7 @@ mod test {
             assert!(peer_2.network.local_peer.public_ip_address.is_none());
         })
     }
-    
+
     #[test]
     #[ignore]
     fn test_step_walk_1_neighbor_bad_epoch() {
@@ -3405,28 +3408,24 @@ mod test {
 
             // peer 1 thinks its always epoch 2.0
             peer_1_config.peer_version = 0x18000000;
-            peer_1_config.epochs = Some(vec![
-                StacksEpoch {
-                    epoch_id: StacksEpochId::Epoch20,
-                    start_height: 0,
-                    end_height: STACKS_EPOCH_MAX,
-                    block_limit: ExecutionCost::max_value(),
-                    network_epoch: PEER_VERSION_EPOCH_2_0,
-                }
-            ]);
+            peer_1_config.epochs = Some(vec![StacksEpoch {
+                epoch_id: StacksEpochId::Epoch20,
+                start_height: 0,
+                end_height: STACKS_EPOCH_MAX,
+                block_limit: ExecutionCost::max_value(),
+                network_epoch: PEER_VERSION_EPOCH_2_0,
+            }]);
 
             // peer 2 thinks its always epoch 2.05
             peer_2_config.peer_version = 0x18000005;
-            peer_2_config.epochs = Some(vec![
-                StacksEpoch {
-                    epoch_id: StacksEpochId::Epoch2_05,
-                    start_height: 0,
-                    end_height: STACKS_EPOCH_MAX,
-                    block_limit: ExecutionCost::max_value(),
-                    network_epoch: PEER_VERSION_EPOCH_2_05,
-                }
-            ]);
-            
+            peer_2_config.epochs = Some(vec![StacksEpoch {
+                epoch_id: StacksEpochId::Epoch2_05,
+                start_height: 0,
+                end_height: STACKS_EPOCH_MAX,
+                block_limit: ExecutionCost::max_value(),
+                network_epoch: PEER_VERSION_EPOCH_2_05,
+            }]);
+
             // peers know about each other, but peer 2 never talks to peer 1 since it believes that
             // it's in a wholly different epoch
             peer_1_config.add_neighbor(&peer_2_config.to_neighbor());

--- a/src/net/neighbors.rs
+++ b/src/net/neighbors.rs
@@ -3083,6 +3083,7 @@ mod test {
     use util::hash::*;
     use util::sleep_ms;
     use util::test::*;
+    use core::{StacksEpoch, StacksEpochId, PEER_VERSION_EPOCH_2_0, PEER_VERSION_EPOCH_2_05, STACKS_EPOCH_MAX};
 
     const TEST_IN_OUT_DEGREES: u64 = 0x1;
 
@@ -3378,6 +3379,107 @@ mod test {
                 };
 
                 i += 1;
+            }
+
+            assert!(peer_1.network.public_ip_learned);
+            assert!(!peer_1.network.public_ip_confirmed);
+            assert!(peer_1.network.local_peer.public_ip_address.is_none());
+
+            assert!(peer_2.network.public_ip_learned);
+            assert!(!peer_2.network.public_ip_confirmed);
+            assert!(peer_2.network.local_peer.public_ip_address.is_none());
+        })
+    }
+    
+    #[test]
+    #[ignore]
+    fn test_step_walk_1_neighbor_bad_epoch() {
+        with_timeout(600, || {
+            let mut peer_1_config = TestPeerConfig::from_port(31998);
+            let mut peer_2_config = TestPeerConfig::from_port(31990);
+
+            peer_1_config.connection_opts.walk_retry_count = 10;
+            peer_2_config.connection_opts.walk_retry_count = 10;
+            peer_1_config.connection_opts.walk_interval = 1;
+            peer_2_config.connection_opts.walk_interval = 1;
+
+            // peer 1 thinks its always epoch 2.0
+            peer_1_config.peer_version = 0x18000000;
+            peer_1_config.epochs = Some(vec![
+                StacksEpoch {
+                    epoch_id: StacksEpochId::Epoch20,
+                    start_height: 0,
+                    end_height: STACKS_EPOCH_MAX,
+                    block_limit: ExecutionCost::max_value(),
+                    network_epoch: PEER_VERSION_EPOCH_2_0,
+                }
+            ]);
+
+            // peer 2 thinks its always epoch 2.05
+            peer_2_config.peer_version = 0x18000005;
+            peer_2_config.epochs = Some(vec![
+                StacksEpoch {
+                    epoch_id: StacksEpochId::Epoch2_05,
+                    start_height: 0,
+                    end_height: STACKS_EPOCH_MAX,
+                    block_limit: ExecutionCost::max_value(),
+                    network_epoch: PEER_VERSION_EPOCH_2_05,
+                }
+            ]);
+            
+            // peers know about each other, but peer 2 never talks to peer 1 since it believes that
+            // it's in a wholly different epoch
+            peer_1_config.add_neighbor(&peer_2_config.to_neighbor());
+            peer_2_config.add_neighbor(&peer_1_config.to_neighbor());
+
+            let mut peer_1 = TestPeer::new(peer_1_config);
+            let mut peer_2 = TestPeer::new(peer_2_config);
+
+            let mut i = 0;
+            let mut walk_1_count = 0;
+            let mut walk_2_count = 0;
+            let mut walk_1_retries = 0;
+            let mut walk_2_retries = 0;
+            let mut walk_1_total = 0;
+            let mut walk_2_total = 0;
+
+            // walks just don't start.
+            // neither peer learns their public IP addresses.
+            while walk_1_retries < 20 && walk_2_retries < 20 {
+                let _ = peer_1.step();
+                let _ = peer_2.step();
+
+                walk_1_count = peer_1.network.walk_total_step_count;
+                walk_2_count = peer_2.network.walk_total_step_count;
+
+                walk_1_total = peer_1.network.walk_count;
+                walk_2_total = peer_2.network.walk_count;
+
+                assert_eq!(walk_1_total, 0);
+                assert_eq!(walk_2_total, 0);
+
+                walk_1_retries = peer_1.network.walk_attempts;
+                walk_2_retries = peer_2.network.walk_attempts;
+
+                match peer_1.network.walk {
+                    Some(ref w) => {
+                        assert_eq!(w.result.broken_connections.len(), 0);
+                        assert_eq!(w.result.replaced_neighbors.len(), 0);
+                    }
+                    None => {}
+                };
+
+                match peer_2.network.walk {
+                    Some(ref w) => {
+                        assert_eq!(w.result.broken_connections.len(), 0);
+                        assert_eq!(w.result.replaced_neighbors.len(), 0);
+                    }
+                    None => {}
+                };
+
+                i += 1;
+
+                debug!("attempts: {},{}", walk_1_retries, walk_2_retries);
             }
 
             assert!(peer_1.network.public_ip_learned);

--- a/src/net/relay.rs
+++ b/src/net/relay.rs
@@ -1352,7 +1352,7 @@ impl PeerNetwork {
 
         let inbound_recipients =
             if inbound_recipients_unshuffled.len() > MAX_BROADCAST_INBOUND_RECEIVERS {
-                &mut inbound_recipients_unshuffled[..].shuffle(&mut thread_rng());
+                let _ = &mut inbound_recipients_unshuffled[..].shuffle(&mut thread_rng());
                 inbound_recipients_unshuffled[0..MAX_BROADCAST_INBOUND_RECEIVERS].to_vec()
             } else {
                 inbound_recipients_unshuffled

--- a/src/vm/database/clarity_db.rs
+++ b/src/vm/database/clarity_db.rs
@@ -52,6 +52,8 @@ use crate::types::chainstate::{
 use crate::types::proof::TrieMerkleProof;
 use crate::vm::types::byte_len_of_serialization;
 
+use core::PEER_VERSION_EPOCH_2_0;
+
 use super::key_value_wrapper::ValueResult;
 
 pub const STORE_CONTRACT_SRC_INTERFACE: bool = true;
@@ -242,6 +244,7 @@ impl BurnStateDB for NullBurnStateDB {
             start_height: 0,
             end_height: u64::MAX,
             block_limit: ExecutionCost::max_value(),
+            network_epoch: PEER_VERSION_EPOCH_2_0,
         })
     }
 

--- a/src/vm/docs/mod.rs
+++ b/src/vm/docs/mod.rs
@@ -1813,7 +1813,7 @@ mod test {
     use super::make_all_api_reference;
     use super::make_json_api_reference;
 
-    use core::{StacksEpoch, StacksEpochId, STACKS_EPOCH_MAX};
+    use core::{StacksEpoch, StacksEpochId, PEER_VERSION_EPOCH_2_0, STACKS_EPOCH_MAX};
     use vm::costs::ExecutionCost;
 
     struct DocHeadersDB {}
@@ -1881,6 +1881,7 @@ mod test {
                 start_height: 0,
                 end_height: STACKS_EPOCH_MAX,
                 block_limit: ExecutionCost::max_value(),
+                network_epoch: PEER_VERSION_EPOCH_2_0,
             })
         }
         fn get_stacks_epoch_by_epoch_id(&self, epoch_id: &StacksEpochId) -> Option<StacksEpoch> {

--- a/src/vm/tests/mod.rs
+++ b/src/vm/tests/mod.rs
@@ -15,7 +15,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use chainstate::stacks::index::storage::TrieFileStorage;
-use core::{FIRST_BURNCHAIN_CONSENSUS_HASH, FIRST_STACKS_BLOCK_HASH};
+use core::{FIRST_BURNCHAIN_CONSENSUS_HASH, FIRST_STACKS_BLOCK_HASH, PEER_VERSION_EPOCH_2_0};
 use util::hash::hex_bytes;
 use vm::contexts::{Environment, GlobalContext, OwnedEnvironment};
 use vm::contracts::Contract;
@@ -142,6 +142,7 @@ impl BurnStateDB for UnitTestBurnStateDB {
             start_height: 0,
             end_height: u64::MAX,
             block_limit: ExecutionCost::max_value(),
+            network_epoch: PEER_VERSION_EPOCH_2_0,
         })
     }
 

--- a/testnet/stacks-node/src/burnchains/mocknet_controller.rs
+++ b/testnet/stacks-node/src/burnchains/mocknet_controller.rs
@@ -11,7 +11,7 @@ use stacks::chainstate::burn::operations::{
     LeaderKeyRegisterOp, PreStxOp, StackStxOp, TransferStxOp, UserBurnSupportOp,
 };
 use stacks::chainstate::burn::BlockSnapshot;
-use stacks::core::{StacksEpoch, StacksEpochId, STACKS_EPOCH_MAX, PEER_VERSION_EPOCH_2_0};
+use stacks::core::{StacksEpoch, StacksEpochId, PEER_VERSION_EPOCH_2_0, STACKS_EPOCH_MAX};
 use stacks::types::chainstate::{BurnchainHeaderHash, PoxId};
 use stacks::util::get_epoch_time_secs;
 use stacks::util::hash::Sha256Sum;
@@ -98,7 +98,7 @@ impl BurnchainController for MocknetController {
                 start_height: 0,
                 end_height: STACKS_EPOCH_MAX,
                 block_limit: ExecutionCost::max_value(),
-                network_epoch: PEER_VERSION_EPOCH_2_0
+                network_epoch: PEER_VERSION_EPOCH_2_0,
             }],
         };
         let db = match SortitionDB::connect(

--- a/testnet/stacks-node/src/burnchains/mocknet_controller.rs
+++ b/testnet/stacks-node/src/burnchains/mocknet_controller.rs
@@ -11,7 +11,7 @@ use stacks::chainstate::burn::operations::{
     LeaderKeyRegisterOp, PreStxOp, StackStxOp, TransferStxOp, UserBurnSupportOp,
 };
 use stacks::chainstate::burn::BlockSnapshot;
-use stacks::core::{StacksEpoch, StacksEpochId, STACKS_EPOCH_MAX};
+use stacks::core::{StacksEpoch, StacksEpochId, STACKS_EPOCH_MAX, PEER_VERSION_EPOCH_2_0};
 use stacks::types::chainstate::{BurnchainHeaderHash, PoxId};
 use stacks::util::get_epoch_time_secs;
 use stacks::util::hash::Sha256Sum;
@@ -98,6 +98,7 @@ impl BurnchainController for MocknetController {
                 start_height: 0,
                 end_height: STACKS_EPOCH_MAX,
                 block_limit: ExecutionCost::max_value(),
+                network_epoch: PEER_VERSION_EPOCH_2_0
             }],
         };
         let db = match SortitionDB::connect(

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -1173,6 +1173,9 @@ impl InitializedNeonNode {
         let sortdb = SortitionDB::open(&config.get_burn_db_file_path(), false)
             .expect("Error while instantiating sortition db");
 
+        let epochs = SortitionDB::get_stacks_epochs(sortdb.conn())
+            .expect("Error while loading stacks epochs");
+
         let view = {
             let sortition_tip = SortitionDB::get_canonical_burn_chain_tip(&sortdb.conn())
                 .expect("Failed to get sortition tip");
@@ -1309,6 +1312,7 @@ impl InitializedNeonNode {
             burnchain.clone(),
             view,
             config.connection_options.clone(),
+            epochs,
         );
 
         // setup the relayer channel

--- a/testnet/stacks-node/src/node.rs
+++ b/testnet/stacks-node/src/node.rs
@@ -440,6 +440,9 @@ impl Node {
         let sortdb = SortitionDB::open(&self.config.get_burn_db_file_path(), true)
             .expect("Error while instantiating burnchain db");
 
+        let epochs = SortitionDB::get_stacks_epochs(sortdb.conn())
+            .expect("Error while loading stacks epochs");
+
         let burnchain = Burnchain::regtest(&self.config.get_burn_db_path());
 
         let view = {
@@ -532,6 +535,7 @@ impl Node {
             burnchain,
             view,
             self.config.connection_options.clone(),
+            epochs,
         );
         let _join_handle = spawn_peer(
             self.config.is_mainnet(),

--- a/testnet/stacks-node/src/tests/epoch_205.rs
+++ b/testnet/stacks-node/src/tests/epoch_205.rs
@@ -13,6 +13,7 @@ use stacks::chainstate::stacks::TransactionPayload;
 use stacks::codec::StacksMessageCodec;
 use stacks::core::StacksEpoch;
 use stacks::core::StacksEpochId;
+use stacks::core::{PEER_VERSION_EPOCH_2_0, PEER_VERSION_EPOCH_2_05};
 use stacks::types::chainstate::BlockHeaderHash;
 use stacks::types::chainstate::BurnchainHeaderHash;
 use stacks::types::chainstate::StacksAddress;
@@ -499,6 +500,7 @@ fn test_cost_limit_switch_version205() {
                 read_count: 150,
                 runtime: 5000000000,
             },
+            network_epoch: PEER_VERSION_EPOCH_2_0,
         },
         StacksEpoch {
             epoch_id: StacksEpochId::Epoch2_05,
@@ -511,6 +513,7 @@ fn test_cost_limit_switch_version205() {
                 read_count: 50,
                 runtime: 5000000000,
             },
+            network_epoch: PEER_VERSION_EPOCH_2_05,
         },
     ]);
 

--- a/testnet/stacks-node/src/tests/integrations.rs
+++ b/testnet/stacks-node/src/tests/integrations.rs
@@ -13,6 +13,7 @@ use stacks::chainstate::stacks::{TokenTransferMemo, TransactionContractCall, Tra
 use stacks::clarity_vm::clarity::ClarityConnection;
 use stacks::codec::StacksMessageCodec;
 use stacks::core::mempool::MAXIMUM_MEMPOOL_TX_CHAINING;
+use stacks::core::PEER_VERSION_EPOCH_2_0;
 use stacks::net::GetIsTraitImplementedResponse;
 use stacks::net::{AccountEntryResponse, CallReadOnlyRequestBody, ContractSrcResponse};
 use stacks::types::chainstate::{StacksAddress, StacksBlockHeader, VRFSeed};
@@ -1821,6 +1822,7 @@ fn block_limit_runtime_test() {
             //    is _painfully_ slow in a opt-level=0 build (i.e., `cargo test`)
             runtime: 1_000_000_000,
         },
+        network_epoch: PEER_VERSION_EPOCH_2_0
     }]);
     conf.burnchain.commit_anchor_block_within = 5000;
 

--- a/testnet/stacks-node/src/tests/integrations.rs
+++ b/testnet/stacks-node/src/tests/integrations.rs
@@ -1822,7 +1822,7 @@ fn block_limit_runtime_test() {
             //    is _painfully_ slow in a opt-level=0 build (i.e., `cargo test`)
             runtime: 1_000_000_000,
         },
-        network_epoch: PEER_VERSION_EPOCH_2_0
+        network_epoch: PEER_VERSION_EPOCH_2_0,
     }]);
     conf.burnchain.commit_anchor_block_within = 5000;
 


### PR DESCRIPTION
This PR repurposes the lowest byte in the `peer_version` field in the `Preamble` struct so that p2p messages can inform remote peers of their _maximum supported_ epoch.  For 2.0, this field is ignored, but the value in all 2.0 nodes right now is `0x00` on mainnet and `0x01` on testnet.  For 2.05 and up, this value must be `0x05` or later once the 2.05 epoch activates (on both mainnet and testnet).  Before the epoch activates, a 2.05 peer will accept connections from either a 2.0 peer or a 2.05 peer.

This PR alters the `is_preamble_valid()` method in `ConversationP2P` to enforce the above constraints. If the remote peer's epoch marker in the `peer_version` field is greater than or equal to the local node's epoch marker, then the connection is accepted.  If it isn't, then as long as the remote peer's epoch marker is greater than or equal to the _current_ epoch's epoch marker, then the connection will be accepted.  This way, a 2.0 node can talk to a 2.05 node during the 2.0 epoch, and while the 2.05 node is bootstrapping, since `0x00 <= 0x05` (and `0x01 <= 0x05` on testnet).  However, once the 2.05 node passes the 2.05 Bitcoin block, it will reject subsequent messages from the 2.0 nodes.

This PR expands the `convo_is_preamble_valid()` test in `src/net/chat.rs` to cover the new code paths.  In addition, this PR adds `test_step_walk_1_neighbor_bad_epoch()` to `src/net/neighbors.rs` to verify that two peers that believe they run in different epochs will never talk to each other.