### PR TITLE
Chore: remove token from codecov.yml

### DIFF
--- a/.github/actions/bitcoin-int-tests/Dockerfile.bitcoin-tests
+++ b/.github/actions/bitcoin-int-tests/Dockerfile.bitcoin-tests
@@ -6,7 +6,7 @@ ENV BITCOIND_TEST 1
 RUN cargo build && \
     cargo test -- --test-threads 1 --ignored "$test_name"
 
-RUN grcov . --binary-path ../../target/debug/ -s ../.. -t lcov --branch --ignore-not-existing --ignore "/*" -o lcov.info
+RUN grcov . --binary-path ../../target/debug/ -s ../.. -t lcov --branch --ignore-not-existing --ignore "/*" -o /lcov.info
 
 FROM scratch AS export-stage
-COPY --from=test /src/lcov.info /
+COPY --from=test /lcov.info /

--- a/.github/actions/bitcoin-int-tests/Dockerfile.bitcoin-tests
+++ b/.github/actions/bitcoin-int-tests/Dockerfile.bitcoin-tests
@@ -1,4 +1,4 @@
-FROM stacks-node:integrations
+FROM stacks-node:integrations AS test
 
 ARG test_name
 ENV BITCOIND_TEST 1
@@ -6,7 +6,7 @@ ENV BITCOIND_TEST 1
 RUN cargo build && \
     cargo test -- --test-threads 1 --ignored "$test_name"
 
-RUN grcov . --binary-path ../../target/debug/ -s ../.. -t lcov --branch --ignore-not-existing --ignore "/*" -o lcov.info && \
-    curl -Os https://uploader.codecov.io/latest/linux/codecov && \
-    chmod +x codecov && \
-    ./codecov --name "$test_name"
+RUN grcov . --binary-path ../../target/debug/ -s ../.. -t lcov --branch --ignore-not-existing --ignore "/*" -o lcov.info
+
+FROM scratch AS export-stage
+COPY --from=test /build/lcov.info /

--- a/.github/actions/bitcoin-int-tests/Dockerfile.bitcoin-tests
+++ b/.github/actions/bitcoin-int-tests/Dockerfile.bitcoin-tests
@@ -9,4 +9,4 @@ RUN cargo build && \
 RUN grcov . --binary-path ../../target/debug/ -s ../.. -t lcov --branch --ignore-not-existing --ignore "/*" -o lcov.info
 
 FROM scratch AS export-stage
-COPY --from=test /build/lcov.info /
+COPY --from=test /src/lcov.info /

--- a/.github/actions/bitcoin-int-tests/Dockerfile.code-cov
+++ b/.github/actions/bitcoin-int-tests/Dockerfile.code-cov
@@ -1,4 +1,4 @@
-FROM rust:bullseye AS build
+FROM rust:bullseye AS test
 
 WORKDIR /build
 
@@ -15,7 +15,7 @@ RUN cargo build && \
     cargo test
 
 # Generate coverage report and upload it to codecov
-RUN grcov . --binary-path ./target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore "/*" -o lcov.info && \
-    curl -Os https://uploader.codecov.io/latest/linux/codecov && \
-    chmod +x codecov && \
-    ./codecov --name "unit_tests"
+RUN grcov . --binary-path ./target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore "/*" -o lcov.info
+
+FROM scratch AS export-stage
+COPY --from=test /build/lcov.info /

--- a/.github/actions/bitcoin-int-tests/Dockerfile.large-genesis
+++ b/.github/actions/bitcoin-int-tests/Dockerfile.large-genesis
@@ -1,4 +1,4 @@
-FROM rust:bullseye
+FROM rust:bullseye AS test
 
 WORKDIR /src
 
@@ -22,7 +22,7 @@ RUN cargo test --no-run --workspace && \
 ENV BITCOIND_TEST 1
 RUN cd testnet/stacks-node && cargo test --release --features prod-genesis-chainstate -- --test-threads 1 --ignored neon_integrations::bitcoind_integration_test
 
