### PR TITLE
Feat/miner structured logging

### DIFF
--- a/.github/workflows/bitcoin-tests.yml
+++ b/.github/workflows/bitcoin-tests.yml
@@ -43,6 +43,7 @@ jobs:
           - tests::neon_integrations::bitcoind_forking_test
           - tests::neon_integrations::should_fix_2771
           - tests::neon_integrations::pox_integration_test
+          - tests::neon_integrations::mining_events_integration_test
           - tests::bitcoin_regtest::bitcoind_integration_test
           - tests::should_succeed_handling_malformed_and_valid_txs
           - tests::neon_integrations::size_overflow_unconfirmed_microblocks_integration_test

--- a/docs/event-dispatcher.md
+++ b/docs/event-dispatcher.md
@@ -245,7 +245,7 @@ Example:
 ```json
 {
   "block_hash": "0x4eaabcd105865e471f697eff5dd5bd85d47ecb5a26a3379d74fae0ae87c40904",
-  "staks_height": 3,
+  "stacks_height": 3,
   "target_burn_height": 745000,
   "block_size": 145000,
   "anchored_cost": {
@@ -261,6 +261,81 @@ Example:
     "write_count": 5,
     "read_length": 150,
     "write_length": 75
-  }
+  },
+  "tx_events": [
+    {
+      "Success": {
+        "txid": "3e04ada5426332bfef446ba0a06d124aace4ade5c11840f541bf88e2e919faf6", 
+        "fee": 0, 
+        "execution_cost": { 
+          "write_length": 0, 
+          "write_count": 0, 
+          "read_length": 0, 
+          "read_count": 0, 
+          "runtime": 0
+        }, 
+        "result": {
+          "ResponseData": 
+          {
+            "committed": true,
+            "data": true
+          }
+        }
+    }}, 
+    {
+      "ProcessingError": {
+        "txid": "eef9f46b20fb637bd07ec92ad3ec175a5a4bdf3e8799259fc5b16a272090d4de",
+        "error": "Duplicate contract 'ST3BMYNT1DW2QSRZWB6M4S183NK1BXGJ41TEBCCH8.example'"
+      }
+    }
+  ]
+}
+```
+
+### `POST /mined_microblock`
+
+This payload includes data related to microblocks mined by this Stacks node. This
+will never be invoked if the node is configured only as a follower. This is invoked
+when the miner **assembles** the microblock; this microblock may or may be incorporated
+into the canonical chain.
+
+This endpoint will only broadcast events to observers that explicitly register for
+`MinedMicroblocks` events, `AnyEvent` observers will not receive the events by default.
+
+Example:
+
+```json
+{
+  "block_hash": "0x4eaabcd105865e471f697eff5dd5bd85d47ecb5a26a3379d74fae0ae87c40904",
+  "sequence": 3,
+  "anchor_block_consensus_hash": "53c166a709a9abd64a92a57f928a8b26aad08992",
+  "anchor_block": "43dbf6095c7622db6607d9584c3f65e908ca4eb77d86ee8cc1352aafec5d68b5",
+  "tx_events": [
+    {
+      "Success": {
+        "txid": "3e04ada5426332bfef446ba0a06d124aace4ade5c11840f541bf88e2e919faf6", 
+        "fee": 0, 
+        "execution_cost": { 
+          "write_length": 10, 
+          "write_count": 10, 
+          "read_length": 20, 
+          "read_count": 10, 
+          "runtime": 1290
+        }, 
+        "result": {
+          "ResponseData": 
+          {
+            "committed": true,
+            "data": true
+          }
+        }
+    }}, 
+    {
+      "Skipped": {
+        "txid": "eef9f46b20fb637bd07ec92ad3ec175a5a4bdf3e8799259fc5b16a272090d4de",
+        "reason": "tx.anchor_mode does not support microblocks, anchor_mode=OnChainOnly."
+      }
+    }
+  ]
 }
 ```

