### PR TITLE
chore: remove regtest from release process in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,7 +429,6 @@ is tagged.
    candidate on various staging infrastructure:
 
    1. Stacks Foundation staging environments.
-   1. Hiro PBC regtest network.
    1. Hiro PBC testnet network.
    1. Hiro PBC mainnet mock miner.
 


### PR DESCRIPTION
## Description

Removes the `Hiro PBC regtest network` step from the release process in the README, as the regtest network has been decommissioned late 2021.

## Type of Change
- API reference/documentation update

## Does this introduce a breaking change?
No
