### PR TITLE
Stacks 2.05: add integration test to verify that the miner can pack a 2.05-sized epoch into a microblock stream

### DIFF
--- a/.github/workflows/bitcoin-tests.yml
+++ b/.github/workflows/bitcoin-tests.yml
@@ -57,6 +57,7 @@ jobs:
           - tests::epoch_205::transition_empty_blocks
           - tests::epoch_205::test_cost_limit_switch_version205
           - tests::epoch_205::test_exact_block_costs
+          - tests::epoch_205::bigger_microblock_streams_in_2_05
     steps:
       - uses: actions/checkout@v2
       - name: Download docker image

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -1111,6 +1111,7 @@ fn spawn_miner_relayer(
                             else {
                                 debug!("Relayer: reset microblock miner state");
                                 microblock_miner_state = None;
+                                set_processed_counter(&microblocks_processed, 0);
                             }
                         }
 

--- a/testnet/stacks-node/src/tests/epoch_205.rs
+++ b/testnet/stacks-node/src/tests/epoch_205.rs
@@ -2,6 +2,7 @@ use stacks::util::get_epoch_time_secs;
 use std::collections::HashMap;
 use std::env;
 use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::thread;
 
@@ -21,6 +22,7 @@ use stacks::types::chainstate::BurnchainHeaderHash;
 use stacks::types::chainstate::StacksAddress;
 use stacks::types::chainstate::StacksBlockHeader;
 use stacks::util::hash::hex_bytes;
+use stacks::util::sleep_ms;
 use stacks::vm::types::PrincipalData;
 use stacks::vm::ContractName;
 use std::convert::TryFrom;
@@ -32,6 +34,7 @@ use crate::tests::bitcoin_regtest::BitcoinCoreController;
 use crate::tests::make_contract_call;
 use crate::tests::make_contract_call_mblock_only;
 use crate::tests::make_contract_publish;
+use crate::tests::make_contract_publish_microblock_only;
 use crate::tests::neon_integrations::*;
 use crate::tests::to_addr;
 use crate::BitcoinRegtestController;
@@ -911,5 +914,294 @@ fn test_cost_limit_switch_version205() {
     );
     assert_eq!(increment_calls_bob.len(), 0);
 
