### PR TITLE
CI: add cancel in progress behavior to PR actions

### DIFF
--- a/.github/workflows/bitcoin-tests.yml
+++ b/.github/workflows/bitcoin-tests.yml
@@ -8,7 +8,7 @@ on:
 concurrency:
   group: stacks-bitcoin-integration-tests-${{ github.ref }}
   # Only cancel in progress if this is for a PR
-  cancel-in-progress: github.event_name == 'pull_request'
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build-integration-image:

--- a/.github/workflows/bitcoin-tests.yml
+++ b/.github/workflows/bitcoin-tests.yml
@@ -5,6 +5,11 @@ name: stacks-bitcoin-integration-tests
 on:
   pull_request:
 
+concurrency:
+  group: stacks-bitcoin-integration-tests-${{ github.ref }}
+  # Only cancel in progress if this is for a PR
+  cancel-in-progress: github.event_name == 'pull_request'
+
 jobs:
   build-integration-image:
     runs-on: ubuntu-latest

--- a/.github/workflows/stacks-blockchain.yml
+++ b/.github/workflows/stacks-blockchain.yml
@@ -15,7 +15,7 @@ on:
 concurrency:
   group: stacks-blockchain-${{ github.ref }}
   # Only cancel in progress if this is for a PR
-  cancel-in-progress: github.event_name == 'pull_request'
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   # Notify Slack channel of workflow start

--- a/.github/workflows/stacks-blockchain.yml
+++ b/.github/workflows/stacks-blockchain.yml
@@ -12,6 +12,11 @@ on:
         description: 'The tag to create (optional)'
         required: false
 
+concurrency:
+  group: stacks-blockchain-${{ github.ref }}
+  # Only cancel in progress if this is for a PR
+  cancel-in-progress: github.event_name == 'pull_request'
+
 jobs:
   # Notify Slack channel of workflow start
   notify-start:


### PR DESCRIPTION
This adds cancel-in-progress behavior to our PR Github actions, where if you push new commits to a PR, it cancels any in progress actions associated with that PR.