### PR TITLE
fix: Create a separate directory for `estimates` tables

### DIFF
--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -780,7 +780,10 @@ impl Config {
     pub fn get_estimates_path(&self) -> PathBuf {
         let mut path = self.get_chainstate_path();
         path.push("estimates");
-        assert!(fs::create_dir_all(&path).is_ok());
+        fs::create_dir_all(&path).expect(&format!(
+            "Failed to create `estimates` directory at {}",
+            path.to_string_lossy()
+        ));
         path
     }
 

--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -776,6 +776,7 @@ impl Config {
         path
     }
 
+    /// Returns the path `{get_chainstate_path()}/estimates`, and ensures it exists.
     pub fn get_estimates_path(&self) -> PathBuf {
         let mut path = self.get_chainstate_path();
         path.push("estimates");


### PR DESCRIPTION
fixes https://github.com/blockstack/stacks-blockchain/issues/2991

1) Create a directory `chainstate/estimates`
2) Ensure this exists
3) Use this for the new estimation db's