### PR TITLE
Refactor: merge block assembly paths for follower and miner

### DIFF
--- a/src/chainstate/coordinator/tests.rs
+++ b/src/chainstate/coordinator/tests.rs
@@ -492,7 +492,7 @@ fn make_genesis_block_with_recipients(
 
     builder.try_mine_tx(&mut epoch_tx, &coinbase_op).unwrap();
 
-    let block = builder.mine_anchored_block(&mut epoch_tx).unwrap();
+    let block = builder.mine_anchored_block(&mut epoch_tx);
     builder.epoch_finish(epoch_tx);
 
     let commit_outs = if let Some(recipients) = recipients {
@@ -726,7 +726,7 @@ fn make_stacks_block_with_input(
 
     builder.try_mine_tx(&mut epoch_tx, &coinbase_op).unwrap();
 
-    let block = builder.mine_anchored_block(&mut epoch_tx).unwrap();
+    let block = builder.mine_anchored_block(&mut epoch_tx);
     builder.epoch_finish(epoch_tx);
 
     let commit_outs = if let Some(recipients) = recipients {

--- a/src/chainstate/coordinator/tests.rs
+++ b/src/chainstate/coordinator/tests.rs
@@ -465,28 +465,9 @@ fn make_genesis_block_with_recipients(
     .unwrap();
 
     let iconn = sort_db.index_conn();
-    let (
-        mut chainstate_tx,
-        clarity_instance,
-        burn_tip,
-        burn_tip_height,
-        parent_microblocks,
-        parent_consensus_hash,
-        parent_header_hash,
-        mainnet,
-    ) = builder.pre_epoch_begin(state, &iconn).unwrap();
+    let mut miner_epoch_info = builder.pre_epoch_begin(state, &iconn).unwrap();
     let mut epoch_tx = builder
-        .epoch_begin(
-            &mut chainstate_tx,
-            clarity_instance,
-            &iconn,
-            burn_tip,
-            burn_tip_height,
-            parent_microblocks,
-            parent_consensus_hash,
-            parent_header_hash,
-            mainnet,
-        )
+        .epoch_begin(&iconn, &mut miner_epoch_info)
         .unwrap()
         .0;
 
@@ -699,28 +680,9 @@ fn make_stacks_block_with_input(
         next_hash160(),
     )
     .unwrap();
-    let (
-        mut chainstate_tx,
-        clarity_instance,
-        burn_tip,
-        burn_tip_height,
-        parent_microblocks,
-        parent_consensus_hash,
-        parent_header_hash,
-        mainnet,
-    ) = builder.pre_epoch_begin(state, &iconn).unwrap();
+    let mut miner_epoch_info = builder.pre_epoch_begin(state, &iconn).unwrap();
     let mut epoch_tx = builder
-        .epoch_begin(
-            &mut chainstate_tx,
-            clarity_instance,
-            &iconn,
-            burn_tip,
-            burn_tip_height,
-            parent_microblocks,
-            parent_consensus_hash,
-            parent_header_hash,
-            mainnet,
-        )
+        .epoch_begin(&iconn, &mut miner_epoch_info)
         .unwrap()
         .0;
 

--- a/src/chainstate/coordinator/tests.rs
+++ b/src/chainstate/coordinator/tests.rs
@@ -465,10 +465,34 @@ fn make_genesis_block_with_recipients(
     .unwrap();
 
     let iconn = sort_db.index_conn();
-    let mut epoch_tx = builder.epoch_begin(state, &iconn).unwrap().0;
+    let (
+        mut chainstate_tx,
+        clarity_instance,
+        burn_tip,
+        burn_tip_height,
+        parent_microblocks,
+        parent_consensus_hash,
+        parent_header_hash,
+        mainnet,
+    ) = builder.pre_epoch_begin(state, &iconn).unwrap();
+    let mut epoch_tx = builder
+        .epoch_begin(
+            &mut chainstate_tx,
+            clarity_instance,
+            &iconn,
+            burn_tip,
+            burn_tip_height,
+            parent_microblocks,
+            parent_consensus_hash,
+            parent_header_hash,
+            mainnet,
+        )
+        .unwrap()
+        .0;
+
     builder.try_mine_tx(&mut epoch_tx, &coinbase_op).unwrap();
 
-    let block = builder.mine_anchored_block(&mut epoch_tx);
+    let block = builder.mine_anchored_block(&mut epoch_tx).unwrap();
     builder.epoch_finish(epoch_tx);
 
     let commit_outs = if let Some(recipients) = recipients {
@@ -675,10 +699,34 @@ fn make_stacks_block_with_input(
         next_hash160(),
     )
     .unwrap();
-    let mut epoch_tx = builder.epoch_begin(state, &iconn).unwrap().0;
+    let (
+        mut chainstate_tx,
+        clarity_instance,
+        burn_tip,
+        burn_tip_height,
+        parent_microblocks,
+        parent_consensus_hash,
+        parent_header_hash,
+        mainnet,
+    ) = builder.pre_epoch_begin(state, &iconn).unwrap();
+    let mut epoch_tx = builder
+        .epoch_begin(
+            &mut chainstate_tx,
+            clarity_instance,
+            &iconn,
+            burn_tip,
+            burn_tip_height,
+            parent_microblocks,
+            parent_consensus_hash,
+            parent_header_hash,
+            mainnet,
+        )
+        .unwrap()
+        .0;
+
     builder.try_mine_tx(&mut epoch_tx, &coinbase_op).unwrap();
 
-    let block = builder.mine_anchored_block(&mut epoch_tx);
+    let block = builder.mine_anchored_block(&mut epoch_tx).unwrap();
     builder.epoch_finish(epoch_tx);
 
     let commit_outs = if let Some(recipients) = recipients {

--- a/src/chainstate/stacks/db/blocks.rs
+++ b/src/chainstate/stacks/db/blocks.rs
@@ -4314,7 +4314,6 @@ impl StacksChainState {
         ),
         Error,
     > {
-        let applied_epoch_transition;
         let parent_index_hash =
             StacksBlockHeader::make_index_block_hash(&parent_consensus_hash, &parent_header_hash);
 
@@ -4445,10 +4444,8 @@ impl StacksChainState {
         clarity_tx.reset_cost(ExecutionCost::zero());
 
         // is this stacks block the first of a new epoch?
-        let (epoch_transition, mut receipts) =
+        let (applied_epoch_transition, mut receipts) =
             StacksChainState::process_epoch_transition(&mut clarity_tx, burn_tip_height)?;
-
-        applied_epoch_transition = epoch_transition;
 
         // process stacking & transfer operations from bitcoin ops
         receipts.extend(StacksChainState::process_stacking_ops(
@@ -4475,8 +4472,9 @@ impl StacksChainState {
 
     /// This function is called in both `append_block` in blocks.rs (follower) and
     /// `mine_anchored_block` in miner.rs.
-    /// Processes matured miner rewards, alters liquid supply of ustx, processes and returns
-    /// stx lock events, and marks the microblock public key as used.
+    /// Processes matured miner rewards, alters liquid supply of ustx, processes
+    /// stx lock events, and marks the microblock public key as used
+    /// Returns stx lockup events.
     pub fn finish_block(
         clarity_tx: &mut ClarityTx,
         miner_payouts: Option<(MinerReward, Vec<MinerReward>, MinerReward)>,

--- a/src/chainstate/stacks/db/blocks.rs
+++ b/src/chainstate/stacks/db/blocks.rs
@@ -4282,6 +4282,251 @@ impl StacksChainState {
         Ok(parent_miner)
     }
 
+    pub fn setup_block<'a>(
+        chainstate_tx: &'a mut ChainstateTx, // possibly compute inline
+        clarity_instance: &'a mut ClarityInstance,
+        burn_dbconn: &'a dyn BurnStateDB,
+        conn: &Connection,
+        chain_tip: &StacksHeaderInfo, // compute inline
+        burn_tip: BurnchainHeaderHash,
+        burn_tip_height: u32,
+        parent_consensus_hash: ConsensusHash,
+        parent_header_hash: BlockHeaderHash,
+        parent_microblocks: &Vec<StacksMicroblock>,
+        mainnet: bool,               // compute inline
+        miner_id_opt: Option<usize>, //compute inline
+    ) -> Result<
+        (
+            ClarityTx<'a>,
+            Vec<StacksTransactionReceipt>,
+            ExecutionCost,
+            u128,
+            u128,
+            Vec<StacksTransactionReceipt>,
+            Option<(MinerReward, Vec<MinerReward>, MinerReward, MinerRewardInfo)>,
+            StacksEpochId,
+            bool,
+        ),
+        Error,
+    > {
+        let applied_epoch_transition;
+        let parent_index_hash =
+            StacksBlockHeader::make_index_block_hash(&parent_consensus_hash, &parent_header_hash);
+
+        // find matured miner rewards, so we can grant them within the Clarity DB tx.
+        let (latest_matured_miners, matured_miner_parent) = {
+            let latest_miners = StacksChainState::get_scheduled_block_rewards(
+                chainstate_tx.deref_mut(),
+                chain_tip,
+            )?;
+            let parent_miner = StacksChainState::get_parent_matured_miner(
+                chainstate_tx.deref_mut(),
+                mainnet,
+                &latest_miners,
+            )?;
+            (latest_miners, parent_miner)
+        };
+
+        let stacking_burn_ops = SortitionDB::get_stack_stx_ops(conn, &burn_tip)?;
+        let transfer_burn_ops = SortitionDB::get_transfer_stx_ops(conn, &burn_tip)?;
+
+        let parent_block_cost = if miner_id_opt.is_none() || !parent_microblocks.is_empty() {
+            let cost = StacksChainState::get_stacks_block_anchored_cost(
+                &chainstate_tx.deref().deref(),
+                &parent_index_hash,
+            )?
+            .ok_or_else(|| {
+                Error::InvalidStacksBlock(format!(
+                    "Failed to load parent block cost. parent_stacks_block_id = {}",
+                    &parent_index_hash
+                ))
+            })?;
+            // TODO - no longer panicking if follower can't load parent block cost
+            debug!(
+                "Parent block {}/{} cost {:?}",
+                &parent_consensus_hash, &parent_header_hash, &cost
+            );
+            cost
+        } else {
+            ExecutionCost::zero()
+        };
+
+        let mut clarity_tx = StacksChainState::chainstate_block_begin(
+            chainstate_tx,
+            clarity_instance,
+            burn_dbconn,
+            &parent_consensus_hash,
+            &parent_header_hash,
+            &MINER_BLOCK_CONSENSUS_HASH,
+            &MINER_BLOCK_HEADER_HASH,
+        );
+
+        let evaluated_epoch = clarity_tx.get_epoch();
+        clarity_tx.reset_cost(parent_block_cost.clone());
+
+        let matured_miner_rewards_opt = match StacksChainState::find_mature_miner_rewards(
+            &mut clarity_tx,
+            &chain_tip,
+            latest_matured_miners,
+            matured_miner_parent,
+        ) {
+            Ok(miner_rewards_opt) => miner_rewards_opt,
+            Err(e) => {
+                if let Some(_) = miner_id_opt {
+                    return Err(e);
+                } else {
+                    let msg = format!("Failed to load miner rewards: {:?}", &e);
+                    warn!("{}", &msg);
+
+                    clarity_tx.rollback_block();
+                    return Err(Error::InvalidStacksBlock(msg));
+                }
+            }
+        };
+
+        if let Some(miner_id) = miner_id_opt {
+            debug!(
+                "Miner {}: Apply {} parent microblocks",
+                miner_id,
+                parent_microblocks.len()
+            );
+        }
+
+        let t1 = get_epoch_time_ms();
+
+        // process microblock stream.
+        // If we go over-budget, then we can't process this block either (which is by design)
+        let (microblock_fees, microblock_burns, microblock_txs_receipts) =
+            match StacksChainState::process_microblocks_transactions(
+                &mut clarity_tx,
+                &parent_microblocks,
+            ) {
+                Ok((fees, burns, events)) => (fees, burns, events),
+                // self.total_confirmed_streamed_fees += fees as u64;
+                Err((e, mblock_header_hash)) => {
+                    let msg = format!(
+                        "Invalid Stacks microblocks {},{} (offender {}): {:?}",
+                        parent_consensus_hash, parent_header_hash, mblock_header_hash, &e
+                    );
+                    warn!("{}", &msg);
+
+                    return Err(Error::InvalidStacksMicroblock(msg, mblock_header_hash));
+                }
+            };
+
+        let t2 = get_epoch_time_ms();
+
+        if let Some(miner_id) = miner_id_opt {
+            debug!(
+                "Miner {}: Finished applying {} parent microblocks in {}ms\n",
+                miner_id,
+                parent_microblocks.len(),
+                t2.saturating_sub(t1)
+            );
+        }
+        // find microblock cost
+        let mut microblock_cost = clarity_tx.cost_so_far();
+        microblock_cost
+            .sub(&parent_block_cost)
+            .expect("BUG: block_cost + microblock_cost < block_cost");
+
+        // if we get here, then we need to reset the block-cost back to 0 since this begins the
+        // epoch defined by this miner.
+        clarity_tx.reset_cost(ExecutionCost::zero());
+
+        // is this stacks block the first of a new epoch?
+        let (epoch_transition, mut receipts) =
+            StacksChainState::process_epoch_transition(&mut clarity_tx, burn_tip_height)?;
+
+        applied_epoch_transition = epoch_transition;
+
+        // process stacking & transfer operations from bitcoin ops
+        receipts.extend(StacksChainState::process_stacking_ops(
+            &mut clarity_tx,
+            stacking_burn_ops,
+        ));
+        receipts.extend(StacksChainState::process_transfer_ops(
+            &mut clarity_tx,
+            transfer_burn_ops,
+        ));
+
+        Ok((
+            clarity_tx,
+            receipts,
+            microblock_cost,
+            microblock_fees,
+            microblock_burns,
+            microblock_txs_receipts,
+            matured_miner_rewards_opt,
+            evaluated_epoch,
+            applied_epoch_transition,
+        ))
+    }
+
+    /// This function is called in both `append_block` in blocks.rs (follower) and
+    /// `mine_anchored_block` in miner.rs.
+    /// Processes matured miner rewards, alters liquid supply of ustx, processes and returns
+    /// stx lock events, and marks the microblock public key as used.
+    pub fn finish_block(
+        clarity_tx: &mut ClarityTx,
+        miner_payouts: Option<(MinerReward, Vec<MinerReward>, MinerReward)>,
+        block_height: u32,
+        mblock_pubkey_hash: Hash160,
+        is_miner: bool,
+    ) -> Result<Vec<StacksTransactionEvent>, Error> {
+        // add miner payments
+        if let Some((ref miner_reward, ref user_rewards, ref parent_reward)) =
+            miner_payouts.as_ref()
+        {
+            // grant in order by miner, then users
+            let matured_ustx = StacksChainState::process_matured_miner_rewards(
+                clarity_tx,
+                miner_reward,
+                user_rewards,
+                parent_reward,
+            )
+            .expect("FATAL: failed to process miner rewards");
+
+            clarity_tx.increment_ustx_liquid_supply(matured_ustx);
+        }
+
+        // process unlocks
+        let (new_unlocked_ustx, lockup_events) =
+            StacksChainState::process_stx_unlocks(clarity_tx).expect("FATAL: failed to unlock STX");
+
+        clarity_tx.increment_ustx_liquid_supply(new_unlocked_ustx);
+
+        // mark microblock public key as used
+        match StacksChainState::insert_microblock_pubkey_hash(
+            clarity_tx,
+            block_height,
+            &mblock_pubkey_hash,
+        ) {
+            Ok(_) => {
+                debug!(
+                    "Added microblock public key {} at height {}",
+                    &mblock_pubkey_hash, block_height
+                );
+            }
+            Err(e) => {
+                if is_miner {
+                    panic!("FATAL: failed to insert microblock pubkey hash: {:?}", e);
+                } else {
+                    let msg = format!(
+                        "Failed to insert microblock pubkey hash {} at height {}: {:?}",
+                        &mblock_pubkey_hash, block_height, &e
+                    );
+                    warn!("{}", &msg);
+
+                    // clarity_tx.rollback_block();
+                    return Err(Error::InvalidStacksBlock(msg));
+                }
+            }
+        }
+
+        Ok(lockup_events)
+    }
+
     /// Process the next pre-processed staging block.
     /// We've already processed parent_chain_tip.  chain_tip refers to a block we have _not_
     /// processed yet.
@@ -4315,7 +4560,6 @@ impl StacksChainState {
 
         let mainnet = chainstate_tx.get_config().mainnet;
         let next_block_height = block.header.total_work.work;
-        let applied_epoch_transition;
 
         // NEW in 2.05
         // if the parent marked an epoch transition -- i.e. its children necessarily run in
@@ -4341,43 +4585,89 @@ impl StacksChainState {
             }
         }
 
-        // find matured miner rewards, so we can grant them within the Clarity DB tx.
-        let latest_matured_miners = StacksChainState::get_scheduled_block_rewards(
-            chainstate_tx.deref_mut(),
-            &parent_chain_tip,
-        )?;
+        let (parent_consensus_hash, parent_block_hash) = if block.is_first_mined() {
+            // has to be the sentinal hashes if this block has no parent
+            (
+                FIRST_BURNCHAIN_CONSENSUS_HASH.clone(),
+                FIRST_STACKS_BLOCK_HASH.clone(),
+            )
+        } else {
+            (
+                parent_chain_tip.consensus_hash.clone(),
+                parent_chain_tip.anchored_header.block_hash(),
+            )
+        };
 
-        let matured_miner_parent = StacksChainState::get_parent_matured_miner(
-            chainstate_tx.deref_mut(),
+        let (last_microblock_hash, last_microblock_seq) = if microblocks.len() > 0 {
+            let _first_mblock_hash = microblocks[0].block_hash();
+            let num_mblocks = microblocks.len();
+            let last_microblock_hash = microblocks[num_mblocks - 1].block_hash();
+            let last_microblock_seq = microblocks[num_mblocks - 1].header.sequence;
+
+            debug!(
+                "\n\nAppend {} microblocks {}/{}-{} off of {}/{}\n",
+                num_mblocks,
+                chain_tip_consensus_hash,
+                _first_mblock_hash,
+                last_microblock_hash,
+                parent_consensus_hash,
+                parent_block_hash
+            );
+            (last_microblock_hash, last_microblock_seq)
+        } else {
+            (EMPTY_MICROBLOCK_PARENT_HASH.clone(), 0)
+        };
+
+        if last_microblock_hash != block.header.parent_microblock
+            || last_microblock_seq != block.header.parent_microblock_sequence
+        {
+            // the pre-processing step should prevent this from being reached
+            panic!("BUG: received discontiguous headers for processing: {} (seq={}) does not connect to {} (microblock parent is {} (seq {}))",
+                   last_microblock_hash, last_microblock_seq, block.block_hash(), block.header.parent_microblock, block.header.parent_microblock_sequence);
+        }
+
+        // get the burnchain block that precedes this block's sortition
+        let parent_burn_hash = SortitionDB::get_block_snapshot_consensus(
+            &burn_dbconn.tx(),
+            &chain_tip_consensus_hash,
+        )?
+        .expect("BUG: Failed to load snapshot for block snapshot during Stacks block processing")
+        .parent_burn_header_hash;
+
+        let (
+            mut clarity_tx,
+            mut tx_receipts,
+            microblock_execution_cost,
+            microblock_fees,
+            microblock_burns,
+            microblock_txs_receipts,
+            matured_miner_rewards_opt,
+            evaluated_epoch,
+            applied_epoch_transition,
+        ) = StacksChainState::setup_block(
+            chainstate_tx,
+            clarity_instance,
+            burn_dbconn,
+            &burn_dbconn.tx(),
+            &parent_chain_tip,
+            parent_burn_hash,
+            chain_tip_burn_header_height,
+            parent_consensus_hash,
+            parent_block_hash,
+            microblocks,
             mainnet,
-            &latest_matured_miners,
+            None,
         )?;
 
         let (
             scheduled_miner_reward,
-            tx_receipts,
-            microblock_execution_cost,
             block_execution_cost,
             matured_rewards,
             matured_rewards_info,
             parent_burn_block_hash,
             parent_burn_block_height,
             parent_burn_block_timestamp,
-            evaluated_epoch,
         ) = {
-            let (parent_consensus_hash, parent_block_hash) = if block.is_first_mined() {
-                // has to be the sentinal hashes if this block has no parent
-                (
-                    FIRST_BURNCHAIN_CONSENSUS_HASH.clone(),
-                    FIRST_STACKS_BLOCK_HASH.clone(),
-                )
-            } else {
-                (
-                    parent_chain_tip.consensus_hash.clone(),
-                    parent_chain_tip.anchored_header.block_hash(),
-                )
-            };
-
             // get previous burn block stats
             let (parent_burn_block_hash, parent_burn_block_height, parent_burn_block_timestamp) =
                 if block.is_first_mined() {
@@ -4402,94 +4692,6 @@ impl StacksChainState {
                         }
                     }
                 };
-
-            let (last_microblock_hash, last_microblock_seq) = if microblocks.len() > 0 {
-                let _first_mblock_hash = microblocks[0].block_hash();
-                let num_mblocks = microblocks.len();
-                let last_microblock_hash = microblocks[num_mblocks - 1].block_hash();
-                let last_microblock_seq = microblocks[num_mblocks - 1].header.sequence;
-
-                debug!(
-                    "\n\nAppend {} microblocks {}/{}-{} off of {}/{}\n",
-                    num_mblocks,
-                    chain_tip_consensus_hash,
-                    _first_mblock_hash,
-                    last_microblock_hash,
-                    parent_consensus_hash,
-                    parent_block_hash
-                );
-                (last_microblock_hash, last_microblock_seq)
-            } else {
-                (EMPTY_MICROBLOCK_PARENT_HASH.clone(), 0)
-            };
-
-            if last_microblock_hash != block.header.parent_microblock
-                || last_microblock_seq != block.header.parent_microblock_sequence
-            {
-                // the pre-processing step should prevent this from being reached
-                panic!("BUG: received discontiguous headers for processing: {} (seq={}) does not connect to {} (microblock parent is {} (seq {}))",
-                       last_microblock_hash, last_microblock_seq, block.block_hash(), block.header.parent_microblock, block.header.parent_microblock_sequence);
-            }
-
-            // get the burnchain block that precedes this block's sortition
-            let parent_burn_hash = SortitionDB::get_block_snapshot_consensus(
-                &burn_dbconn.tx(),
-                &chain_tip_consensus_hash,
-            )?
-            .expect(
-                "BUG: Failed to load snapshot for block snapshot during Stacks block processing",
-            )
-            .parent_burn_header_hash;
-            let stacking_burn_ops =
-                SortitionDB::get_stack_stx_ops(&burn_dbconn.tx(), &parent_burn_hash)?;
-            let transfer_burn_ops =
-                SortitionDB::get_transfer_stx_ops(&burn_dbconn.tx(), &parent_burn_hash)?;
-
-            let parent_block_cost = StacksChainState::get_stacks_block_anchored_cost(
-                &chainstate_tx.deref().deref(),
-                &StacksBlockHeader::make_index_block_hash(
-                    &parent_consensus_hash,
-                    &parent_block_hash,
-                ),
-            )?
-            .expect(&format!(
-                "BUG: no execution cost found for parent block {}/{}",
-                parent_consensus_hash, parent_block_hash
-            ));
-
-            let mut clarity_tx = StacksChainState::chainstate_block_begin(
-                chainstate_tx,
-                clarity_instance,
-                burn_dbconn,
-                &parent_consensus_hash,
-                &parent_block_hash,
-                &MINER_BLOCK_CONSENSUS_HASH,
-                &MINER_BLOCK_HEADER_HASH,
-            );
-
-            let evaluated_epoch = clarity_tx.get_epoch();
-
-            debug!(
-                "Parent block {}/{} cost {:?}",
-                &parent_consensus_hash, &parent_block_hash, &parent_block_cost
-            );
-            clarity_tx.reset_cost(parent_block_cost.clone());
-
-            let matured_miner_rewards_opt = match StacksChainState::find_mature_miner_rewards(
-                &mut clarity_tx,
-                parent_chain_tip,
-                latest_matured_miners,
-                matured_miner_parent,
-            ) {
-                Ok(miner_rewards_opt) => miner_rewards_opt,
-                Err(e) => {
-                    let msg = format!("Failed to load miner rewards: {:?}", &e);
-                    warn!("{}", &msg);
-
-                    clarity_tx.rollback_block();
-                    return Err(Error::InvalidStacksBlock(msg));
-                }
-            };
 
             // validation check -- is this microblock public key hash new to this fork?  It must
             // be, or this block is invalid.
@@ -4524,42 +4726,6 @@ impl StacksChainState {
                 }
             }
 
-            // process microblock stream.
-            // If we go over-budget, then we can't process this block either (which is by design)
-            let (microblock_fees, microblock_burns, microblock_txs_receipts) =
-                match StacksChainState::process_microblocks_transactions(
-                    &mut clarity_tx,
-                    &microblocks,
-                ) {
-                    Err((e, offending_mblock_header_hash)) => {
-                        let msg = format!(
-                            "Invalid Stacks microblocks {},{} (offender {}): {:?}",
-                            block.header.parent_microblock,
-                            block.header.parent_microblock_sequence,
-                            offending_mblock_header_hash,
-                            &e
-                        );
-                        warn!("{}", &msg);
-
-                        clarity_tx.rollback_block();
-                        return Err(Error::InvalidStacksMicroblock(
-                            msg,
-                            offending_mblock_header_hash,
-                        ));
-                    }
-                    Ok((fees, burns, events)) => (fees, burns, events),
-                };
-
-            // find microblock cost
-            let mut microblock_cost = clarity_tx.cost_so_far();
-            microblock_cost
-                .sub(&parent_block_cost)
-                .expect("BUG: block_cost + microblock_cost < block_cost");
-
-            // if we get here, then we need to reset the block-cost back to 0 since this begins the
-            // epoch defined by this miner.
-            clarity_tx.reset_cost(ExecutionCost::zero());
-
             debug!("Append block";
                    "block" => %format!("{}/{}", chain_tip_consensus_hash, block.block_hash()),
                    "parent_block" => %format!("{}/{}", parent_consensus_hash, parent_block_hash),
@@ -4569,25 +4735,6 @@ impl StacksChainState {
                    "microblock_parent_seq" => %last_microblock_seq,
                    "microblock_parent_count" => %microblocks.len(),
                    "evaluated_epoch" => %evaluated_epoch);
-
-            // is this stacks block the first of a new epoch?
-            let (epoch_transition, mut receipts) = StacksChainState::process_epoch_transition(
-                &mut clarity_tx,
-                chain_tip_burn_header_height,
-            )?;
-
-            applied_epoch_transition = epoch_transition;
-
-            // process stacking operations from bitcoin ops
-            receipts.extend(StacksChainState::process_stacking_ops(
-                &mut clarity_tx,
-                stacking_burn_ops,
-            ));
-
-            receipts.extend(StacksChainState::process_transfer_ops(
-                &mut clarity_tx,
-                transfer_burn_ops,
-            ));
 
             // process anchored block
             let (block_fees, block_burns, txs_receipts) =
@@ -4604,40 +4751,26 @@ impl StacksChainState {
                     }
                 };
 
-            receipts.extend(txs_receipts.into_iter());
+            tx_receipts.extend(txs_receipts.into_iter());
 
             let block_cost = clarity_tx.cost_so_far();
 
-            // grant matured miner rewards
-            let new_liquid_miner_ustx =
-                if let Some((ref miner_reward, ref user_rewards, ref parent_miner_reward, _)) =
-                    matured_miner_rewards_opt.as_ref()
-                {
-                    // grant in order by miner, then users
-                    StacksChainState::process_matured_miner_rewards(
-                        &mut clarity_tx,
-                        miner_reward,
-                        user_rewards,
-                        parent_miner_reward,
-                    )?
-                } else {
-                    0
-                };
-
-            clarity_tx.increment_ustx_liquid_supply(new_liquid_miner_ustx);
-
             // obtain reward info for receipt
-            let (matured_rewards, matured_rewards_info) =
+            let (matured_rewards, matured_rewards_info, miner_payouts_opt) =
                 if let Some((miner_reward, mut user_rewards, parent_reward, reward_ptr)) =
                     matured_miner_rewards_opt
                 {
                     let mut ret = vec![];
-                    ret.push(miner_reward);
+                    ret.push(miner_reward.clone());
                     ret.append(&mut user_rewards);
-                    ret.push(parent_reward);
-                    (ret, Some(reward_ptr))
+                    ret.push(parent_reward.clone());
+                    (
+                        ret,
+                        Some(reward_ptr),
+                        Some((miner_reward, user_rewards, parent_reward)),
+                    )
                 } else {
-                    (vec![], None)
+                    (vec![], None, None)
                 };
 
             // total burns
@@ -4645,48 +4778,35 @@ impl StacksChainState {
                 .checked_add(microblock_burns)
                 .expect("Overflow: Too many STX burnt");
 
-            // unlock any uSTX
-            let (new_unlocked_ustx, mut lockup_events) =
-                StacksChainState::process_stx_unlocks(&mut clarity_tx)?;
+            let mut lockup_events = match StacksChainState::finish_block(
+                &mut clarity_tx,
+                miner_payouts_opt,
+                block.header.total_work.work as u32,
+                block.header.microblock_pubkey_hash,
+                false,
+            ) {
+                Err(Error::InvalidStacksBlock(e)) => {
+                    clarity_tx.rollback_block();
+                    return Err(Error::InvalidStacksBlock(e));
+                }
+                Err(e) => return Err(e),
+                Ok(lockup_events) => lockup_events,
+            };
 
             // if any, append lockups events to the coinbase receipt
             if lockup_events.len() > 0 {
                 // Receipts are appended in order, so the first receipt should be
                 // the one of the coinbase transaction
-                if let Some(receipt) = receipts.get_mut(0) {
+                if let Some(receipt) = tx_receipts.get_mut(0) {
                     if receipt.is_coinbase_tx() {
                         receipt.events.append(&mut lockup_events);
+                    } else {
+                        warn!("Unable to attach lockups events, block's first transaction is not a coinbase transaction")
                     }
                 } else {
-                    warn!("Unable to attach lockups events, first block's transaction is not a coinbase transaction")
+                    warn!("Unable to attach lockups events, block's first transaction is not a coinbase transaction")
                 }
             }
-
-            clarity_tx.increment_ustx_liquid_supply(new_unlocked_ustx);
-
-            // record that this microblock public key hash was used at this height
-            match StacksChainState::insert_microblock_pubkey_hash(
-                &mut clarity_tx,
-                block.header.total_work.work as u32,
-                &block.header.microblock_pubkey_hash,
-            ) {
-                Ok(_) => {
-                    debug!(
-                        "Added microblock public key {} at height {}",
-                        &block.header.microblock_pubkey_hash, block.header.total_work.work
-                    );
-                }
-                Err(e) => {
-                    let msg = format!(
-                        "Failed to insert microblock pubkey hash {} at height {}: {:?}",
-                        &block.header.microblock_pubkey_hash, block.header.total_work.work, &e
-                    );
-                    warn!("{}", &msg);
-
-                    clarity_tx.rollback_block();
-                    return Err(Error::InvalidStacksBlock(msg));
-                }
-            };
 
             let root_hash = clarity_tx.get_root_hash();
             if root_hash != block.header.state_index_root {
@@ -4703,7 +4823,7 @@ impl StacksChainState {
             }
 
             debug!("Reached state root {}", root_hash;
-                   "microblock cost" => %microblock_cost,
+                   "microblock cost" => %microblock_execution_cost,
                    "block cost" => %block_cost);
 
             // good to go!
@@ -4742,19 +4862,16 @@ impl StacksChainState {
             )
             .expect("FATAL: parsed and processed a block without a coinbase");
 
-            receipts.extend(microblock_txs_receipts.into_iter());
+            tx_receipts.extend(microblock_txs_receipts.into_iter());
 
             (
                 scheduled_miner_reward,
-                receipts,
-                microblock_cost,
                 block_cost,
                 matured_rewards,
                 matured_rewards_info,
                 parent_burn_block_hash,
                 parent_burn_block_height,
                 parent_burn_block_timestamp,
-                evaluated_epoch,
             )
         };
 

--- a/src/chainstate/stacks/miner.rs
+++ b/src/chainstate/stacks/miner.rs
@@ -1025,7 +1025,7 @@ impl StacksBlockBuilder {
     /// Finish building the anchored block.
     /// TODO: expand to deny mining a block whose anchored static checks fail (and allow the caller
     /// to disable this, in order to test mining invalid blocks)
-    /// returns: stacks block
+    /// Returns: stacks block
     pub fn mine_anchored_block(&mut self, clarity_tx: &mut ClarityTx) -> StacksBlock {
         assert!(!self.anchored_done);
         StacksChainState::finish_block(
@@ -1214,7 +1214,7 @@ impl StacksBlockBuilder {
             self.set_parent_microblock(&EMPTY_MICROBLOCK_PARENT_HASH, 0);
         } else {
             let num_mblocks = parent_microblocks.len();
-            let last_mblock_hdr = parent_microblocks[num_mblocks - 1].clone().header;
+            let last_mblock_hdr = parent_microblocks[num_mblocks - 1].header.clone();
             self.set_parent_microblock(&last_mblock_hdr.block_hash(), last_mblock_hdr.sequence);
         };
 

--- a/src/chainstate/stacks/mod.rs
+++ b/src/chainstate/stacks/mod.rs
@@ -868,6 +868,8 @@ pub struct StacksBlockBuilder {
     prev_microblock_header: StacksMicroblockHeader,
     miner_privkey: StacksPrivateKey,
     miner_payouts: Option<(MinerReward, Vec<MinerReward>, MinerReward)>,
+    parent_consensus_hash: ConsensusHash,
+    parent_header_hash: BlockHeaderHash,
     parent_microblock_hash: Option<BlockHeaderHash>,
     miner_id: usize,
 }

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -3403,30 +3403,11 @@ pub mod test {
                         StacksChainState::open(false, network_id, &chainstate_path).unwrap();
                     let sort_iconn = sortdb.index_conn();
 
-                    let (
-                        mut chainstate_tx,
-                        clarity_instance,
-                        burn_tip,
-                        burn_tip_height,
-                        parent_microblocks,
-                        parent_consensus_hash,
-                        parent_header_hash,
-                        mainnet,
-                    ) = builder
+                    let mut miner_epoch_info = builder
                         .pre_epoch_begin(&mut miner_chainstate, &sort_iconn)
                         .unwrap();
                     let mut epoch = builder
-                        .epoch_begin(
-                            &mut chainstate_tx,
-                            clarity_instance,
-                            &sort_iconn,
-                            burn_tip,
-                            burn_tip_height,
-                            parent_microblocks,
-                            parent_consensus_hash,
-                            parent_header_hash,
-                            mainnet,
-                        )
+                        .epoch_begin(&sort_iconn, &mut miner_epoch_info)
                         .unwrap()
                         .0;
 

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -3402,8 +3402,31 @@ pub mod test {
                     let (mut miner_chainstate, _) =
                         StacksChainState::open(false, network_id, &chainstate_path).unwrap();
                     let sort_iconn = sortdb.index_conn();
+
+                    let (
+                        mut chainstate_tx,
+                        clarity_instance,
+                        burn_tip,
+                        burn_tip_height,
+                        parent_microblocks,
+                        parent_consensus_hash,
+                        parent_header_hash,
+                        mainnet,
+                    ) = builder
+                        .pre_epoch_begin(&mut miner_chainstate, &sort_iconn)
+                        .unwrap();
                     let mut epoch = builder
-                        .epoch_begin(&mut miner_chainstate, &sort_iconn)
+                        .epoch_begin(
+                            &mut chainstate_tx,
+                            clarity_instance,
+                            &sort_iconn,
+                            burn_tip,
+                            burn_tip_height,
+                            parent_microblocks,
+                            parent_consensus_hash,
+                            parent_header_hash,
+                            mainnet,
+                        )
                         .unwrap()
                         .0;
 


### PR DESCRIPTION
Fixes #2914

Added `setup_block` and `finish_block` to consolidate some logic in block assembly. 
Refactored following functions:
- `epoch_begin` in `miner.rs`
- `append_block` in `chainstate/stacks/db/blocks.rs`

Reviewer notes: 
- The one change I'm aware of between the existing implementation and my refactor is that the follower used to panic if the call to `get_stacks_block_anchored_cost` fails (when getting the parent execution cost). The code now returns an error. I can make this panic if need be. 

To review this, I went through the code paths of both the follower and miner and ensured all the logic was being executed. 
- follower: checked that all the lines in `append_block` are still being called (and in a order that still makes sense). 
- miner: checked that the logic in `epoch_begin` and `mine_anchored_block` is preserved. 

Tests: 
Since this was a refactor, no new tests were added. 
