### PR TITLE
Ci/next costs coverage

### DIFF
--- a/.github/actions/bitcoin-int-tests/Dockerfile.bitcoin-tests
+++ b/.github/actions/bitcoin-int-tests/Dockerfile.bitcoin-tests
@@ -3,5 +3,10 @@ FROM stacks-node:integrations
 ARG test_name
 ENV BITCOIND_TEST 1
 
-RUN cargo test -- --test-threads 1 --ignored "$test_name"
+RUN cargo build && \
+    cargo test -- --test-threads 1 --ignored "$test_name"
 
+RUN grcov . --binary-path ../../target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore "/*" -o lcov.info && \
+    curl -Os https://uploader.codecov.io/latest/linux/codecov && \
+    chmod +x codecov && \
+    ./codecov

--- a/.github/actions/bitcoin-int-tests/Dockerfile.bitcoin-tests
+++ b/.github/actions/bitcoin-int-tests/Dockerfile.bitcoin-tests
@@ -5,7 +5,7 @@ ENV BITCOIND_TEST 1
 
 RUN cargo test -- --test-threads 1 --ignored "$test_name"
 
-RUN grcov . --binary-path ../../target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore "/*" -o lcov.info && \
+RUN grcov . --binary-path ../../target/debug/ -s ../.. -t lcov --branch --ignore-not-existing --ignore "/*" -o lcov.info && \
     curl -Os https://uploader.codecov.io/latest/linux/codecov && \
     chmod +x codecov && \
     ./codecov --name "$test_name"

--- a/.github/actions/bitcoin-int-tests/Dockerfile.bitcoin-tests
+++ b/.github/actions/bitcoin-int-tests/Dockerfile.bitcoin-tests
@@ -8,4 +8,4 @@ RUN cargo test -- --test-threads 1 --ignored "$test_name"
 RUN grcov . --binary-path ../../target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore "/*" -o lcov.info && \
     curl -Os https://uploader.codecov.io/latest/linux/codecov && \
     chmod +x codecov && \
-    ./codecov
+    ./codecov --name "$test_name"

--- a/.github/actions/bitcoin-int-tests/Dockerfile.bitcoin-tests
+++ b/.github/actions/bitcoin-int-tests/Dockerfile.bitcoin-tests
@@ -3,8 +3,7 @@ FROM stacks-node:integrations
 ARG test_name
 ENV BITCOIND_TEST 1
 
-RUN cargo build && \
-    cargo test -- --test-threads 1 --ignored "$test_name"
+RUN cargo test -- --test-threads 1 --ignored "$test_name"
 
 RUN grcov . --binary-path ../../target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore "/*" -o lcov.info && \
     curl -Os https://uploader.codecov.io/latest/linux/codecov && \

--- a/.github/actions/bitcoin-int-tests/Dockerfile.code-cov
+++ b/.github/actions/bitcoin-int-tests/Dockerfile.code-cov
@@ -18,4 +18,4 @@ RUN cargo build && \
 RUN grcov . --binary-path ./target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore "/*" -o lcov.info && \
     curl -Os https://uploader.codecov.io/latest/linux/codecov && \
     chmod +x codecov && \
-    ./codecov
+    ./codecov --name "unit_tests"

--- a/.github/actions/bitcoin-int-tests/Dockerfile.code-cov
+++ b/.github/actions/bitcoin-int-tests/Dockerfile.code-cov
@@ -16,4 +16,6 @@ RUN cargo build && \
 
 # Generate coverage report and upload it to codecov
 RUN grcov . --binary-path ./target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore "/*" -o lcov.info && \
-    bash -c "bash <(curl -s https://codecov.io/bash)"
+    curl -Os https://uploader.codecov.io/latest/linux/codecov && \
+    chmod +x codecov && \
+    ./codecov

--- a/.github/actions/bitcoin-int-tests/Dockerfile.generic.bitcoin-tests
+++ b/.github/actions/bitcoin-int-tests/Dockerfile.generic.bitcoin-tests
@@ -13,7 +13,8 @@ RUN rustup override set nightly && \
 ENV RUSTFLAGS="-Zinstrument-coverage" \
     LLVM_PROFILE_FILE="stacks-blockchain-%p-%m.profraw"
 
-RUN cargo build
+RUN cargo test --norun && \
+    cargo build
 
 RUN cd / && wget https://bitcoin.org/bin/bitcoin-core-0.20.0/bitcoin-0.20.0-x86_64-linux-gnu.tar.gz
 RUN cd / && tar -xvzf bitcoin-0.20.0-x86_64-linux-gnu.tar.gz

--- a/.github/actions/bitcoin-int-tests/Dockerfile.generic.bitcoin-tests
+++ b/.github/actions/bitcoin-int-tests/Dockerfile.generic.bitcoin-tests
@@ -5,7 +5,15 @@ WORKDIR /src/
 COPY . .
 
 WORKDIR /src/testnet/stacks-node
