### PR TITLE
fix: significantly increase the speed of most RPC endpoints

### DIFF
--- a/src/chainstate/burn/db/sortdb.rs
+++ b/src/chainstate/burn/db/sortdb.rs
@@ -487,7 +487,7 @@ const SORTITION_DB_INITIAL_SCHEMA: &'static [&'static str] = &[
     "CREATE INDEX snapshots_block_stacks_hashes ON snapshots(num_sortitions,index_root,winning_stacks_block_hash);",
     "CREATE INDEX snapshots_block_heights ON snapshots(burn_header_hash,block_height);",
     "CREATE INDEX snapshots_block_winning_hash ON snapshots(winning_stacks_block_hash);",
-    "CREATE INDEX snapshots_canonical_chain_tip(pox_valid,block_height DESC,burn_header_hash ASC);",
+    "CREATE INDEX snapshots_canonical_chain_tip ON snapshots(pox_valid,block_height DESC,burn_header_hash ASC);",
     "CREATE INDEX block_arrivals ON snapshots(arrival_index,burn_header_hash);",
     "CREATE INDEX arrival_indexes ON snapshots(arrival_index);",
     r#"

--- a/src/chainstate/burn/db/sortdb.rs
+++ b/src/chainstate/burn/db/sortdb.rs
@@ -487,6 +487,7 @@ const SORTITION_DB_INITIAL_SCHEMA: &'static [&'static str] = &[
     "CREATE INDEX snapshots_block_stacks_hashes ON snapshots(num_sortitions,index_root,winning_stacks_block_hash);",
     "CREATE INDEX snapshots_block_heights ON snapshots(burn_header_hash,block_height);",
     "CREATE INDEX snapshots_block_winning_hash ON snapshots(winning_stacks_block_hash);",
+    "CREATE INDEX snapshots_pox_valid(pox_valid);",
     "CREATE INDEX block_arrivals ON snapshots(arrival_index,burn_header_hash);",
     "CREATE INDEX arrival_indexes ON snapshots(arrival_index);",
     r#"

--- a/src/chainstate/burn/db/sortdb.rs
+++ b/src/chainstate/burn/db/sortdb.rs
@@ -487,7 +487,7 @@ const SORTITION_DB_INITIAL_SCHEMA: &'static [&'static str] = &[
     "CREATE INDEX snapshots_block_stacks_hashes ON snapshots(num_sortitions,index_root,winning_stacks_block_hash);",
     "CREATE INDEX snapshots_block_heights ON snapshots(burn_header_hash,block_height);",
     "CREATE INDEX snapshots_block_winning_hash ON snapshots(winning_stacks_block_hash);",
-    "CREATE INDEX snapshots_pox_valid(pox_valid);",
+    "CREATE INDEX snapshots_canonical_chain_tip(pox_valid,block_height DESC,burn_header_hash ASC);",
     "CREATE INDEX block_arrivals ON snapshots(arrival_index,burn_header_hash);",
     "CREATE INDEX arrival_indexes ON snapshots(arrival_index);",
     r#"


### PR DESCRIPTION
This PR improves querying the canonical chain tip by a couple orders of magnitude, using this One Weird Trick (tm).

It improves network responsiveness considerably, and probably also helps chain boot-up (but I need to test this to get an actual number).

It's so much faster on the Foundation's public node that RPC queries that used to take ~200 ms now take 0 ms.  I don't even know what the true multiplier is.  I'm dumbfounded that we didn't find this sooner.

Please consider adding to 2.05.0.1.0.