### PR TITLE
chore: sync costs-2.clar with SIP-012

### DIFF
--- a/src/chainstate/stacks/boot/costs-2.clar
+++ b/src/chainstate/stacks/boot/costs-2.clar
@@ -323,7 +323,7 @@
     (runtime u13400))
 
 (define-read-only (cost_principal_of (n uint))
-    (runtime u235))
+    (runtime u999))
 
 
 (define-read-only (cost_at_block (n uint))


### PR DESCRIPTION
This syncs the (seemingly last) set of changes from SIP-012 to the `costs-2.clar` contract in `next-costs`.