-RUN cargo test --no-run
+
+RUN rustup override set nightly && \
+    rustup component add llvm-tools-preview && \
+    cargo install grcov
+
+ENV RUSTFLAGS="-Zinstrument-coverage" \
+    LLVM_PROFILE_FILE="stacks-blockchain-%p-%m.profraw"
+
+RUN cargo build
 
 RUN cd / && wget https://bitcoin.org/bin/bitcoin-core-0.20.0/bitcoin-0.20.0-x86_64-linux-gnu.tar.gz
 RUN cd / && tar -xvzf bitcoin-0.20.0-x86_64-linux-gnu.tar.gz

--- a/.github/actions/bitcoin-int-tests/Dockerfile.generic.bitcoin-tests
+++ b/.github/actions/bitcoin-int-tests/Dockerfile.generic.bitcoin-tests
@@ -13,7 +13,7 @@ RUN rustup override set nightly && \
 ENV RUSTFLAGS="-Zinstrument-coverage" \
     LLVM_PROFILE_FILE="stacks-blockchain-%p-%m.profraw"
 
-RUN cargo test --norun && \
+RUN cargo test --no-run && \
     cargo build
 
 RUN cd / && wget https://bitcoin.org/bin/bitcoin-core-0.20.0/bitcoin-0.20.0-x86_64-linux-gnu.tar.gz

--- a/.github/actions/bitcoin-int-tests/Dockerfile.large-genesis
+++ b/.github/actions/bitcoin-int-tests/Dockerfile.large-genesis
@@ -13,7 +13,9 @@ RUN rustup override set nightly && \
     rustup component add llvm-tools-preview && \
     cargo install grcov
 
-RUN cargo build --workspace
+RUN cargo test --norun --workspace && \
+    cargo build --workspace
+
 ENV RUSTFLAGS="-Zinstrument-coverage" \
     LLVM_PROFILE_FILE="stacks-blockchain-%p-%m.profraw"
 

--- a/.github/actions/bitcoin-int-tests/Dockerfile.large-genesis
+++ b/.github/actions/bitcoin-int-tests/Dockerfile.large-genesis
@@ -25,4 +25,4 @@ RUN cd testnet/stacks-node && cargo test --release --features prod-genesis-chain
 RUN grcov . --binary-path ./target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore "/*" -o lcov.info && \
     curl -Os https://uploader.codecov.io/latest/linux/codecov && \
     chmod +x codecov && \
-    ./codecov
+    ./codecov --name "large_genesis"

--- a/.github/actions/bitcoin-int-tests/Dockerfile.large-genesis
+++ b/.github/actions/bitcoin-int-tests/Dockerfile.large-genesis
@@ -4,12 +4,24 @@ WORKDIR /src
 
 COPY . .
 
-RUN cargo test --no-run --workspace
+RUN cargo build --workspace
 
 RUN cd / && wget https://bitcoin.org/bin/bitcoin-core-0.20.0/bitcoin-0.20.0-x86_64-linux-gnu.tar.gz
 RUN cd / && tar -xvzf bitcoin-0.20.0-x86_64-linux-gnu.tar.gz
 
 RUN ln -s /bitcoin-0.20.0/bin/bitcoind /bin/
 
+RUN rustup override set nightly && \
+    rustup component add llvm-tools-preview && \
+    cargo install grcov
+
+ENV RUSTFLAGS="-Zinstrument-coverage" \
+    LLVM_PROFILE_FILE="stacks-blockchain-%p-%m.profraw"
+
 ENV BITCOIND_TEST 1
 RUN cd testnet/stacks-node && cargo test --release --features prod-genesis-chainstate -- --test-threads 1 --ignored neon_integrations::bitcoind_integration_test
+
+RUN grcov . --binary-path ../../target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore "/*" -o lcov.info && \
+    curl -Os https://uploader.codecov.io/latest/linux/codecov && \
+    chmod +x codecov && \
+    ./codecov

--- a/.github/actions/bitcoin-int-tests/Dockerfile.large-genesis
+++ b/.github/actions/bitcoin-int-tests/Dockerfile.large-genesis
@@ -4,8 +4,6 @@ WORKDIR /src
 
 COPY . .
 
-RUN cargo build --workspace
-
 RUN cd / && wget https://bitcoin.org/bin/bitcoin-core-0.20.0/bitcoin-0.20.0-x86_64-linux-gnu.tar.gz
 RUN cd / && tar -xvzf bitcoin-0.20.0-x86_64-linux-gnu.tar.gz
 
@@ -15,13 +13,14 @@ RUN rustup override set nightly && \
     rustup component add llvm-tools-preview && \
     cargo install grcov
 