--- a/src/chainstate/stacks/miner.rs
+++ b/src/chainstate/stacks/miner.rs
@@ -136,7 +136,7 @@ impl From<&UnconfirmedState> for MicroblockMinerRuntime {
 #[derive(Debug, Clone, PartialEq)]
 pub struct TransactionSuccess {
     pub tx: StacksTransaction,
-    // The fee that was charged to the user for doing this transaction.
+    /// The fee that was charged to the user for doing this transaction.
     pub fee: u64,
     pub receipt: StacksTransactionReceipt,
 }
@@ -152,6 +152,7 @@ pub struct TransactionError {
 #[derive(Debug)]
 pub struct TransactionSkipped {
     pub tx: StacksTransaction,
+    /// This error is the reason the transaction was skipped (ex: BlockTooBigError)
     pub error: Error,
 }
 

--- a/src/chainstate/stacks/mod.rs
+++ b/src/chainstate/stacks/mod.rs
@@ -144,12 +144,13 @@ pub enum Error {
     InvalidFee,
     InvalidStacksBlock(String),
     InvalidStacksMicroblock(String, BlockHeaderHash),
+    // The bool is true if the invalid transaction was quietly ignored.
     InvalidStacksTransaction(String, bool),
     /// This error indicates that the considered transaction was skipped
     /// because of the current state of the block assembly algorithm,
     /// but the transaction otherwise may be valid (e.g., block assembly is
     /// only considering STX transfers and this tx isn't a transfer).
-    StacksTransactionSkipped,
+    StacksTransactionSkipped(String),
     PostConditionFailed(String),
     NoSuchBlockError,
     InvalidChainstateDB,
@@ -234,8 +235,12 @@ impl fmt::Display for Error {
             Error::PoxAlreadyLocked => write!(f, "Account has already locked STX for PoX"),
             Error::PoxInsufficientBalance => write!(f, "Not enough STX to lock"),
             Error::PoxNoRewardCycle => write!(f, "No such reward cycle"),
-            Error::StacksTransactionSkipped => {
-                write!(f, "Stacks transaction skipped during assembly")
+            Error::StacksTransactionSkipped(ref r) => {
+                write!(
+                    f,
+                    "Stacks transaction skipped during assembly due to: {}",
+                    r
+                )
             }
         }
     }
@@ -269,7 +274,7 @@ impl error::Error for Error {
             Error::PoxAlreadyLocked => None,
             Error::PoxInsufficientBalance => None,
             Error::PoxNoRewardCycle => None,
-            Error::StacksTransactionSkipped => None,
+            Error::StacksTransactionSkipped(ref _r) => None,
         }
     }
 }
@@ -302,7 +307,7 @@ impl Error {
             Error::PoxAlreadyLocked => "PoxAlreadyLocked",
             Error::PoxInsufficientBalance => "PoxInsufficientBalance",
             Error::PoxNoRewardCycle => "PoxNoRewardCycle",
-            Error::StacksTransactionSkipped => "StacksTransactionSkipped",
+            Error::StacksTransactionSkipped(ref _r) => "StacksTransactionSkipped",
         }
     }
 

--- a/src/core/mempool.rs
+++ b/src/core/mempool.rs
@@ -73,6 +73,7 @@ use crate::cost_estimates::UnitEstimator;
 use crate::monitoring;
 use crate::types::chainstate::{BlockHeaderHash, StacksAddress, StacksBlockHeader};
 use crate::util::db::table_exists;
+use chainstate::stacks::miner::TransactionResult;
 
 // maximum number of confirmations a transaction can have before it's garbage-collected
 pub const MEMPOOL_MAX_TRANSACTION_AGE: u64 = 256;
