### PR TITLE
Stacks 2.05: make the node abort if it starts in epoch 2.05 but still has epoch 2.0 chainstate

### DIFF
--- a/src/chainstate/coordinator/tests.rs
+++ b/src/chainstate/coordinator/tests.rs
@@ -3855,3 +3855,78 @@ fn preprocess_block(
         )
         .unwrap();
 }
+
+#[test]
+fn test_check_chainstate_db_versions() {
+    let path = "/tmp/stacks-blockchain-check_chainstate_db_versions";
+    let _ = std::fs::remove_dir_all(path);
+
+    let sortdb_path = format!("{}/sortdb", &path);
+    let chainstate_path = format!("{}/chainstate", &path);
+
+    let epoch_2 = StacksEpoch {
+        epoch_id: StacksEpochId::Epoch20,
+        start_height: 0,
+        end_height: 10000,
+        block_limit: BLOCK_LIMIT_MAINNET_20.clone(),
+        network_epoch: PEER_VERSION_EPOCH_2_0,
+    };
+    let epoch_2_05 = StacksEpoch {
+        epoch_id: StacksEpochId::Epoch2_05,
+        start_height: 0,
+        end_height: 10000,
+        block_limit: BLOCK_LIMIT_MAINNET_205.clone(),
+        network_epoch: PEER_VERSION_EPOCH_2_05,
+    };
+
+    // should work just fine in epoch 2 if the DBs don't exist
+    assert!(
+        check_chainstate_db_versions(&[epoch_2.clone()], &sortdb_path, &chainstate_path).unwrap()
+    );
+
+    // should work just fine in epoch 2.05 if the DBs don't exist
+    assert!(
+        check_chainstate_db_versions(&[epoch_2_05.clone()], &sortdb_path, &chainstate_path)
+            .unwrap()
+    );
+
+    StacksChainState::make_chainstate_dirs(&chainstate_path).unwrap();
+
+    let sortdb_v1 =
+        SortitionDB::connect_v1(&sortdb_path, 100, &BurnchainHeaderHash([0x00; 32]), 0, true)
+            .unwrap();
+    let chainstate_v1 = StacksChainState::open_db_without_migrations(
+        false,
+        0x80000000,
+        &StacksChainState::header_index_root_path(PathBuf::from(&chainstate_path))
+            .to_str()
+            .unwrap(),
+    )
+    .unwrap();
+
+    assert!(fs::metadata(&chainstate_path).is_ok());
+    assert!(fs::metadata(&sortdb_path).is_ok());
+    assert_eq!(
+        StacksChainState::get_db_config_from_path(&chainstate_path)
+            .unwrap()
+            .version,
+        "1"
+    );
+    assert_eq!(
+        SortitionDB::get_db_version_from_path(&sortdb_path)
+            .unwrap()
+            .unwrap(),
+        "1"
+    );
+
+    // should work just fine in epoch 2
+    assert!(
+        check_chainstate_db_versions(&[epoch_2.clone()], &sortdb_path, &chainstate_path).unwrap()
+    );
+
+    // should fail in epoch 2.05
+    assert!(
+        !check_chainstate_db_versions(&[epoch_2_05.clone()], &sortdb_path, &chainstate_path)
+            .unwrap()
+    );
+}