+RUN cargo build --workspace
 ENV RUSTFLAGS="-Zinstrument-coverage" \
     LLVM_PROFILE_FILE="stacks-blockchain-%p-%m.profraw"
 
 ENV BITCOIND_TEST 1
 RUN cd testnet/stacks-node && cargo test --release --features prod-genesis-chainstate -- --test-threads 1 --ignored neon_integrations::bitcoind_integration_test
 
-RUN grcov . --binary-path ../../target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore "/*" -o lcov.info && \
+RUN grcov . --binary-path ./target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore "/*" -o lcov.info && \
     curl -Os https://uploader.codecov.io/latest/linux/codecov && \
     chmod +x codecov && \
     ./codecov

--- a/.github/actions/bitcoin-int-tests/Dockerfile.large-genesis
+++ b/.github/actions/bitcoin-int-tests/Dockerfile.large-genesis
@@ -13,7 +13,7 @@ RUN rustup override set nightly && \
     rustup component add llvm-tools-preview && \
     cargo install grcov
 
-RUN cargo test --norun --workspace && \
+RUN cargo test --no-run --workspace && \
     cargo build --workspace
 
 ENV RUSTFLAGS="-Zinstrument-coverage" \

--- a/.github/actions/bitcoin-int-tests/Dockerfile.large-genesis
+++ b/.github/actions/bitcoin-int-tests/Dockerfile.large-genesis
@@ -13,11 +13,11 @@ RUN rustup override set nightly && \
     rustup component add llvm-tools-preview && \
     cargo install grcov
 
-RUN cargo test --no-run --workspace && \
-    cargo build --workspace
-
 ENV RUSTFLAGS="-Zinstrument-coverage" \
     LLVM_PROFILE_FILE="stacks-blockchain-%p-%m.profraw"
+
+RUN cargo test --no-run --workspace && \
+    cargo build --workspace
 
 ENV BITCOIND_TEST 1
 RUN cd testnet/stacks-node && cargo test --release --features prod-genesis-chainstate -- --test-threads 1 --ignored neon_integrations::bitcoind_integration_test

--- a/.github/workflows/bitcoin-tests.yml
+++ b/.github/workflows/bitcoin-tests.yml
@@ -13,7 +13,10 @@ jobs:
       - name: Build bitcoin integration testing image
         env:
           DOCKER_BUILDKIT: 1
-        run: docker build -f ./.github/actions/bitcoin-int-tests/Dockerfile.generic.bitcoin-tests -t stacks-node:integrations .
+        # Remove .dockerignore file so codecov has access to git info
+        run: |
+          rm .dockerignore
+          docker build -f ./.github/actions/bitcoin-int-tests/Dockerfile.generic.bitcoin-tests -t stacks-node:integrations .
       - name: Export docker image as tarball
         run: docker save -o integration-image.tar stacks-node:integrations
       - name: Upload built docker image

--- a/.github/workflows/stacks-blockchain.yml
+++ b/.github/workflows/stacks-blockchain.yml
@@ -49,7 +49,10 @@ jobs:
       - name: Run units tests (with coverage)
         env:
           DOCKER_BUILDKIT: 1
-        run: docker build -f ./.github/actions/bitcoin-int-tests/Dockerfile.code-cov .
+        # Remove .dockerignore file so codecov has access to git info
+        run: |
+          rm .dockerignore
+          docker build -f ./.github/actions/bitcoin-int-tests/Dockerfile.code-cov .
 
   open-api-validation:
     runs-on: ubuntu-latest

--- a/.github/workflows/stacks-blockchain.yml
+++ b/.github/workflows/stacks-blockchain.yml
@@ -39,7 +39,10 @@ jobs:
       - name: Single full genesis integration test
         env:
           DOCKER_BUILDKIT: 1
-        run: docker build -f ./.github/actions/bitcoin-int-tests/Dockerfile.large-genesis .
+        # Remove .dockerignore file so codecov has access to git info
+        run: |
+          rm .dockerignore
+          docker build -f ./.github/actions/bitcoin-int-tests/Dockerfile.large-genesis .
 
   # Run unit tests with code coverage
   unit-tests:


### PR DESCRIPTION
## Description

Cherry-picking changes from [this PR](https://github.com/blockstack/stacks-blockchain/pull/2932) to `next-costs` branch. Also, adding code coverage for one more integration test, `bitcoind_integration_test`.

Fixes code coverage uploads.
About 7 months ago test coverage reports stopped uploading to codecov - not going to go into the details here, but they had a MiM and had to stop using the original method of upload.

This PR fixes the codecoverage upload step using their new CLI.

Code coverage of this repo can be found here:
https://app.codecov.io/gh/blockstack/stacks-blockchain/

## Type of Change
- Other 

## Does this introduce a breaking change?
No