### PR TITLE
Stacks 2.05: only report neighbors in the current or later epoch

### DIFF
--- a/src/net/db.rs
+++ b/src/net/db.rs
@@ -1242,6 +1242,7 @@ impl PeerDB {
     pub fn get_random_neighbors(
         conn: &DBConn,
         network_id: u32,
+        network_epoch: u8,
         count: u32,
         block_height: u64,
         always_include_allowed: bool,
@@ -1253,9 +1254,13 @@ impl PeerDB {
 
         if always_include_allowed {
             // always include allowed neighbors, freshness be damned
-            let allow_qry = "SELECT * FROM frontier WHERE network_id = ?1 AND denied < ?2 AND (allowed < 0 OR ?3 < allowed)".to_string();
-            let allow_args: &[&dyn ToSql] =
-                &[&network_id, &u64_to_sql(now_secs)?, &u64_to_sql(now_secs)?];
+            let allow_qry = "SELECT * FROM frontier WHERE network_id = ?1 AND denied < ?2 AND (allowed < 0 OR ?3 < allowed) AND (peer_version & 0x000000ff) >= ?4".to_string();
+            let allow_args: &[&dyn ToSql] = &[
+                &network_id,
+                &u64_to_sql(now_secs)?,
+                &u64_to_sql(now_secs)?,
+                &network_epoch,
+            ];
             let mut allow_rows = query_rows::<Neighbor, _>(conn, &allow_qry, allow_args)?;
 
             if allow_rows.len() >= (count as usize) {
@@ -1267,14 +1272,17 @@ impl PeerDB {
 
             ret.append(&mut allow_rows);
         }
+        if (ret.len() as u32) >= count {
+            return Ok(ret);
+        }
 
         // fill in with non-allowed, randomly-chosen, fresh peers
         let random_peers_qry = if always_include_allowed {
             "SELECT * FROM frontier WHERE network_id = ?1 AND last_contact_time >= 0 AND ?2 < expire_block_height AND denied < ?3 AND \
-                 (allowed >= 0 AND allowed <= ?4) ORDER BY RANDOM() LIMIT ?5".to_string()
+                 (allowed >= 0 AND allowed <= ?4) AND (peer_version & 0x000000ff) >= ?5 ORDER BY RANDOM() LIMIT ?6".to_string()
         } else {
             "SELECT * FROM frontier WHERE network_id = ?1 AND last_contact_time >= 0 AND ?2 < expire_block_height AND denied < ?3 AND \
-                 (allowed < 0 OR (allowed >= 0 AND allowed <= ?4)) ORDER BY RANDOM() LIMIT ?5".to_string()
+                 (allowed < 0 OR (allowed >= 0 AND allowed <= ?4)) AND (peer_version & 0x000000ff) >= ?5 ORDER BY RANDOM() LIMIT ?6".to_string()
         };
 
         let random_peers_args: &[&dyn ToSql] = &[
@@ -1282,6 +1290,7 @@ impl PeerDB {
             &u64_to_sql(block_height)?,
             &u64_to_sql(now_secs)?,
             &u64_to_sql(now_secs)?,
+            &network_epoch,
             &(count - (ret.len() as u32)),
         ];
         let mut random_peers =
@@ -1298,10 +1307,11 @@ impl PeerDB {
     pub fn get_initial_neighbors(
         conn: &DBConn,
         network_id: u32,
+        network_epoch: u8,
         count: u32,
         block_height: u64,
     ) -> Result<Vec<Neighbor>, db_error> {
-        PeerDB::get_random_neighbors(conn, network_id, count, block_height, true)
+        PeerDB::get_random_neighbors(conn, network_id, network_epoch, count, block_height, true)
     }
 
     /// Get a randomized set of peers for walking the peer graph.
@@ -1309,10 +1319,11 @@ impl PeerDB {
     pub fn get_random_walk_neighbors(
         conn: &DBConn,
         network_id: u32,
+        network_epoch: u8,
         count: u32,
         block_height: u64,
     ) -> Result<Vec<Neighbor>, db_error> {
-        PeerDB::get_random_neighbors(conn, network_id, count, block_height, false)
+        PeerDB::get_random_neighbors(conn, network_id, network_epoch, count, block_height, false)
     }
 
     /// Add an IPv4 <--> ASN mapping
@@ -1632,17 +1643,17 @@ mod test {
         )
         .unwrap();
 
-        let n5 = PeerDB::get_initial_neighbors(db.conn(), 0x9abcdef0, 5, 23455).unwrap();
+        let n5 = PeerDB::get_initial_neighbors(db.conn(), 0x9abcdef0, 0x78, 5, 23455).unwrap();
         assert!(are_present(&n5, &initial_neighbors));
 
-        let n10 = PeerDB::get_initial_neighbors(db.conn(), 0x9abcdef0, 10, 23455).unwrap();
+        let n10 = PeerDB::get_initial_neighbors(db.conn(), 0x9abcdef0, 0x78, 10, 23455).unwrap();
         assert!(are_present(&n10, &initial_neighbors));
 
-        let n20 = PeerDB::get_initial_neighbors(db.conn(), 0x9abcdef0, 20, 23455).unwrap();
+        let n20 = PeerDB::get_initial_neighbors(db.conn(), 0x9abcdef0, 0x78, 20, 23455).unwrap();
         assert!(are_present(&initial_neighbors, &n20));
 
         let n15_fresh =
-            PeerDB::get_initial_neighbors(db.conn(), 0x9abcdef0, 15, 23456 + 14).unwrap();
+            PeerDB::get_initial_neighbors(db.conn(), 0x9abcdef0, 0x78, 15, 23456 + 14).unwrap();
         assert!(are_present(
             &n15_fresh[10..15].to_vec(),
             &initial_neighbors[10..20].to_vec()
@@ -1661,6 +1672,126 @@ mod test {
             )
             .unwrap());
         }
+    }
+
+    #[test]
+    fn test_get_neighbors_in_current_epoch() {
+        let mut initial_neighbors = vec![];
+        let now_secs = util::get_epoch_time_secs();
+        for i in 0..10 {
+            // epoch 2.0 neighbors
+            initial_neighbors.push(Neighbor {
+                addr: NeighborKey {
+                    peer_version: 0x18000000,
+                    network_id: 0x9abcdef0,
+                    addrbytes: PeerAddress([i as u8; 16]),
+                    port: i,
+                },
+                public_key: Secp256k1PublicKey::from_private(&Secp256k1PrivateKey::new()),
+                expire_block: (i + 23456) as u64,
+                last_contact_time: (1552509642 + (i as u64)) as u64,
+                allowed: -1,
+                denied: -1,
+                asn: (34567 + i) as u32,
+                org: (45678 + i) as u32,
+                in_degree: 1,
+                out_degree: 1,
+            });
+        }
+
+        for i in 10..20 {
+            // epoch 2.05 neighbors
+            initial_neighbors.push(Neighbor {
+                addr: NeighborKey {
+                    peer_version: 0x18000005,
+                    network_id: 0x9abcdef0,
+                    addrbytes: PeerAddress([i as u8; 16]),
+                    port: i,
+                },
+                public_key: Secp256k1PublicKey::from_private(&Secp256k1PrivateKey::new()),
+                expire_block: (i + 23456) as u64,
+                last_contact_time: (1552509642 + (i as u64)) as u64,
+                allowed: -1,
+                denied: -1,
+                asn: (34567 + i) as u32,
+                org: (45678 + i) as u32,
+                in_degree: 1,
+                out_degree: 1,
+            });
+        }
+
+        fn are_present(ne: &Vec<Neighbor>, nei: &Vec<Neighbor>) -> bool {
+            for n in ne {
+                let mut found = false;
+                for ni in nei {
+                    if *n == *ni {
+                        found = true;
+                        break;
+                    }
+                }
+                if !found {
+                    eprintln!("Not found: {:?}", &n);
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        let db = PeerDB::connect_memory(
+            0x9abcdef0,
+            12345,
+            0,
+            "http://foo.com".into(),
+            &vec![],
+            &initial_neighbors,
+        )
+        .unwrap();
+
+        // epoch 2.0
+        let n5 =
+            PeerDB::get_random_neighbors(db.conn(), 0x9abcdef0, 0x00, 5, 23455, false).unwrap();
+        assert_eq!(n5.len(), 5);
+        assert!(are_present(&n5, &initial_neighbors));
+
+        let n10 =
+            PeerDB::get_random_neighbors(db.conn(), 0x9abcdef0, 0x00, 10, 23455, false).unwrap();
+        assert_eq!(n10.len(), 10);
+        assert!(are_present(&n10, &initial_neighbors));
+
+        let n20 =
+            PeerDB::get_random_neighbors(db.conn(), 0x9abcdef0, 0x00, 20, 23455, false).unwrap();
+        assert_eq!(n20.len(), 20);
+        assert!(are_present(&initial_neighbors, &n20));
+
+        // epoch 2.05
+        let n5 =
+            PeerDB::get_random_neighbors(db.conn(), 0x9abcdef0, 0x05, 5, 23455, false).unwrap();
+        assert_eq!(n5.len(), 5);
+        assert!(are_present(&n5, &initial_neighbors));
+        for n in n5 {
+            assert_eq!(n.addr.peer_version, 0x18000005);
+        }
+
+        let n10 =
+            PeerDB::get_random_neighbors(db.conn(), 0x9abcdef0, 0x05, 10, 23455, false).unwrap();
+        assert_eq!(n10.len(), 10);
+        assert!(are_present(&n10, &initial_neighbors));
+        for n in n10 {
+            assert_eq!(n.addr.peer_version, 0x18000005);
+        }
+
+        let n20 =
+            PeerDB::get_random_neighbors(db.conn(), 0x9abcdef0, 0x05, 20, 23455, false).unwrap();
+        assert_eq!(n20.len(), 10); // only 10 such neighbors are recent enough
+        assert!(are_present(&n20, &initial_neighbors));
+        for n in n20 {
+            assert_eq!(n.addr.peer_version, 0x18000005);
+        }
+
+        // post epoch 2.05 -- no such neighbors
+        let n20 =
+            PeerDB::get_random_neighbors(db.conn(), 0x9abcdef0, 0x06, 20, 23455, false).unwrap();
+        assert_eq!(n20.len(), 0);
     }
 
     #[test]

--- a/src/net/neighbors.rs
+++ b/src/net/neighbors.rs
@@ -1709,15 +1709,18 @@ impl NeighborWalk {
 }
 
 impl PeerNetwork {
-    /// Get some initial fresh random neighbor(s) to crawl
+    /// Get some initial fresh random neighbor(s) to crawl,
+    /// given the number of neighbors and current burn block height
     pub fn walk_get_random_neighbors(
         &self,
         num_neighbors: u64,
         block_height: u64,
     ) -> Result<Vec<Neighbor>, net_error> {
+        let cur_epoch = self.get_current_epoch();
         let neighbors = PeerDB::get_random_walk_neighbors(
             &self.peerdb.conn(),
             self.local_peer.network_id,
+            cur_epoch.network_epoch,
             num_neighbors as u32,
             block_height,
         )

--- a/src/net/p2p.rs
+++ b/src/net/p2p.rs
@@ -429,6 +429,17 @@ impl PeerNetwork {
         network
     }
 
+    /// Get the current epoch
+    pub fn get_current_epoch(&self) -> StacksEpoch {
+        let epoch_index = StacksEpoch::find_epoch(&self.epochs, self.chain_view.burn_block_height)
+            .expect(&format!(
+                "BUG: block {} is not in a known epoch",
+                &self.chain_view.burn_block_height
+            ));
+        let epoch = self.epochs[epoch_index].clone();
+        epoch
+    }
+
     /// Do something with the HTTP peer.
     /// NOTE: the HTTP peer is *always* instantiated; it's just an Option<..> so its methods can
     /// receive a ref to the PeerNetwork that contains it.

--- a/src/net/rpc.rs
+++ b/src/net/rpc.rs
@@ -422,6 +422,7 @@ impl RPCNeighborsInfo {
     /// Load neighbor address information from the peer network
     pub fn from_p2p(
         network_id: u32,
+        network_epoch: u8,
         peers: &PeerMap,
         chain_view: &BurnchainView,
         peerdb: &PeerDB,
@@ -429,6 +430,7 @@ impl RPCNeighborsInfo {
         let neighbor_sample = PeerDB::get_random_neighbors(
             peerdb.conn(),
             network_id,
+            network_epoch,
             MAX_NEIGHBORS_DATA_LEN,
             chain_view.burn_block_height,
             false,
@@ -757,9 +759,12 @@ impl ConversationHttp {
         req: &HttpRequestType,
         network: &PeerNetwork,
     ) -> Result<(), net_error> {
+        let epoch = network.get_current_epoch();
+
         let response_metadata = HttpResponseMetadata::from(req);
         let neighbor_data = RPCNeighborsInfo::from_p2p(
             network.local_peer.network_id,
+            epoch.network_epoch,
             &network.peers,
             &network.chain_view,
             &network.peerdb,


### PR DESCRIPTION
This PR updates the peer database query logic to only select for neighbors whose peer version epoch marker meets or exceeds a given epoch marker, which in turn is derived from whatever epoch the node is currently in.  A 2.05 node running in the 2.0 epoch will return neighbors with either `0x00` or `0x05` as their epoch marker, but a 2.05 node running in the 2.05 epoch will only return neighbors with `0x05` (note that the neighbors returned depends not on the epochs the node supports per se, but on where the node is in processing the burnchain).  The logic here prevents a node from serving neighbors that are no longer compatible with the current consensus rules to peers that ask for them -- either via `/v2/neighbors` or via a `GetNeighbors` p2p request.