### PR TITLE
Ci/fix codecov

### DIFF
--- a/.github/actions/bitcoin-int-tests/Dockerfile.bitcoin-tests
+++ b/.github/actions/bitcoin-int-tests/Dockerfile.bitcoin-tests
@@ -3,9 +3,10 @@ FROM stacks-node:integrations
 ARG test_name
 ENV BITCOIND_TEST 1
 
-RUN cargo test -- --test-threads 1 --ignored "$test_name"
+RUN cargo build && \
+    cargo test -- --test-threads 1 --ignored "$test_name"
 
-RUN grcov . --binary-path ./target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore "/*" -o lcov.info && \
+RUN grcov . --binary-path ../../target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore "/*" -o lcov.info && \
     curl -Os https://uploader.codecov.io/latest/linux/codecov && \
     chmod +x codecov && \
     ./codecov

--- a/.github/actions/bitcoin-int-tests/Dockerfile.bitcoin-tests
+++ b/.github/actions/bitcoin-int-tests/Dockerfile.bitcoin-tests
@@ -5,3 +5,7 @@ ENV BITCOIND_TEST 1
 
 RUN cargo test -- --test-threads 1 --ignored "$test_name"
 
+RUN grcov . --binary-path ./target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore "/*" -o lcov.info && \
+    curl -Os https://uploader.codecov.io/latest/linux/codecov && \
+    chmod +x codecov && \
+    ./codecov

--- a/.github/actions/bitcoin-int-tests/Dockerfile.code-cov
+++ b/.github/actions/bitcoin-int-tests/Dockerfile.code-cov
@@ -16,4 +16,6 @@ RUN cargo build && \
 
 # Generate coverage report and upload it to codecov
 RUN grcov . --binary-path ./target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore "/*" -o lcov.info && \
-    bash -c "bash <(curl -s https://codecov.io/bash)"
+    curl -Os https://uploader.codecov.io/latest/linux/codecov && \
+    chmod +x codecov && \
+    ./codecov

--- a/.github/actions/bitcoin-int-tests/Dockerfile.generic.bitcoin-tests
+++ b/.github/actions/bitcoin-int-tests/Dockerfile.generic.bitcoin-tests
@@ -5,6 +5,14 @@ WORKDIR /src/
 COPY . .
 
 WORKDIR /src/testnet/stacks-node
+
+RUN rustup override set nightly && \
+    rustup component add llvm-tools-preview && \
+    cargo install grcov
+
+ENV RUSTFLAGS="-Zinstrument-coverage" \
+    LLVM_PROFILE_FILE="stacks-blockchain-%p-%m.profraw"
+
 RUN cargo test --no-run
 
 RUN cd / && wget https://bitcoin.org/bin/bitcoin-core-0.20.0/bitcoin-0.20.0-x86_64-linux-gnu.tar.gz

--- a/.github/actions/bitcoin-int-tests/Dockerfile.generic.bitcoin-tests
+++ b/.github/actions/bitcoin-int-tests/Dockerfile.generic.bitcoin-tests
@@ -13,7 +13,7 @@ RUN rustup override set nightly && \
 ENV RUSTFLAGS="-Zinstrument-coverage" \
     LLVM_PROFILE_FILE="stacks-blockchain-%p-%m.profraw"
 
-RUN cargo test --no-run
+RUN cargo build
 
 RUN cd / && wget https://bitcoin.org/bin/bitcoin-core-0.20.0/bitcoin-0.20.0-x86_64-linux-gnu.tar.gz
 RUN cd / && tar -xvzf bitcoin-0.20.0-x86_64-linux-gnu.tar.gz

--- a/.github/workflows/bitcoin-tests.yml
+++ b/.github/workflows/bitcoin-tests.yml
@@ -13,7 +13,10 @@ jobs:
       - name: Build bitcoin integration testing image
         env:
           DOCKER_BUILDKIT: 1
-        run: docker build -f ./.github/actions/bitcoin-int-tests/Dockerfile.generic.bitcoin-tests -t stacks-node:integrations .
+        # Remove .dockerignore file so codecov has access to git info
+        run: |
+          rm .dockerignore
+          docker build -f ./.github/actions/bitcoin-int-tests/Dockerfile.generic.bitcoin-tests -t stacks-node:integrations .
       - name: Export docker image as tarball
         run: docker save -o integration-image.tar stacks-node:integrations
       - name: Upload built docker image

--- a/.github/workflows/stacks-blockchain.yml
+++ b/.github/workflows/stacks-blockchain.yml
@@ -49,7 +49,10 @@ jobs:
       - name: Run units tests (with coverage)
         env:
           DOCKER_BUILDKIT: 1
-        run: docker build -f ./.github/actions/bitcoin-int-tests/Dockerfile.code-cov .
+        # Remove .dockerignore file so codecov has access to git info
+        run: |
+          rm .dockerignore
+          docker build -f ./.github/actions/bitcoin-int-tests/Dockerfile.code-cov .
 
   open-api-validation:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

Fixes code coverage uploads.
About 7 months ago test coverage reports stopped uploading to codecov - not going to go into the details here, but they had a MiM and had to stop using the original method of upload.

This PR fixes the codecoverage upload step using their new CLI.

Code coverage of this repo can be found here:
https://app.codecov.io/gh/blockstack/stacks-blockchain/

## Type of Change
- Other 

## Does this introduce a breaking change?
No