### PR TITLE
feat: Improved Fee Rate Computation

### DIFF
--- a/src/cost_estimates/fee_medians.rs
+++ b/src/cost_estimates/fee_medians.rs
@@ -308,9 +308,7 @@ fn fee_rate_and_weight_from_receipt(
     block_limit: &ExecutionCost,
 ) -> Option<FeeRateAndWeight> {
     let (payload, fee, tx_size) = match tx_receipt.transaction {
-        TransactionOrigin::Stacks(ref tx) => {
-            Some((&tx.payload, tx.get_tx_fee(), tx.tx_len()))
-        }
+        TransactionOrigin::Stacks(ref tx) => Some((&tx.payload, tx.get_tx_fee(), tx.tx_len())),
         TransactionOrigin::Burn(_) => None,
     }?;
     let scalar_cost = match payload {

--- a/src/cost_estimates/fee_medians.rs
+++ b/src/cost_estimates/fee_medians.rs
@@ -53,7 +53,7 @@ pub struct WeightedMedianFeeRateEstimator<M: CostMetric> {
     /// We only look back `window_size` fee rates when averaging past estimates.
     window_size: u32,
     /// The weight of a "full block" in abstract scalar cost units. This is the weight of
-    /// a block that is filled on each dimension.
+    /// a block that is filled *one single* dimension.
     full_block_weight: u64,
     /// Use this cost metric in fee rate calculations.
     metric: M,
@@ -86,7 +86,7 @@ impl<M: CostMetric> WeightedMedianFeeRateEstimator<M> {
             db,
             metric,
             window_size,
-            full_block_weight: 6 * PROPORTION_RESOLUTION,
+            full_block_weight: PROPORTION_RESOLUTION,
         })
     }
 

--- a/src/cost_estimates/fee_medians.rs
+++ b/src/cost_estimates/fee_medians.rs
@@ -1,0 +1,334 @@
+use std::cmp;
+use std::cmp::Ordering;
+use std::convert::TryFrom;
+use std::{iter::FromIterator, path::Path};
+
+use rusqlite::Transaction as SqlTransaction;
+use rusqlite::{
+    types::{FromSql, FromSqlError},
+    Connection, Error as SqliteError, OptionalExtension, ToSql,
+};
+use serde_json::Value as JsonValue;
+
+use chainstate::stacks::TransactionPayload;
+use util::db::sqlite_open;
+use util::db::tx_begin_immediate_sqlite;
+use util::db::u64_to_sql;
+
+use vm::costs::ExecutionCost;
+
+use chainstate::stacks::db::StacksEpochReceipt;
+use chainstate::stacks::events::TransactionOrigin;
+
+use crate::util::db::sql_pragma;
+use crate::util::db::table_exists;
+
+use super::metrics::CostMetric;
+use super::FeeRateEstimate;
+use super::{EstimatorError, FeeEstimator};
+
+use super::metrics::PROPORTION_RESOLUTION;
+use cost_estimates::StacksTransactionReceipt;
+
+const SINGLETON_ROW_ID: i64 = 1;
+const CREATE_TABLE: &'static str = "
+CREATE TABLE median_fee_estimator (
+    measure_key INTEGER PRIMARY KEY AUTOINCREMENT,
+    high NUMBER NOT NULL,
+    middle NUMBER NOT NULL,
+    low NUMBER NOT NULL
+)";
+
+/// This struct estimates fee rates by translating a transaction's `ExecutionCost`
+/// into a scalar using `ExecutionCost::proportion_dot_product` and computing
+/// the subsequent fee rate using the actual paid fee. The 5th, 50th and 95th
+/// percentile fee rates for each block are used as the low, middle, and high
+/// estimates. Estimates are updated via exponential decay windowing.
+pub struct ScalarFeeRateEstimator<M: CostMetric> {
+    db: Connection,
+    /// We only look back `window_size` fee rates when averaging past estimates.
+    window_size: u32,
+    metric: M,
+}
+
+/// Pair of "fee rate" and a "weight". The "weight" is a non-negative integer for a transaction
+/// that gets its meaning relative to the other weights in the block.
+struct FeeRateAndWeight {
+    pub fee_rate: f64,
+    pub weight: u64,
+}
+
+impl<M: CostMetric> ScalarFeeRateEstimator<M> {
+    /// Open a fee rate estimator at the given db path. Creates if not existent.
+    pub fn open(p: &Path, metric: M) -> Result<Self, SqliteError> {
+        let db =
+            sqlite_open(p, rusqlite::OpenFlags::SQLITE_OPEN_READ_WRITE, false).or_else(|e| {
+                if let SqliteError::SqliteFailure(ref internal, _) = e {
+                    if let rusqlite::ErrorCode::CannotOpen = internal.code {
+                        let mut db = sqlite_open(
+                            p,
+                            rusqlite::OpenFlags::SQLITE_OPEN_CREATE
+                                | rusqlite::OpenFlags::SQLITE_OPEN_READ_WRITE,
+                            false,
+                        )?;
+                        let tx = tx_begin_immediate_sqlite(&mut db)?;
+                        Self::instantiate_db(&tx)?;
+                        tx.commit()?;
+                        Ok(db)
+                    } else {
+                        Err(e)
+                    }
+                } else {
+                    Err(e)
+                }
+            })?;
+
+        Ok(Self {
+            db,
+            metric,
+            window_size: 5,
+        })
+    }
+
+    /// Check if the SQL database was already created. Necessary to avoid races if
+    ///  different threads open an estimator at the same time.
+    fn db_already_instantiated(tx: &SqlTransaction) -> Result<bool, SqliteError> {
+        table_exists(tx, "median_fee_estimator")
+    }
+
+    fn instantiate_db(tx: &SqlTransaction) -> Result<(), SqliteError> {
+        if !Self::db_already_instantiated(tx)? {
+            tx.execute(CREATE_TABLE, rusqlite::NO_PARAMS)?;
+        }
+
+        Ok(())
+    }
+
+    fn get_rate_estimates_from_sql(
+        conn: &Connection,
+        window_size: u32,
+    ) -> Result<FeeRateEstimate, EstimatorError> {
+        let sql =
+            "SELECT high, middle, low FROM median_fee_estimator ORDER BY measure_key DESC LIMIT ?";
+        let mut stmt = conn.prepare(sql).expect("SQLite failure");
+
+        // shuttle high, low, middle estimates into these lists, and then sort and find median.
+        let mut highs = Vec::with_capacity(window_size as usize);
+        let mut mids = Vec::with_capacity(window_size as usize);
+        let mut lows = Vec::with_capacity(window_size as usize);
+        let results = stmt
+            .query_and_then::<_, SqliteError, _, _>(&[window_size], |row| {
+                let high: f64 = row.get(0)?;
+                let middle: f64 = row.get(1)?;
+                let low: f64 = row.get(2)?;
+                Ok((low, middle, high))
+            })
+            .expect("SQLite failure");
+
+        for result in results {
+            let (low, middle, high) = result.expect("SQLite failure");
+            highs.push(high);
+            mids.push(middle);
+            lows.push(low);
+        }
+
+        if highs.is_empty() || mids.is_empty() || lows.is_empty() {
+            return Err(EstimatorError::NoEstimateAvailable);
+        }
+
+        fn median(len: usize, l: Vec<f64>) -> f64 {
+            if len % 2 == 1 {
+                l[len / 2]
+            } else {
+                // note, measures_len / 2 - 1 >= 0, because
+                //  len % 2 == 0 and emptiness is checked above
+                (l[len / 2] + l[len / 2 - 1]) / 2f64
+            }
+        }
+
+        // sort our float arrays. for float values that do not compare easily,
+        //  treat them as equals.
+        highs.sort_by(|a, b| a.partial_cmp(b).unwrap_or(Ordering::Equal));
+        mids.sort_by(|a, b| a.partial_cmp(b).unwrap_or(Ordering::Equal));
+        lows.sort_by(|a, b| a.partial_cmp(b).unwrap_or(Ordering::Equal));
+
+        Ok(FeeRateEstimate {
+            high: median(highs.len(), highs),
+            middle: median(mids.len(), mids),
+            low: median(lows.len(), lows),
+        })
+    }
+
+    fn update_estimate(&mut self, new_measure: FeeRateEstimate) {
+        let tx = tx_begin_immediate_sqlite(&mut self.db).expect("SQLite failure");
+
+        let insert_sql = "INSERT INTO median_fee_estimator
+                          (high, middle, low) VALUES (?, ?, ?)";
+
+        let deletion_sql = "DELETE FROM median_fee_estimator
+                            WHERE measure_key <= (
+                               SELECT MAX(measure_key) - ?
+                               FROM median_fee_estimator )";
+
+        tx.execute(
+            insert_sql,
+            rusqlite::params![new_measure.high, new_measure.middle, new_measure.low,],
+        )
+        .expect("SQLite failure");
+
+        tx.execute(deletion_sql, rusqlite::params![self.window_size])
+            .expect("SQLite failure");
+
+        let estimate = Self::get_rate_estimates_from_sql(&tx, self.window_size);
+
+        tx.commit().expect("SQLite failure");
+
+        if let Ok(next_estimate) = estimate {
+            debug!("Updating fee rate estimate for new block";
+                   "new_measure_high" => new_measure.high,
+                   "new_measure_middle" => new_measure.middle,
+                   "new_measure_low" => new_measure.low,
+                   "new_estimate_high" => next_estimate.high,
+                   "new_estimate_middle" => next_estimate.middle,
+                   "new_estimate_low" => next_estimate.low);
+        }
+    }
+}
+
+impl<M: CostMetric> FeeEstimator for ScalarFeeRateEstimator<M> {
+    /// Compute a FeeRateEstimate for this block. Update the
+    /// running estimate using this rounds estimate.
+    fn notify_block(
+        &mut self,
+        receipt: &StacksEpochReceipt,
+        block_limit: &ExecutionCost,
+    ) -> Result<(), EstimatorError> {
+        // Calculate sorted fee rate for each transaction in the block.
+        let mut working_fee_rates: Vec<FeeRateAndWeight> = receipt
+            .tx_receipts
+            .iter()
+            .filter_map(|tx_receipt| {
+                fee_rate_and_weight_from_receipt(&self.metric, &tx_receipt, block_limit)
+            })
+            .collect();
+
+        // If necessary, add the "minimum" fee rate to fill the block.
+        maybe_add_minimum_fee_rate(&mut working_fee_rates, PROPORTION_RESOLUTION);
+
+        // Compute a FeeRateEstimate from the sorted, adjusted fee rates.
+        let block_estimate = fee_rate_esimate_from_sorted_weights(&working_fee_rates);
+
+        // Update the running estimate using this rounds estimate.
+        self.update_estimate(block_estimate);
+
+        Ok(())
+    }
+
+    fn get_rate_estimates(&self) -> Result<FeeRateEstimate, EstimatorError> {
+        let sql = "SELECT high, middle, low FROM scalar_fee_estimator WHERE estimate_key = ?";
+        self.db
+            .query_row(sql, &[SINGLETON_ROW_ID], |row| {
+                let high: f64 = row.get(0)?;
+                let middle: f64 = row.get(1)?;
+                let low: f64 = row.get(2)?;
+                Ok((high, middle, low))
+            })
+            .optional()
+            .expect("SQLite failure")
+            .map(|(high, middle, low)| FeeRateEstimate { high, middle, low })
+            .ok_or_else(|| EstimatorError::NoEstimateAvailable)
+    }
+}
+
+fn fee_rate_esimate_from_sorted_weights(
+    sorted_fee_rates: &Vec<FeeRateAndWeight>,
+) -> FeeRateEstimate {
+    let mut total_weight = 0u64;
+    for rate_and_weight in sorted_fee_rates {
+        total_weight += rate_and_weight.weight;
+    }
+    let mut cumulative_weight = 0u64;
+    let mut percentiles = Vec::new();
+    for rate_and_weight in sorted_fee_rates {
+        cumulative_weight += rate_and_weight.weight;
+        let percentile_n: f64 =
+            (cumulative_weight as f64 - rate_and_weight.weight as f64 / 2f64) / total_weight as f64;
+        percentiles.push(percentile_n);
+    }
+
+    let target_percentiles = vec![0.05, 0.5, 0.95];
+    let mut fees_index = 1; // index into `sorted_fee_rates`
+    let mut values_at_target_percentiles = Vec::new();
+    for target_percentile in target_percentiles {
+        while fees_index < percentiles.len() && percentiles[fees_index] < target_percentile {
+            fees_index += 1;
+        }
+        // TODO: use an interpolation
+        values_at_target_percentiles.push(&sorted_fee_rates[fees_index - 1]);
+    }
+
+    FeeRateEstimate {
+        high: values_at_target_percentiles[2].fee_rate,
+        middle: values_at_target_percentiles[1].fee_rate,
+        low: values_at_target_percentiles[0].fee_rate,
+    }
+}
+fn maybe_add_minimum_fee_rate(working_rates: &mut Vec<FeeRateAndWeight>, full_block_weight: u64) {
+    let mut total_weight = 0u64;
+    for rate_and_weight in working_rates.into_iter() {
+        total_weight += rate_and_weight.weight;
+    }
+
+    if total_weight < full_block_weight {
+        working_rates.push(FeeRateAndWeight {
+            fee_rate: 1f64,
+            weight: total_weight,
+        })
+    }
+}
+
+/// The fee rate is the `fee_paid/cost_metric_used`
+fn fee_rate_and_weight_from_receipt(
+    metric: &dyn CostMetric,
+    tx_receipt: &StacksTransactionReceipt,
+    block_limit: &ExecutionCost,
+) -> Option<FeeRateAndWeight> {
+    let (payload, fee, tx_size) = match tx_receipt.transaction {
+        TransactionOrigin::Stacks(ref tx) => Some((&tx.payload, tx.get_tx_fee(), tx.tx_len())),
+        TransactionOrigin::Burn(_) => None,
+    }?;
+    let scalar_cost = match payload {
+        TransactionPayload::TokenTransfer(_, _, _) => {
+            // TokenTransfers *only* contribute tx_len, and just have an empty ExecutionCost.
+            metric.from_len(tx_size)
+        }
+        TransactionPayload::Coinbase(_) => {
+            // Coinbase txs are "free", so they don't factor into the fee market.
+            return None;
+        }
+        TransactionPayload::PoisonMicroblock(_, _)
+        | TransactionPayload::ContractCall(_)
+        | TransactionPayload::SmartContract(_) => {
+            // These transaction payload types all "work" the same: they have associated ExecutionCosts
+            // and contibute to the block length limit with their tx_len
+            metric.from_cost_and_len(&tx_receipt.execution_cost, &block_limit, tx_size)
+        }
+    };
+    let denominator = if scalar_cost >= 1 {
+        scalar_cost as f64
+    } else {
+        1f64
+    };
+    let fee_rate = fee as f64 / denominator;
+    if fee_rate >= 1f64 && fee_rate.is_finite() {
+        Some(FeeRateAndWeight {
+            fee_rate,
+            weight: scalar_cost,
+        })
+    } else {
+        Some(FeeRateAndWeight {
+            fee_rate: 1f64,
+            weight: scalar_cost,
+        })
+    }
+}

--- a/src/cost_estimates/fee_medians.rs
+++ b/src/cost_estimates/fee_medians.rs
@@ -254,6 +254,7 @@ pub fn fee_rate_estimate_from_sorted_weighted_fees(
             (cumulative_weight as f64 - rate_and_weight.weight as f64 / 2f64) / total_weight as f64;
         percentiles.push(percentile_n);
     }
+    assert_eq!(percentiles.len(), sorted_fee_rates.len());
 
     let target_percentiles = vec![0.05, 0.5, 0.95];
     let mut fees_index = 0; // index into `sorted_fee_rates`

--- a/src/cost_estimates/fee_medians.rs
+++ b/src/cost_estimates/fee_medians.rs
@@ -56,6 +56,7 @@ pub struct WeightedMedianFeeRateEstimator<M: CostMetric> {
 }
 
 /// Convenience pair for return values.
+#[derive(Debug)]
 struct FeeRateAndWeight {
     pub fee_rate: f64,
     pub weight: u64,
@@ -242,6 +243,8 @@ fn fee_rate_esimate_from_sorted_weights(
     let target_percentiles = vec![0.05, 0.5, 0.95];
     let mut fees_index = 1; // index into `sorted_fee_rates`
     let mut values_at_target_percentiles = Vec::new();
+    warn!("percentiles {:?}", &percentiles);
+    warn!("sorted_fee_rates {:?}", &sorted_fee_rates);
     for target_percentile in target_percentiles {
         while fees_index < percentiles.len() && percentiles[fees_index] < target_percentile {
             fees_index += 1;
@@ -263,9 +266,10 @@ fn maybe_add_minimum_fee_rate(working_rates: &mut Vec<FeeRateAndWeight>, full_bl
     }
 
     if total_weight < full_block_weight {
+        let weight_remaining = full_block_weight - total_weight;
         working_rates.push(FeeRateAndWeight {
             fee_rate: 1f64,
-            weight: total_weight,
+            weight: weight_remaining,
         })
     }
 }

--- a/src/cost_estimates/fee_medians.rs
+++ b/src/cost_estimates/fee_medians.rs
@@ -44,7 +44,7 @@ CREATE TABLE median_fee_estimator (
 /// the subsequent fee rate using the actual paid fee. The 5th, 50th and 95th
 /// percentile fee rates for each block are used as the low, middle, and high
 /// estimates. Estimates are updated via exponential decay windowing.
-pub struct ScalarFeeRateEstimator<M: CostMetric> {
+pub struct WeightedMedianFeeRateEstimator<M: CostMetric> {
     db: Connection,
     /// We only look back `window_size` fee rates when averaging past estimates.
     window_size: u32,
@@ -58,7 +58,7 @@ struct FeeRateAndWeight {
     pub weight: u64,
 }
 
-impl<M: CostMetric> ScalarFeeRateEstimator<M> {
+impl<M: CostMetric> WeightedMedianFeeRateEstimator<M> {
     /// Open a fee rate estimator at the given db path. Creates if not existent.
     pub fn open(p: &Path, metric: M) -> Result<Self, SqliteError> {
         let db =
@@ -195,7 +195,7 @@ impl<M: CostMetric> ScalarFeeRateEstimator<M> {
     }
 }
 
-impl<M: CostMetric> FeeEstimator for ScalarFeeRateEstimator<M> {
+impl<M: CostMetric> FeeEstimator for WeightedMedianFeeRateEstimator<M> {
     /// Compute a FeeRateEstimate for this block. Update the
     /// running estimate using this rounds estimate.
     fn notify_block(

--- a/src/cost_estimates/fee_medians.rs
+++ b/src/cost_estimates/fee_medians.rs
@@ -63,7 +63,7 @@ struct FeeRateAndWeight {
 
 impl<M: CostMetric> WeightedMedianFeeRateEstimator<M> {
     /// Open a fee rate estimator at the given db path. Creates if not existent.
-    pub fn open(p: &Path, metric: M) -> Result<Self, SqliteError> {
+    pub fn open(p: &Path, metric: M, window_size: u32) -> Result<Self, SqliteError> {
         let mut db = sqlite_open(
             p,
             rusqlite::OpenFlags::SQLITE_OPEN_CREATE | rusqlite::OpenFlags::SQLITE_OPEN_READ_WRITE,
@@ -80,7 +80,7 @@ impl<M: CostMetric> WeightedMedianFeeRateEstimator<M> {
         Ok(Self {
             db,
             metric,
-            window_size: 5,
+            window_size,
         })
     }
 

--- a/src/cost_estimates/fee_medians.rs
+++ b/src/cost_estimates/fee_medians.rs
@@ -61,7 +61,7 @@ pub struct WeightedMedianFeeRateEstimator<M: CostMetric> {
 
 /// Convenience struct for passing around this pair.
 #[derive(Debug)]
-struct FeeRateAndWeight {
+pub struct FeeRateAndWeight {
     pub fee_rate: f64,
     pub weight: u64,
 }
@@ -235,7 +235,7 @@ impl<M: CostMetric> FeeEstimator for WeightedMedianFeeRateEstimator<M> {
 /// The percentiles computed are [0.05, 0.5, 0.95].
 ///
 /// `sorted_fee_rates` must be non-empty.
-fn fee_rate_estimate_from_sorted_weighted_fees(
+pub fn fee_rate_estimate_from_sorted_weighted_fees(
     sorted_fee_rates: &Vec<FeeRateAndWeight>,
 ) -> FeeRateEstimate {
     if sorted_fee_rates.is_empty() {

--- a/src/cost_estimates/fee_medians.rs
+++ b/src/cost_estimates/fee_medians.rs
@@ -289,7 +289,10 @@ pub fn fee_rate_estimate_from_sorted_weighted_fees(
 fn maybe_add_minimum_fee_rate(working_rates: &mut Vec<FeeRateAndWeight>, full_block_weight: u64) {
     let mut total_weight = 0u64;
     for rate_and_weight in working_rates.into_iter() {
-        total_weight += rate_and_weight.weight;
+        total_weight = match total_weight.checked_add(rate_and_weight.weight) {
+            Some(result) => result,
+            None => return,
+        };
     }
 
     if total_weight < full_block_weight {

--- a/src/cost_estimates/fee_medians.rs
+++ b/src/cost_estimates/fee_medians.rs
@@ -222,8 +222,7 @@ impl<M: CostMetric> FeeEstimator for WeightedMedianFeeRateEstimator<M> {
                     .unwrap_or(Ordering::Equal)
             });
 
-            let block_estimate =
-                fee_rate_estimate_from_sorted_weighted_fees(&working_fee_rates);
+            let block_estimate = fee_rate_estimate_from_sorted_weighted_fees(&working_fee_rates);
             self.update_estimate(block_estimate);
         }
 

--- a/src/cost_estimates/fee_medians.rs
+++ b/src/cost_estimates/fee_medians.rs
@@ -242,14 +242,14 @@ pub fn fee_rate_estimate_from_sorted_weighted_fees(
         panic!("`sorted_fee_rates` cannot be empty.");
     }
 
-    let mut total_weight = 0u64;
+    let mut total_weight = 0f64;
     for rate_and_weight in sorted_fee_rates {
-        total_weight += rate_and_weight.weight;
+        total_weight += rate_and_weight.weight as f64;
     }
-    let mut cumulative_weight = 0u64;
+    let mut cumulative_weight = 0f64;
     let mut percentiles = Vec::new();
     for rate_and_weight in sorted_fee_rates {
-        cumulative_weight += rate_and_weight.weight;
+        cumulative_weight += rate_and_weight.weight as f64;
         let percentile_n: f64 =
             (cumulative_weight as f64 - rate_and_weight.weight as f64 / 2f64) / total_weight as f64;
         percentiles.push(percentile_n);

--- a/src/cost_estimates/fee_medians.rs
+++ b/src/cost_estimates/fee_medians.rs
@@ -225,7 +225,7 @@ impl<M: CostMetric> FeeEstimator for WeightedMedianFeeRateEstimator<M> {
     }
 
     fn get_rate_estimates(&self) -> Result<FeeRateEstimate, EstimatorError> {
-        let sql = "SELECT high, middle, low FROM scalar_fee_estimator WHERE estimate_key = ?";
+        let sql = "SELECT high, middle, low FROM median_fee_estimator WHERE estimate_key = ?";
         self.db
             .query_row(sql, &[SINGLETON_ROW_ID], |row| {
                 let high: f64 = row.get(0)?;

--- a/src/cost_estimates/fee_scalar.rs
+++ b/src/cost_estimates/fee_scalar.rs
@@ -52,27 +52,18 @@ pub struct ScalarFeeRateEstimator<M: CostMetric> {
 impl<M: CostMetric> ScalarFeeRateEstimator<M> {
     /// Open a fee rate estimator at the given db path. Creates if not existent.
     pub fn open(p: &Path, metric: M) -> Result<Self, SqliteError> {
-        let db =
-            sqlite_open(p, rusqlite::OpenFlags::SQLITE_OPEN_READ_WRITE, false).or_else(|e| {
-                if let SqliteError::SqliteFailure(ref internal, _) = e {
-                    if let rusqlite::ErrorCode::CannotOpen = internal.code {
-                        let mut db = sqlite_open(
-                            p,
-                            rusqlite::OpenFlags::SQLITE_OPEN_CREATE
-                                | rusqlite::OpenFlags::SQLITE_OPEN_READ_WRITE,
-                            false,
-                        )?;
-                        let tx = tx_begin_immediate_sqlite(&mut db)?;
-                        Self::instantiate_db(&tx)?;
-                        tx.commit()?;
-                        Ok(db)
-                    } else {
-                        Err(e)
-                    }
-                } else {
-                    Err(e)
-                }
-            })?;
+        let mut db = sqlite_open(
+            p,
+            rusqlite::OpenFlags::SQLITE_OPEN_CREATE | rusqlite::OpenFlags::SQLITE_OPEN_READ_WRITE,
+            false,
+        )?;
+
+        // check if the db needs to be instantiated regardless of whether or not
+        //  it was newly created: the db itself may be shared with other fee estimators,
+        //  which would not have created the necessary table for this estimator.
+        let tx = tx_begin_immediate_sqlite(&mut db)?;
+        Self::instantiate_db(&tx)?;
+        tx.commit()?;
 
         Ok(Self {
             db,

--- a/src/cost_estimates/fee_scalar.rs
+++ b/src/cost_estimates/fee_scalar.rs
@@ -216,15 +216,19 @@ impl<M: CostMetric> FeeEstimator for ScalarFeeRateEstimator<M> {
     ) -> Result<(), EstimatorError> {
         // Step 1: Calculate a fee rate for each transaction in the block.
         // TODO: use the unused part of the block as being at fee rate minum (part 3)
-        let mut sorted_fee_rates: Vec<_> = receipt
-            .tx_receipts
-            .iter()
-            .filter_map(|tx_receipt| self.fee_rate_from_receipt(&tx_receipt, block_limit))
-            .collect();
-        sorted_fee_rates.sort_by(|a, b| {
-            a.partial_cmp(b)
-                .expect("BUG: Fee rates should be orderable: NaN and infinite values are filtered")
-        });
+        let sorted_fee_rates: Vec<_> = {
+            let mut result = receipt
+                .tx_receipts
+                .iter()
+                .filter_map(|tx_receipt| self.fee_rate_from_receipt(&tx_receipt, block_limit))
+                .collect();
+            result.sort_by(|a, b| {
+                a.partial_cmp(b).expect(
+                    "BUG: Fee rates should be orderable: NaN and infinite values are filtered",
+                )
+            });
+            result
+        };
 
         // Step 2: If we have fee rates, update them.
         let num_fee_rates = sorted_fee_rates.len();

--- a/src/cost_estimates/fee_scalar.rs
+++ b/src/cost_estimates/fee_scalar.rs
@@ -1,5 +1,4 @@
 use std::cmp;
-use std::cmp::Ordering;
 use std::convert::TryFrom;
 use std::{iter::FromIterator, path::Path};
 
@@ -27,13 +26,10 @@ use super::metrics::CostMetric;
 use super::FeeRateEstimate;
 use super::{EstimatorError, FeeEstimator};
 
-use super::metrics::PROPORTION_RESOLUTION;
-use cost_estimates::StacksTransactionReceipt;
-
 const SINGLETON_ROW_ID: i64 = 1;
 const CREATE_TABLE: &'static str = "
-CREATE TABLE median_fee_estimator (
-    measure_key INTEGER PRIMARY KEY AUTOINCREMENT,
+CREATE TABLE scalar_fee_estimator (
+    estimate_key NUMBER PRIMARY KEY,
     high NUMBER NOT NULL,
     middle NUMBER NOT NULL,
     low NUMBER NOT NULL
@@ -46,16 +42,11 @@ CREATE TABLE median_fee_estimator (
 /// estimates. Estimates are updated via exponential decay windowing.
 pub struct ScalarFeeRateEstimator<M: CostMetric> {
     db: Connection,
-    /// We only look back `window_size` fee rates when averaging past estimates.
-    window_size: u32,
+    /// how quickly does the current estimate decay
+    /// compared to the newly received block estimate
+    ///      new_estimate := (decay_rate) * old_estimate + (1 - decay_rate) * new_measure
+    decay_rate: f64,
     metric: M,
-}
-
-/// Pair of "fee rate" and a "weight". The "weight" is a non-negative integer for a transaction
-/// that gets its meaning relative to the other weights in the block.
-struct FeeRateAndWeight {
-    pub fee_rate: f64,
-    pub weight: u64,
 }
 
 impl<M: CostMetric> ScalarFeeRateEstimator<M> {
@@ -86,14 +77,14 @@ impl<M: CostMetric> ScalarFeeRateEstimator<M> {
         Ok(Self {
             db,
             metric,
-            window_size: 5,
+            decay_rate: 0.5_f64,
         })
     }
 
     /// Check if the SQL database was already created. Necessary to avoid races if
     ///  different threads open an estimator at the same time.
     fn db_already_instantiated(tx: &SqlTransaction) -> Result<bool, SqliteError> {
-        table_exists(tx, "median_fee_estimator")
+        table_exists(tx, "scalar_fee_estimator")
     }
 
     fn instantiate_db(tx: &SqlTransaction) -> Result<(), SqliteError> {
@@ -104,122 +95,140 @@ impl<M: CostMetric> ScalarFeeRateEstimator<M> {
         Ok(())
     }
 
-    fn get_rate_estimates_from_sql(
-        conn: &Connection,
-        window_size: u32,
-    ) -> Result<FeeRateEstimate, EstimatorError> {
-        let sql =
-            "SELECT high, middle, low FROM median_fee_estimator ORDER BY measure_key DESC LIMIT ?";
-        let mut stmt = conn.prepare(sql).expect("SQLite failure");
-
-        // shuttle high, low, middle estimates into these lists, and then sort and find median.
-        let mut highs = Vec::with_capacity(window_size as usize);
-        let mut mids = Vec::with_capacity(window_size as usize);
-        let mut lows = Vec::with_capacity(window_size as usize);
-        let results = stmt
-            .query_and_then::<_, SqliteError, _, _>(&[window_size], |row| {
-                let high: f64 = row.get(0)?;
-                let middle: f64 = row.get(1)?;
-                let low: f64 = row.get(2)?;
-                Ok((low, middle, high))
-            })
-            .expect("SQLite failure");
-
-        for result in results {
-            let (low, middle, high) = result.expect("SQLite failure");
-            highs.push(high);
-            mids.push(middle);
-            lows.push(low);
-        }
-
-        if highs.is_empty() || mids.is_empty() || lows.is_empty() {
-            return Err(EstimatorError::NoEstimateAvailable);
-        }
-
-        fn median(len: usize, l: Vec<f64>) -> f64 {
-            if len % 2 == 1 {
-                l[len / 2]
-            } else {
-                // note, measures_len / 2 - 1 >= 0, because
-                //  len % 2 == 0 and emptiness is checked above
-                (l[len / 2] + l[len / 2 - 1]) / 2f64
-            }
-        }
-
-        // sort our float arrays. for float values that do not compare easily,
-        //  treat them as equals.
-        highs.sort_by(|a, b| a.partial_cmp(b).unwrap_or(Ordering::Equal));
-        mids.sort_by(|a, b| a.partial_cmp(b).unwrap_or(Ordering::Equal));
-        lows.sort_by(|a, b| a.partial_cmp(b).unwrap_or(Ordering::Equal));
-
-        Ok(FeeRateEstimate {
-            high: median(highs.len(), highs),
-            middle: median(mids.len(), mids),
-            low: median(lows.len(), lows),
-        })
-    }
-
     fn update_estimate(&mut self, new_measure: FeeRateEstimate) {
+        let next_estimate = match self.get_rate_estimates() {
+            Ok(old_estimate) => {
+                // compute the exponential windowing:
+                // estimate = (a/b * old_estimate) + ((1 - a/b) * new_estimate)
+                let prior_component = old_estimate.clone() * self.decay_rate;
+                let next_component = new_measure.clone() * (1_f64 - self.decay_rate);
+                let mut next_computed = prior_component + next_component;
+
+                // because of integer math, we can end up with some edge effects
+                // when the estimate is < decay_rate_fraction.1, so just saturate
+                // on the low end at a rate of "1"
+                next_computed.high = if next_computed.high >= 1f64 {
+                    next_computed.high
+                } else {
+                    1f64
+                };
+                next_computed.middle = if next_computed.middle >= 1f64 {
+                    next_computed.middle
+                } else {
+                    1f64
+                };
+                next_computed.low = if next_computed.low >= 1f64 {
+                    next_computed.low
+                } else {
+                    1f64
+                };
+
+                next_computed
+            }
+            Err(EstimatorError::NoEstimateAvailable) => new_measure.clone(),
+            Err(e) => {
+                warn!("Error in fee estimator fetching current estimates"; "err" => ?e);
+                return;
+            }
+        };
+
+        debug!("Updating fee rate estimate for new block";
+               "new_measure_high" => new_measure.high,
+               "new_measure_middle" => new_measure.middle,
+               "new_measure_low" => new_measure.low,
+               "new_estimate_high" => next_estimate.high,
+               "new_estimate_middle" => next_estimate.middle,
+               "new_estimate_low" => next_estimate.low);
+
+        let sql = "INSERT OR REPLACE INTO scalar_fee_estimator
+                     (estimate_key, high, middle, low) VALUES (?, ?, ?, ?)";
+
         let tx = tx_begin_immediate_sqlite(&mut self.db).expect("SQLite failure");
 
-        let insert_sql = "INSERT INTO median_fee_estimator
-                          (high, middle, low) VALUES (?, ?, ?)";
-
-        let deletion_sql = "DELETE FROM median_fee_estimator
-                            WHERE measure_key <= (
-                               SELECT MAX(measure_key) - ?
-                               FROM median_fee_estimator )";
-
         tx.execute(
-            insert_sql,
-            rusqlite::params![new_measure.high, new_measure.middle, new_measure.low,],
+            sql,
+            rusqlite::params![
+                SINGLETON_ROW_ID,
+                next_estimate.high,
+                next_estimate.middle,
+                next_estimate.low,
+            ],
         )
         .expect("SQLite failure");
 
-        tx.execute(deletion_sql, rusqlite::params![self.window_size])
-            .expect("SQLite failure");
-
-        let estimate = Self::get_rate_estimates_from_sql(&tx, self.window_size);
-
         tx.commit().expect("SQLite failure");
-
-        if let Ok(next_estimate) = estimate {
-            debug!("Updating fee rate estimate for new block";
-                   "new_measure_high" => new_measure.high,
-                   "new_measure_middle" => new_measure.middle,
-                   "new_measure_low" => new_measure.low,
-                   "new_estimate_high" => next_estimate.high,
-                   "new_estimate_middle" => next_estimate.middle,
-                   "new_estimate_low" => next_estimate.low);
-        }
     }
 }
 
 impl<M: CostMetric> FeeEstimator for ScalarFeeRateEstimator<M> {
-    /// Compute a FeeRateEstimate for this block. Update the
-    /// running estimate using this rounds estimate.
     fn notify_block(
         &mut self,
         receipt: &StacksEpochReceipt,
         block_limit: &ExecutionCost,
     ) -> Result<(), EstimatorError> {
-        // Calculate sorted fee rate for each transaction in the block.
-        let mut working_fee_rates: Vec<FeeRateAndWeight> = receipt
+        let mut all_fee_rates: Vec<_> = receipt
             .tx_receipts
             .iter()
             .filter_map(|tx_receipt| {
-                fee_rate_and_weight_from_receipt(&self.metric, &tx_receipt, block_limit)
+                let (payload, fee, tx_size) = match tx_receipt.transaction {
+                    TransactionOrigin::Stacks(ref tx) => {
+                        Some((&tx.payload, tx.get_tx_fee(), tx.tx_len()))
+                    }
+                    TransactionOrigin::Burn(_) => None,
+                }?;
+                let scalar_cost = match payload {
+                    TransactionPayload::TokenTransfer(_, _, _) => {
+                        // TokenTransfers *only* contribute tx_len, and just have an empty ExecutionCost.
+                        self.metric.from_len(tx_size)
+                    }
+                    TransactionPayload::Coinbase(_) => {
+                        // Coinbase txs are "free", so they don't factor into the fee market.
+                        return None;
+                    }
+                    TransactionPayload::PoisonMicroblock(_, _)
+                    | TransactionPayload::ContractCall(_)
+                    | TransactionPayload::SmartContract(_) => {
+                        // These transaction payload types all "work" the same: they have associated ExecutionCosts
+                        // and contibute to the block length limit with their tx_len
+                        self.metric.from_cost_and_len(
+                            &tx_receipt.execution_cost,
+                            &block_limit,
+                            tx_size,
+                        )
+                    }
+                };
+                let fee_rate = fee as f64
+                    / if scalar_cost >= 1 {
+                        scalar_cost as f64
+                    } else {
+                        1f64
+                    };
+                if fee_rate >= 1f64 && fee_rate.is_finite() {
+                    Some(fee_rate)
+                } else {
+                    Some(1f64)
+                }
             })
             .collect();
+        all_fee_rates.sort_by(|a, b| {
+            a.partial_cmp(b)
+                .expect("BUG: Fee rates should be orderable: NaN and infinite values are filtered")
+        });
 
-        // If necessary, add the "minimum" fee rate to fill the block.
-        maybe_add_minimum_fee_rate(&mut working_fee_rates, PROPORTION_RESOLUTION);
+        let measures_len = all_fee_rates.len();
+        if measures_len > 0 {
+            // use 5th, 50th, and 95th percentiles from block
+            let highest_index = measures_len - cmp::max(1, measures_len / 20);
+            let median_index = measures_len / 2;
+            let lowest_index = measures_len / 20;
+            let block_estimate = FeeRateEstimate {
+                high: all_fee_rates[highest_index],
+                middle: all_fee_rates[median_index],
+                low: all_fee_rates[lowest_index],
+            };
 
-        // Compute a FeeRateEstimate from the sorted, adjusted fee rates.
-        let block_estimate = fee_rate_esimate_from_sorted_weights(&working_fee_rates);
-
-        // Update the running estimate using this rounds estimate.
-        self.update_estimate(block_estimate);
+            self.update_estimate(block_estimate);
+        }
 
         Ok(())
     }
@@ -237,98 +246,5 @@ impl<M: CostMetric> FeeEstimator for ScalarFeeRateEstimator<M> {
             .expect("SQLite failure")
             .map(|(high, middle, low)| FeeRateEstimate { high, middle, low })
             .ok_or_else(|| EstimatorError::NoEstimateAvailable)
-    }
-}
-
-fn fee_rate_esimate_from_sorted_weights(
-    sorted_fee_rates: &Vec<FeeRateAndWeight>,
-) -> FeeRateEstimate {
-    let mut total_weight = 0u64;
-    for rate_and_weight in sorted_fee_rates {
-        total_weight += rate_and_weight.weight;
-    }
-    let mut cumulative_weight = 0u64;
-    let mut percentiles = Vec::new();
-    for rate_and_weight in sorted_fee_rates {
-        cumulative_weight += rate_and_weight.weight;
-        let percentile_n: f64 =
-            (cumulative_weight as f64 - rate_and_weight.weight as f64 / 2f64) / total_weight as f64;
-        percentiles.push(percentile_n);
-    }
-
-    let target_percentiles = vec![0.05, 0.5, 0.95];
-    let mut fees_index = 1; // index into `sorted_fee_rates`
-    let mut values_at_target_percentiles = Vec::new();
-    for target_percentile in target_percentiles {
-        while fees_index < percentiles.len() && percentiles[fees_index] < target_percentile {
-            fees_index += 1;
-        }
-        // TODO: use an interpolation
-        values_at_target_percentiles.push(&sorted_fee_rates[fees_index - 1]);
-    }
-
-    FeeRateEstimate {
-        high: values_at_target_percentiles[2].fee_rate,
-        middle: values_at_target_percentiles[1].fee_rate,
-        low: values_at_target_percentiles[0].fee_rate,
-    }
-}
-fn maybe_add_minimum_fee_rate(working_rates: &mut Vec<FeeRateAndWeight>, full_block_weight: u64) {
-    let mut total_weight = 0u64;
-    for rate_and_weight in working_rates.into_iter() {
-        total_weight += rate_and_weight.weight;
-    }
-
-    if total_weight < full_block_weight {
-        working_rates.push(FeeRateAndWeight {
-            fee_rate: 1f64,
-            weight: total_weight,
-        })
-    }
-}
-
-/// The fee rate is the `fee_paid/cost_metric_used`
-fn fee_rate_and_weight_from_receipt(
-    metric: &dyn CostMetric,
-    tx_receipt: &StacksTransactionReceipt,
-    block_limit: &ExecutionCost,
-) -> Option<FeeRateAndWeight> {
-    let (payload, fee, tx_size) = match tx_receipt.transaction {
-        TransactionOrigin::Stacks(ref tx) => Some((&tx.payload, tx.get_tx_fee(), tx.tx_len())),
-        TransactionOrigin::Burn(_) => None,
-    }?;
-    let scalar_cost = match payload {
-        TransactionPayload::TokenTransfer(_, _, _) => {
-            // TokenTransfers *only* contribute tx_len, and just have an empty ExecutionCost.
-            metric.from_len(tx_size)
-        }
-        TransactionPayload::Coinbase(_) => {
-            // Coinbase txs are "free", so they don't factor into the fee market.
-            return None;
-        }
-        TransactionPayload::PoisonMicroblock(_, _)
-        | TransactionPayload::ContractCall(_)
-        | TransactionPayload::SmartContract(_) => {
-            // These transaction payload types all "work" the same: they have associated ExecutionCosts
-            // and contibute to the block length limit with their tx_len
-            metric.from_cost_and_len(&tx_receipt.execution_cost, &block_limit, tx_size)
-        }
-    };
-    let denominator = if scalar_cost >= 1 {
-        scalar_cost as f64
-    } else {
-        1f64
-    };
-    let fee_rate = fee as f64 / denominator;
-    if fee_rate >= 1f64 && fee_rate.is_finite() {
-        Some(FeeRateAndWeight {
-            fee_rate,
-            weight: scalar_cost,
-        })
-    } else {
-        Some(FeeRateAndWeight {
-            fee_rate: 1f64,
-            weight: scalar_cost,
-        })
     }
 }

--- a/src/cost_estimates/metrics.rs
+++ b/src/cost_estimates/metrics.rs
@@ -5,6 +5,11 @@ use crate::vm::costs::ExecutionCost;
 /// This trait defines metrics used to convert `ExecutionCost` and tx_len usage into single-dimensional
 /// metrics that can be used to compute a fee rate.
 pub trait CostMetric: Send {
+    /// Returns a single-dimensional integer representing the proportion of `block_limit` that
+    /// `cost` and `tx_len` up.
+    ///
+    /// TODO: Can we state more invariants about this? E.g., that the sum of all costs in a block
+    /// equals some constant value?
     fn from_cost_and_len(
         &self,
         cost: &ExecutionCost,

--- a/src/cost_estimates/metrics.rs
+++ b/src/cost_estimates/metrics.rs
@@ -29,6 +29,7 @@ impl CostMetric for Box<dyn CostMetric> {
         block_limit: &ExecutionCost,
         tx_len: u64,
     ) -> u64 {
+        warn!("check");
         self.as_ref().from_cost_and_len(cost, block_limit, tx_len)
     }
 
@@ -81,6 +82,10 @@ impl CostMetric for ProportionalDotProduct {
     ) -> u64 {
         let exec_proportion = cost.proportion_dot_product(block_limit, PROPORTION_RESOLUTION);
         let len_proportion = self.calculate_len_proportion(tx_len);
+        warn!(
+            "exec_proportion {} len_proportion {}",
+            exec_proportion, len_proportion
+        );
         exec_proportion + len_proportion
     }
 
@@ -100,6 +105,7 @@ impl CostMetric for UnitMetric {
         _block_limit: &ExecutionCost,
         _tx_len: u64,
     ) -> u64 {
+        warn!("check");
         1
     }
 

--- a/src/cost_estimates/metrics.rs
+++ b/src/cost_estimates/metrics.rs
@@ -5,11 +5,6 @@ use crate::vm::costs::ExecutionCost;
 /// This trait defines metrics used to convert `ExecutionCost` and tx_len usage into single-dimensional
 /// metrics that can be used to compute a fee rate.
 pub trait CostMetric: Send {
-    /// Returns a single-dimensional integer representing the proportion of `block_limit` that
-    /// `cost` and `tx_len` up.
-    ///
-    /// TODO: Can we state more invariants about this? E.g., that the sum of all costs in a block
-    /// equals some constant value?
     fn from_cost_and_len(
         &self,
         cost: &ExecutionCost,
@@ -29,7 +24,6 @@ impl CostMetric for Box<dyn CostMetric> {
         block_limit: &ExecutionCost,
         tx_len: u64,
     ) -> u64 {
-        warn!("check");
         self.as_ref().from_cost_and_len(cost, block_limit, tx_len)
     }
 
@@ -82,10 +76,6 @@ impl CostMetric for ProportionalDotProduct {
     ) -> u64 {
         let exec_proportion = cost.proportion_dot_product(block_limit, PROPORTION_RESOLUTION);
         let len_proportion = self.calculate_len_proportion(tx_len);
-        warn!(
-            "exec_proportion {} len_proportion {}",
-            exec_proportion, len_proportion
-        );
         exec_proportion + len_proportion
     }
 
@@ -105,7 +95,6 @@ impl CostMetric for UnitMetric {
         _block_limit: &ExecutionCost,
         _tx_len: u64,
     ) -> u64 {
-        warn!("check");
         1
     }
 

--- a/src/cost_estimates/mod.rs
+++ b/src/cost_estimates/mod.rs
@@ -14,6 +14,7 @@ use burnchains::Txid;
 use chainstate::stacks::db::StacksEpochReceipt;
 
 pub mod fee_scalar;
+pub mod fee_medians;
 pub mod metrics;
 pub mod pessimistic;
 

--- a/src/cost_estimates/mod.rs
+++ b/src/cost_estimates/mod.rs
@@ -13,8 +13,8 @@ use vm::costs::ExecutionCost;
 use burnchains::Txid;
 use chainstate::stacks::db::StacksEpochReceipt;
 
-pub mod fee_scalar;
 pub mod fee_medians;
+pub mod fee_scalar;
 pub mod metrics;
 pub mod pessimistic;
 

--- a/src/cost_estimates/tests/fee_medians.rs
+++ b/src/cost_estimates/tests/fee_medians.rs
@@ -1,0 +1,332 @@
+use std::{env, path::PathBuf};
+use time::Instant;
+
+use rand::seq::SliceRandom;
+use rand::Rng;
+
+use cost_estimates::metrics::CostMetric;
+use cost_estimates::{EstimatorError, FeeEstimator};
+use vm::costs::ExecutionCost;
+
+use chainstate::burn::ConsensusHash;
+use chainstate::stacks::db::{StacksEpochReceipt, StacksHeaderInfo};
+use chainstate::stacks::events::StacksTransactionReceipt;
+use types::chainstate::{BlockHeaderHash, BurnchainHeaderHash, StacksBlockHeader, StacksWorkScore};
+use types::proof::TrieHash;
+use util::hash::{to_hex, Hash160, Sha512Trunc256Sum};
+use util::vrf::VRFProof;
+
+use crate::chainstate::stacks::{
+    CoinbasePayload, StacksTransaction, TokenTransferMemo, TransactionAuth,
+    TransactionContractCall, TransactionPayload, TransactionSpendingCondition, TransactionVersion,
+};
+use crate::core::StacksEpochId;
+use crate::cost_estimates::fee_medians::WeightedMedianFeeRateEstimator;
+use crate::cost_estimates::FeeRateEstimate;
+use crate::types::chainstate::StacksAddress;
+use crate::vm::types::{PrincipalData, StandardPrincipalData};
+use crate::vm::Value;
+
+fn instantiate_test_db<CM: CostMetric>(m: CM) -> WeightedMedianFeeRateEstimator<CM> {
+    let mut path = env::temp_dir();
+    let random_bytes = rand::thread_rng().gen::<[u8; 32]>();
+    path.push(&format!("fee_db_{}.sqlite", &to_hex(&random_bytes)[0..8]));
+
+    WeightedMedianFeeRateEstimator::open(&path, m).expect("Test failure: could not open fee rate DB")
+}
+
+/// This struct implements a simple metric used for unit testing the
+/// the fee rate estimator. It always returns a cost of 1, making the
+/// fee rate of a transaction always equal to the paid fee.
+struct TestCostMetric;
+
+impl CostMetric for TestCostMetric {
+    fn from_cost_and_len(
+        &self,
+        _cost: &ExecutionCost,
+        _block_limit: &ExecutionCost,
+        _tx_len: u64,
+    ) -> u64 {
+        1
+    }
+
+    fn from_len(&self, _tx_len: u64) -> u64 {
+        1
+    }
+
+    fn change_per_byte(&self) -> f64 {
+        0f64
+    }
+}
+
+#[test]
+fn test_empty_fee_estimator() {
+    let metric = TestCostMetric;
+    let estimator = instantiate_test_db(metric);
+    assert_eq!(
+        estimator
+            .get_rate_estimates()
+            .expect_err("Empty rate estimator should error."),
+        EstimatorError::NoEstimateAvailable
+    );
+}
+
+fn make_block_receipt(tx_receipts: Vec<StacksTransactionReceipt>) -> StacksEpochReceipt {
+    StacksEpochReceipt {
+        header: StacksHeaderInfo {
+            anchored_header: StacksBlockHeader {
+                version: 1,
+                total_work: StacksWorkScore { burn: 1, work: 1 },
+                proof: VRFProof::empty(),
+                parent_block: BlockHeaderHash([0; 32]),
+                parent_microblock: BlockHeaderHash([0; 32]),
+                parent_microblock_sequence: 0,
+                tx_merkle_root: Sha512Trunc256Sum([0; 32]),
+                state_index_root: TrieHash([0; 32]),
+                microblock_pubkey_hash: Hash160([0; 20]),
+            },
+            microblock_tail: None,
+            block_height: 1,
+            index_root: TrieHash([0; 32]),
+            consensus_hash: ConsensusHash([2; 20]),
+            burn_header_hash: BurnchainHeaderHash([1; 32]),
+            burn_header_height: 2,
+            burn_header_timestamp: 2,
+            anchored_block_size: 1,
+        },
+        tx_receipts,
+        matured_rewards: vec![],
+        matured_rewards_info: None,
+        parent_microblocks_cost: ExecutionCost::zero(),
+        anchored_block_cost: ExecutionCost::zero(),
+        parent_burn_block_hash: BurnchainHeaderHash([0; 32]),
+        parent_burn_block_height: 1,
+        parent_burn_block_timestamp: 1,
+        evaluated_epoch: StacksEpochId::Epoch20,
+    }
+}
+
+fn make_dummy_coinbase_tx() -> StacksTransaction {
+    StacksTransaction::new(
+        TransactionVersion::Mainnet,
+        TransactionAuth::Standard(TransactionSpendingCondition::new_initial_sighash()),
+        TransactionPayload::Coinbase(CoinbasePayload([0; 32])),
+    )
+}
+
+fn make_dummy_transfer_tx(fee: u64) -> StacksTransactionReceipt {
+    let mut tx = StacksTransaction::new(
+        TransactionVersion::Mainnet,
+        TransactionAuth::Standard(TransactionSpendingCondition::new_initial_sighash()),
+        TransactionPayload::TokenTransfer(
+            PrincipalData::Standard(StandardPrincipalData(0, [0; 20])),
+            1,
+            TokenTransferMemo([0; 34]),
+        ),
+    );
+    tx.set_tx_fee(fee);
+
+    StacksTransactionReceipt::from_stx_transfer(
+        tx,
+        vec![],
+        Value::okay(Value::Bool(true)).unwrap(),
+        ExecutionCost::zero(),
+    )
+}
+
+fn make_dummy_cc_tx(fee: u64) -> StacksTransactionReceipt {
+    let mut tx = StacksTransaction::new(
+        TransactionVersion::Mainnet,
+        TransactionAuth::Standard(TransactionSpendingCondition::new_initial_sighash()),
+        TransactionPayload::ContractCall(TransactionContractCall {
+            address: StacksAddress::new(0, Hash160([0; 20])),
+            contract_name: "cc-dummy".into(),
+            function_name: "func-name".into(),
+            function_args: vec![],
+        }),
+    );
+    tx.set_tx_fee(fee);
+    StacksTransactionReceipt::from_contract_call(
+        tx,
+        vec![],
+        Value::okay(Value::Bool(true)).unwrap(),
+        0,
+        ExecutionCost::zero(),
+    )
+}
+
+#[test]
+fn test_fee_estimator() {
+    let metric = TestCostMetric;
+    let mut estimator = instantiate_test_db(metric);
+
+    assert_eq!(
+        estimator
+            .get_rate_estimates()
+            .expect_err("Empty rate estimator should error."),
+        EstimatorError::NoEstimateAvailable,
+        "Empty rate estimator should return no estimate available"
+    );
+
+    let empty_block_receipt = make_block_receipt(vec![]);
+    let block_limit = ExecutionCost::max_value();
+    estimator
+        .notify_block(&empty_block_receipt, &block_limit)
+        .expect("Should be able to process an empty block");
+
+    assert_eq!(
+        estimator
+            .get_rate_estimates()
+            .expect_err("Empty rate estimator should error."),
+        EstimatorError::NoEstimateAvailable,
+        "Empty block should not update the estimator"
+    );
+
+    let coinbase_only_receipt = make_block_receipt(vec![StacksTransactionReceipt::from_coinbase(
+        make_dummy_coinbase_tx(),
+    )]);
+
+    estimator
+        .notify_block(&coinbase_only_receipt, &block_limit)
+        .expect("Should be able to process an empty block");
+
+    assert_eq!(
+        estimator
+            .get_rate_estimates()
+            .expect_err("Empty rate estimator should error."),
+        EstimatorError::NoEstimateAvailable,
+        "Coinbase-only block should not update the estimator"
+    );
+
+    let single_tx_receipt = make_block_receipt(vec![
+        StacksTransactionReceipt::from_coinbase(make_dummy_coinbase_tx()),
+        make_dummy_cc_tx(1),
+    ]);
+
+    estimator
+        .notify_block(&single_tx_receipt, &block_limit)
+        .expect("Should be able to process block receipt");
+
+    assert_eq!(
+        estimator
+            .get_rate_estimates()
+            .expect("Should be able to create estimate now"),
+        FeeRateEstimate {
+            high: 1f64,
+            middle: 1f64,
+            low: 1f64
+        }
+    );
+
+    let double_tx_receipt = make_block_receipt(vec![
+        StacksTransactionReceipt::from_coinbase(make_dummy_coinbase_tx()),
+        make_dummy_cc_tx(1),
+        make_dummy_transfer_tx(10),
+    ]);
+
+    estimator
+        .notify_block(&double_tx_receipt, &block_limit)
+        .expect("Should be able to process block receipt");
+
+    // estimate should increase for "high" and "middle":
+    // 10 * 1/2 + 1 * 1/2 = 5.5
+    assert_eq!(
+        estimator
+            .get_rate_estimates()
+            .expect("Should be able to create estimate now"),
+        FeeRateEstimate {
+            high: 5.5f64,
+            middle: 5.5f64,
+            low: 1f64
+        }
+    );
+
+    // estimate should increase for "high" and "middle":
+    // new value: 10 * 1/2 + 5.5 * 1/2 = 7.75
+    estimator
+        .notify_block(&double_tx_receipt, &block_limit)
+        .expect("Should be able to process block receipt");
+    assert_eq!(
+        estimator
+            .get_rate_estimates()
+            .expect("Should be able to create estimate now"),
+        FeeRateEstimate {
+            high: 7.75f64,
+            middle: 7.75f64,
+            low: 1f64
+        }
+    );
+
+    // estimate should increase for "high" and "middle":
+    // new value: 10 * 1/2 + 7.75 * 1/2 = 8.875
+    estimator
+        .notify_block(&double_tx_receipt, &block_limit)
+        .expect("Should be able to process block receipt");
+    assert_eq!(
+        estimator
+            .get_rate_estimates()
+            .expect("Should be able to create estimate now"),
+        FeeRateEstimate {
+            high: 8.875f64,
+            middle: 8.875f64,
+            low: 1f64
+        }
+    );
+
+    // estimate should increase for "high" and "middle":
+    // new value: 10 * 1/2 + 8.875 * 1/2 = 9.4375
+    estimator
+        .notify_block(&double_tx_receipt, &block_limit)
+        .expect("Should be able to process block receipt");
+    assert_eq!(
+        estimator
+            .get_rate_estimates()
+            .expect("Should be able to create estimate now"),
+        FeeRateEstimate {
+            high: 9.4375f64,
+            middle: 9.4375f64,
+            low: 1f64
+        }
+    );
+
+    // estimate should increase for "high" and "middle":
+    // new value: 10 * 1/2 + 9.4375 * 1/2 = 9
+    estimator
+        .notify_block(&double_tx_receipt, &block_limit)
+        .expect("Should be able to process block receipt");
+    assert_eq!(
+        estimator
+            .get_rate_estimates()
+            .expect("Should be able to create estimate now"),
+        FeeRateEstimate {
+            high: 9.71875f64,
+            middle: 9.71875f64,
+            low: 1f64
+        }
+    );
+
+    // make a large block receipt, and expect:
+    //  measured high = 950, middle = 500, low = 50
+    //  new high: 950/2 + 9.71875/2 = 479.859375
+    //  new middle: 500/2 + 9.71875/2 = 254.859375
+    //  new low: 50/2 + 1/2 = 25.5
+
+    let mut receipts: Vec<_> = (0..100).map(|i| make_dummy_cc_tx(i * 10)).collect();
+    let mut rng = rand::thread_rng();
+    receipts.shuffle(&mut rng);
+
+    estimator
+        .notify_block(&make_block_receipt(receipts), &block_limit)
+        .expect("Should be able to process block receipt");
+
+    assert_eq!(
+        estimator
+            .get_rate_estimates()
+            .expect("Should be able to create estimate now"),
+        FeeRateEstimate {
+            high: 479.859375f64,
+            middle: 254.859375f64,
+            low: 25.5f64
+        }
+    );
+}

--- a/src/cost_estimates/tests/fee_medians.rs
+++ b/src/cost_estimates/tests/fee_medians.rs
@@ -27,6 +27,8 @@ use crate::cost_estimates::FeeRateEstimate;
 use crate::types::chainstate::StacksAddress;
 use crate::vm::types::{PrincipalData, StandardPrincipalData};
 use crate::vm::Value;
+use cost_estimates::fee_medians::fee_rate_estimate_from_sorted_weighted_fees;
+use cost_estimates::fee_medians::FeeRateAndWeight;
 
 /// Tolerance for approximate comparison.
 const error_epsilon: f64 = 0.1;
@@ -315,4 +317,71 @@ fn test_ten_blocks_mostly_filled() {
             low: 1f64
         }
     ));
+}
+
+//pub fn fee_rate_estimate_from_sorted_weighted_fees(
+//    sorted_fee_rates: &Vec<FeeRateAndWeight>,
+//) -> FeeRateEstimate {
+
+#[test]
+fn test_fee_rate_estimate_from_sorted_weighted_fees_5() {
+    assert_eq!(
+        fee_rate_estimate_from_sorted_weighted_fees(&vec![
+            FeeRateAndWeight {
+                fee_rate: 1f64,
+                weight: 5u64,
+            },
+            FeeRateAndWeight {
+                fee_rate: 10f64,
+                weight: 95u64,
+            },
+        ]),
+        FeeRateEstimate {
+            high: 10.0f64,
+            middle: 9.549999999999999f64,
+            low: 1.45f64
+        }
+    );
+}
+
+#[test]
+fn test_fee_rate_estimate_from_sorted_weighted_fees_2() {
+    assert_eq!(
+        fee_rate_estimate_from_sorted_weighted_fees(&vec![
+            FeeRateAndWeight {
+                fee_rate: 1f64,
+                weight: 50u64,
+            },
+            FeeRateAndWeight {
+                fee_rate: 10f64,
+                weight: 50u64,
+            },
+        ]),
+        FeeRateEstimate {
+            high: 10.0f64,
+            middle: 5.5f64,
+            low: 1.0f64
+        }
+    );
+}
+
+#[test]
+fn test_fee_rate_estimate_from_sorted_weighted_fees_3() {
+    assert_eq!(
+        fee_rate_estimate_from_sorted_weighted_fees(&vec![
+            FeeRateAndWeight {
+                fee_rate: 1f64,
+                weight: 95u64,
+            },
+            FeeRateAndWeight {
+                fee_rate: 10f64,
+                weight: 5u64,
+            },
+        ]),
+        FeeRateEstimate {
+            high: 9.549999999999999f64,
+            middle: 1.4500000000000004f64,
+            low: 1.0f64
+        }
+    );
 }

--- a/src/cost_estimates/tests/fee_medians.rs
+++ b/src/cost_estimates/tests/fee_medians.rs
@@ -202,6 +202,8 @@ fn test_one_block_partially_filled() {
         .expect("Should be able to process block receipt");
 
     // The higher fee is 10, because that's what we paid.
+    // The middle fee should be near 1, because the block is mostly empty, and dominated by the
+    // minimum fee rate padding.
     // The lower fee is 1 because of the minimum fee rate padding.
     assert!(is_close(
         estimator
@@ -233,6 +235,7 @@ fn test_one_block_mostly_filled() {
         .expect("Should be able to process block receipt");
 
     // The higher fee is 10, because that's what we paid.
+    // The middle fee should be 10, because the block is mostly filled.
     // The lower fee is 1 because of the minimum fee rate padding.
     assert!(is_close(
         estimator
@@ -267,8 +270,7 @@ fn test_five_blocks_mostly_filled() {
             .expect("Should be able to process block receipt");
     }
 
-    // The higher fee is 10, because of the contract.
-    // The lower fee is 1 because of the minimum fee rate padding.
+    // The fee should be 30, because it's the median of [10, 20, .., 50].
     assert!(is_close(
         estimator
             .get_rate_estimates()
@@ -302,8 +304,7 @@ fn test_ten_blocks_mostly_filled() {
             .expect("Should be able to process block receipt");
     }
 
-    // The higher fee is 10, because of the contract.
-    // The lower fee is 1 because of the minimum fee rate padding.
+    // The fee should be 80, because we forgot the first five estimates.
     assert!(is_close(
         estimator
             .get_rate_estimates()

--- a/src/cost_estimates/tests/fee_medians.rs
+++ b/src/cost_estimates/tests/fee_medians.rs
@@ -145,13 +145,16 @@ const block_limit: ExecutionCost = ExecutionCost {
     runtime: 100,
 };
 
-const operation_cost: ExecutionCost = ExecutionCost {
+const tenth_operation_cost: ExecutionCost = ExecutionCost {
     write_length: 10,
     write_count: 10,
     read_length: 10,
     read_count: 10,
     runtime: 10,
 };
+
+// The scalar cost of `make_dummy_cc_tx(_, &tenth_operation_cost)`.
+const contract_call_cost_basis:u64 = 5160;
 
 #[test]
 fn test_empty_fee_estimator() {
@@ -195,11 +198,9 @@ fn test_single_contract_call() {
     let metric = ProportionalDotProduct::new(10_000);
     let mut estimator = instantiate_test_db(metric);
 
-    // The scalar cost of `make_dummy_cc_tx(_, &operation_cost)`.
-    let operation_cost_basis = 5160;
     let single_tx_receipt = make_block_receipt(vec![
         StacksTransactionReceipt::from_coinbase(make_dummy_coinbase_tx()),
-        make_dummy_cc_tx(10 * operation_cost_basis, &operation_cost),
+        make_dummy_cc_tx(10 * contract_call_cost_basis, &tenth_operation_cost),
     ]);
 
     estimator
@@ -229,7 +230,7 @@ fn test_five_contract_calls() {
         warn!("i {}", i);
         let single_tx_receipt = make_block_receipt(vec![
             StacksTransactionReceipt::from_coinbase(make_dummy_coinbase_tx()),
-            make_dummy_cc_tx(i * 10, &operation_cost),
+            make_dummy_cc_tx(i * 10 * contract_call_cost_basis, &tenth_operation_cost),
         ]);
 
         estimator

--- a/src/cost_estimates/tests/fee_medians.rs
+++ b/src/cost_estimates/tests/fee_medians.rs
@@ -286,186 +286,41 @@ fn test_five_blocks_mostly_filled() {
             .get_rate_estimates()
             .expect("Should be able to create estimate now"),
         FeeRateEstimate {
-            high: 10f64,
-            middle: 10f64,
+            high: 30f64,
+            middle: 30f64,
             low: 1f64
         }
     ));
 }
 
-//
-//#[test]
-//fn test_fee_estimator() {
-//    let metric = ProportionalDotProduct;
-//    let mut estimator = instantiate_test_db(metric);
-//
-//    assert_eq!(
-//        estimator
-//            .get_rate_estimates()
-//            .expect_err("Empty rate estimator should error."),
-//        EstimatorError::NoEstimateAvailable,
-//        "Empty rate estimator should return no estimate available"
-//    );
-//
-//    let empty_block_receipt = make_block_receipt(vec![]);
-//    let block_limit = ExecutionCost::max_value();
-//    estimator
-//        .notify_block(&empty_block_receipt, &block_limit)
-//        .expect("Should be able to process an empty block");
-//
-//    assert_eq!(
-//        estimator
-//            .get_rate_estimates()
-//            .expect_err("Empty rate estimator should error."),
-//        EstimatorError::NoEstimateAvailable,
-//        "Empty block should not update the estimator"
-//    );
-//
-//    let coinbase_only_receipt = make_block_receipt(vec![StacksTransactionReceipt::from_coinbase(
-//        make_dummy_coinbase_tx(),
-//    )]);
-//
-//    estimator
-//        .notify_block(&coinbase_only_receipt, &block_limit)
-//        .expect("Should be able to process an empty block");
-//
-//    assert_eq!(
-//        estimator
-//            .get_rate_estimates()
-//            .expect_err("Empty rate estimator should error."),
-//        EstimatorError::NoEstimateAvailable,
-//        "Coinbase-only block should not update the estimator"
-//    );
-//
-//    let single_tx_receipt = make_block_receipt(vec![
-//        StacksTransactionReceipt::from_coinbase(make_dummy_coinbase_tx()),
-//        make_dummy_cc_tx(1),
-//    ]);
-//
-//    estimator
-//        .notify_block(&single_tx_receipt, &block_limit)
-//        .expect("Should be able to process block receipt");
-//
-//    assert_eq!(
-//        estimator
-//            .get_rate_estimates()
-//            .expect("Should be able to create estimate now"),
-//        FeeRateEstimate {
-//            high: 1f64,
-//            middle: 1f64,
-//            low: 1f64
-//        }
-//    );
-//
-//    let double_tx_receipt = make_block_receipt(vec![
-//        StacksTransactionReceipt::from_coinbase(make_dummy_coinbase_tx()),
-//        make_dummy_cc_tx(1),
-//        make_dummy_transfer_tx(10),
-//    ]);
-//
-//    estimator
-//        .notify_block(&double_tx_receipt, &block_limit)
-//        .expect("Should be able to process block receipt");
-//
-//    // estimate should increase for "high" and "middle":
-//    // 10 * 1/2 + 1 * 1/2 = 5.5
-//    assert_eq!(
-//        estimator
-//            .get_rate_estimates()
-//            .expect("Should be able to create estimate now"),
-//        FeeRateEstimate {
-//            high: 5.5f64,
-//            middle: 5.5f64,
-//            low: 1f64
-//        }
-//    );
-//
-//    // estimate should increase for "high" and "middle":
-//    // new value: 10 * 1/2 + 5.5 * 1/2 = 7.75
-//    estimator
-//        .notify_block(&double_tx_receipt, &block_limit)
-//        .expect("Should be able to process block receipt");
-//    assert_eq!(
-//        estimator
-//            .get_rate_estimates()
-//            .expect("Should be able to create estimate now"),
-//        FeeRateEstimate {
-//            high: 7.75f64,
-//            middle: 7.75f64,
-//            low: 1f64
-//        }
-//    );
-//
-//    // estimate should increase for "high" and "middle":
-//    // new value: 10 * 1/2 + 7.75 * 1/2 = 8.875
-//    estimator
-//        .notify_block(&double_tx_receipt, &block_limit)
-//        .expect("Should be able to process block receipt");
-//    assert_eq!(
-//        estimator
-//            .get_rate_estimates()
-//            .expect("Should be able to create estimate now"),
-//        FeeRateEstimate {
-//            high: 8.875f64,
-//            middle: 8.875f64,
-//            low: 1f64
-//        }
-//    );
-//
-//    // estimate should increase for "high" and "middle":
-//    // new value: 10 * 1/2 + 8.875 * 1/2 = 9.4375
-//    estimator
-//        .notify_block(&double_tx_receipt, &block_limit)
-//        .expect("Should be able to process block receipt");
-//    assert_eq!(
-//        estimator
-//            .get_rate_estimates()
-//            .expect("Should be able to create estimate now"),
-//        FeeRateEstimate {
-//            high: 9.4375f64,
-//            middle: 9.4375f64,
-//            low: 1f64
-//        }
-//    );
-//
-//    // estimate should increase for "high" and "middle":
-//    // new value: 10 * 1/2 + 9.4375 * 1/2 = 9
-//    estimator
-//        .notify_block(&double_tx_receipt, &block_limit)
-//        .expect("Should be able to process block receipt");
-//    assert_eq!(
-//        estimator
-//            .get_rate_estimates()
-//            .expect("Should be able to create estimate now"),
-//        FeeRateEstimate {
-//            high: 9.71875f64,
-//            middle: 9.71875f64,
-//            low: 1f64
-//        }
-//    );
-//
-//    // make a large block receipt, and expect:
-//    //  measured high = 950, middle = 500, low = 50
-//    //  new high: 950/2 + 9.71875/2 = 479.859375
-//    //  new middle: 500/2 + 9.71875/2 = 254.859375
-//    //  new low: 50/2 + 1/2 = 25.5
-//
-//    let mut receipts: Vec<_> = (0..100).map(|i| make_dummy_cc_tx(i * 10)).collect();
-//    let mut rng = rand::thread_rng();
-//    receipts.shuffle(&mut rng);
-//
-//    estimator
-//        .notify_block(&make_block_receipt(receipts), &block_limit)
-//        .expect("Should be able to process block receipt");
-//
-//    assert_eq!(
-//        estimator
-//            .get_rate_estimates()
-//            .expect("Should be able to create estimate now"),
-//        FeeRateEstimate {
-//            high: 479.859375f64,
-//            middle: 254.859375f64,
-//            low: 25.5f64
-//        }
-//    );
-//}
+#[test]
+fn test_ten_blocks_mostly_filled() {
+    let metric = ProportionalDotProduct::new(10_000);
+    let mut estimator = instantiate_test_db(metric);
+
+    for i in 1..11 {
+        warn!("i {}", i);
+        let single_tx_receipt = make_block_receipt(vec![
+            StacksTransactionReceipt::from_coinbase(make_dummy_coinbase_tx()),
+            make_dummy_cc_tx(i * 10 * half_operation_cost_basis, &half_operation_cost),
+            make_dummy_cc_tx(i * 10 * half_operation_cost_basis, &half_operation_cost),
+        ]);
+
+        estimator
+            .notify_block(&single_tx_receipt, &block_limit)
+            .expect("Should be able to process block receipt");
+    }
+
+    // The higher fee is 10, because of the contract.
+    // The lower fee is 1 because of the minimum fee rate padding.
+    assert!(is_close(
+        estimator
+            .get_rate_estimates()
+            .expect("Should be able to create estimate now"),
+        FeeRateEstimate {
+            high: 80f64,
+            middle: 80f64,
+            low: 1f64
+        }
+    ));
+}

--- a/src/cost_estimates/tests/fee_medians.rs
+++ b/src/cost_estimates/tests/fee_medians.rs
@@ -319,12 +319,8 @@ fn test_ten_blocks_mostly_filled() {
     ));
 }
 
-//pub fn fee_rate_estimate_from_sorted_weighted_fees(
-//    sorted_fee_rates: &Vec<FeeRateAndWeight>,
-//) -> FeeRateEstimate {
-
 #[test]
-fn test_fee_rate_estimate_from_sorted_weighted_fees_5() {
+fn test_fee_rate_estimate_5_vs_95() {
     assert_eq!(
         fee_rate_estimate_from_sorted_weighted_fees(&vec![
             FeeRateAndWeight {
@@ -345,7 +341,7 @@ fn test_fee_rate_estimate_from_sorted_weighted_fees_5() {
 }
 
 #[test]
-fn test_fee_rate_estimate_from_sorted_weighted_fees_2() {
+fn test_fee_rate_estimate_50_vs_50() {
     assert_eq!(
         fee_rate_estimate_from_sorted_weighted_fees(&vec![
             FeeRateAndWeight {
@@ -366,7 +362,7 @@ fn test_fee_rate_estimate_from_sorted_weighted_fees_2() {
 }
 
 #[test]
-fn test_fee_rate_estimate_from_sorted_weighted_fees_3() {
+fn test_fee_rate_estimate_95_vs_5() {
     assert_eq!(
         fee_rate_estimate_from_sorted_weighted_fees(&vec![
             FeeRateAndWeight {
@@ -382,6 +378,46 @@ fn test_fee_rate_estimate_from_sorted_weighted_fees_3() {
             high: 9.549999999999999f64,
             middle: 1.4500000000000004f64,
             low: 1.0f64
+        }
+    );
+}
+
+#[test]
+fn test_fee_rate_estimate_20() {
+    let mut pairs = vec![];
+    for i in 1..21 {
+        pairs.push(FeeRateAndWeight {
+            fee_rate: 1f64 * i as f64,
+            weight: 1u64,
+        })
+    }
+
+    assert_eq!(
+        fee_rate_estimate_from_sorted_weighted_fees(&pairs),
+        FeeRateEstimate {
+            high: 19.5f64,
+            middle: 10.5f64,
+            low: 1.5f64
+        }
+    );
+}
+
+#[test]
+fn test_fee_rate_estimate_100() {
+    let mut pairs = vec![];
+    for i in 1..101 {
+        pairs.push(FeeRateAndWeight {
+            fee_rate: 1f64 * i as f64,
+            weight: 1u64,
+        })
+    }
+
+    assert_eq!(
+        fee_rate_estimate_from_sorted_weighted_fees(&pairs),
+        FeeRateEstimate {
+            high: 95.5f64,
+            middle: 50.5f64,
+            low: 5.5f64
         }
     );
 }

--- a/src/cost_estimates/tests/fee_medians.rs
+++ b/src/cost_estimates/tests/fee_medians.rs
@@ -34,7 +34,6 @@ const error_epsilon: f64 = 0.1;
 /// Returns `true` iff each value in `left` is within `error_epsilon` of the
 /// corresponding value in `right`.
 fn is_close(left: FeeRateEstimate, right: FeeRateEstimate) -> bool {
-    warn!("Checking ExecutionCost's. {:?} vs {:?}", left, right);
     let is_ok = (left.high - right.high).abs() < error_epsilon
         && (left.middle - right.middle).abs() < error_epsilon
         && (left.low - right.low).abs() < error_epsilon;
@@ -257,7 +256,6 @@ fn test_five_blocks_mostly_filled() {
     let mut estimator = instantiate_test_db(metric);
 
     for i in 1..6 {
-        warn!("i {}", i);
         let single_tx_receipt = make_block_receipt(vec![
             StacksTransactionReceipt::from_coinbase(make_dummy_coinbase_tx()),
             make_dummy_cc_tx(i * 10 * half_operation_cost_basis, &half_operation_cost),
@@ -293,7 +291,6 @@ fn test_ten_blocks_mostly_filled() {
     let mut estimator = instantiate_test_db(metric);
 
     for i in 1..11 {
-        warn!("i {}", i);
         let single_tx_receipt = make_block_receipt(vec![
             StacksTransactionReceipt::from_coinbase(make_dummy_coinbase_tx()),
             make_dummy_cc_tx(i * 10 * half_operation_cost_basis, &half_operation_cost),

--- a/src/cost_estimates/tests/mod.rs
+++ b/src/cost_estimates/tests/mod.rs
@@ -2,6 +2,7 @@ use cost_estimates::FeeRateEstimate;
 
 pub mod cost_estimators;
 pub mod fee_scalar;
+pub mod fee_medians;
 pub mod metrics;
 
 #[test]

--- a/src/cost_estimates/tests/mod.rs
+++ b/src/cost_estimates/tests/mod.rs
@@ -1,8 +1,8 @@
 use cost_estimates::FeeRateEstimate;
 
 pub mod cost_estimators;
-pub mod fee_scalar;
 pub mod fee_medians;
+pub mod fee_scalar;
 pub mod metrics;
 
 #[test]


### PR DESCRIPTION
Addresses #2954

https://github.com/blockstack/stacks-blockchain/issues/2954#issuecomment-983017453 discusses four proposals for improving fee estimation.

We address these first three:

1. Address outlier block sensitivity by using a median of a window, rather than exponential windowing.
2. Address impact of STX transfers by using percentiles weighted by the proportion of the block limit consumed rather than 5th, 50th, and 95th percentiles. See weighted percentiles.
3. Address impact of non-full blocks by treating the non-full proportion of the block as a transaction at the relay fee minimum (a fee of 0 is too low for admission to the mempool).

These changes are tested with a suite of new unit tests.