-RUN grcov . --binary-path ./target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore "/*" -o lcov.info && \
-    curl -Os https://uploader.codecov.io/latest/linux/codecov && \
-    chmod +x codecov && \
-    ./codecov --name "large_genesis"
+RUN grcov . --binary-path ./target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore "/*" -o lcov.info
+
+FROM scratch AS export-stage
+COPY --from=test /build/lcov.info /

--- a/.github/actions/bitcoin-int-tests/Dockerfile.large-genesis
+++ b/.github/actions/bitcoin-int-tests/Dockerfile.large-genesis
@@ -25,4 +25,4 @@ RUN cd testnet/stacks-node && cargo test --release --features prod-genesis-chain
 RUN grcov . --binary-path ./target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore "/*" -o lcov.info
 
 FROM scratch AS export-stage
-COPY --from=test /build/lcov.info /
+COPY --from=test /src/lcov.info /

--- a/.github/workflows/bitcoin-tests.yml
+++ b/.github/workflows/bitcoin-tests.yml
@@ -70,7 +70,12 @@ jobs:
         env:
           DOCKER_BUILDKIT: 1
           TEST_NAME: ${{ matrix.test-name }}
-        run: docker build --build-arg test_name=${{ matrix.test-name }} -f ./.github/actions/bitcoin-int-tests/Dockerfile.bitcoin-tests .
+        run: docker build -o coverage-output --build-arg test_name=${{ matrix.test-name }} -f ./.github/actions/bitcoin-int-tests/Dockerfile.bitcoin-tests .
+      - uses: codecov/codecov-action@v2
+        with:
+          files: ./coverage-output/lcov.info
+          name: ${{ matrix.test-name }}
+          fail_ci_if_error: true
   atlas-test:
     if: ${{ true }}
     runs-on: ubuntu-latest

--- a/.github/workflows/bitcoin-tests.yml
+++ b/.github/workflows/bitcoin-tests.yml
@@ -95,4 +95,9 @@ jobs:
         env:
           DOCKER_BUILDKIT: 1
           TEST_NAME: ${{ matrix.test-name }}
-        run: docker build --build-arg test_name=${{ matrix.test-name }} -f ./.github/actions/bitcoin-int-tests/Dockerfile.bitcoin-tests .
+        run: docker build -o coverage-output --build-arg test_name=${{ matrix.test-name }} -f ./.github/actions/bitcoin-int-tests/Dockerfile.bitcoin-tests .
+      - uses: codecov/codecov-action@v2
+        with:
+          files: ./coverage-output/lcov.info
+          name: ${{ matrix.test-name }}
+          fail_ci_if_error: true

--- a/.github/workflows/stacks-blockchain.yml
+++ b/.github/workflows/stacks-blockchain.yml
@@ -42,7 +42,12 @@ jobs:
         # Remove .dockerignore file so codecov has access to git info
         run: |
           rm .dockerignore
-          docker build -f ./.github/actions/bitcoin-int-tests/Dockerfile.large-genesis .
+          docker build -o coverage-output -f ./.github/actions/bitcoin-int-tests/Dockerfile.large-genesis .
+      - uses: codecov/codecov-action@v2
+        with:
+          files: ./coverage-output/lcov.info
+          name: large_genesis
+          fail_ci_if_error: true
 
   # Run unit tests with code coverage
   unit-tests:
@@ -55,7 +60,12 @@ jobs:
         # Remove .dockerignore file so codecov has access to git info
         run: |
           rm .dockerignore
-          docker build -f ./.github/actions/bitcoin-int-tests/Dockerfile.code-cov .
+          docker build -o coverage-output -f ./.github/actions/bitcoin-int-tests/Dockerfile.code-cov .
+      - uses: codecov/codecov-action@v2
+        with:
+          files: ./coverage-output/lcov.info
+          name: unit_tests
+          fail_ci_if_error: true
 
   open-api-validation:
     runs-on: ubuntu-latest

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,3 @@
-codecov:
-  token: 7f1d0962-14d3-4749-ab94-905cd4fc4c00
-
 coverage:
   status:
     patch: off


### PR DESCRIPTION
Codecov does not need a token to be provided when uploads are from a public repository:

https://docs.codecov.com/docs/frequently-asked-questions#where-is-the-repository-upload-token-found

This removes the codecov token (which is also a defunct token) from our codecov.yaml.