+    channel.stop_chains_coordinator();
+}
+
+// mine a stream of microblocks, and verify that microblock streams can get bigger after the epoch
+// transition
+#[test]
+#[ignore]
+fn bigger_microblock_streams_in_2_05() {
+    if env::var("BITCOIND_TEST") != Ok("1".into()) {
+        return;
+    }
+
+    let spender_sks: Vec<_> = (0..20)
+        .into_iter()
+        .map(|_| StacksPrivateKey::new())
+        .collect();
+    let spender_addrs: Vec<PrincipalData> = spender_sks.iter().map(|x| to_addr(x).into()).collect();
+
+    let txs: Vec<Vec<_>> = spender_sks
+        .iter()
+        .enumerate()
+        .map(|(ix, spender_sk)| {
+            // almost fills a whole block
+            make_contract_publish_microblock_only(
+                spender_sk,
+                0,
+                1049230,
+                &format!("large-{}", ix),
+                &format!("
+                    ;; a single one of these transactions consumes over half the runtime budget
+                    (define-constant BUFF_TO_BYTE (list 
+                       0x00 0x01 0x02 0x03 0x04 0x05 0x06 0x07 0x08 0x09 0x0a 0x0b 0x0c 0x0d 0x0e 0x0f
+                       0x10 0x11 0x12 0x13 0x14 0x15 0x16 0x17 0x18 0x19 0x1a 0x1b 0x1c 0x1d 0x1e 0x1f
+                       0x20 0x21 0x22 0x23 0x24 0x25 0x26 0x27 0x28 0x29 0x2a 0x2b 0x2c 0x2d 0x2e 0x2f
+                       0x30 0x31 0x32 0x33 0x34 0x35 0x36 0x37 0x38 0x39 0x3a 0x3b 0x3c 0x3d 0x3e 0x3f
+                       0x40 0x41 0x42 0x43 0x44 0x45 0x46 0x47 0x48 0x49 0x4a 0x4b 0x4c 0x4d 0x4e 0x4f
+                       0x50 0x51 0x52 0x53 0x54 0x55 0x56 0x57 0x58 0x59 0x5a 0x5b 0x5c 0x5d 0x5e 0x5f
+                       0x60 0x61 0x62 0x63 0x64 0x65 0x66 0x67 0x68 0x69 0x6a 0x6b 0x6c 0x6d 0x6e 0x6f
+                       0x70 0x71 0x72 0x73 0x74 0x75 0x76 0x77 0x78 0x79 0x7a 0x7b 0x7c 0x7d 0x7e 0x7f
+                       0x80 0x81 0x82 0x83 0x84 0x85 0x86 0x87 0x88 0x89 0x8a 0x8b 0x8c 0x8d 0x8e 0x8f
+                       0x90 0x91 0x92 0x93 0x94 0x95 0x96 0x97 0x98 0x99 0x9a 0x9b 0x9c 0x9d 0x9e 0x9f
+                       0xa0 0xa1 0xa2 0xa3 0xa4 0xa5 0xa6 0xa7 0xa8 0xa9 0xaa 0xab 0xac 0xad 0xae 0xaf
+                       0xb0 0xb1 0xb2 0xb3 0xb4 0xb5 0xb6 0xb7 0xb8 0xb9 0xba 0xbb 0xbc 0xbd 0xbe 0xbf
+                       0xc0 0xc1 0xc2 0xc3 0xc4 0xc5 0xc6 0xc7 0xc8 0xc9 0xca 0xcb 0xcc 0xcd 0xce 0xcf
+                       0xd0 0xd1 0xd2 0xd3 0xd4 0xd5 0xd6 0xd7 0xd8 0xd9 0xda 0xdb 0xdc 0xdd 0xde 0xdf
+                       0xe0 0xe1 0xe2 0xe3 0xe4 0xe5 0xe6 0xe7 0xe8 0xe9 0xea 0xeb 0xec 0xed 0xee 0xef
+                       0xf0 0xf1 0xf2 0xf3 0xf4 0xf5 0xf6 0xf7 0xf8 0xf9 0xfa 0xfb 0xfc 0xfd 0xfe 0xff
+                    ))
+                    (define-private (crash-me-folder (input (buff 1)) (ctr uint))
+                        (begin
+                            (unwrap-panic (index-of BUFF_TO_BYTE input))
+                            (unwrap-panic (index-of BUFF_TO_BYTE input))
+                            (unwrap-panic (index-of BUFF_TO_BYTE input))
+                            (unwrap-panic (index-of BUFF_TO_BYTE input))
+                            (unwrap-panic (index-of BUFF_TO_BYTE input))
+                            (unwrap-panic (index-of BUFF_TO_BYTE input))
+                            (unwrap-panic (index-of BUFF_TO_BYTE input))
+                            (unwrap-panic (index-of BUFF_TO_BYTE input))
+                            (+ u1 ctr)
+                        )
+                    )
+                    (define-public (crash-me (name (string-ascii 128)))
+                        (begin
+                            (fold crash-me-folder BUFF_TO_BYTE u0)
+                            (print name)
+                            (ok u0)
+                        )
+                    )
+                    (begin
+                        (crash-me \"{}\"))
+                    ",
+                    &format!("large-contract-{}", &ix)
+                )
+            )
+        })
+        .collect();
+
+    let (mut conf, miner_account) = neon_integration_test_conf();
+
+    for spender_addr in spender_addrs.iter() {
+        conf.initial_balances.push(InitialBalance {
+            address: spender_addr.clone(),
+            amount: 10492300000,
+        });
+    }
+
+    conf.node.mine_microblocks = true;
+    conf.node.wait_time_for_microblocks = 1000;
+    conf.node.microblock_frequency = 1000;
+    conf.node.max_microblocks = 65536;
+    conf.burnchain.max_rbf = 1000000;
+
+    conf.miner.min_tx_fee = 1;
+    conf.miner.first_attempt_time_ms = i64::max_value() as u64;
+    conf.miner.subsequent_attempt_time_ms = i64::max_value() as u64;
+
+    conf.burnchain.epochs = Some(vec![
+        StacksEpoch {
+            epoch_id: StacksEpochId::Epoch20,
+            start_height: 0,
+            end_height: 208,
+            block_limit: ExecutionCost {
+                write_length: 15000000,
+                write_count: 7750,
+                read_length: 100000000,
+                read_count: 7750,
+                runtime: 5000000000,
+            },
+            network_epoch: PEER_VERSION_EPOCH_2_0,
+        },
+        StacksEpoch {
+            epoch_id: StacksEpochId::Epoch2_05,
+            start_height: 208,
+            end_height: 9223372036854775807,
+            block_limit: ExecutionCost {
+                write_length: 15000000 * 2,
+                write_count: 7750 * 2,
+                read_length: 100000000 * 2,
+                read_count: 7750 * 2,
+                runtime: 5000000000 * 2,
+            },
+            network_epoch: PEER_VERSION_EPOCH_2_05,
+        },
+    ]);
+
+    test_observer::spawn();
+    conf.events_observers.push(EventObserverConfig {
+        endpoint: format!("localhost:{}", test_observer::EVENT_OBSERVER_PORT),
+        events_keys: vec![EventKeyType::AnyEvent],
+    });
+
+    let mut btcd_controller = BitcoinCoreController::new(conf.clone());
+    btcd_controller
+        .start_bitcoind()
+        .map_err(|_e| ())
+        .expect("Failed starting bitcoind");
+
+    let mut btc_regtest_controller = BitcoinRegtestController::new(conf.clone(), None);
+    let http_origin = format!("http://{}", &conf.node.rpc_bind);
+
+    btc_regtest_controller.bootstrap_chain(201);
+
+    eprintln!("Chain bootstrapped...");
+
+    let mut run_loop = neon::RunLoop::new(conf);
+    let blocks_processed = run_loop.get_blocks_processed_arc();
+    let microblocks_processed = run_loop.get_microblocks_processed_arc();
+
+    let channel = run_loop.get_coordinator_channel().unwrap();
+
+    thread::spawn(move || run_loop.start(None, 0));
+
+    // give the run loop some time to start up!
+    wait_for_runloop(&blocks_processed);
+
+    // first block wakes up the run loop
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+
+    // first block will hold our VRF registration
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+
+    // second block will be the first mined Stacks block
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+
+    // let's query the miner's account nonce:
+    let account = get_account(&http_origin, &miner_account);
+    assert_eq!(account.nonce, 1);
+    assert_eq!(account.balance, 0);
+
+    for spender_addr in spender_addrs.iter() {
+        let account = get_account(&http_origin, &spender_addr);
+        assert_eq!(account.nonce, 0);
+        assert_eq!(account.balance, 10492300000);
+    }
+
+    let mut ctr = 0;
+    while ctr < txs.len() {
+        submit_tx(&http_origin, &txs[ctr]);
+        if !wait_for_microblocks(&microblocks_processed, 180) {
+            // we time out if we *can't* mine any more microblocks
+            break;
+        }
+        ctr += 1;
+    }
+
+    // only one fit
+    assert_eq!(ctr, 1);
+    sleep_ms(5_000);
+
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+
+    eprintln!("First confirmed microblock stream!");
+
+    microblocks_processed.store(0, Ordering::SeqCst);
+
+    // send the rest of the transactions
+    while ctr < txs.len() {
+        submit_tx(&http_origin, &txs[ctr]);
+        ctr += 1;
+    }
+    wait_for_microblocks(&microblocks_processed, 180);
+
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+
+    eprintln!("Second confirmed microblock stream!");
+
+    wait_for_microblocks(&microblocks_processed, 180);
+
+    // confirm it
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+    wait_for_microblocks(&microblocks_processed, 180);
+
+    eprintln!("expect epoch transition");
+
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+    wait_for_microblocks(&microblocks_processed, 180);
+
+    eprintln!("expect microblock stream");
+
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+    wait_for_microblocks(&microblocks_processed, 180);
+
+    // this test can sometimes miss a mine block event.
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+
+    let blocks = test_observer::get_blocks();
+    assert!(blocks.len() >= 5, "Should have produced at least 5 blocks");
+
+    let mut max_big_txs_per_microblock_20 = 0;
+    let mut total_big_txs_per_microblock_20 = 0;
+
+    let mut max_big_txs_per_microblock_205 = 0;
+    let mut total_big_txs_per_microblock_205 = 0;
+
+    let mut in_205 = false;
+
+    // NOTE: this only counts the number of txs per stream, not in each microblock
+    for block in blocks {
+        let transactions = block.get("transactions").unwrap().as_array().unwrap();
+        eprintln!("{}", transactions.len());
+
+        let mut num_big_microblock_txs = 0;
+
+        for tx in transactions.iter() {
+            let raw_tx = tx.get("raw_tx").unwrap().as_str().unwrap();
+            if raw_tx == "0x00" {
+                continue;
+            }
+            let tx_bytes = hex_bytes(&raw_tx[2..]).unwrap();
+            let parsed = StacksTransaction::consensus_deserialize(&mut &tx_bytes[..]).unwrap();
+            if let TransactionPayload::SmartContract(tsc) = parsed.payload {
+                if tsc.name.to_string().find("costs-2").is_some() {
+                    in_205 = true;
+                }
+                if tsc.name.to_string().find("large").is_some() {
+                    if in_205 {
+                        num_big_microblock_txs += 1;
+                        total_big_txs_per_microblock_205 += 1;
+                    } else {
+                        num_big_microblock_txs += 1;
+                        total_big_txs_per_microblock_20 += 1;
+                    }
+                }
+            }
+        }
+        if in_205 && num_big_microblock_txs > max_big_txs_per_microblock_205 {
+            max_big_txs_per_microblock_205 = num_big_microblock_txs;
+        }
+        if !in_205 && num_big_microblock_txs > max_big_txs_per_microblock_20 {
+            max_big_txs_per_microblock_20 = num_big_microblock_txs;
+        }
+    }
+
+    eprintln!(
+        "max_big_txs_per_microblock_20: {}, total_big_txs_per_microblock_20: {}",
+        max_big_txs_per_microblock_20, total_big_txs_per_microblock_20
+    );
+    eprintln!(
+        "max_big_txs_per_microblock_205: {}, total_big_txs_per_microblock_205: {}",
+        max_big_txs_per_microblock_205, total_big_txs_per_microblock_205
+    );
+
+    assert!(max_big_txs_per_microblock_20 < 2);
+    assert!(total_big_txs_per_microblock_20 < 2);
+
+    assert!(max_big_txs_per_microblock_205 >= 18);
+    assert!(total_big_txs_per_microblock_205 >= 18);
+
+    test_observer::clear();
     channel.stop_chains_coordinator();
 }

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -331,7 +331,7 @@ pub fn wait_for_runloop(blocks_processed: &Arc<AtomicU64>) {
     }
 }
 
-fn wait_for_microblocks(microblocks_processed: &Arc<AtomicU64>, timeout: u64) -> bool {
+pub fn wait_for_microblocks(microblocks_processed: &Arc<AtomicU64>, timeout: u64) -> bool {
     let mut current = microblocks_processed.load(Ordering::SeqCst);
     let start = Instant::now();
     info!("Waiting for next microblock");

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -331,10 +331,12 @@ pub fn wait_for_runloop(blocks_processed: &Arc<AtomicU64>) {
     }
 }
 
+/// Wait for at least one microblock to be mined, up to a given timeout (in seconds).
+/// Returns true if the microblock was mined; false if we timed out.
 pub fn wait_for_microblocks(microblocks_processed: &Arc<AtomicU64>, timeout: u64) -> bool {
     let mut current = microblocks_processed.load(Ordering::SeqCst);
     let start = Instant::now();
-    info!("Waiting for next microblock");
+    info!("Waiting for next microblock (current = {})", &current);
     loop {
         let now = microblocks_processed.load(Ordering::SeqCst);
         if now == 0 && current != 0 {
@@ -351,12 +353,13 @@ pub fn wait_for_microblocks(microblocks_processed: &Arc<AtomicU64>, timeout: u64
         }
 
         if start.elapsed() > Duration::from_secs(timeout) {
-            warn!("Timed out waiting for microblocks to process");
+            warn!("Timed out waiting for microblocks to process ({})", timeout);
             return false;
         }
 
         thread::sleep(Duration::from_millis(100));
     }
+    info!("Next microblock acknowledged");
     return true;
 }
 


### PR DESCRIPTION
No new features in this PR; this just fixes #2912 by adding an integration test to verify that we can pack a *lot* more compute power into a microblock stream after the 2.05 epoch transition.