@@ -714,7 +715,8 @@ impl MemPoolDB {
     ///  highest-fee-first order.  This method is interruptable -- in the `settings` struct, the
     ///  caller may choose how long to spend iterating before this method stops.
     ///
-    ///  Returns the number of transactions considered on success.
+    ///  `todo` must return a result of type StacksTransactionResult, indicating the outcome of the
+    ///  transaction.
     pub fn iterate_candidates<F, E, C>(
         &mut self,
         clarity_tx: &mut C,

--- a/src/core/mempool.rs
+++ b/src/core/mempool.rs
@@ -34,11 +34,11 @@ use rusqlite::NO_PARAMS;
 
 use burnchains::Txid;
 use chainstate::burn::ConsensusHash;
-use chainstate::stacks::TransactionPayload;
 use chainstate::stacks::{
     db::blocks::MemPoolRejection, db::ClarityTx, db::StacksChainState, index::Error as MarfError,
     Error as ChainstateError, StacksTransaction,
 };
+use chainstate::stacks::{StacksMicroblock, TransactionPayload};
 use core::ExecutionCost;
 use core::StacksEpochId;
 use core::FIRST_BURNCHAIN_CONSENSUS_HASH;
@@ -73,7 +73,7 @@ use crate::cost_estimates::UnitEstimator;
 use crate::monitoring;
 use crate::types::chainstate::{BlockHeaderHash, StacksAddress, StacksBlockHeader};
 use crate::util::db::table_exists;
-use chainstate::stacks::miner::TransactionResult;
+use chainstate::stacks::miner::TransactionEvent;
 
 // maximum number of confirmations a transaction can have before it's garbage-collected
 pub const MEMPOOL_MAX_TRANSACTION_AGE: u64 = 256;
@@ -154,6 +154,14 @@ pub trait MemPoolEventDispatcher {
         block_size_bytes: u64,
         consumed: &ExecutionCost,
         confirmed_microblock_cost: &ExecutionCost,
+        tx_results: Vec<TransactionEvent>,
+    );
+    fn mined_microblock_event(
+        &self,
+        microblock: &StacksMicroblock,
+        tx_results: Vec<TransactionEvent>,
+        anchor_block_consensus_hash: ConsensusHash,
+        anchor_block: BlockHeaderHash,
     );
 }
 

--- a/src/core/mempool.rs
+++ b/src/core/mempool.rs
@@ -723,7 +723,7 @@ impl MemPoolDB {
     ///  highest-fee-first order.  This method is interruptable -- in the `settings` struct, the
     ///  caller may choose how long to spend iterating before this method stops.
     ///
-    ///  `todo` returns the number of transactions considered on success.
+    ///  `todo` returns a boolean representing whether or not to keep iterating.
     pub fn iterate_candidates<F, E, C>(
         &mut self,
         clarity_tx: &mut C,

--- a/src/core/mempool.rs
+++ b/src/core/mempool.rs
@@ -723,8 +723,7 @@ impl MemPoolDB {
     ///  highest-fee-first order.  This method is interruptable -- in the `settings` struct, the
     ///  caller may choose how long to spend iterating before this method stops.
     ///
-    ///  `todo` must return a result of type StacksTransactionResult, indicating the outcome of the
-    ///  transaction.
+    ///  `todo` returns the number of transactions considered on success.
     pub fn iterate_candidates<F, E, C>(
         &mut self,
         clarity_tx: &mut C,

--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -1471,6 +1471,7 @@ pub enum EventKeyType {
     AnyEvent,
     BurnchainBlocks,
     MinedBlocks,
+    MinedMicroblocks,
 }
 
 impl EventKeyType {

--- a/testnet/stacks-node/src/event_dispatcher.rs
+++ b/testnet/stacks-node/src/event_dispatcher.rs
@@ -21,14 +21,16 @@ use stacks::chainstate::stacks::events::{
     FTEventType, NFTEventType, STXEventType, StacksTransactionEvent, StacksTransactionReceipt,
     TransactionOrigin,
 };
-use stacks::chainstate::stacks::StacksBlock;
 use stacks::chainstate::stacks::{
     db::accounts::MinerReward, db::MinerRewardInfo, StacksTransaction,
 };
+use stacks::chainstate::stacks::{StacksBlock, StacksMicroblock};
 use stacks::codec::StacksMessageCodec;
 use stacks::core::mempool::{MemPoolDropReason, MemPoolEventDispatcher};
 use stacks::net::atlas::{Attachment, AttachmentInstance};
-use stacks::types::chainstate::{BurnchainHeaderHash, StacksAddress, StacksBlockId};
+use stacks::types::chainstate::{
+    BlockHeaderHash, BurnchainHeaderHash, StacksAddress, StacksBlockId,
+};
 use stacks::util::hash::bytes_to_hex;
 use stacks::vm::analysis::contract_interface_builder::build_contract_interface;
 use stacks::vm::costs::ExecutionCost;
@@ -36,7 +38,9 @@ use stacks::vm::types::{AssetIdentifier, QualifiedContractIdentifier, Value};
 
 use super::config::{EventKeyType, EventObserverConfig};
 use super::node::ChainTip;
+use stacks::chainstate::burn::ConsensusHash;
 use stacks::chainstate::stacks::db::unconfirmed::ProcessedUnconfirmedState;
+use stacks::chainstate::stacks::miner::TransactionEvent;
 
 #[derive(Debug, Clone)]
 struct EventObserver {
@@ -61,11 +65,12 @@ pub const PATH_MICROBLOCK_SUBMIT: &str = "new_microblocks";
 pub const PATH_MEMPOOL_TX_SUBMIT: &str = "new_mempool_tx";
 pub const PATH_MEMPOOL_TX_DROP: &str = "drop_mempool_tx";
 pub const PATH_MINED_BLOCK: &str = "mined_block";
+pub const PATH_MINED_MICROBLOCK: &str = "mined_microblock";
 pub const PATH_BURN_BLOCK_SUBMIT: &str = "new_burn_block";
 pub const PATH_BLOCK_PROCESSED: &str = "new_block";
 pub const PATH_ATTACHMENT_PROCESSED: &str = "attachments/new";
 
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct MinedBlockEvent {
     pub target_burn_height: u64,
     pub block_hash: String,
@@ -73,6 +78,16 @@ pub struct MinedBlockEvent {
     pub block_size: u64,
     pub anchored_cost: ExecutionCost,
     pub confirmed_microblocks_cost: ExecutionCost,
+    pub tx_events: Vec<TransactionEvent>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct MinedMicroblockEvent {
+    pub block_hash: String,
+    pub sequence: u16,
+    pub tx_events: Vec<TransactionEvent>,
+    pub anchor_block_consensus_hash: ConsensusHash,
+    pub anchor_block: BlockHeaderHash,
 }
 
 impl EventObserver {
@@ -311,6 +326,10 @@ impl EventObserver {
         self.send_payload(payload, PATH_MINED_BLOCK);
     }
 
+    fn send_mined_microblock(&self, payload: &serde_json::Value) {
+        self.send_payload(payload, PATH_MINED_MICROBLOCK);
+    }
+
     fn send_new_burn_block(&self, payload: &serde_json::Value) {
         self.send_payload(payload, PATH_BURN_BLOCK_SUBMIT);
     }
@@ -385,6 +404,7 @@ pub struct EventDispatcher {
     stx_observers_lookup: HashSet<u16>,
     any_event_observers_lookup: HashSet<u16>,
     miner_observers_lookup: HashSet<u16>,
+    mined_microblocks_observers_lookup: HashSet<u16>,
     boot_receipts: Arc<Mutex<Option<Vec<StacksTransactionReceipt>>>>,
 }
 
@@ -402,6 +422,7 @@ impl MemPoolEventDispatcher for EventDispatcher {
         block_size_bytes: u64,
         consumed: &ExecutionCost,
         confirmed_microblock_cost: &ExecutionCost,
+        tx_events: Vec<TransactionEvent>,
     ) {
         self.process_mined_block_event(
             target_burn_height,
@@ -409,7 +430,23 @@ impl MemPoolEventDispatcher for EventDispatcher {
             block_size_bytes,
             consumed,
             confirmed_microblock_cost,
+            tx_events,
         )
+    }
+
+    fn mined_microblock_event(
+        &self,
+        microblock: &StacksMicroblock,
+        tx_events: Vec<TransactionEvent>,
+        anchor_block_consensus_hash: ConsensusHash,
+        anchor_block: BlockHeaderHash,
+    ) {
+        self.process_mined_microblock_event(
+            microblock,
+            tx_events,
+            anchor_block_consensus_hash,
+            anchor_block,
+        );
     }
 }
 
@@ -483,6 +520,7 @@ impl EventDispatcher {
             microblock_observers_lookup: HashSet::new(),
             boot_receipts: Arc::new(Mutex::new(None)),
             miner_observers_lookup: HashSet::new(),
+            mined_microblocks_observers_lookup: HashSet::new(),
         }
     }
 
@@ -790,6 +828,7 @@ impl EventDispatcher {
         block_size_bytes: u64,
         consumed: &ExecutionCost,
         confirmed_microblock_cost: &ExecutionCost,
+        tx_events: Vec<TransactionEvent>,
     ) {
         let interested_observers: Vec<_> = self
             .registered_observers
@@ -808,11 +847,46 @@ impl EventDispatcher {
             block_size: block_size_bytes,
             anchored_cost: consumed.clone(),
             confirmed_microblocks_cost: confirmed_microblock_cost.clone(),
+            tx_events,
         })
         .unwrap();
 
         for (_, observer) in interested_observers.iter() {
             observer.send_mined_block(&payload);
+        }
+    }
+
+    pub fn process_mined_microblock_event(
+        &self,
+        microblock: &StacksMicroblock,
+        tx_events: Vec<TransactionEvent>,
+        anchor_block_consensus_hash: ConsensusHash,
+        anchor_block: BlockHeaderHash,
+    ) {
+        let interested_observers: Vec<_> = self
+            .registered_observers
+            .iter()
+            .enumerate()
+            .filter(|(obs_id, _observer)| {
+                self.mined_microblocks_observers_lookup
+                    .contains(&(*obs_id as u16))
+            })
+            .collect();
+        if interested_observers.len() < 1 {
+            return;
+        }
+
+        let payload = serde_json::to_value(MinedMicroblockEvent {
+            block_hash: microblock.block_hash().to_string(),
+            sequence: microblock.header.sequence,
+            tx_events,
+            anchor_block_consensus_hash,
+            anchor_block,
+        })
+        .unwrap();
+
+        for (_, observer) in interested_observers.iter() {
+            observer.send_mined_microblock(&payload);
         }
     }
 
@@ -939,6 +1013,10 @@ impl EventDispatcher {
                 }
                 EventKeyType::MinedBlocks => {
                     self.miner_observers_lookup.insert(observer_index);
+                }
+                EventKeyType::MinedMicroblocks => {
+                    self.mined_microblocks_observers_lookup
+                        .insert(observer_index);
                 }
             }
         }

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -333,6 +333,7 @@ fn mine_one_microblock(
     sortdb: &SortitionDB,
     chainstate: &mut StacksChainState,
     mempool: &mut MemPoolDB,
+    event_dispatcher: &EventDispatcher,
 ) -> Result<StacksMicroblock, ChainstateError> {
     debug!(
         "Try to mine one microblock off of {}/{} (total: {})",
@@ -368,7 +369,11 @@ fn mine_one_microblock(
 
         let t1 = get_epoch_time_ms();
 
-        let mblock = microblock_miner.mine_next_microblock(mempool, &microblock_state.miner_key)?;
+        let mblock = microblock_miner.mine_next_microblock(
+            mempool,
+            &microblock_state.miner_key,
+            event_dispatcher,
+        )?;
         let new_cost_so_far = microblock_miner.get_cost_so_far().expect("BUG: cannot read cost so far from miner -- indicates that the underlying Clarity Tx is somehow in use still.");
         let t2 = get_epoch_time_ms();
 
@@ -411,6 +416,7 @@ fn try_mine_microblock(
     sortdb: &SortitionDB,
     mem_pool: &mut MemPoolDB,
     winning_tip: (ConsensusHash, BlockHeaderHash, Secp256k1PrivateKey),
+    event_dispatcher: &EventDispatcher,
 ) -> Result<Option<StacksMicroblock>, NetError> {
     let ch = winning_tip.0;
     let bhh = winning_tip.1;
@@ -471,7 +477,13 @@ fn try_mine_microblock(
                     get_epoch_time_secs() - 600,
                 )?;
                 if num_attachable == 0 {
-                    match mine_one_microblock(&mut microblock_miner, sortdb, chainstate, mem_pool) {
+                    match mine_one_microblock(
+                        &mut microblock_miner,
+                        sortdb,
+                        chainstate,
+                        mem_pool,
+                        event_dispatcher,
+                    ) {
                         Ok(microblock) => {
                             // will need to relay this
                             next_microblock = Some(microblock);
@@ -526,6 +538,7 @@ fn run_microblock_tenure(
         sortdb,
         mem_pool,
         miner_tip.clone(),
+        event_dispatcher,
     ) {
         Ok(x) => x,
         Err(e) => {

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -71,6 +71,9 @@ use super::{
     make_microblock, make_stacks_transfer, make_stacks_transfer_mblock_only, to_addr, ADDR_4, SK_1,
     SK_2,
 };
+use stacks::chainstate::stacks::miner::{
+    TransactionErrorEvent, TransactionEvent, TransactionSkippedEvent, TransactionSuccessEvent,
+};
 
 pub fn neon_integration_test_conf() -> (Config, StacksAddress) {
     let mut conf = super::new_test_conf();
@@ -116,13 +119,15 @@ pub mod test_observer {
     use warp;
     use warp::Filter;
 
-    use crate::event_dispatcher::MinedBlockEvent;
+    use crate::event_dispatcher::{MinedBlockEvent, MinedMicroblockEvent};
+    use stacks::chainstate::stacks::miner::TransactionResult;
 
     pub const EVENT_OBSERVER_PORT: u16 = 50303;
 
     lazy_static! {
         pub static ref NEW_BLOCKS: Mutex<Vec<serde_json::Value>> = Mutex::new(Vec::new());
         pub static ref MINED_BLOCKS: Mutex<Vec<MinedBlockEvent>> = Mutex::new(Vec::new());
+        pub static ref MINED_MICROBLOCKS: Mutex<Vec<MinedMicroblockEvent>> = Mutex::new(Vec::new());
         pub static ref NEW_MICROBLOCKS: Mutex<Vec<serde_json::Value>> = Mutex::new(Vec::new());
         pub static ref BURN_BLOCKS: Mutex<Vec<serde_json::Value>> = Mutex::new(Vec::new());
         pub static ref MEMTXS: Mutex<Vec<String>> = Mutex::new(Vec::new());
@@ -155,6 +160,14 @@ pub mod test_observer {
     async fn handle_mined_block(block: serde_json::Value) -> Result<impl warp::Reply, Infallible> {
         let mut mined_blocks = MINED_BLOCKS.lock().unwrap();
         mined_blocks.push(serde_json::from_value(block).unwrap());
+        Ok(warp::http::StatusCode::OK)
+    }
+
+    async fn handle_mined_microblock(
+        tx_event: serde_json::Value,
+    ) -> Result<impl warp::Reply, Infallible> {
+        let mut mined_txs = MINED_MICROBLOCKS.lock().unwrap();
+        mined_txs.push(serde_json::from_value(tx_event).unwrap());
         Ok(warp::http::StatusCode::OK)
     }
 
@@ -229,6 +242,10 @@ pub mod test_observer {
         MINED_BLOCKS.lock().unwrap().clone()
     }
 
+    pub fn get_mined_microblocks() -> Vec<MinedMicroblockEvent> {
+        MINED_MICROBLOCKS.lock().unwrap().clone()
+    }
+
     /// each path here should correspond to one of the paths listed in `event_dispatcher.rs`
     async fn serve() {
         let new_blocks = warp::path!("new_block")
@@ -259,6 +276,10 @@ pub mod test_observer {
             .and(warp::post())
             .and(warp::body::json())
             .and_then(handle_mined_block);
+        let mined_microblocks = warp::path!("mined_microblock")
+            .and(warp::post())
+            .and(warp::body::json())
+            .and_then(handle_mined_microblock);
 
         info!("Spawning warp server");
         warp::serve(
@@ -268,7 +289,8 @@ pub mod test_observer {
                 .or(new_burn_blocks)
                 .or(new_attachments)
                 .or(new_microblocks)
-                .or(mined_blocks),
+                .or(mined_blocks)
+                .or(mined_microblocks),
         )
         .run(([127, 0, 0, 1], EVENT_OBSERVER_PORT))
         .await
@@ -3719,6 +3741,222 @@ fn cost_voting_integration() {
 
 #[test]
 #[ignore]
+fn mining_events_integration_test() {
+    if env::var("BITCOIND_TEST") != Ok("1".into()) {
+        return;
+    }
+
+    let small_contract = "(define-public (f) (ok 1))".to_string();
+
+    let spender_sk = StacksPrivateKey::from_hex(SK_1).unwrap();
+    let addr = to_addr(&spender_sk);
+
+    let spender_sk_2 = StacksPrivateKey::from_hex(SK_2).unwrap();
+    let addr_2 = to_addr(&spender_sk_2);
+
+    let tx = make_contract_publish(&spender_sk, 0, 600000, "small", &small_contract);
+    let tx_2 = make_contract_publish(&spender_sk, 1, 610000, "small", &small_contract);
+    let mb_tx =
+        make_contract_publish_microblock_only(&spender_sk_2, 0, 620000, "small", &small_contract);
+
+    let (mut conf, miner_account) = neon_integration_test_conf();
+
+    conf.initial_balances.push(InitialBalance {
+        address: addr.clone().into(),
+        amount: 10000000,
+    });
+    conf.initial_balances.push(InitialBalance {
+        address: addr_2.clone().into(),
+        amount: 10000000,
+    });
+
+    conf.node.mine_microblocks = true;
+    conf.node.wait_time_for_microblocks = 30000;
+    conf.node.microblock_frequency = 1000;
+
+    conf.miner.min_tx_fee = 1;
+    conf.miner.first_attempt_time_ms = i64::max_value() as u64;
+    conf.miner.subsequent_attempt_time_ms = i64::max_value() as u64;
+
+    test_observer::spawn();
+
+    conf.events_observers.push(EventObserverConfig {
+        endpoint: format!("localhost:{}", test_observer::EVENT_OBSERVER_PORT),
+        events_keys: vec![
+            EventKeyType::AnyEvent,
+            EventKeyType::MinedBlocks,
+            EventKeyType::MinedMicroblocks,
+        ],
+    });
+
+    let mut btcd_controller = BitcoinCoreController::new(conf.clone());
+    btcd_controller
+        .start_bitcoind()
+        .map_err(|_e| ())
+        .expect("Failed starting bitcoind");
+
+    let mut btc_regtest_controller = BitcoinRegtestController::new(conf.clone(), None);
+    let http_origin = format!("http://{}", &conf.node.rpc_bind);
+
+    btc_regtest_controller.bootstrap_chain(201);
+
+    eprintln!("Chain bootstrapped...");
+
+    let mut run_loop = neon::RunLoop::new(conf);
+    let blocks_processed = run_loop.get_blocks_processed_arc();
+
+    let channel = run_loop.get_coordinator_channel().unwrap();
+
+    thread::spawn(move || run_loop.start(None, 0));
+
+    // give the run loop some time to start up!
+    wait_for_runloop(&blocks_processed);
+
+    // first block wakes up the run loop
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+
+    // first block will hold our VRF registration
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+
+    // second block will be the first mined Stacks block
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+
+    let account = get_account(&http_origin, &miner_account);
+    assert_eq!(account.nonce, 1);
+    assert_eq!(account.balance, 0);
+
+    let account = get_account(&http_origin, &addr);
+    assert_eq!(account.nonce, 0);
+    assert_eq!(account.balance, 10000000);
+
+    let account = get_account(&http_origin, &addr_2);
+    assert_eq!(account.nonce, 0);
+    assert_eq!(account.balance, 10000000);
+
+    submit_tx(&http_origin, &tx); // should succeed
+    submit_tx(&http_origin, &tx_2); // should fail since it tries to publish contract with same name
+    submit_tx(&http_origin, &mb_tx); // should be in microblock bc it is microblock only
+    sleep_ms(20_000);
+
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+    sleep_ms(20_000);
+
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+
+    // check that the nonces have gone up
+    let res = get_account(&http_origin, &addr);
+    assert_eq!(res.nonce, 1);
+
+    let res = get_account(&http_origin, &addr_2);
+    assert_eq!(res.nonce, 1);
+
+    // check mined microblock events
+    let mined_microblock_events = test_observer::get_mined_microblocks();
+    assert!(mined_microblock_events.len() >= 1);
+
+    // check tx events in the first microblock
+    // 1 success: 1 contract publish, 2 error (on chain transactions)
+    let microblock_tx_events = &mined_microblock_events[0].tx_events;
+    assert_eq!(microblock_tx_events.len(), 3);
+
+    // contract publish
+    match &microblock_tx_events[0] {
+        TransactionEvent::Success(TransactionSuccessEvent {
+            txid,
+            result,
+            fee,
+            execution_cost,
+        }) => {
+            assert_eq!(result.clone().expect_result_ok().expect_bool(), true);
+            assert_eq!(fee, &620000);
+            assert_eq!(
+                execution_cost,
+                &ExecutionCost {
+                    write_length: 35,
+                    write_count: 2,
+                    read_length: 1,
+                    read_count: 1,
+                    runtime: 311000
+                }
+            )
+        }
+        _ => panic!("unexpected event type"),
+    }
+    for i in 1..3 {
+        // on chain only transactions will be skipped in a microblock
+        match &microblock_tx_events[i] {
+            TransactionEvent::Skipped(TransactionSkippedEvent { txid, reason }) => {
+                assert_eq!(
+                    reason,
+                    "tx.anchor_mode does not support microblocks, anchor_mode=OnChainOnly."
+                );
+            }
+            _ => panic!("unexpected event type"),
+        }
+    }
+
+    // check mined block events
+    let mined_block_events = test_observer::get_mined_blocks();
+    assert!(mined_block_events.len() >= 3);
+
+    // check the tx events in the third mined block
+    // 2 success: 1 coinbase tx event + 1 contract publish, 1 error (duplicate contract)
+    let third_block_tx_events = &mined_block_events[2].tx_events;
+    assert_eq!(third_block_tx_events.len(), 3);
+
+    // coinbase event
+    match &third_block_tx_events[0] {
+        TransactionEvent::Success(TransactionSuccessEvent { txid, result, .. }) => {
+            assert_eq!(
+                txid.to_string(),
+                "3e04ada5426332bfef446ba0a06d124aace4ade5c11840f541bf88e2e919faf6"
+            );
+            assert_eq!(result.clone().expect_result_ok().expect_bool(), true);
+        }
+        _ => panic!("unexpected event type"),
+    }
+
+    // contract publish event
+    match &third_block_tx_events[1] {
+        TransactionEvent::Success(TransactionSuccessEvent {
+            txid,
+            result,
+            fee,
+            execution_cost,
+        }) => {
+            assert_eq!(result.clone().expect_result_ok().expect_bool(), true);
+            assert_eq!(fee, &600000);
+            assert_eq!(
+                execution_cost,
+                &ExecutionCost {
+                    write_length: 35,
+                    write_count: 2,
+                    read_length: 1,
+                    read_count: 1,
+                    runtime: 311000
+                }
+            )
+        }
+        _ => panic!("unexpected event type"),
+    }
+
+    // dupe contract error event
+    match &third_block_tx_events[2] {
+        TransactionEvent::ProcessingError(TransactionErrorEvent { txid, error }) => {
+            assert_eq!(
+                error,
+                "Duplicate contract 'ST3WM51TCWMJYGZS1QFMC28DH5YP86782YGR113C1.small'"
+            );
+        }
+        _ => panic!("unexpected event type"),
+    }
+
+    test_observer::clear();
+    channel.stop_chains_coordinator();
+}
+
+#[test]
+#[ignore]
 fn near_full_block_integration_test() {
     if env::var("BITCOIND_TEST") != Ok("1".into()) {
         return;
@@ -3747,7 +3985,7 @@ fn near_full_block_integration_test() {
     let spender_sk = StacksPrivateKey::new();
     let addr = to_addr(&spender_sk);
 
-    let tx = make_contract_publish(&spender_sk, 0, 58450, "max", &max_contract_src);
+    let tx = make_contract_publish(&spender_sk, 0, 59070, "max", &max_contract_src);
 
     let (mut conf, miner_account) = neon_integration_test_conf();
 

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -162,6 +162,8 @@ pub mod test_observer {
         Ok(warp::http::StatusCode::OK)
     }
 
+    /// Called by the process listening to events on a mined microblock event. The event is added
+    /// to the mutex-guarded vector `MINED_MICROBLOCKS`.
     async fn handle_mined_microblock(
         tx_event: serde_json::Value,
     ) -> Result<impl warp::Reply, Infallible> {
@@ -3819,18 +3821,6 @@ fn mining_events_integration_test() {
 
     // second block will be the first mined Stacks block
     next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
-
-    let account = get_account(&http_origin, &miner_account);
-    assert_eq!(account.nonce, 1);
-    assert_eq!(account.balance, 0);
-
-    let account = get_account(&http_origin, &addr);
-    assert_eq!(account.nonce, 0);
-    assert_eq!(account.balance, 10000000);
-
-    let account = get_account(&http_origin, &addr_2);
-    assert_eq!(account.nonce, 0);
-    assert_eq!(account.balance, 10000000);
 
     submit_tx(&http_origin, &tx); // should succeed
     submit_tx(&http_origin, &tx_2); // should fail since it tries to publish contract with same name


### PR DESCRIPTION
## Description
Re-implements #2821: This PR adds the type `TransactionResult`, which is used to track outcomes of transaction inclusion by miners in both blocks and microblocks. 
There are three result types for a transactions: 
- Success - the tx is included in the (micro)block being mined
- Skipped - the tx is skipped over (this could be due to space constraints, or the tx might be invalid) 
- ProcessingError - the miner attempt to process the tx for inclusion in the block, but there was an error

Moreover, this PR updates the `mined_blocks` event and adds the `mined_microblocks` event. Each of these events has a field `tx_events`, which is a list of `TransactionEvents` (which are constructed from `TransactionResults`; they contain a subset of that data)

## Areas for Feedback
- The event dispatcher uses the set `miner_observers_lookup` to determine which observers to send `mined_blocks` events too. Instead of using this set, I created another set, `mined_microblocks_observers_lookup` for the new `mined_microblocks` event. I could:
     -  remove `mined_microblocks_observers_lookup` and just use `miner_observers_lookup` for both `mined_blocks` and `mined_microblocks` events
     - update the name of `miner_observers_lookup` to be `mined_blocks_observers_lookup`
     -  have three categories, `miner_observers_lookup`, `mined_blocks_observers_lookup` and `mined_microblocks_observers_lookup`. The first group `miner_observers_lookup` would subscribe to both the `mined_blocks` and `mined_microblocks` events
- Can use feedback on the payload for the following types (do we want any more data transmitted for the tx event?): 
     - `TransactionSuccessEvent`
     - `MinedMicroblockEvent`

## Testing 
Added `mining_events_integration_test` to `neon_integrations`