--- a/src/chainstate/coordinator/tests.rs
+++ b/src/chainstate/coordinator/tests.rs
@@ -3897,7 +3897,7 @@ fn test_check_chainstate_db_versions() {
             .unwrap();
     let chainstate_v1 = StacksChainState::open_db_without_migrations(
         false,
-        0x80000000,
+        CHAIN_ID_TESTNET,
         &StacksChainState::header_index_root_path(PathBuf::from(&chainstate_path))
             .to_str()
             .unwrap(),

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -229,6 +229,9 @@ pub struct StacksEpoch {
 }
 
 impl StacksEpoch {
+    /// Determine which epoch, if any, in a list of epochs, a given burnchain height falls into.
+    /// Returns Some(index) if there is such an epoch in the list.
+    /// Returns None if not.
     pub fn find_epoch(epochs: &[StacksEpoch], height: u64) -> Option<usize> {
         for (i, epoch) in epochs.iter().enumerate() {
             if epoch.start_height <= height && height < epoch.end_height {

--- a/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
+++ b/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
@@ -1482,13 +1482,8 @@ impl BurnchainController for BitcoinRegtestController {
     }
 
     fn get_stacks_epochs(&self) -> Vec<StacksEpoch> {
-        match self.config.burnchain.epochs.as_ref() {
-            Some(epochs) => epochs.clone(),
-            None => {
-                let (_, indexer) = self.setup_indexer_runtime();
-                indexer.get_stacks_epochs()
-            }
-        }
+        let (_, indexer) = self.setup_indexer_runtime();
+        indexer.get_stacks_epochs()
     }
 
     fn start(

--- a/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
+++ b/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
@@ -42,6 +42,7 @@ use stacks::chainstate::burn::operations::{
 };
 use stacks::chainstate::coordinator::comm::CoordinatorChannels;
 use stacks::codec::StacksMessageCodec;
+use stacks::core::StacksEpoch;
 use stacks::deps::bitcoin::blockdata::opcodes;
 use stacks::deps::bitcoin::blockdata::script::{Builder, Script};
 use stacks::deps::bitcoin::blockdata::transaction::{OutPoint, Transaction, TxIn, TxOut};
@@ -320,7 +321,7 @@ impl BitcoinRegtestController {
         }
     }
 
-    fn setup_indexer_runtime(&mut self) -> (Burnchain, BitcoinIndexer) {
+    fn setup_indexer_runtime(&self) -> (Burnchain, BitcoinIndexer) {
         let (_, network_type) = self.config.burnchain.get_bitcoin_network();
         let indexer_runtime = BitcoinIndexerRuntime::new(network_type);
         let burnchain_indexer = BitcoinIndexer {
@@ -1478,6 +1479,16 @@ impl BurnchainController for BitcoinRegtestController {
             burnchain_indexer.get_first_block_header_timestamp()?,
         )?;
         Ok(())
+    }
+
+    fn get_stacks_epochs(&self) -> Vec<StacksEpoch> {
+        match self.config.burnchain.epochs.as_ref() {
+            Some(epochs) => epochs.clone(),
+            None => {
+                let (_, indexer) = self.setup_indexer_runtime();
+                indexer.get_stacks_epochs()
+            }
+        }
     }
 
     fn start(

--- a/testnet/stacks-node/src/burnchains/mocknet_controller.rs
+++ b/testnet/stacks-node/src/burnchains/mocknet_controller.rs
@@ -86,12 +86,8 @@ impl BurnchainController for MocknetController {
         }
     }
 
-    fn start(
-        &mut self,
-        _ignored_target_height_opt: Option<u64>,
-    ) -> Result<(BurnchainTip, u64), BurnchainControllerError> {
-        // If `config` sets a value, use that. Otherwise, use a default.
-        let epoch_vector = match &self.config.burnchain.epochs {
+    fn get_stacks_epochs(&self) -> Vec<StacksEpoch> {
+        match &self.config.burnchain.epochs {
             Some(epochs) => epochs.clone(),
             None => vec![StacksEpoch {
                 epoch_id: StacksEpochId::Epoch20,
@@ -100,7 +96,15 @@ impl BurnchainController for MocknetController {
                 block_limit: ExecutionCost::max_value(),
                 network_epoch: PEER_VERSION_EPOCH_2_0,
             }],
-        };
+        }
+    }
+
+    fn start(
+        &mut self,
+        _ignored_target_height_opt: Option<u64>,
+    ) -> Result<(BurnchainTip, u64), BurnchainControllerError> {
+        // If `config` sets a value, use that. Otherwise, use a default.
+        let epoch_vector = self.get_stacks_epochs();
         let db = match SortitionDB::connect(
             &self.config.get_burn_db_file_path(),
             0,

--- a/testnet/stacks-node/src/burnchains/mod.rs
+++ b/testnet/stacks-node/src/burnchains/mod.rs
@@ -15,6 +15,8 @@ use stacks::chainstate::burn::db::sortdb::SortitionDB;
 use stacks::chainstate::burn::operations::BlockstackOperationType;
 use stacks::chainstate::burn::BlockSnapshot;
 
+use stacks::core::StacksEpoch;
+
 #[derive(Debug)]
 pub enum Error {
     CoordinatorClosed,
@@ -52,6 +54,8 @@ pub trait BurnchainController {
     /// Invoke connect() on underlying burnchain and sortition databases, to perform any migration
     ///  or instantiation before other callers may use open()
     fn connect_dbs(&mut self) -> Result<(), Error>;
+    fn get_stacks_epochs(&self) -> Vec<StacksEpoch>;
+
     #[cfg(test)]
     fn bootstrap_chain(&mut self, blocks_count: u64);
 }


### PR DESCRIPTION
This fixes #2899 by adding a top-level `check_chainstate_db_versions()` method in `src/chainstate/coordinators/mod.rs` that inspects the sortition DB and chainstate DB, and verifies that their current schemas are supported in the given epoch (if they exist at all).  I made the `RunLoop::start()` method in the neon node invoke this early in its initialization, so that if the node is starting from existing chainstate, it will abort if the epoch of the last sortition processed is not supported by either of the chainstate schemas.  I added a unit test to `src/chainstate/stacks/coordinator/tests.rs` that verifies that an epoch 2.0 sortition DB and epoch 2.0 chainstate DB cannot be opened if the system is in epoch 2.05.

In writing this, I also refactored the code for generating directories and paths to the various files in the chainstate directory to make them a bit more approachable (and to make it possible to query the `DBConfig` directly, from the chainstate path).